### PR TITLE
api: rename TimeoutPolicy.Request to Response

### DIFF
--- a/apis/projectcontour/v1alpha1/httpproxy.go
+++ b/apis/projectcontour/v1alpha1/httpproxy.go
@@ -159,7 +159,7 @@ type HealthCheck struct {
 type TimeoutPolicy struct {
 	// Timeout for receiving a response from the server after processing a request from client.
 	// If not supplied the timeout duration is undefined.
-	Request string `json:"request"`
+	Response string `json:"Response"`
 }
 
 // RetryPolicy define the attributes associated with retrying policy

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -912,11 +912,14 @@ func route(ingress *v1beta1.Ingress, path string, service *Service) *Route {
 	}
 
 	var timeout *TimeoutPolicy
-	if request, ok := ingress.Annotations[annotationRequestTimeout]; ok {
+	if response, ok := ingress.Annotations[annotationRequestTimeout]; ok {
 		// if the request timeout annotation is present on this ingress
 		// construct and use the ingressroute timeout policy logic.
+		// Note: due to a misunderstanding the name of the annotation is
+		// request timeout, but it is actually applied as a timeout on
+		// the response body.
 		timeout = timeoutPolicy(&projcontour.TimeoutPolicy{
-			Request: request,
+			Response: response,
 		})
 	}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2747,7 +2747,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
+								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
 							},
 						}),
 					),
@@ -2767,7 +2767,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
+								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
 							},
 						}),
 					),
@@ -2787,7 +2787,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: 90 * time.Second,
+								ResponseTimeout: 90 * time.Second,
 							},
 						}),
 					),
@@ -2807,7 +2807,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: 90 * time.Second,
+								ResponseTimeout: 90 * time.Second,
 							},
 						}),
 					),
@@ -2827,7 +2827,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: -1,
+								ResponseTimeout: -1,
 							},
 						}),
 					),
@@ -2847,7 +2847,7 @@ func TestDAGInsert(t *testing.T) {
 							Conditions: prefix("/"),
 							Clusters:   clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
-								Timeout: -1,
+								ResponseTimeout: -1,
 							},
 						}),
 					),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -97,13 +97,13 @@ type Route struct {
 	PrefixRewrite string
 }
 
-// TimeoutPolicy defines the timeout request/idle
+// TimeoutPolicy defines the timeout policy for a route.
 type TimeoutPolicy struct {
-	// A timeout applied to requests on this route.
+	// ResponseTimeout is the timeout applied to the response
+	// from the backend server.
 	// A timeout of zero implies "use envoy's default"
 	// A timeout of -1 represents "infinity"
-	// TODO(dfc) should this move to service?
-	Timeout time.Duration
+	ResponseTimeout time.Duration
 }
 
 // RetryPolicy defines the retry / number / timeout options

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -37,7 +37,10 @@ func ingressrouteTimeoutPolicy(tp *ingressroutev1.TimeoutPolicy) *TimeoutPolicy 
 		return nil
 	}
 	return &TimeoutPolicy{
-		Timeout: parseTimeout(tp.Request),
+		// due to a misunderstanding the name of the field ingressroute is
+		// Request, however the timeout applies to the response resulting from
+		// a request.
+		ResponseTimeout: parseTimeout(tp.Request),
 	}
 }
 
@@ -46,7 +49,7 @@ func timeoutPolicy(tp *projcontour.TimeoutPolicy) *TimeoutPolicy {
 		return nil
 	}
 	return &TimeoutPolicy{
-		Timeout: parseTimeout(tp.Request),
+		ResponseTimeout: parseTimeout(tp.Response),
 	}
 }
 

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -42,7 +42,7 @@ func Route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Rout
 func RouteRoute(r *dag.Route) *envoy_api_v2_route.Route_Route {
 	ra := envoy_api_v2_route.RouteAction{
 		RetryPolicy:   retryPolicy(r),
-		Timeout:       timeout(r),
+		Timeout:       responseTimeout(r),
 		PrefixRewrite: r.PrefixRewrite,
 		HashPolicy:    hashPolicy(r),
 	}
@@ -89,12 +89,12 @@ func hashPolicy(r *dag.Route) []*envoy_api_v2_route.RouteAction_HashPolicy {
 	return nil
 }
 
-func timeout(r *dag.Route) *duration.Duration {
+func responseTimeout(r *dag.Route) *duration.Duration {
 	if r.TimeoutPolicy == nil {
 		return nil
 	}
 
-	switch r.TimeoutPolicy.Timeout {
+	switch r.TimeoutPolicy.ResponseTimeout {
 	case 0:
 		// no timeout specified
 		return nil
@@ -103,7 +103,7 @@ func timeout(r *dag.Route) *duration.Duration {
 		// envoy "infinite timeout"
 		return protobuf.Duration(0)
 	default:
-		return protobuf.Duration(r.TimeoutPolicy.Timeout)
+		return protobuf.Duration(r.TimeoutPolicy.ResponseTimeout)
 	}
 }
 

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -240,7 +240,7 @@ func TestRouteRoute(t *testing.T) {
 		"timeout 90s": {
 			route: &dag.Route{
 				TimeoutPolicy: &dag.TimeoutPolicy{
-					Timeout: 90 * time.Second,
+					ResponseTimeout: 90 * time.Second,
 				},
 				Clusters: []*dag.Cluster{c1},
 			},
@@ -256,7 +256,7 @@ func TestRouteRoute(t *testing.T) {
 		"timeout infinity": {
 			route: &dag.Route{
 				TimeoutPolicy: &dag.TimeoutPolicy{
-					Timeout: -1,
+					ResponseTimeout: -1,
 				},
 				Clusters: []*dag.Cluster{c1},
 			},


### PR DESCRIPTION
Updates #944

Rename spec.routes.timeout.request to respose because it is actually a
response timeout. The Envoy docs describe routeaction.timeout as

> This spans between the point at which the entire downstream request
(i.e. end-of-stream) has been processed and when the upstream response
has been completely processed. A value of 0 will disable the route’s
timeout.

When we initially added this field it was called request, which is not
accurate, this timeout is the response in reaction to a request.

We can't fix this for ingressroute, but we can for httpproxy, and patch
it up as best we can for ingressroute.

Signed-off-by: Dave Cheney <dave@cheney.net>