### PR TITLE
RateLimiting implementation

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -69,6 +69,8 @@ type Route struct {
 	PermitInsecure bool `json:"permitInsecure,omitempty"`
 	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
 	PrefixRewrite string `json:"prefixRewrite,omitempty"`
+	// RateLimitConfiguration defunes ratelimiting options which are passed to the rate limiting implementation service
+	RateLimitConfiguration map[string]string `json:"rateLimit,omitempty"`
 }
 
 // TCPProxy contains the set of services to proxy TCP connections.

--- a/apis/contour/v1beta1/zz_generated.deepcopy.go
+++ b/apis/contour/v1beta1/zz_generated.deepcopy.go
@@ -165,6 +165,13 @@ func (in *Route) DeepCopyInto(out *Route) {
 		*out = new(Delegate)
 		**out = **in
 	}
+	if in.RateLimitConfiguration != nil {
+		in, out := &in.RateLimitConfiguration, &out.RateLimitConfiguration
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -57,6 +57,9 @@ func main() {
 	bootstrap.Flag("statsd-enabled", "enable statsd output").BoolVar(&config.StatsdEnabled)
 	bootstrap.Flag("statsd-address", "statsd address").StringVar(&config.StatsdAddress)
 	bootstrap.Flag("statsd-port", "statsd port").IntVar(&config.StatsdPort)
+	bootstrap.Flag("rate-limit-enabled", "enable rate limit service").BoolVar(&config.RateLimitServiceEnabled)
+	bootstrap.Flag("rate-limit-address", "rate limit service address").StringVar(&config.RateLimitServiceAddress)
+	bootstrap.Flag("rate-limit-port", "rate limit service port").IntVar(&config.RateLimitServicePort)
 
 	cli := app.Command("cli", "A CLI client for the Heptio Contour Kubernetes ingress controller.")
 	var client Client
@@ -132,6 +135,7 @@ func main() {
 	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ch.UseProxyProto)
 	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&reh.IngressClass)
 	serve.Flag("ingressroute-root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringVar(&ingressrouteRootNamespaceFlag)
+	serve.Flag("rate-limit-stage", "Stage used for rate limiting").StringVar(&reh.IngressClass)
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {

--- a/deployment/common/redis.yaml
+++ b/deployment/common/redis.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: redis
+ namespace: heptio-contour
+spec:
+ ports:
+ - port: 6379
+   protocol: TCP
+ selector:
+   app: redis
+ type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: redis
+  name: redis
+  namespace: heptio-contour
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: contour
+        image: redis:alpine
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 6379
+          name: redis
+          protocol: TCP
+      serviceAccountName: contour
+

--- a/deployment/ds-hostnet-split-ratelimit/0-service-ratelimit.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/0-service-ratelimit.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratelimit
+  namespace: heptio-contour
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    app: ratelimit
+  type: ClusterIP

--- a/deployment/ds-hostnet-split-ratelimit/01-common.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/01-common.yaml
@@ -1,0 +1,1 @@
+../common/common.yaml

--- a/deployment/ds-hostnet-split-ratelimit/02-rbac.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/02-rbac.yaml
@@ -1,0 +1,1 @@
+../common/rbac.yaml

--- a/deployment/ds-hostnet-split-ratelimit/02-service-contour.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/02-service-contour.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: contour
+ namespace: heptio-contour
+spec:
+ ports:
+ - port: 8001
+   name: xds
+   protocol: TCP
+   targetPort: 8001
+ selector:
+   app: contour
+ type: ClusterIP

--- a/deployment/ds-hostnet-split-ratelimit/02-service-envoy.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/02-service-envoy.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: envoy
+ namespace: heptio-contour
+ annotations:
+   service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+ externalTrafficPolicy: Local
+ ports:
+ - port: 80
+   name: http
+   protocol: TCP
+ - port: 443
+   name: https
+   protocol: TCP
+ selector:
+   app: envoy
+ type: LoadBalancer

--- a/deployment/ds-hostnet-split-ratelimit/02-service-redis.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/02-service-redis.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: heptio-contour
+spec:
+  ports:
+  - port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: redis
+  type: ClusterIP

--- a/deployment/ds-hostnet-split-ratelimit/03-contour.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/03-contour.yaml
@@ -50,15 +50,5 @@ spec:
         - containerPort: 8000
           name: debug
           protocol: TCP
-      - name: ratelimit
-        image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-          name: grpc
-          protocol: TCP
-        - containerPort: 6070
-          name: another
-          protocol: TCP
       dnsPolicy: ClusterFirst
       serviceAccountName: contour

--- a/deployment/ds-hostnet-split-ratelimit/03-envoy.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/03-envoy.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: envoy
   name: envoy
-  namespace: gimbal-contour
+  namespace: heptio-contour
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -68,6 +68,9 @@ spec:
         - $(CONTOUR_SERVICE_HOST)
         - --xds-port
         - $(CONTOUR_SERVICE_PORT)
+        - --rate-limit-enabled
+        - --rate-limit-address
+        - $(RATELIMIT_SERVICE_HOST)
         command:
         - contour
         image: gcr.io/heptio-images/contour:master
@@ -80,7 +83,4 @@ spec:
       volumes:
         - name: contour-config
           emptyDir: {}
-        - name: ratelimit-config
-          configMap:
-            name: ratelimit-config
       restartPolicy: Always

--- a/deployment/ds-hostnet-split-ratelimit/03-ratelimit_config.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/03-ratelimit_config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    ---
+    domain: contour
+    descriptors:
+      - key: generic_key
+        value: default
+        rate_limit:
+          unit: minute
+          requests_per_unit: 5
+kind: ConfigMap
+metadata:
+  name: ratelimit-config
+  namespace: heptio-contour

--- a/deployment/ds-hostnet-split-ratelimit/04-ratelimit.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/04-ratelimit.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ratelimit
+  name: ratelimit
+  namespace: heptio-contour
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ratelimit
+  template:
+    metadata:
+      labels:
+        app: ratelimit
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: ratelimit
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - name: ratelimit
+        image: gcr.io/heptio-images/ratelimit:459ed655
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8081
+          name: grpc
+          protocol: TCP
+        - containerPort: 6070
+          name: debug
+          protocol: TCP
+        env:
+        - name: USE_STATSD
+          value: "false"
+        - name: LOG_LEVEL
+          value: debug
+        - name: REDIS_SOCKET_TYPE
+          value: tcp
+        - name: REDIS_URL
+          value: redis:6379
+        - name: RUNTIME_ROOT
+          value: /data
+        - name: RUNTIME_SUBDIRECTORY
+          value: ratelimit
+        command:
+        - ratelimit
+        volumeMounts:
+          - mountPath: /data/ratelimit
+            name: ratelimit-config 
+      volumes:
+        - name: ratelimit-config
+          configMap:
+            name: ratelimit-config
+      dnsPolicy: ClusterFirst
+      serviceAccountName: contour

--- a/deployment/ds-hostnet-split-ratelimit/04-redis.yaml
+++ b/deployment/ds-hostnet-split-ratelimit/04-redis.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  generation: 1
+  labels:
+    app: redis
+  name: redis
+  namespace: heptio-contour
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: redis:alpine
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: redis
+          protocol: TCP
+      restartPolicy: Always

--- a/deployment/example-workload/kuard-ingressroute-ratelimit.yaml
+++ b/deployment/example-workload/kuard-ingressroute-ratelimit.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: kuard
+  template:
+    metadata:
+      labels:
+        app: kuard
+    spec:
+      containers:
+      - image: gcr.io/kuar-demo/kuard-amd64:1
+        name: kuard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kuard
+  name: kuard
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: kuard
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  labels:
+    app: kuard
+  name: kuard-ratelimit
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: marketing.local
+  routes: 
+    - match: /
+      rateLimit:
+        generic_key: default
+      services: 
+        - name: kuard
+          port: 80

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -16,23 +16,26 @@ package contour
 import (
 	"sync"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/gogo/protobuf/proto"
 	"github.com/heptio/contour/internal/dag"
 	"github.com/heptio/contour/internal/envoy"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
-	ENVOY_HTTP_LISTENER            = "ingress_http"
-	ENVOY_HTTPS_LISTENER           = "ingress_https"
-	DEFAULT_HTTP_ACCESS_LOG        = "/dev/stdout"
-	DEFAULT_HTTP_LISTENER_ADDRESS  = "0.0.0.0"
-	DEFAULT_HTTP_LISTENER_PORT     = 8080
-	DEFAULT_HTTPS_ACCESS_LOG       = "/dev/stdout"
-	DEFAULT_HTTPS_LISTENER_ADDRESS = DEFAULT_HTTP_LISTENER_ADDRESS
-	DEFAULT_HTTPS_LISTENER_PORT    = 8443
+	ENVOY_HTTP_LISTENER                          = "ingress_http"
+	ENVOY_HTTPS_LISTENER                         = "ingress_https"
+	DEFAULT_HTTP_ACCESS_LOG                      = "/dev/stdout"
+	DEFAULT_HTTP_LISTENER_ADDRESS                = "0.0.0.0"
+	DEFAULT_HTTP_LISTENER_PORT                   = 8080
+	DEFAULT_HTTPS_ACCESS_LOG                     = "/dev/stdout"
+	DEFAULT_HTTPS_LISTENER_ADDRESS               = DEFAULT_HTTP_LISTENER_ADDRESS
+	DEFAULT_HTTPS_LISTENER_PORT                  = 8443
+	DEFAULT_RATE_LIMIT_SERVICE_DOMAIN            = "contour"
+	DEFAULT_RATE_LIMIT_SERVICE_STAGE             = 0
+	DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY = false
 )
 
 // ListenerVisitorConfig holds configuration parameters for visitListeners.
@@ -61,10 +64,23 @@ type ListenerVisitorConfig struct {
 	// If not set, defaults to DEFAULT_HTTPS_ACCESS_LOG.
 	HTTPSAccessLog string
 
-	// UseProxyProto configurs all listeners to expect a PROXY protocol
+	// UseProxyProto configures all listeners to expect a PROXY protocol
 	// V1 header on new connections.
 	// If not set, defaults to false.
 	UseProxyProto bool
+
+	// RateLimitServiceDomain configures the domain for rate limit service
+	// If not set, defaults to "contour"
+	RateLimitServiceDomain string
+
+	// RateLimitServiceStage configures the stage for rate limit service
+	// If not set, defaults to 0
+	RateLimitServiceStage *int
+
+	// RateLimitFailureModeDeny configures if rate limiting should respond with error
+	// given the service cannot be contacted
+	// If not set, defaults to false
+	RateLimitFailureModeDeny *bool
 }
 
 // httpAddress returns the port for the HTTP (non TLS)
@@ -119,6 +135,33 @@ func (lvc *ListenerVisitorConfig) httpsAccessLog() string {
 		return lvc.HTTPSAccessLog
 	}
 	return DEFAULT_HTTPS_ACCESS_LOG
+}
+
+// rateLimitServiceDomain returns the domain used for rate limit
+// service listener or DEFAULT_RATE_LIMIT_SERVICE_DOMAIN if not configured.
+func (lvc *ListenerVisitorConfig) rateLimitServiceDomain() string {
+	if lvc.RateLimitServiceDomain != "" {
+		return lvc.RateLimitServiceDomain
+	}
+	return DEFAULT_RATE_LIMIT_SERVICE_DOMAIN
+}
+
+// rateLimitServiceStage returns the stage used for rate limit
+// service listener or DEFAULT_RATE_LIMIT_SERVICE_STAGE if not configured.
+func (lvc *ListenerVisitorConfig) rateLimitServiceStage() int {
+	if lvc.RateLimitServiceStage != nil {
+		return *lvc.RateLimitServiceStage
+	}
+	return DEFAULT_RATE_LIMIT_SERVICE_STAGE
+}
+
+// rateLimitFailureModeDeny returnss if the rate limit service listener
+// should respond or DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY if not configured.
+func (lvc *ListenerVisitorConfig) rateLimitFailureModeDeny() bool {
+	if lvc.RateLimitFailureModeDeny != nil {
+		return *lvc.RateLimitFailureModeDeny
+	}
+	return DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY
 }
 
 // ListenerCache manages the contents of the gRPC LDS cache.
@@ -197,7 +240,7 @@ func visitListeners(root dag.Vertex, lvc *ListenerVisitorConfig) map[string]*v2.
 				Address: envoy.SocketAddress(lvc.httpAddress(), lvc.httpPort()),
 				FilterChains: []listener.FilterChain{{
 					Filters: []listener.Filter{
-						envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, lvc.httpAccessLog()),
+						envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, lvc.httpAccessLog(), lvc.rateLimitServiceDomain(), lvc.rateLimitServiceStage(), lvc.rateLimitFailureModeDeny()),
 					},
 					UseProxyProto: bv(lvc.UseProxyProto),
 				}},
