### PR TITLE
internal/dag: do not set VHost on non root IngressRoutes

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -376,7 +376,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			objs: []interface{}{ir1, ir4, s3},
 			want: metrics.IngressRouteMetric{
 				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
+					{Namespace: "roots"}: 1,
 				},
 				Valid: map[metrics.Meta]int{
 					{Namespace: "roots", VHost: "example.com"}: 1,
@@ -426,7 +426,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			objs: []interface{}{ir7, ir8},
 			want: metrics.IngressRouteMetric{
 				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
+					{Namespace: "roots"}: 1,
 				},
 				Valid: map[metrics.Meta]int{
 					{Namespace: "roots", VHost: "example.com"}: 1,
@@ -474,10 +474,11 @@ func TestIngressRouteMetrics(t *testing.T) {
 			objs: []interface{}{ir10, ir11, ir12, s1, s2},
 			want: metrics.IngressRouteMetric{
 				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
+					{Namespace: "roots"}: 1,
 				},
 				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 2,
+					{Namespace: "roots"}:                       1,
+					{Namespace: "roots", VHost: "example.com"}: 1,
 				},
 				Orphaned: map[metrics.Meta]int{},
 				Root: map[metrics.Meta]int{
@@ -513,7 +514,8 @@ func TestIngressRouteMetrics(t *testing.T) {
 					{Namespace: "roots"}: 1,
 				},
 				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 2,
+					{Namespace: "roots", VHost: "example.com"}: 1,
+					{Namespace: "roots"}:                       1,
 				},
 				Orphaned: map[metrics.Meta]int{},
 				Root: map[metrics.Meta]int{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -762,7 +762,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 			}
 
 			// follow the link and process the target ingress route
-			sw, commit := sw.WithObject(dest)
+			sw, commit := b.WithObject(dest)
 			b.processIngressRoutes(sw, dest, route.Match, visited, host, enforceTLS)
 			commit()
 		}


### PR DESCRIPTION
This PR removes the Vhost setting on non root ingressroute records.
The included test shows that the Vhost status on a delegated
ingressroute is unstable, it depends on the order in which the
ingressroute's that delegate to it are processed and ultimaltely is
incorrect in both cases -- status only lets us set the Vhost field once,
yet more than one root ingressroute with different fqdns delegates to
ir31.

Signed-off-by: Dave Cheney <dave@cheney.net>