### PR TITLE
Dockerfile: update to Go 1.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS build
+FROM golang:1.13.1 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Even thgouh we don't directly expose the Go net/http package to the
outside world, this is good hygene.

https://groups.google.com/forum/m/#!topic/golang-announce/cszieYyuL9Q

Signed-off-by: Dave Cheney <dave@cheney.net>