### PR TITLE
internal/contour: clean up route visitor tests

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -142,14 +142,10 @@ func TestRouteVisit(t *testing.T) {
 	}{
 		"nothing": {
 			objs: nil,
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http"),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"one http only ingress with service": {
 			objs: []interface{}{
@@ -176,21 +172,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"one http only ingress with regex match": {
 			objs: []interface{}{
@@ -229,21 +218,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"one http only ingressroute": {
 			objs: []interface{}{
@@ -281,21 +263,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/backend/80/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/backend/80/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"default backend ingress with secret": {
 			objs: []interface{}{
@@ -334,21 +309,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*", // default backend
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https", // no https for default backend
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"vhost ingress with secret": {
 			objs: []interface{}{
@@ -400,28 +368,18 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+			),
 		},
 		"simple ingressroute with secret": {
 			objs: []interface{}{
@@ -470,13 +428,10 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: []*envoy_api_v2_route.Route{{
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						&envoy_api_v2_route.Route{
 							Match: envoy.RoutePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
 								Redirect: &envoy_api_v2_route.RedirectAction{
@@ -485,20 +440,15 @@ func TestRouteVisit(t *testing.T) {
 									},
 								},
 							},
-						}},
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/backend/8080/da39a3ee5e")),
-						),
-					}},
-				},
-			},
+						},
+					),
+				),
+				envoy.RouteConfiguration("ingress_https",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/backend/8080/da39a3ee5e")),
+					),
+				),
+			),
 		},
 		"simple tls ingress with allow-http:false": {
 			objs: []interface{}{
@@ -553,21 +503,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http"),
+				envoy.RouteConfiguration("ingress_https",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+			),
 		},
 		"simple tls ingress with force-ssl-redirect": {
 			objs: []interface{}{
@@ -622,13 +565,10 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: []*envoy_api_v2_route.Route{{
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						&envoy_api_v2_route.Route{
 							Match: envoy.RoutePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
 								Redirect: &envoy_api_v2_route.RedirectAction{
@@ -637,20 +577,15 @@ func TestRouteVisit(t *testing.T) {
 									},
 								},
 							},
-						}},
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-			},
+						},
+					),
+				),
+				envoy.RouteConfiguration("ingress_https",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+			),
 		},
 		"ingress with websocket annotation": {
 			objs: []interface{}{
@@ -700,22 +635,15 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/ws1"), websocketroute("default/kuard/8080/da39a3ee5e")),
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/ws1"), websocketroute("default/kuard/8080/da39a3ee5e")),
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress invalid timeout": {
 			objs: []interface{}{
@@ -745,21 +673,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 0)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 0)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress infinite timeout": {
 			objs: []interface{}{
@@ -789,21 +710,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 0)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 0)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress 90 second timeout": {
 			objs: []interface{}{
@@ -833,21 +747,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 90*time.Second)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routetimeout("default/kuard/8080/da39a3ee5e", 90*time.Second)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"vhost name exceeds 60 chars": { // heptio/contour#25
 			objs: []interface{}{
@@ -888,21 +795,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "d31bb322ca62bb395acad00b3cbf45a3aa1010ca28dca7cddb4f7db786fa",
-						Domains: domains("my-very-very-long-service-host-name.subdomain.boring-dept.my.company"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("my-very-very-long-service-host-name.subdomain.boring-dept.my.company",
+						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress retry-on": {
 			objs: []interface{}{
@@ -932,21 +832,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 0)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 0)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress retry-on, num-retries": {
 			objs: []interface{}{
@@ -977,21 +870,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingress retry-on, per-try-timeout": {
 			objs: []interface{}{
@@ -1022,21 +908,14 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "*",
-						Domains: domains("*"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond)),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("*",
+						envoy.Route(envoy.RoutePrefix("/"), routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond)),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingressroute no weights defined": {
 			objs: []interface{}{
@@ -1088,33 +967,26 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
-								Route: &envoy_api_v2_route.RouteAction{
-									ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
-										WeightedClusters: &envoy_api_v2_route.WeightedCluster{
-											Clusters: weightedClusters(
-												weightedCluster("default/backend/80/da39a3ee5e", 1),
-												weightedCluster("default/backendtwo/80/da39a3ee5e", 1),
-											),
-											TotalWeight: protobuf.UInt32(2),
-										},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
+							Route: &envoy_api_v2_route.RouteAction{
+								ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
+									WeightedClusters: &envoy_api_v2_route.WeightedCluster{
+										Clusters: weightedClusters(
+											weightedCluster("default/backend/80/da39a3ee5e", 1),
+											weightedCluster("default/backendtwo/80/da39a3ee5e", 1),
+										),
+										TotalWeight: protobuf.UInt32(2),
 									},
 								},
-							}),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+							},
+						}),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingressroute one weight defined": {
 			objs: []interface{}{
@@ -1167,33 +1039,26 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
-								Route: &envoy_api_v2_route.RouteAction{
-									ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
-										WeightedClusters: &envoy_api_v2_route.WeightedCluster{
-											Clusters: weightedClusters(
-												weightedCluster("default/backend/80/da39a3ee5e", 0),
-												weightedCluster("default/backendtwo/80/da39a3ee5e", 50),
-											),
-											TotalWeight: protobuf.UInt32(50),
-										},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
+							Route: &envoy_api_v2_route.RouteAction{
+								ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
+									WeightedClusters: &envoy_api_v2_route.WeightedCluster{
+										Clusters: weightedClusters(
+											weightedCluster("default/backend/80/da39a3ee5e", 0),
+											weightedCluster("default/backendtwo/80/da39a3ee5e", 50),
+										),
+										TotalWeight: protobuf.UInt32(50),
 									},
 								},
-							}),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+							},
+						}),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingressroute all weights defined": {
 			objs: []interface{}{
@@ -1247,33 +1112,26 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http",
-					VirtualHosts: []*envoy_api_v2_route.VirtualHost{{
-						Name:    "www.example.com",
-						Domains: domains("www.example.com"),
-						Routes: envoy.Routes(
-							envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
-								Route: &envoy_api_v2_route.RouteAction{
-									ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
-										WeightedClusters: &envoy_api_v2_route.WeightedCluster{
-											Clusters: weightedClusters(
-												weightedCluster("default/backend/80/da39a3ee5e", 22),
-												weightedCluster("default/backendtwo/80/da39a3ee5e", 50),
-											),
-											TotalWeight: protobuf.UInt32(72),
-										},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						envoy.Route(envoy.RoutePrefix("/"), &envoy_api_v2_route.Route_Route{
+							Route: &envoy_api_v2_route.RouteAction{
+								ClusterSpecifier: &envoy_api_v2_route.RouteAction_WeightedClusters{
+									WeightedClusters: &envoy_api_v2_route.WeightedCluster{
+										Clusters: weightedClusters(
+											weightedCluster("default/backend/80/da39a3ee5e", 22),
+											weightedCluster("default/backendtwo/80/da39a3ee5e", 50),
+										),
+										TotalWeight: protobuf.UInt32(72),
 									},
 								},
-							}),
-						),
-					}},
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+							},
+						}),
+					),
+				),
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 		"ingressroute w/ missing fqdn": {
 			objs: []interface{}{
@@ -1309,14 +1167,10 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*v2.RouteConfiguration{
-				"ingress_http": {
-					Name: "ingress_http", // should be blank, no fqdn defined.
-				},
-				"ingress_https": {
-					Name: "ingress_https",
-				},
-			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http"), // should be blank, no fqdn defined.
+				envoy.RouteConfiguration("ingress_https"),
+			),
 		},
 	}
 
