### PR TITLE
internal/dag: Look for duplicate header conditions and mark Proxy as invalid

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ The root-level README can get you started. Here you can dig into the details.
   * Advanced deployment: 
     * [AWS with NLB](deploy-aws-nlb.md)
   * [TLS support](tls.md)
+  * [HTTPProxy API](httpproxy.md)
   * [IngressRoute API](ingressroute.md)
 * [About Contour and Envoy](about.md)
 * [Image tagging policy](tagging.md)

--- a/docs/httpproxy.md
+++ b/docs/httpproxy.md
@@ -777,7 +777,7 @@ This may result in duplicates, for example two `prefix:` conditions, or two head
 To resolve this Contour applies the following logic.
 
 - `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
-- Repeated identical `header:` conditions (the same fields exactly) are deduplicated to a single `header:` condition in the final Envoy config.
+- Proxies with repeated identical `header:` conditions of type "exact match" (the same header keys exactly) are marked as "Invalid" since they create an un-routable configuration.
 
 ### Configuring inclusion
 
@@ -1039,3 +1039,4 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Delegation chain produces a cycle.
 - Root HTTPProxy does not specify fqdn.
 - Multiple prefixes cannot be specified on the same set of route conditions.
+- Multiple header conditions of type "exact match" with the same header key.

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -541,9 +541,17 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			return nil
 		}
 
+		conds := append(conditions, route.Conditions...)
+
+		// Look for duplicate exact match headers on this route
+		if !headerConditionsAreValid(conds) {
+			sw.SetInvalid("cannot specify duplicate header 'exact match' conditions in the same route")
+			return nil
+		}
+
 		r := &Route{
-			PathCondition:    pathCondition(append(conditions, route.Conditions...)),
-			HeaderConditions: headerConditions(append(conditions, route.Conditions...)),
+			PathCondition:    pathCondition(conds),
+			HeaderConditions: headerConditions(conds),
 			Websocket:        route.EnableWebsockets,
 			HTTPSUpgrade:     routeEnforceTLS(enforceTLS, route.PermitInsecure && !b.DisablePermitInsecure),
 			PrefixRewrite:    route.PrefixRewrite,

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -15,6 +15,7 @@ package dag
 
 import (
 	"path"
+	"strings"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
@@ -82,4 +83,24 @@ func headerConditions(conds []projcontour.Condition) []HeaderCondition {
 		}
 	}
 	return hc
+}
+
+func headerConditionsAreValid(conditions []projcontour.Condition) bool {
+	// Look for duplicate "exact match" headers on conditions
+	// if found, set error condition on HTTPProxy
+	encountered := map[string]bool{}
+	for _, v := range conditions {
+		if v.Header == nil {
+			continue
+		}
+		switch {
+		case v.Header.Exact != "":
+			headerName := strings.ToLower(v.Header.Name)
+			if encountered[headerName] {
+				return false
+			}
+			encountered[headerName] = true
+		}
+	}
+	return true
 }

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -279,3 +279,75 @@ func TestConditionsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateHeaderConditions(t *testing.T) {
+	tests := map[string]struct {
+		conditions []projcontour.Condition
+		want       bool
+	}{
+		"empty condition list": {
+			conditions: nil,
+			want:       true,
+		},
+		"valid conditions": {
+			conditions: []projcontour.Condition{
+				{
+					Header: &projcontour.HeaderCondition{
+						Name:     "x-header",
+						Contains: "abc",
+					},
+				},
+			},
+			want: true,
+		},
+		"invalid conditions": {
+			conditions: []projcontour.Condition{
+				{
+					Header: &projcontour.HeaderCondition{
+						Name:  "x-header",
+						Exact: "abc",
+					},
+				}, {
+					Header: &projcontour.HeaderCondition{
+						Name:  "x-header",
+						Exact: "123",
+					},
+				},
+			},
+			want: false,
+		},
+		"prefix only": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "/blog",
+				},
+			},
+			want: true,
+		},
+		"prefix conditions + valid headers": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "/blog",
+				}, {
+					Header: &projcontour.HeaderCondition{
+						Name:        "x-header",
+						NotContains: "abc",
+					},
+				}, {
+					Header: &projcontour.HeaderCondition{
+						Name:        "another-header",
+						NotContains: "123",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := headerConditionsAreValid(tc.conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1559 by looking for any route that has duplicate header keys and marking them as invalid if found. The logic this includes is to only mark duplicate headers with the "exact" match type. I could see folks setting up multiple "notexact" or "notcontains" headers which should be logical match types.

Signed-off-by: Steve Sloka <slokas@vmware.com>