### PR TITLE
internal/envoy: move x-request-start header to RouteConfiguration

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -90,13 +90,19 @@ type routeVisitor struct {
 }
 
 func visitRoutes(root dag.Vertex) map[string]*v2.RouteConfiguration {
+	headers := envoy.Headers(
+		envoy.AppendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
+	)
+
 	rv := routeVisitor{
 		routes: map[string]*v2.RouteConfiguration{
 			"ingress_http": {
-				Name: "ingress_http",
+				Name:                "ingress_http",
+				RequestHeadersToAdd: headers,
 			},
 			"ingress_https": {
-				Name: "ingress_https",
+				Name:                "ingress_https",
+				RequestHeadersToAdd: headers,
 			},
 		},
 	}
@@ -121,7 +127,6 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 
 						if r.HTTPSUpgrade {
 							rr.Action = envoy.UpgradeHTTPS()
-							rr.RequestHeadersToAdd = nil
 						}
 						routes = append(routes, rr)
 					case *dag.RegexRoute:
@@ -129,7 +134,6 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 
 						if r.HTTPSUpgrade {
 							rr.Action = envoy.UpgradeHTTPS()
-							rr.RequestHeadersToAdd = nil
 						}
 						routes = append(routes, rr)
 					}

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -31,9 +31,8 @@ func Routes(routes ...*envoy_api_v2_route.Route) []*envoy_api_v2_route.Route {
 // Route returns a *envoy_api_v2_route.Route for the supplied match and action.
 func Route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Route_Route) *envoy_api_v2_route.Route {
 	return &envoy_api_v2_route.Route{
-		Match:               match,
-		Action:              action,
-		RequestHeadersToAdd: RouteHeaders(),
+		Match:  match,
+		Action: action,
 	}
 }
 
@@ -139,13 +138,6 @@ func UpgradeHTTPS() *envoy_api_v2_route.Route_Redirect {
 	}
 }
 
-// RouteHeaders returns a list of headers to be applied at the Route level on envoy
-func RouteHeaders() []*envoy_api_v2_core.HeaderValueOption {
-	return headers(
-		appendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
-	)
-}
-
 // weightedClusters returns a route.WeightedCluster for multiple services.
 func weightedClusters(clusters []*dag.Cluster) *envoy_api_v2_route.WeightedCluster {
 	var wc envoy_api_v2_route.WeightedCluster
@@ -206,6 +198,9 @@ func RouteConfiguration(name string, virtualhosts ...*envoy_api_v2_route.Virtual
 	return &v2.RouteConfiguration{
 		Name:         name,
 		VirtualHosts: virtualhosts,
+		RequestHeadersToAdd: Headers(
+			AppendHeader("x-request-start", "t=%START_TIME(%s.%3f)%"),
+		),
 	}
 }
 
@@ -221,11 +216,11 @@ func (c clusterWeightByName) Less(i, j int) bool {
 
 }
 
-func headers(first *envoy_api_v2_core.HeaderValueOption, rest ...*envoy_api_v2_core.HeaderValueOption) []*envoy_api_v2_core.HeaderValueOption {
+func Headers(first *envoy_api_v2_core.HeaderValueOption, rest ...*envoy_api_v2_core.HeaderValueOption) []*envoy_api_v2_core.HeaderValueOption {
 	return append([]*envoy_api_v2_core.HeaderValueOption{first}, rest...)
 }
 
-func appendHeader(key, value string) *envoy_api_v2_core.HeaderValueOption {
+func AppendHeader(key, value string) *envoy_api_v2_core.HeaderValueOption {
 	return &envoy_api_v2_core.HeaderValueOption{
 		Header: &envoy_api_v2_core.HeaderValue{
 			Key:   key,


### PR DESCRIPTION
This PR fell out of debugging #1514.

A year ago #730 added the x-request-start header to each incoming
request. At the time this was done by adding the hedaer on each
route. This is verbose to see in the configuration and can be done
once at the enclosing RouteConfiguration.

This change means empty RouteConfigurations will have a
RequestHeadersToAdd field, but this is of little consiquence as it
applies to no routes as the list of virtualhosts is empty.

Another side effect of this change is the x-request-start header will be
added to redirects, however as this is a _request_ header, it is never
presented downstream during 301 processing so again it should have
little impact.

Signed-off-by: Dave Cheney <dave@cheney.net>