### PR TITLE
internal/dag: merge route conditions in dag builder

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1559,7 +1559,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "contains",
@@ -1615,7 +1615,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "contains",
@@ -1672,7 +1672,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "exact",
@@ -1729,7 +1729,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 							Name:      "x-header",
 							Value:     "abc",
 							MatchType: "exact",
@@ -1786,7 +1786,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http",
 					envoy.VirtualHost("www.example.com",
-						envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+						envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 							Name:      "x-header",
 							MatchType: "present",
 						}), routecluster("default/backend/80/da39a3ee5e")),
@@ -1854,13 +1854,13 @@ func TestSortLongestRouteFirst(t *testing.T) {
 			routes: []*envoy_api_v2_route.Route{{
 				Match: envoy.RoutePrefix("/"),
 			}, {
-				Match: envoy.RoutePrefix("/", &dag.HeaderCondition{
+				Match: envoy.RoutePrefix("/", dag.HeaderCondition{
 					Name:      "x-request-id",
 					MatchType: "present",
 				}),
 			}},
 			want: []*envoy_api_v2_route.Route{{
-				Match: envoy.RoutePrefix("/", &dag.HeaderCondition{
+				Match: envoy.RoutePrefix("/", dag.HeaderCondition{
 					Name:      "x-request-id",
 					MatchType: "present",
 				}),

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2801,8 +2801,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
 							},
@@ -2821,8 +2821,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
 							},
@@ -2841,8 +2841,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: 90 * time.Second,
 							},
@@ -2861,8 +2861,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: 90 * time.Second,
 							},
@@ -2881,8 +2881,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: -1,
 							},
@@ -2901,8 +2901,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							TimeoutPolicy: &TimeoutPolicy{
 								ResponseTimeout: -1,
 							},
@@ -3047,8 +3047,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							RetryPolicy: &RetryPolicy{
 								RetryOn:       "5xx",
 								NumRetries:    6,
@@ -3069,8 +3069,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							RetryPolicy: &RetryPolicy{
 								RetryOn:       "5xx",
 								NumRetries:    6,
@@ -3092,8 +3092,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							RetryPolicy: &RetryPolicy{
 								RetryOn:       "5xx",
 								NumRetries:    1,
@@ -3114,8 +3114,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
-							Conditions: prefix("/"),
-							Clusters:   clustermap(s1),
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s1),
 							RetryPolicy: &RetryPolicy{
 								RetryOn:       "gateway-error",
 								NumRetries:    6,
@@ -3136,8 +3136,8 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
-							Conditions: regex("/[^/]+/invoices(/.*|/?)"),
-							Clusters:   clustermap(s1),
+							PathCondition: regex("/[^/]+/invoices(/.*|/?)"),
+							Clusters:      clustermap(s1),
 						}),
 					),
 				},
@@ -3830,10 +3830,7 @@ func TestDAGInsert(t *testing.T) {
 								},
 							),
 							&Route{
-								Conditions: conditions(
-									prefixCondition("/blog"),
-									prefixCondition("/infotech"),
-								),
+								PathCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
 										Name:        s4.Name,
@@ -3866,10 +3863,7 @@ func TestDAGInsert(t *testing.T) {
 								},
 							),
 							&Route{
-								Conditions: conditions(
-									prefixCondition("/blog"),
-									prefixCondition("/infotech"),
-								),
+								PathCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
 										Name:        s4.Name,
@@ -3888,11 +3882,7 @@ func TestDAGInsert(t *testing.T) {
 								},
 							),
 							&Route{
-								Conditions: conditions(
-									prefixCondition("/blog"),
-									prefixCondition("/it"),
-									prefixCondition("/foo"),
-								),
+								PathCondition: prefix("/blog/it/foo"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
 										Name:        s11.Name,
@@ -4506,19 +4496,15 @@ func routes(routes ...*Route) map[string]*Route {
 func prefixroute(prefix string, first *Service, rest ...*Service) *Route {
 	services := append([]*Service{first}, rest...)
 	return &Route{
-		Conditions: conditions(
-			prefixCondition(prefix),
-		),
-		Clusters: clusters(services...),
+		PathCondition: &PrefixCondition{Prefix: prefix},
+		Clusters:      clusters(services...),
 	}
 }
 
 func routeCluster(prefix string, first *Cluster, rest ...*Cluster) *Route {
 	return &Route{
-		Conditions: conditions(
-			prefixCondition(prefix),
-		),
-		Clusters: append([]*Cluster{first}, rest...),
+		PathCondition: &PrefixCondition{Prefix: prefix},
+		Clusters:      append([]*Cluster{first}, rest...),
 	}
 }
 
@@ -4603,14 +4589,8 @@ func listeners(ls ...*Listener) []Vertex {
 	return v
 }
 
-func prefix(prefix string) []Condition        { return conditions(prefixCondition(prefix)) }
-func prefixCondition(prefix string) Condition { return &PrefixCondition{Prefix: prefix} }
-func regex(regex string) []Condition          { return conditions(regexCondition(regex)) }
-func regexCondition(regex string) Condition   { return &RegexCondition{Regex: regex} }
-
-func conditions(c ...Condition) []Condition {
-	return c
-}
+func prefix(prefix string) Condition { return &PrefixCondition{Prefix: prefix} }
+func regex(regex string) Condition   { return &RegexCondition{Regex: regex} }
 
 func withMirror(r *Route, mirror *Service) *Route {
 	r.MirrorPolicy = &MirrorPolicy{

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"path"
+
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+)
+
+func pathCondition(conds []projcontour.Condition) Condition {
+	prefix := "/"
+	for _, cond := range conds {
+		prefix = path.Join(prefix, cond.Prefix)
+	}
+	return &PrefixCondition{
+		Prefix: prefix,
+	}
+}
+
+func headerConditions(conds []projcontour.Condition) []HeaderCondition {
+	var hc []HeaderCondition
+	for _, cond := range conds {
+		switch {
+		case cond.Header == nil:
+			// skip it
+		case cond.Header.Present:
+			hc = append(hc, HeaderCondition{
+				Name:      cond.Header.Name,
+				MatchType: "present",
+			})
+		case cond.Header.Contains != "":
+			hc = append(hc, HeaderCondition{
+				Name:      cond.Header.Name,
+				Value:     cond.Header.Contains,
+				MatchType: "contains",
+			})
+		case cond.Header.NotContains != "":
+			hc = append(hc, HeaderCondition{
+				Name:      cond.Header.Name,
+				Value:     cond.Header.NotContains,
+				MatchType: "contains",
+				Invert:    true,
+			})
+		case cond.Header.Exact != "":
+			hc = append(hc, HeaderCondition{
+				Name:      cond.Header.Name,
+				Value:     cond.Header.Exact,
+				MatchType: "exact",
+			})
+		case cond.Header.NotExact != "":
+			hc = append(hc, HeaderCondition{
+				Name:      cond.Header.Name,
+				Value:     cond.Header.NotExact,
+				MatchType: "exact",
+				Invert:    true,
+			})
+		}
+	}
+	return hc
+}

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -1,0 +1,226 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"testing"
+
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/assert"
+)
+
+func TestPathCondition(t *testing.T) {
+	tests := map[string]struct {
+		conditions []projcontour.Condition
+		want       Condition
+	}{
+		"empty condition list": {
+			conditions: nil,
+			want:       &PrefixCondition{Prefix: "/"},
+		},
+		"single slash": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/",
+			}},
+			want: &PrefixCondition{Prefix: "/"},
+		},
+		"two slashes": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/",
+			}, {
+				Prefix: "/",
+			}},
+			want: &PrefixCondition{Prefix: "/"},
+		},
+		"mixed conditions": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/a/",
+			}, {
+				Prefix: "/b",
+			}},
+			want: &PrefixCondition{Prefix: "/a/b"},
+		},
+		"trailing slash": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/a/",
+			}},
+			// TODO(dfc) issue 1597
+			want: &PrefixCondition{Prefix: "/a"},
+		},
+		"header condition": {
+			conditions: []projcontour.Condition{{
+				Header: new(projcontour.HeaderCondition),
+			}},
+			want: &PrefixCondition{Prefix: "/"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := pathCondition(tc.conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestHeaderConditions(t *testing.T) {
+	tests := map[string]struct {
+		conditions []projcontour.Condition
+		want       []HeaderCondition
+	}{
+		"empty condition list": {
+			conditions: nil,
+			want:       nil,
+		},
+		"prefix": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/",
+			}},
+			want: nil,
+		},
+		"header condition empty": {
+			conditions: []projcontour.Condition{{
+				Header: new(projcontour.HeaderCondition),
+			}},
+			want: nil,
+		},
+		"header present": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:    "x-request-id",
+					Present: true,
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "present",
+			}},
+		},
+		"header name but missing condition": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name: "x-request-id",
+				},
+			}},
+			// this should be filtered out beforehand, but in case it leaks
+			// through the behavior is to ignore the header contains entry.
+			want: nil,
+		},
+		"header contains": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-request-id",
+					Contains: "abcdef",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "contains",
+				Value:     "abcdef",
+			}},
+		},
+		"header not contains": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:        "x-request-id",
+					NotContains: "abcdef",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "contains",
+				Value:     "abcdef",
+				Invert:    true,
+			}},
+		},
+		"header exact": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:  "x-request-id",
+					Exact: "abcdef",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "exact",
+				Value:     "abcdef",
+			}},
+		},
+		"header not exact": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-request-id",
+					NotExact: "abcdef",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "exact",
+				Value:     "abcdef",
+				Invert:    true,
+			}},
+		},
+		"two header contains": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-request-id",
+					Contains: "abcdef",
+				},
+			}, {
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-request-id",
+					Contains: "cedfg",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "contains",
+				Value:     "abcdef",
+			}, {
+				Name:      "x-request-id",
+				MatchType: "contains",
+				Value:     "cedfg",
+			}},
+		},
+		"two header contains different case": {
+			conditions: []projcontour.Condition{{
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-request-id",
+					Contains: "abcdef",
+				},
+			}, {
+				Header: &projcontour.HeaderCondition{
+					Name:     "X-Request-Id",
+					Contains: "abcdef",
+				},
+			}},
+			want: []HeaderCondition{{
+				Name:      "x-request-id",
+				MatchType: "contains",
+				Value:     "abcdef",
+			}, {
+				Name:      "X-Request-Id",
+				MatchType: "contains",
+				Value:     "abcdef",
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := headerConditions(tc.conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -84,9 +84,13 @@ func (hc *HeaderCondition) String() string {
 // Route defines the properties of a route to a Cluster.
 type Route struct {
 
-	// A list of conditions the incoming request must
-	// match for this route.
-	Conditions []Condition
+	// PathCondition specifies a Condition to match on the request path.
+	// Must not be nil.
+	PathCondition Condition
+
+	// HeaderConditions specifies a set of additional Conditions to
+	// match on the request headers.
+	HeaderConditions []HeaderCondition
 
 	Clusters []*Cluster
 
@@ -176,8 +180,8 @@ func (v *VirtualHost) addRoute(route *Route) {
 }
 
 func conditionsToString(r *Route) string {
-	var s []string
-	for _, cond := range r.Conditions {
+	s := []string{r.PathCondition.String()}
+	for _, cond := range r.HeaderConditions {
 		s = append(s, cond.String())
 	}
 	return strings.Join(s, ",")

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -54,7 +54,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.SecureVirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{https://%s}"]`+"\n", v, v.VirtualHost.Name)
 	case *dag.Route:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{%s}"]`+"\n", v, v.Conditions[0].String())
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{%s}"]`+"\n", v, v.PathCondition.String())
 	case *dag.TCPProxy:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{tcpproxy}"]`+"\n", v)
 	case *dag.Cluster:

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2898,13 +2898,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
@@ -2952,13 +2952,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "contains",
 				Invert:    true,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "contains",
@@ -3006,13 +3006,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "exact",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "exact",
@@ -3060,13 +3060,13 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "123",
 				MatchType: "exact",
 				Invert:    true,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 				Name:      "x-header",
 				Value:     "abc",
 				MatchType: "exact",
@@ -3114,12 +3114,12 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	assertRDS(t, cc, "1", virtualhosts(
 		envoy.VirtualHost("hello.world",
-			envoy.Route(envoy.RoutePrefix("/blog", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/blog", dag.HeaderCondition{
 				Name:      "x-header",
 				MatchType: "present",
 				Invert:    false,
 			}), routecluster("default/svc3/80/da39a3ee5e")),
-			envoy.Route(envoy.RoutePrefix("/", &dag.HeaderCondition{
+			envoy.Route(envoy.RoutePrefix("/", dag.HeaderCondition{
 				Name:      "x-header",
 				MatchType: "present",
 				Invert:    false,


### PR DESCRIPTION
Updates #1579

Rather than merging route conditions during the route visitor walk,
merge them earlier during the dag building stage. This simplifies the
dag.Route object to a single set of conditions. This also makes
dag.Route similer to envoy's route object, but because we control it we
stand a better chance of sorting it.

Signed-off-by: Dave Cheney <dave@cheney.net>