### PR TITLE
internal/dag: add logger to KubernetesCache

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -567,6 +567,7 @@ func TestIngressRouteMetrics(t *testing.T) {
 			builder := dag.Builder{
 				Source: dag.KubernetesCache{
 					IngressRouteRootNamespaces: tc.rootNamespaces,
+					FieldLogger:                testLogger(t),
 				},
 			}
 			for _, o := range tc.objs {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3106,7 +3106,8 @@ func TestBuilderLookupHTTPService(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			b := Builder{
 				Source: KubernetesCache{
-					services: services,
+					services:    services,
+					FieldLogger: testLogger(t),
 				},
 			}
 			b.reset()
@@ -3236,6 +3237,7 @@ func TestDAGRootNamespaces(t *testing.T) {
 			builder := Builder{
 				Source: KubernetesCache{
 					IngressRouteRootNamespaces: tc.rootNamespaces,
+					FieldLogger:                testLogger(t),
 				},
 			}
 
@@ -3804,6 +3806,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			builder := Builder{
 				Source: KubernetesCache{
 					IngressRouteRootNamespaces: []string{"roots"},
+					FieldLogger:                testLogger(t),
 				},
 			}
 			for _, o := range tc.objs {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	ingressroutev1 "github.com/heptio/contour/apis/contour/v1beta1"
+	"github.com/sirupsen/logrus"
 )
 
 const DEFAULT_INGRESS_CLASS = "contour"
@@ -40,6 +41,8 @@ type KubernetesCache struct {
 	secrets       map[Meta]*v1.Secret
 	delegations   map[Meta]*ingressroutev1.TLSCertificateDelegation
 	services      map[Meta]*v1.Service
+
+	logrus.FieldLogger
 }
 
 // Meta holds the name and namespace of a Kubernetes object.
@@ -98,6 +101,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		return true
 	default:
 		// not an interesting object
+		kc.WithField("object", obj).Error("insert unknown object")
 		return false
 	}
 }
@@ -148,6 +152,7 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		return ok
 	default:
 		// not interesting
+		kc.WithField("object", obj).Error("remove unknown object")
 		return false
 	}
 }


### PR DESCRIPTION
Updates #513
Updates #1614

Add a logger to the KubernetesCache. This is useful at the moment to
spot failures to promulgate the projectcontour.HTTPLoadbalancer objects
through Contour.

This will also be useful to log cert validation failures, see #513.

Signed-off-by: Dave Cheney <dave@cheney.net>