### PR TITLE
internal/dag: infer object type during SetValid

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -488,7 +488,7 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 	}
 
 	// Set default status
-	sw.SetValid().WithValue("description", "valid HTTPProxy")
+	sw.SetValid()
 
 	// Loop over and process all includes
 	b.processIncludes(sw, proxy, host, nil, enforceTLS, nil)
@@ -500,6 +500,7 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 	case proxy.Spec.Routes != nil:
 		b.processRoutes(sw, proxy, host, nil, enforceTLS)
 	}
+
 }
 
 // mergeConditions merges any two conditions when they are delegated
@@ -766,7 +767,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 			commit()
 		}
 	}
-	sw.SetValid().WithValue("description", "valid IngressRoute")
+	sw.SetValid()
 }
 
 func (b *Builder) processRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPProxy, host string, condition *projcontour.Condition, enforceTLS bool) {
@@ -878,7 +879,7 @@ func (b *Builder) processTCPProxy(sw *ObjectStatusWriter, ir *ingressroutev1.Ing
 			})
 		}
 		b.lookupSecureVirtualHost(host).TCPProxy = &proxy
-		sw.SetValid().WithValue("description", "valid TCPProxy")
+		sw.SetValid()
 		return
 	}
 
@@ -916,7 +917,7 @@ func (b *Builder) processTCPProxy(sw *ObjectStatusWriter, ir *ingressroutev1.Ing
 		commit()
 	}
 
-	sw.SetValid().WithValue("description", "valid TCPProxy")
+	sw.SetValid()
 }
 
 func conditionPath(routeCondition, includeCondition *projcontour.Condition) string {

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -14,6 +14,8 @@
 package dag
 
 import (
+	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	projcontour "github.com/heptio/contour/apis/projectcontour/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,8 +94,15 @@ func (osw *ObjectStatusWriter) SetInvalid(desc string) {
 	osw.WithValue("description", desc).WithValue("status", StatusInvalid)
 }
 
-func (osw *ObjectStatusWriter) SetValid() *ObjectStatusWriter {
-	return osw.WithValue("status", StatusValid)
+func (osw *ObjectStatusWriter) SetValid() {
+	switch osw.obj.(type) {
+	case *projcontour.HTTPProxy:
+		osw.WithValue("description", "valid HTTPProxy").WithValue("status", StatusValid)
+	case *ingressroutev1.IngressRoute:
+		osw.WithValue("description", "valid IngressRoute").WithValue("status", StatusValid)
+	default:
+		// not a supported type
+	}
 }
 
 // WithObject returns a new ObjectStatusWriter with a copy of the current


### PR DESCRIPTION
The ObjectStatusWriter knows the object its operating on, we can use
that information to set the Valid description accordingly.

Signed-off-by: Dave Cheney <dave@cheney.net>