### PR TITLE
Revert Contour deployment to Rolling Update

### DIFF
--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -8,7 +8,11 @@ metadata:
 spec:
   replicas: 2
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 50%
   selector:
     matchLabels:
       app: contour

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -430,7 +430,11 @@ metadata:
 spec:
   replicas: 2
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 50%
   selector:
     matchLabels:
       app: contour


### PR DESCRIPTION
Also set maxSurge so that new pods will be created before old pods are removed.

Signed-off-by: Nick Young <ynick@vmware.com>