### PR TITLE
internal/dag: Set status on HTTPProxy if multiple path conditions are specified

### DIFF
--- a/docs/httpproxy.md
+++ b/docs/httpproxy.md
@@ -776,7 +776,7 @@ When conditions are combined through inclusion Contour merges the conditions inh
 This may result in duplicates, for example two `prefix:` conditions, or two header match conditions with the same name and value.
 To resolve this Contour applies the following logic.
 
-- `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions.
+- `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
 - Repeated identical `header:` conditions (the same fields exactly) are deduplicated to a single `header:` condition in the final Envoy config.
 
 ### Configuring inclusion
@@ -1038,3 +1038,4 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Orphaned route.
 - Delegation chain produces a cycle.
 - Root HTTPProxy does not specify fqdn.
+- Multiple prefixes cannot be specified on the same set of route conditions.

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -517,6 +517,11 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				return nil
 			}
 
+			if !pathConditionsValid(include.Conditions) {
+				sw.SetInvalid("include: cannot specify multiple path conditions in the same include")
+				return nil
+			}
+
 			sw, commit := b.WithObject(delegate)
 			routes = append(routes, b.computeRoutes(sw, delegate, append(conditions, include.Conditions...), visited, enforceTLS)...)
 			commit()
@@ -529,6 +534,11 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 		if len(route.Services) > 1 && route.EnableWebsockets {
 			sw.SetInvalid("route: cannot specify multiple services and enable websockets")
 			continue
+		}
+
+		if !pathConditionsValid(route.Conditions) {
+			sw.SetInvalid("route: cannot specify multiple path conditions in the same route")
+			return nil
 		}
 
 		r := &Route{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2131,6 +2131,76 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	proxy102 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/v1",
+				}, {
+					Prefix: "/api",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy103 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name:      "www",
+				Namespace: "teama",
+				Conditions: []projcontour.Condition{{
+					Prefix: "/v1",
+				}, {
+					Prefix: "/api",
+				}},
+			}},
+			Routes: []projcontour.Route{{
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy103a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "www",
+			Namespace: "teama",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/v1",
+				}, {
+					Prefix: "/api",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
 	tests := map[string]struct {
 		objs                  []interface{}
 		disablePermitInsecure bool
@@ -4148,6 +4218,18 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 			),
+		},
+		"insert httpproxy with multiple prefix conditions on route": {
+			objs: []interface{}{
+				proxy102, s1,
+			},
+			want: listeners(),
+		},
+		"insert httpproxy with multiple prefix conditions on include": {
+			objs: []interface{}{
+				proxy103, proxy103a, s1,
+			},
+			want: listeners(),
 		},
 	}
 

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -29,6 +29,19 @@ func pathCondition(conds []projcontour.Condition) Condition {
 	}
 }
 
+func pathConditionsValid(conds []projcontour.Condition) bool {
+	found := 0
+	for _, cond := range conds {
+		if cond.Prefix != "" {
+			found++
+		}
+		if found > 1 {
+			return false
+		}
+	}
+	return true
+}
+
 func headerConditions(conds []projcontour.Condition) []HeaderCondition {
 	var hc []HeaderCondition
 	for _, cond := range conds {

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -224,3 +224,58 @@ func TestHeaderConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestConditionsValid(t *testing.T) {
+	tests := map[string]struct {
+		conditions []projcontour.Condition
+		want       bool
+	}{
+		"empty condition list": {
+			conditions: nil,
+			want:       true,
+		},
+		"valid path condition only": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/api",
+			}},
+			want: true,
+		},
+		"valid path condition with headers": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/api",
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-header",
+					Contains: "abc",
+				},
+			}},
+			want: true,
+		},
+		"invalid path conditions": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/api",
+			}, {
+				Prefix: "/v1",
+			}},
+			want: false,
+		},
+		"invalid path condition with headers": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/api",
+				Header: &projcontour.HeaderCondition{
+					Name:     "x-header",
+					Contains: "abc",
+				},
+			}, {
+				Prefix: "/v1",
+			}},
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := pathConditionsValid(tc.conditions)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1611 
Set status on HTTPProxy if multiple path conditions are specified on a Route or Include.

Invalid Route Conditions:
```
apiVersion: projectcontour.io/v1
kind: HTTPProxy
metadata:
  name: root
spec:
  virtualhost:
    fqdn: kind.local
  routes:
  - services:
    - name: app
      port: 80
    conditions:
      - prefix: /v1
      - prefix: /api
```
Invalid Include Conditions:
```
apiVersion: projectcontour.io/v1
kind: HTTPProxy
metadata:
  name: root
spec:
  virtualhost:
    fqdn: kind.local
  includes:
  - name: blogsite
    namespace: teama
    conditions:
    - prefix: /v1
    - prefix: /api
  routes:
  - services:
    - name: app
      port: 80
```


Signed-off-by: Steve Sloka <slokas@vmware.com>