### PR TITLE
dag: add support for traffic mirroring

### DIFF
--- a/apis/projectcontour/v1alpha1/httpproxy.go
+++ b/apis/projectcontour/v1alpha1/httpproxy.go
@@ -135,6 +135,8 @@ type Service struct {
 	Strategy string `json:"strategy,omitempty"`
 	// UpstreamValidation defines how to verify the backend service's certificate
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
+	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+	Mirror bool `json:"mirror,omitempty"`
 }
 
 // HealthCheck defines optional healthchecks on the upstream service
@@ -155,7 +157,7 @@ type HealthCheck struct {
 	HealthyThresholdCount uint32 `json:"healthyThresholdCount"`
 }
 
-// TimeoutPolicy define the attributes associated with timeout
+// TimeoutPolicy defines the attributes associated with timeout.
 type TimeoutPolicy struct {
 	// Timeout for receiving a response from the server after processing a request from client.
 	// If not supplied the timeout duration is undefined.
@@ -166,7 +168,7 @@ type TimeoutPolicy struct {
 	Idle string `json:"idle"`
 }
 
-// RetryPolicy define the attributes associated with retrying policy
+// RetryPolicy defines the attributes associated with retrying policy.
 type RetryPolicy struct {
 	// NumRetries is maximum allowed number of retries.
 	// If not supplied, the number of retries is zero.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -106,6 +106,9 @@ type Route struct {
 
 	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
 	PrefixRewrite string
+
+	// Mirror Policy defines the mirroring policy for this Route.
+	MirrorPolicy *MirrorPolicy
 }
 
 // TimeoutPolicy defines the timeout policy for a route.
@@ -133,6 +136,11 @@ type RetryPolicy struct {
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if RetryOn is blank.
 	PerTryTimeout time.Duration
+}
+
+// MirrorPolicy desinges the mirroring policy for a route.
+type MirrorPolicy struct {
+	Cluster *Cluster
 }
 
 // UpstreamValidation defines how to validate the certificate on the upstream service

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -43,11 +43,12 @@ func Route(match *envoy_api_v2_route.RouteMatch, action *envoy_api_v2_route.Rout
 // weighted cluster.
 func RouteRoute(r *dag.Route) *envoy_api_v2_route.Route_Route {
 	ra := envoy_api_v2_route.RouteAction{
-		RetryPolicy:   retryPolicy(r),
-		Timeout:       responseTimeout(r),
-		IdleTimeout:   idleTimeout(r),
-		PrefixRewrite: r.PrefixRewrite,
-		HashPolicy:    hashPolicy(r),
+		RetryPolicy:         retryPolicy(r),
+		Timeout:             responseTimeout(r),
+		IdleTimeout:         idleTimeout(r),
+		PrefixRewrite:       r.PrefixRewrite,
+		HashPolicy:          hashPolicy(r),
+		RequestMirrorPolicy: mirrorPolicy(r),
 	}
 
 	if r.Websocket {
@@ -90,6 +91,15 @@ func hashPolicy(r *dag.Route) []*envoy_api_v2_route.RouteAction_HashPolicy {
 		}
 	}
 	return nil
+}
+
+func mirrorPolicy(r *dag.Route) *envoy_api_v2_route.RouteAction_RequestMirrorPolicy {
+	if r.MirrorPolicy == nil {
+		return nil
+	}
+	return &envoy_api_v2_route.RouteAction_RequestMirrorPolicy{
+		Cluster: Clustername(r.MirrorPolicy.Cluster),
+	}
 }
 
 func responseTimeout(r *dag.Route) *duration.Duration {

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -41,3 +41,10 @@ func withIdleTimeout(route *envoy_api_v2_route.Route_Route, timeout time.Duratio
 	route.Route.IdleTimeout = protobuf.Duration(timeout)
 	return route
 }
+
+func withMirrorPolicy(route *envoy_api_v2_route.Route_Route, mirror string) *envoy_api_v2_route.Route_Route {
+	route.Route.RequestMirrorPolicy = &envoy_api_v2_route.RouteAction_RequestMirrorPolicy{
+		Cluster: mirror,
+	}
+	return route
+}

--- a/internal/featuretests/mirrorpolicy_test.go
+++ b/internal/featuretests/mirrorpolicy_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuretests
+
+import (
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/contour"
+	"github.com/projectcontour/contour/internal/envoy"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestMirrorPolicy(t *testing.T) {
+	rh, c, done := setup(t, func(reh *contour.EventHandler) {
+		reh.Builder.Source.IngressClass = "linkerd"
+	})
+	defer done()
+
+	svc1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	svc2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: svc1.Namespace,
+		},
+		Spec: svc1.Spec,
+	}
+	rh.OnAdd(svc1)
+	rh.OnAdd(svc2)
+
+	p1 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: svc1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "example.com"},
+			Routes: []projcontour.Route{{
+				Conditions: prefixCondition("/"),
+				Services: []projcontour.Service{{
+					Name: svc1.Name,
+					Port: 8080,
+				}, {
+					Name:   svc2.Name,
+					Port:   8080,
+					Mirror: true,
+				}},
+			}},
+		},
+	}
+	rh.OnAdd(p1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(p1.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"),
+						withMirrorPolicy(routeCluster("default/kuard/8080/da39a3ee5e"), "default/kuarder/8080/da39a3ee5e")),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+}


### PR DESCRIPTION
Fixes #459

Add support for per route traffic mirroring. Only available in HTTPProxy

```yaml
spec:
  routes:
  - conditions:
     - prefix: "/"
  - services:
     - name: kuard
       port: 8080
     - name: kuard-mirror
       port: 8080
       mirror: true
```


Signed-off-by: Dave Cheney <dave@cheney.net>