### PR TITLE
internal/contour: fix shadowing error

### DIFF
--- a/internal/contour/cond_test.go
+++ b/internal/contour/cond_test.go
@@ -55,3 +55,54 @@ func TestCondRegisterAfterNotifyWithCorrectSequenceShouldNotBroadcast(t *testing
 	default:
 	}
 }
+
+func TestCondRegisterWithHintShouldNotifyWithoutHint(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Register(ch, 1, "ingress_https")
+	c.Notify()
+	select {
+	case v := <-ch:
+		if v != 1 {
+			t.Fatal("ch was notified with the wrong sequence number", v)
+		}
+	default:
+		t.Fatal("ch was not notified")
+	}
+}
+
+func TestCondRegisterWithHintShouldNotifyWithHint(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Register(ch, 1, "ingress_https")
+	c.Notify("ingress_https")
+	select {
+	case v := <-ch:
+		if v != 1 {
+			t.Fatal("ch was notified with the wrong sequence number", v)
+		}
+	default:
+		t.Fatal("ch was not notified")
+	}
+}
+
+func TestCondRegisterWithHintShouldNotNotifyWithWrongHint(t *testing.T) {
+	var c Cond
+	ch := make(chan int, 1)
+	c.Register(ch, 1, "ingress_https")
+	c.Notify("banana")
+	select {
+	case v := <-ch:
+		t.Fatal("ch was notified when it should not be", v)
+	default:
+	}
+	c.Notify("ingress_https")
+	select {
+	case v := <-ch:
+		if v != 2 {
+			t.Fatal("ch was notified with the wrong sequence number", v)
+		}
+	default:
+		t.Fatal("ch was not notified")
+	}
+}


### PR DESCRIPTION
Fixes #1514

On Sept 10th I introduced a bug in #1480 which caused Cond.Register()
calls that supplied a hint, such as Envoy's RDS requests, to only
receive one initial update then ignore any further table updates.

The cause was a shadowing but on line 64 where `hints` was shadow from
outside the loop. The result was the `len(hints) == 0` condition would
be false, yet the map lookup version later would never be true because
the map would be empty.

Rewrite `Notify` to make it harder to shadow the variable `hints` and
also avoid the deeply nested logic requiring a break from the inner loop
to the outer loop. The new approach is slower for large values of
registered or notifited hints, but the former is usually no more than
one as Envoy either asks for everything, or a specific resource, and the
latter is often zero and only in the case of EDS one entry, so the
overall cost should be reasonable compared with the previous
implementation.

Signed-off-by: Dave Cheney <dave@cheney.net>