### PR TITLE
examples: Update HTTPProxy CRD / validation

### DIFF
--- a/examples/contour/01-common.yaml
+++ b/examples/contour/01-common.yaml
@@ -83,11 +83,17 @@ metadata:
     component: httpproxy
 spec:
   group: projectcontour.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   scope: Namespaced
   names:
     plural: httpproxies
+    singular: httpproxy
     kind: HTTPProxy
+    shortNames:
+      - proxy
   additionalPrinterColumns:
     - name: FQDN
       type: string
@@ -109,186 +115,6 @@ spec:
       type: string
       description: Description of the current status
       JSONPath: .status.description
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            virtualhost:
-              properties:
-                fqdn:
-                  type: string
-                  # This regex handles two cases:
-                  # 1. A reasonably well-formed FQDN, which is allowed
-                  #    a hyphen in the top-level label (not usually
-                  #    the case for TLDs.) This fixes https://github.com/projectcontour/contour/issues/1117
-                  #    This is the first option in the regex.
-                  # 2. A bareword containing a hyphen, no periods. This fixes 
-                  #    https://github.com/projectcontour/contour/issues/755 and is the
-                  #    second option in the regex
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[\-a-z0-9]{2,}|[\-a-z0-9]+$
-                tls:
-                  properties:
-                    secretName:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    minimumProtocolVersion:
-                      type: string
-                      enum:
-                        - "1.3"
-                        - "1.2"
-                        - "1.1"
-            strategy:
-              type: string
-              enum:
-                - RoundRobin
-                - WeightedLeastRequest
-                - Random
-                - Cookie
-            healthCheck:
-              type: object
-              required:
-                - path
-              properties:
-                path:
-                  type: string
-                  pattern: ^\/.*$
-                intervalSeconds:
-                  type: integer
-                timeoutSeconds:
-                  type: integer
-                unhealthyThresholdCount:
-                  type: integer
-                healthyThresholdCount:
-                  type: integer
-            tcpproxy:
-              type: object
-              properties:
-                services:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                      - port
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                      port:
-                        type: integer
-                      weight:
-                        type: integer
-                      strategy:
-                        type: string
-                        enum:
-                          - RoundRobin
-                          - WeightedLeastRequest
-                          - Random
-                          - Cookie
-                      healthCheck:
-                        type: object
-                        required:
-                          - path
-                        properties:
-                          path:
-                            type: string
-                            pattern: ^\/.*$
-                          intervalSeconds:
-                            type: integer
-                          timeoutSeconds:
-                            type: integer
-                          unhealthyThresholdCount:
-                            type: integer
-                          healthyThresholdCount:
-                            type: integer
-                delegate:
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                    namespace:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-            includes:
-              type: array
-              items:
-                properties:
-                  name:
-                    type: string
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                  namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  conditions:
-                    type: array
-                    items:
-                      prefix:
-                        type: string
-                        pattern: ^\/.*$
-                      headersMatch:
-                        items:
-            routes:
-              type: array
-              items:
-                required:
-                  - match
-                properties:
-                  match:
-                    type: string
-                    pattern: ^\/.*$
-                  delegate:
-                    type: object
-                    required:
-                      - name
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                      namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  services:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - name
-                        - port
-                      properties:
-                        name:
-                          type: string
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                        port:
-                          type: integer
-                        weight:
-                          type: integer
-                        strategy:
-                          type: string
-                          enum:
-                            - RoundRobin
-                            - WeightedLeastRequest
-                            - Random
-                            - Cookie
-                        healthCheck:
-                          type: object
-                          required:
-                            - path
-                          properties:
-                            path:
-                              type: string
-                              pattern: ^\/.*$
-                            intervalSeconds:
-                              type: integer
-                            timeoutSeconds:
-                              type: integer
-                            unhealthyThresholdCount:
-                              type: integer
-                            healthyThresholdCount:
-                              type: integer
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -86,11 +86,17 @@ metadata:
     component: httpproxy
 spec:
   group: projectcontour.io
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   scope: Namespaced
   names:
     plural: httpproxies