@@ -231,7 +274,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 		v.http = true
 	case *dag.SecureVirtualHost:
 		filters := []listener.Filter{
-			envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, v.httpsAccessLog()),
+			envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, v.httpsAccessLog(), v.rateLimitServiceDomain(), v.rateLimitServiceStage(), v.rateLimitFailureModeDeny()),
 		}
 		alpnProtos := []string{"h2", "http/1.1"}
 		if vh.VirtualHost.TCPProxy != nil {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -17,14 +17,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -59,7 +59,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}),
 		},
@@ -91,7 +92,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}),
 		},
@@ -125,7 +127,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -135,7 +138,8 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					Filters: filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				}},
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
@@ -172,7 +176,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}),
 		},
@@ -214,7 +219,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -224,7 +230,8 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					Filters: filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				}},
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
@@ -288,7 +295,8 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					Filters: filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				}},
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
@@ -331,7 +339,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("127.0.0.100", 9100),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(false, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -341,7 +350,8 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:    filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					Filters: filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				}},
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
@@ -381,7 +391,8 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG)),
+					filterchain(true, envoy.HTTPConnectionManager(ENVOY_HTTP_LISTENER, DEFAULT_HTTP_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 				},
 			}, &v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -390,8 +401,9 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TlsContext:    tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:       filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG)),
