### PR TITLE
Fix HTTPProxy include so it assumes the same namespace if not present

### DIFF
--- a/docs/httpproxy.md
+++ b/docs/httpproxy.md
@@ -782,7 +782,10 @@ To resolve this Contour applies the following logic.
 ### Configuring inclusion
 
 Inclusion is a top-level part of the HTTPProxy `spec` element.
-It requires two fields, `name` and `namespace`, with the option of including a `conditions` block.
+It requires one field, `name`, and has two optional fields:
+
+- `namespace`. This will assume the included HTTPProxy is in the same namespace if it's not specified.
+- a `conditions` block.
 
 #### Within the same namespace
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -505,7 +505,13 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 	var routes []*Route
 	// Loop over and process all includes
 	for _, include := range proxy.Spec.Includes {
-		if delegate, ok := b.Source.httpproxies[Meta{name: include.Name, namespace: include.Namespace}]; ok {
+
+		namespace := include.Namespace
+		if namespace == "" {
+			namespace = proxy.Namespace
+		}
+
+		if delegate, ok := b.Source.httpproxies[Meta{name: include.Name, namespace: namespace}]; ok {
 			if delegate.Spec.VirtualHost != nil {
 				sw.SetInvalid("root httpproxy cannot delegate to another root httpproxy")
 				return nil


### PR DESCRIPTION
Fixes #1574.

Signed-off-by: Nick Young <ynick@vmware.com>