### PR TITLE
Makefile: add yamllint target

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,53 @@
+---
+
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    level: warning
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 1
+  empty-values:
+    forbid-in-block-mappings: false
+    forbid-in-flow-mappings: true
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  key-ordering: disable
+  line-length:
+    max: 150
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy:
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,9 @@ updategenerated:
 	@echo Updating CRD generated code...
 	@(bash hack/update-generated-crd-code.sh)
 
+yamllint:
+	docker run --rm -ti -v $(CURDIR):/workdir giantswarm/yamllint examples/ site/examples/ 
+
 gofmt:
 	@echo Checking code is gofmted
 	@test -z "$(shell gofmt -s -l -d -e $(SRCDIRS) | tee /dev/stderr)"


### PR DESCRIPTION
Yamllint is too noisy at the moment so it's not added to the check
target but we need to address these warnings before 1.0.

Signed-off-by: Dave Cheney <dave@cheney.net>