+					TlsContext: tlscontext(auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					Filters: filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, DEFAULT_HTTPS_ACCESS_LOG,
+						DEFAULT_RATE_LIMIT_SERVICE_DOMAIN, DEFAULT_RATE_LIMIT_SERVICE_STAGE, DEFAULT_RATE_LIMIT_SERVICE_FAILURE_MODE_DENY)),
 					UseProxyProto: bv(true),
 				}},
 				ListenerFilters: []listener.ListenerFilter{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -608,11 +608,12 @@ func (b *builder) processRoutes(ir *ingressroutev1.IngressRoute, prefixMatch str
 			}
 
 			r := &Route{
-				Prefix:        route.Match,
-				object:        ir,
-				Websocket:     route.EnableWebsockets,
-				HTTPSUpgrade:  routeEnforceTLS(enforceTLS, route.PermitInsecure),
-				PrefixRewrite: route.PrefixRewrite,
+				Prefix:                 route.Match,
+				object:                 ir,
+				Websocket:              route.EnableWebsockets,
+				HTTPSUpgrade:           routeEnforceTLS(enforceTLS, route.PermitInsecure),
+				PrefixRewrite:          route.PrefixRewrite,
+				RateLimitConfiguration: route.RateLimitConfiguration,
 			}
 			for _, service := range route.Services {
 				if service.Port < 1 || service.Port > 65535 {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -18,7 +18,7 @@ package dag
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
@@ -81,6 +81,9 @@ type Route struct {
 
 	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
 	PrefixRewrite string
+
+	// Defines ratelimiting configuration if specified
+	RateLimitConfiguration map[string]string
 }
 
 func (r *Route) addHTTPService(s *HTTPService) {

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -20,7 +20,7 @@ import (
 
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
@@ -34,7 +34,7 @@ import (
 	"github.com/heptio/contour/internal/envoy"
 	"github.com/heptio/contour/internal/k8s"
 	"google.golang.org/grpc"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -73,7 +73,7 @@ func TestNonTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -128,7 +128,7 @@ func TestNonTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -188,13 +188,13 @@ func TestTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 			any(t, &v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -230,7 +230,7 @@ func TestTLSListener(t *testing.T) {
 			any(t, &v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -328,7 +328,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	l1 := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -345,7 +345,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 			any(t, l1),
@@ -363,7 +363,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -377,7 +377,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 	l2 := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -394,7 +394,7 @@ func TestIngressRouteTLSListener(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 			any(t, l2),
@@ -446,7 +446,7 @@ func TestLDSFilter(t *testing.T) {
 			any(t, &v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -465,7 +465,7 @@ func TestLDSFilter(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -533,7 +533,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 			any(t, &v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 				ListenerFilters: []listener.ListenerFilter{
 					envoy.TLSInspector(),
 				},
@@ -566,7 +566,7 @@ func TestLDSTLSMinimumProtocolVersion(t *testing.T) {
 	l1 := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -620,7 +620,7 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -680,7 +680,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 	ingress_https := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -693,7 +693,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(true, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 			any(t, ingress_https),
@@ -758,13 +758,13 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Name:    "ingress_http",
 		Address: envoy.SocketAddress("127.0.0.100", 9100),
 		FilterChains: []listener.FilterChain{
-			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 		},
 	}
 	ingress_https := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("127.0.0.200", 9200),
-		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},
@@ -826,7 +826,7 @@ func TestLDSIngressRouteInsideRootNamespaces(t *testing.T) {
 				Name:    "ingress_http",
 				Address: envoy.SocketAddress("0.0.0.0", 8080),
 				FilterChains: []listener.FilterChain{
-					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+					filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 				},
 			}),
 		},
@@ -944,14 +944,14 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		Name:    "ingress_http",
 		Address: envoy.SocketAddress("0.0.0.0", 8080),
 		FilterChains: []listener.FilterChain{
-			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout")),
+			filterchain(false, envoy.HTTPConnectionManager("ingress_http", "/dev/stdout", "contour", 0, false)),
 		},
 	}
 
 	ingressHTTPS := &v2.Listener{
 		Name:         "ingress_https",
 		Address:      envoy.SocketAddress("0.0.0.0", 8443),
-		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout"), "h2", "http/1.1"),
+		FilterChains: filterchaintls("example.com", envoy.HTTPConnectionManager("ingress_https", "/dev/stdout", "contour", 0, false), "h2", "http/1.1"),
 		ListenerFilters: []listener.ListenerFilter{
 			envoy.TLSInspector(),
 		},

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -70,6 +70,18 @@ type ConfigWriter struct {
 	// StatsdPort is port of the statsd endpoint
 	// Defaults to 9125.
 	StatsdPort int
+
+	// RateLimitServiceEnabled enables ratelimiting filter
+	// Defaults to false.
+	RateLimitServiceEnabled bool
+
+	// RateLimitServiceName is the address of the ratelimiting impl service
+	// Defaults to 127.0.0.1
+	RateLimitServiceAddress string
+
+	// RateLimitServicePort is the port of the ratelimiting impl service
+	// Defaults to 8081.
+	RateLimitServicePort int
 }
 
 const yamlConfig = `dynamic_resources:
@@ -117,7 +129,16 @@ static_resources:
           protocol: TCP
           address: 127.0.0.1
           port_value: {{ if .AdminPort }}{{ .AdminPort }}{{ else }}9001{{ end }}
-  listeners:
+{{ if .RateLimitServiceEnabled }}  - name: rate_limit_cluster
+    type: STATIC
+    connect_timeout: 0.25s
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    - socket_address:
+        address: {{ if .RateLimitServiceAddress }}{{ .RateLimitServiceAddress }}{{ else }}127.0.0.1{{ end }}
+        port_value: {{ if .RateLimitServicePort }}{{ .RateLimitServicePort }}{{ else }}8081{{ end }} 
+{{ end }}  listeners:
     - address:
         socket_address:
           protocol: TCP
@@ -162,11 +183,18 @@ static_resources:
     socket_address:
       address: {{ if .AdminAddress }}{{ .AdminAddress }}{{ else }}127.0.0.1{{ end }}
       port_value: {{ if .AdminPort }}{{ .AdminPort }}{{ else }}9001{{ end }}
+{{ if .RateLimitServiceEnabled }}rate_limit_service:
+    grpc_service:
+        envoy_grpc:
+            cluster_name: rate_limit_cluster
+        timeout: 0.25s
+{{ end -}}
 `
 
 // WriteYAML writes the configuration to the supplied writer in YAML v2 format.
 // If the supplied io.Writer is a file, it should end with a .yaml extension.
 func (c *ConfigWriter) WriteYAML(w io.Writer) error {
+
 	t, err := template.New("config").Parse(yamlConfig)
 	if err != nil {
 		return err

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -207,6 +207,110 @@ admin:
       port_value: 9001
 `,
 		},
+		"ratelimiting defined": {
+			ConfigWriter: ConfigWriter{
+				RateLimitServiceEnabled: true,
+				RateLimitServiceAddress: "1.2.3.4",
+				RateLimitServicePort:    1234,
+			},
+			want: `dynamic_resources:
+  lds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+  cds_config:
+    api_config_source:
+      api_type: GRPC
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: contour
+static_resources:
+  clusters:
+  - name: contour
+    connect_timeout: { seconds: 5 }
+    type: STRICT_DNS
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8001
+    lb_policy: ROUND_ROBIN
+    http2_protocol_options: {}
+    circuit_breakers:
+      thresholds:
+        - priority: high
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+        - priority: default
+          max_connections: 100000
+          max_pending_requests: 100000
+          max_requests: 60000000
+          max_retries: 50
+  - name: service_stats
+    connect_timeout: 0.250s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    hosts:
+      - socket_address:
+          protocol: TCP
+          address: 127.0.0.1
+          port_value: 9001
+  - name: rate_limit_cluster
+    type: STATIC
+    connect_timeout: 0.25s
+    lb_policy: round_robin
+    http2_protocol_options: {}
+    hosts:
+    - socket_address:
+        address: 1.2.3.4
+        port_value: 1234 
+  listeners:
+    - address:
+        socket_address:
+          protocol: TCP
+          address: 0.0.0.0
+          port_value: 8002
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: AUTO
+                stat_prefix: stats
+                route_config:
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: /stats
+                          route:
+                            cluster: service_stats
+                http_filters:
+                  - name: envoy.health_check
+                    config:
+                      pass_through_mode: false
+                      headers:
+                      - name: ":path"
+                        exact_match: "/healthz"
+                  - name: envoy.router
+                    config:
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9001
+rate_limit_service:
+    grpc_service:
+        envoy_grpc:
+            cluster_name: rate_limit_cluster
+        timeout: 0.25s
+`,
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -36,7 +36,7 @@ func TLSInspector() listener.ListenerFilter {
 
 // HTTPConnectionManager creates a new HTTP Connection Manager filter
 // for the supplied route and access log.
-func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
+func HTTPConnectionManager(routename, accessLogPath, rateLimitDomain string, rateLimitStage int, rateLimitFailureModeDeny bool) listener.Filter {
 	return listener.Filter{
 		Name: util.HTTPConnectionManager,
 		ConfigType: &listener.Filter_Config{
@@ -64,6 +64,22 @@ func HTTPConnectionManager(routename, accessLogPath string) listener.Filter {
 						}),
 						st(map[string]*types.Value{
 							"name": sv(util.GRPCWeb),
+						}),
+						st(map[string]*types.Value{
+							"name": sv("envoy.rate_limit"),
+							"config": st(map[string]*types.Value{
+								"domain": sv(rateLimitDomain),
+								"stage": {
+									Kind: &types.Value_NumberValue{
+										NumberValue: float64(rateLimitStage),
+									},
+								},
+								"failure_mode_deny": {
+									Kind: &types.Value_BoolValue{
+										BoolValue: rateLimitFailureModeDeny,
+									},
+								},
+							}),
 						}),
 						st(map[string]*types.Value{
 							"name": sv(util.Router),


### PR DESCRIPTION
Updates #370 by implementing RateLimiting for Contour. This PR only implements for `IngressRoutes`, a future PR could add support for Ingress. 

I also need to add docs to explain how to configure/setup, that will come next, but wanted to agree on the impl and get a review first. 

Signed-off-by: Steve Sloka <slokas@vmware.com>