@@ -1446,4 +1300,12 @@ func weightedCluster(name string, weight uint32) *envoy_api_v2_route.WeightedClu
 		Name:   name,
 		Weight: protobuf.UInt32(weight),
 	}
+}
+
+func routeConfigurations(rcs ...*v2.RouteConfiguration) map[string]*v2.RouteConfiguration {
+	m := make(map[string]*v2.RouteConfiguration)
+	for _, rc := range rcs {
+		m[rc.Name] = rc
+	}
+	return m
 }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -99,15 +99,10 @@ func TestEditIngress(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*", envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e"))),
-				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*", envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e"))),
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -137,15 +132,10 @@ func TestEditIngress(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*", envoy.Route(envoy.RoutePrefix("/testing"), routecluster("default/kuard/80/da39a3ee5e"))),
-				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*", envoy.Route(envoy.RoutePrefix("/testing"), routecluster("default/kuard/80/da39a3ee5e"))),
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",
@@ -211,17 +201,12 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/hello"), routecluster("default/hello/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/hello"), routecluster("default/hello/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",
@@ -288,17 +273,12 @@ func TestEditIngressInPlace(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("hello.example.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("hello.example.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",
@@ -334,18 +314,13 @@ func TestEditIngressInPlace(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "3",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("hello.example.com",
-						envoy.Route(envoy.RoutePrefix("/whoop"), routecluster("default/kerpow/9000/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("hello.example.com",
+					envoy.Route(envoy.RoutePrefix("/whoop"), routecluster("default/kerpow/9000/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "3",
@@ -386,22 +361,19 @@ func TestEditIngressInPlace(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "4",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("hello.example.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/whoop"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("hello.example.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/whoop"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{Name: "ingress_https"},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "4",
@@ -459,30 +431,24 @@ func TestEditIngressInPlace(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "5",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("hello.example.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/whoop"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("hello.example.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/whoop"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("hello.example.com",
-						envoy.Route(envoy.RoutePrefix("/whoop"), routecluster("default/kerpow/9000/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("hello.example.com",
+					envoy.Route(envoy.RoutePrefix("/whoop"), routecluster("default/kerpow/9000/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/wowie/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "5",
@@ -1009,21 +975,18 @@ func TestRDSFilter(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "5",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("example.com",
-						envoy.Route(
-							envoy.RoutePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-							routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
-						),
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/"), // match all
-							Action: envoy.UpgradeHTTPS(),
-						},
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("example.com",
+					envoy.Route(
+						envoy.RoutePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 					),
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/"), // match all
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "5",
@@ -1032,18 +995,15 @@ func TestRDSFilter(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "5",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("example.com",
-						envoy.Route(
-							envoy.RoutePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
-							routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
-						),
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/app-service/8080/da39a3ee5e")),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("example.com",
+					envoy.Route(
+						envoy.RoutePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
+						routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 					),
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/app-service/8080/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "5",
@@ -1377,18 +1337,15 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/kuard"), routecluster("default/kuard/8080/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
-					envoy.VirtualHost("test-gui",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/test-gui/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/kuard"), routecluster("default/kuard/8080/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+				envoy.VirtualHost("test-gui",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/test-gui/80/da39a3ee5e")),
+				),
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -1439,14 +1396,11 @@ func TestRDSIngressRouteInsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("example.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("roots/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("example.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("roots/kuard/8080/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -1497,9 +1451,7 @@ func TestRDSIngressRouteOutsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
+			envoy.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -1893,25 +1845,19 @@ func TestRouteWithTLS(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/a"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/a"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/a"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/a"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -1995,27 +1941,21 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/secure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/secure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -2104,30 +2044,24 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/secure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/insecure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/secure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/insecure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -2597,18 +2531,13 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"), routecluster("default/kuard/80/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RouteRegex("/[^/]+/invoices(/.*|/?)"), routecluster("default/kuard/80/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -2679,17 +2608,12 @@ func TestRDSIngressRouteRootCannotDelegateToAnotherRoot(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("www.containersteve.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("marketing/green/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("www.containersteve.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("marketing/green/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",
@@ -2702,14 +2626,8 @@ func assertRDS(t *testing.T, cc *grpc.ClientConn, versioninfo string, ingress_ht
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: versioninfo,
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name:         "ingress_http",
-				VirtualHosts: ingress_http,
-			},
-			&v2.RouteConfiguration{
-				Name:         "ingress_https",
-				VirtualHosts: ingress_https,
-			},
+			envoy.RouteConfiguration("ingress_http", ingress_http...),
+			envoy.RouteConfiguration("ingress_https", ingress_https...),
 		),
 		TypeUrl: routeType,
 		Nonce:   versioninfo,
@@ -2884,9 +2802,7 @@ func TestRDSHTTPProxyOutsideRootNamespaces(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
+			envoy.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -3232,25 +3148,19 @@ func TestHTTPProxyRouteWithTLS(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/a"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/a"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/a"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/a"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -3339,27 +3249,21 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/secure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/secure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -3452,30 +3356,24 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testin
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/secure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-						&envoy_api_v2_route.Route{
-							Match:  envoy.RoutePrefix("/insecure"),
-							Action: envoy.UpgradeHTTPS(),
-						},
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("test2.test.com",
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/secure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
+					&envoy_api_v2_route.Route{
+						Match:  envoy.RoutePrefix("/insecure"),
+						Action: envoy.UpgradeHTTPS(),
+					},
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("test2.test.com",
-						envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
-						envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
-					),
+			),
+			envoy.RouteConfiguration("ingress_https",
+				envoy.VirtualHost("test2.test.com",
+					envoy.Route(envoy.RoutePrefix("/secure"), routecluster("default/svc2/80/da39a3ee5e")),
+					envoy.Route(envoy.RoutePrefix("/insecure"), routecluster("default/kuard/80/da39a3ee5e")),
 				),
-			},
+			),
 		),
 		TypeUrl: routeType,
 		Nonce:   "1",
@@ -3542,17 +3440,12 @@ func TestRDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	assertEqual(t, &v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("www.containersteve.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("marketing/green/80/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("www.containersteve.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("marketing/green/80/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",

--- a/internal/envoy/accesslog_test.go
+++ b/internal/envoy/accesslog_test.go
@@ -14,8 +14,6 @@
 package envoy
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
@@ -111,11 +109,6 @@ func TestJSONFileAccessLog(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := FileAccessLogJSON(tc.path, tc.headers)
-			output, err := json.Marshal(got)
-			if err != nil {
-				t.Fatal(err)
-			}
-			fmt.Printf("%s\n", output)
 			if diff := cmp.Diff(tc.want, got, cmpopts.AcyclicTransformer("unmarshalAny", unmarshalAny)); diff != "" {
 				t.Fatal(diff)
 			}

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -15,6 +15,7 @@ package envoy
 import (
 	"sort"
 
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/ptypes/duration"
@@ -197,6 +198,14 @@ func VirtualHost(hostname string, routes ...*envoy_api_v2_route.Route) *envoy_ap
 		Name:    hashname(60, hostname),
 		Domains: domains,
 		Routes:  routes,
+	}
+}
+
+// RouteConfiguration returns a *v2.RouteConfiguration.
+func RouteConfiguration(name string, virtualhosts ...*envoy_api_v2_route.VirtualHost) *v2.RouteConfiguration {
+	return &v2.RouteConfiguration{
+		Name:         name,
+		VirtualHosts: virtualhosts,
 	}
 }
 

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -62,17 +62,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress object without a class matches any ingress controller
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -94,12 +89,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -121,12 +112,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -148,17 +135,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class matches explicitly.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -180,17 +162,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class matches explicitly.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -212,12 +189,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -239,17 +212,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class matches explicitly.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("*",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -258,12 +226,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// gone
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -290,17 +254,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("www.example.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -330,12 +289,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -365,12 +320,9 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			}),
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
+		),
 		TypeUrl: routeType,
 	})
 
@@ -399,17 +351,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(ir4.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(ir4.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -437,16 +384,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(ir5.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(ir5.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https"},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -476,12 +419,9 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			}),
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
+		),
 		TypeUrl: routeType,
 	})
 
@@ -510,16 +450,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(ir5.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(ir5.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https"},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -547,17 +483,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("www.example.com",
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -587,12 +518,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -622,12 +549,9 @@ func TestIngressClassAnnotation(t *testing.T) {
 	// ingress class does not match ingress controller, ignored.
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			}),
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
+		),
 		TypeUrl: routeType,
 	})
 
@@ -655,17 +579,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(proxy4.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(proxy4.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -693,16 +612,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(proxy5.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(proxy5.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https"},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -731,12 +646,8 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https",
-			},
+			envoy.RouteConfiguration("ingress_http"),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -765,16 +676,12 @@ func TestIngressClassAnnotation(t *testing.T) {
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			&v2.RouteConfiguration{
-				Name: "ingress_http",
-				VirtualHosts: virtualhosts(
-					envoy.VirtualHost(proxy5.Spec.VirtualHost.Fqdn,
-						envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
-					),
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(proxy5.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), routecluster("default/kuard/8080/da39a3ee5e")),
 				),
-			},
-			&v2.RouteConfiguration{
-				Name: "ingress_https"},
+			),
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})


### PR DESCRIPTION
Clean up the route visitor tests by introducing helpers from the envoy
package that we use elsewhere.

Signed-off-by: Dave Cheney <dave@cheney.net>