### PR TITLE
Fix problems with example deployment

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -12,8 +12,8 @@ data:
     # kubeconfig: /path/to/.kube/config
     #
     # disable ingressroute permitInsecure field
-    # disablePermitInsecure: false
-    # tls:
+    disablePermitInsecure: false
+    tls:
     #   minimum TLS version that Contour will negotiate
     #   minimum-protocol-version: "1.1"
     # The following config shows the defaults for the leader election.
@@ -22,7 +22,7 @@ data:
     #   configmap-namespace: leader-elect
     ### Logging options
     # Default setting
-    # accesslog-format: clf
+    accesslog-format: clf
     # To enable JSON logging in Envoy
     # accesslog-format: json
     # The default fields that will be logged are specified below.

--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -51,6 +51,7 @@ spec:
       containers:
       - name: contour
         image: docker.io/projectcontour/contour:master
+        imagePullPolicy: Always
         command:
         - contour
         - certgen

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -164,8 +164,8 @@ data:
     # kubeconfig: /path/to/.kube/config
     #
     # disable ingressroute permitInsecure field
-    # disablePermitInsecure: false
-    # tls:
+    disablePermitInsecure: false
+    tls:
     #   minimum TLS version that Contour will negotiate
     #   minimum-protocol-version: "1.1"
     # The following config shows the defaults for the leader election.
@@ -174,7 +174,7 @@ data:
     #   configmap-namespace: leader-elect
     ### Logging options
     # Default setting
-    # accesslog-format: clf
+    accesslog-format: clf
     # To enable JSON logging in Envoy
     # accesslog-format: json
     # The default fields that will be logged are specified below.
@@ -258,6 +258,7 @@ spec:
       containers:
       - name: contour
         image: docker.io/projectcontour/contour:master
+        imagePullPolicy: Always
         command:
         - contour
         - certgen


### PR DESCRIPTION
- Config file must have at least one value uncommented. Fixes #1527.
- Certgen Job must have imagePullPolicy set to Always for namespace change to take effect.

Signed-off-by: Nick Young <ynick@vmware.com>