### PR TITLE
internal/contour: move dag.Route condition parsing to internal/envoy

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1559,7 +1559,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "contains",
@@ -1615,7 +1615,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "contains",
@@ -1672,7 +1672,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "exact",
@@ -1729,7 +1729,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "exact",
@@ -1786,7 +1786,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 							Name:      "x-header",
 							MatchType: "present",
 						}), routecluster("default/backend/80/da39a3ee5e")),
@@ -1854,13 +1854,13 @@ func TestSortLongestRouteFirst(t *testing.T) {
 			routes: []*envoy_api_v2_route.Route{{
 				Match: envoy.RoutePrefix("/"),
 			}, {
-				Match: envoy.RoutePrefix("/", dag.HeaderCondition{
+				Match: envoy.RoutePrefix("/", &dag.HeaderCondition{
 					Name:      "x-request-id",
 					MatchType: "present",
 				}),
 			}},
 			want: []*envoy_api_v2_route.Route{{
-				Match: envoy.RoutePrefix("/", dag.HeaderCondition{
+				Match: envoy.RoutePrefix("/", &dag.HeaderCondition{
 					Name:      "x-request-id",
 					MatchType: "present",
 				}),

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2898,13 +2898,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
@@ -2952,13 +2952,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
 				Invert:    true,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "contains",
@@ -3006,13 +3006,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "exact",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "exact",
@@ -3060,13 +3060,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "exact",
 				Invert:    true,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "exact",
@@ -3114,12 +3114,12 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
 				Name:      "x-header",
 				MatchType: "present",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
 				Name:      "x-header",
 				MatchType: "present",
 				Invert:    false,

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -67,7 +67,6 @@ func Listener(name, address string, port int, lf []*envoy_api_v2_listener.Listen
 // HTTPConnectionManager creates a new HTTP Connection Manager filter
 // for the supplied route and access log.
 func HTTPConnectionManager(routename string, accesslogger []*accesslog.AccessLog) *envoy_api_v2_listener.Filter {
-
 	return &envoy_api_v2_listener.Filter{
 		Name: wellknown.HTTPConnectionManager,
 		ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -20,7 +20,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
@@ -59,9 +59,7 @@ func TestRoute(t *testing.T) {
 		Match:  match,
 		Action: action,
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestRouteRoute(t *testing.T) {
@@ -387,9 +385,7 @@ func TestRouteRoute(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteRoute(tc.route)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -506,9 +502,7 @@ func TestWeightedClusters(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := weightedClusters(tc.clusters)
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -557,9 +551,7 @@ func TestRouteConfiguration(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteConfiguration(tc.name, tc.virtualhosts...)
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -590,9 +582,7 @@ func TestVirtualHost(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := VirtualHost(tc.hostname)
-			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -607,9 +597,7 @@ func TestUpgradeHTTPS(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.Equal(t, want, got)
 }
 
 func virtualhosts(v ...*envoy_api_v2_route.VirtualHost) []*envoy_api_v2_route.VirtualHost { return v }


### PR DESCRIPTION
Updates #1579

Preparation for a larger change to come next which will give us a
foothold to sort a set of *dag.Route objects.

This PR moves a lot of the duplicated logic out of
internal/contour/route.go into internal/envoy helpers.

Signed-off-by: Dave Cheney <dave@cheney.net>