+    singular: httpproxy
     kind: HTTPProxy
+    shortNames:
+      - proxy
   additionalPrinterColumns:
     - name: FQDN
       type: string
@@ -112,186 +118,6 @@ spec:
       type: string
       description: Description of the current status
       JSONPath: .status.description
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            virtualhost:
-              properties:
-                fqdn:
-                  type: string
-                  # This regex handles two cases:
-                  # 1. A reasonably well-formed FQDN, which is allowed
-                  #    a hyphen in the top-level label (not usually
-                  #    the case for TLDs.) This fixes https://github.com/projectcontour/contour/issues/1117
-                  #    This is the first option in the regex.
-                  # 2. A bareword containing a hyphen, no periods. This fixes 
-                  #    https://github.com/projectcontour/contour/issues/755 and is the
-                  #    second option in the regex
-                  pattern: ^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[\-a-z0-9]{2,}|[\-a-z0-9]+$
-                tls:
-                  properties:
-                    secretName:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([\.\/][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    minimumProtocolVersion:
-                      type: string
-                      enum:
-                        - "1.3"
-                        - "1.2"
-                        - "1.1"
-            strategy:
-              type: string
-              enum:
-                - RoundRobin
-                - WeightedLeastRequest
-                - Random
-                - Cookie
-            healthCheck:
-              type: object
-              required:
-                - path
-              properties:
-                path:
-                  type: string
-                  pattern: ^\/.*$
-                intervalSeconds:
-                  type: integer
-                timeoutSeconds:
-                  type: integer
-                unhealthyThresholdCount:
-                  type: integer
-                healthyThresholdCount:
-                  type: integer
-            tcpproxy:
-              type: object
-              properties:
-                services:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                      - port
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                      port:
-                        type: integer
-                      weight:
-                        type: integer
-                      strategy:
-                        type: string
-                        enum:
-                          - RoundRobin
-                          - WeightedLeastRequest
-                          - Random
-                          - Cookie
-                      healthCheck:
-                        type: object
-                        required:
-                          - path
-                        properties:
-                          path:
-                            type: string
-                            pattern: ^\/.*$
-                          intervalSeconds:
-                            type: integer
-                          timeoutSeconds:
-                            type: integer
-                          unhealthyThresholdCount:
-                            type: integer
-                          healthyThresholdCount:
-                            type: integer
-                delegate:
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                    namespace:
-                      type: string
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-            includes:
-              type: array
-              items:
-                properties:
-                  name:
-                    type: string
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                  namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  conditions:
-                    type: array
-                    items:
-                      prefix:
-                        type: string
-                        pattern: ^\/.*$
-                      headersMatch:
-                        items:
-            routes:
-              type: array
-              items:
-                required:
-                  - match
-                properties:
-                  match:
-                    type: string
-                    pattern: ^\/.*$
-                  delegate:
-                    type: object
-                    required:
-                      - name
-                    properties:
-                      name:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # DNS-1123 subdomain
-                      namespace:
-                        type: string
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ # DNS-1123 label
-                  services:
-                    type: array
-                    items:
-                      type: object
-                      required:
-                        - name
-                        - port
-                      properties:
-                        name:
-                          type: string
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$ # DNS-1035 label
-                        port:
-                          type: integer
-                        weight:
-                          type: integer
-                        strategy:
-                          type: string
-                          enum:
-                            - RoundRobin
-                            - WeightedLeastRequest
-                            - Random
-                            - Cookie
-                        healthCheck:
-                          type: object
-                          required:
-                            - path
-                          properties:
-                            path:
-                              type: string
-                              pattern: ^\/.*$
-                            intervalSeconds:
-                              type: integer
-                            timeoutSeconds:
-                              type: integer
-                            unhealthyThresholdCount:
-                              type: integer
-                            healthyThresholdCount:
-                              type: integer
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Updates #1516 which removed the working version of the HTTPProxy CRD. 

Signed-off-by: Steve Sloka <slokas@vmware.com>