### PR TITLE
internal: Add header contains support to HTTPProxy 

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -490,6 +490,26 @@ func httpProxyConditions(conds []projcontour.Condition) []Condition {
 				Prefix: cond.Prefix,
 			})
 		}
+		if cond.Header != nil {
+			// Header present only
+			if cond.Header.Present {
+				c = append(c, &HeaderCondition{
+					Name:      cond.Header.Name,
+					MatchType: "present",
+					Invert:    false,
+				})
+			} else {
+				// Header contains
+				if cond.Header.Contains != "" {
+					c = append(c, &HeaderCondition{
+						Name:      cond.Header.Name,
+						Value:     cond.Header.Contains,
+						MatchType: "contains",
+						Invert:    false,
+					})
+				}
+			}
+		}
 	}
 	return c
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -70,6 +70,17 @@ func (rc *RegexCondition) String() string {
 	return "regex: " + rc.Regex
 }
 
+type HeaderCondition struct {
+	Name      string
+	Value     string
+	MatchType string
+	Invert    bool
+}
+
+func (hc *HeaderCondition) String() string {
+	return "header: " + hc.Name
+}
+
 // Route defines the properties of a route to a Cluster.
 type Route struct {
 


### PR DESCRIPTION
This PR allows all header conditions to be merged together and passed off to Envoy.

**NOTE**: This is currently missing tests to properly cover the new code. 

Signed-off-by: Steve Sloka <slokas@vmware.com>