### PR TITLE
internal: Add wildcard path prefix to HTTPProxy

### DIFF
--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -15,6 +15,7 @@ package dag
 
 import (
 	"path"
+	"strings"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
@@ -23,6 +24,12 @@ func pathCondition(conds []projcontour.Condition) Condition {
 	prefix := "/"
 	for _, cond := range conds {
 		prefix = path.Join(prefix, cond.Prefix)
+	}
+
+	if strings.Contains(prefix, "*") {
+		return &WildcardPathCondition{
+			Prefix: prefix,
+		}
 	}
 	return &PrefixCondition{
 		Prefix: prefix,

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -64,6 +64,12 @@ func TestPathCondition(t *testing.T) {
 			}},
 			want: &PrefixCondition{Prefix: "/"},
 		},
+		"wildcard condition": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/foo/*/bar",
+			}},
+			want: &WildcardPathCondition{Prefix: "/foo/*/bar"},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -61,6 +61,15 @@ func (pc *PrefixCondition) String() string {
 	return "prefix: " + pc.Prefix
 }
 
+// WildcardPathCondition matches the start of a URL.
+type WildcardPathCondition struct {
+	Prefix string
+}
+
+func (pc *WildcardPathCondition) String() string {
+	return "wildcard path: " + pc.Prefix
+}
+
 // RegexCondition matches the URL by regular expression.
 type RegexCondition struct {
 	Regex string

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestRoute(t *testing.T) {
+func TestRoutePrefix(t *testing.T) {
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -58,6 +58,17 @@ func TestRoute(t *testing.T) {
 	want := &envoy_api_v2_route.Route{
 		Match:  match,
 		Action: action,
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestRouteWildcardPrefix(t *testing.T) {
+	prefix := "/foo/*/bar"
+	got := RouteWilcard(prefix)
+	want := &envoy_api_v2_route.RouteMatch{
+		PathSpecifier: &envoy_api_v2_route.RouteMatch_Regex{
+			Regex: "/foo/[0-9a-zA-Z-]*/bar.*",
+		},
 	}
 	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
Fixes #1179 
Updates #1457 

Adds a new Condition to the `prefix` condition already existing. Users can now specify a pathPrefix which includes a wildcard in the path (e.g. `/foo/*/blog`). 

This means that the prefix would match `/foo/[anyvalid]/bar*` since it's still treated like a path prefix. 

In the event this in part of an include, the same rules apply where paths are appended together. 

Signed-off-by: Steve Sloka <slokas@vmware.com>