### PR TITLE
Fix TLS minimum protocol version enums

### DIFF
--- a/deployment/common/common.yaml
+++ b/deployment/common/common.yaml
@@ -63,9 +63,9 @@ spec:
                     minimumProtocolVersion:
                       type: string
                       enum:
-                        - 1.3
-                        - 1.2
-                        - 1.1
+                        - "1.3"
+                        - "1.2"
+                        - "1.1"
             strategy:
               type: string
               enum:

--- a/deployment/render/daemonset-rbac.yaml
+++ b/deployment/render/daemonset-rbac.yaml
@@ -66,9 +66,9 @@ spec:
                     minimumProtocolVersion:
                       type: string
                       enum:
-                        - 1.3
-                        - 1.2
-                        - 1.1
+                        - "1.3"
+                        - "1.2"
+                        - "1.1"
             strategy:
               type: string
               enum:

--- a/deployment/render/deployment-rbac.yaml
+++ b/deployment/render/deployment-rbac.yaml
@@ -66,9 +66,9 @@ spec:
                     minimumProtocolVersion:
                       type: string
                       enum:
-                        - 1.3
-                        - 1.2
-                        - 1.1
+                        - "1.3"
+                        - "1.2"
+                        - "1.1"
             strategy:
               type: string
               enum:


### PR DESCRIPTION
The OpenAPI Schema for ingress routes has an incompatible type and enum fields for the TLS minimum protocol version. The field's type is string but the enums are numbers (as they are unquoted in the YAML file) which makes it impossible to create an ingress route using this field. When adding `minimumProtocolVersion: "1.1"` to the ingress route, applying the resource will return the error:

```
spec.virtualhost.tls.minimumProtocolVersion in body should be one of [1.3 1.2 1.1]
```

This PR resolves the issue by quote the version numbers in the enum. This seems to be the correct choice as the version number should be a string according to the type definition: https://github.com/heptio/contour/blob/e03d63d515d1b38c42e60589ed1d573744750bc3/apis/contour/v1beta1/ingressroute.go#L48