### PR TITLE
internal/dag: Set default CircuitBreaking defaults for both MaxConnections/MaxRequests

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -218,6 +218,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				}),
 		},
 		"single named service": {
@@ -255,6 +261,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				}),
 		},
 		"h2c upstream": {
@@ -297,6 +309,12 @@ func TestClusterVisit(t *testing.T) {
 					LbPolicy:             v2.Cluster_ROUND_ROBIN,
 					Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
 					CommonLbConfig:       envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -332,6 +350,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				}),
 		},
 		"two service ports": {
@@ -381,6 +405,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 				&v2.Cluster{
 					Name:                 "default/backend/8080/da39a3ee5e",
@@ -393,6 +423,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -451,6 +487,12 @@ func TestClusterVisit(t *testing.T) {
 					}},
 					CommonLbConfig:                envoy.ClusterCommonLBConfig(),
 					DrainConnectionsOnHostRemoval: true,
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -514,6 +556,12 @@ func TestClusterVisit(t *testing.T) {
 					}},
 					CommonLbConfig:                envoy.ClusterCommonLBConfig(),
 					DrainConnectionsOnHostRemoval: true,
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -557,6 +605,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -600,6 +654,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_LEAST_REQUEST,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -643,6 +703,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_RANDOM,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -693,6 +759,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_RANDOM,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 				&v2.Cluster{
 					Name:                 "default/backend/80/8bf87fefba",
@@ -705,6 +777,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_LEAST_REQUEST,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -748,6 +826,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				},
 			),
 		},
@@ -843,6 +927,12 @@ func TestClusterVisit(t *testing.T) {
 					ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 					LbPolicy:       v2.Cluster_ROUND_ROBIN,
 					CommonLbConfig: envoy.ClusterCommonLBConfig(),
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+							MaxConnections: protobuf.UInt32(100000),
+							MaxRequests:    protobuf.UInt32(100000),
+						}},
+					},
 				}),
 		},
 	}

--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -37,6 +37,9 @@ const (
 	annotationRetryOn            = "contour.heptio.com/retry-on"
 	annotationNumRetries         = "contour.heptio.com/num-retries"
 	annotationPerTryTimeout      = "contour.heptio.com/per-try-timeout"
+
+	defaultMaxConnections = 100000
+	defaultMaxRequests    = 100000
 )
 
 // parseUInt32 parses the supplied string as if it were a uint32.
@@ -45,6 +48,26 @@ func parseUInt32(s string) uint32 {
 	v, err := strconv.ParseUint(s, 10, 32)
 	if err != nil {
 		return 0
+	}
+	return uint32(v)
+}
+
+// parseMaxConnections parses the supplied string as if it were a uint32.
+// If the value is not present, or malformed, or outside uint32's range, a default value is returned.
+func parseMaxConnections(s string) uint32 {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return defaultMaxConnections
+	}
+	return uint32(v)
+}
+
+// parseMaxRequests parses the supplied string as if it were a uint32.
+// If the value is not present, or malformed, or outside uint32's range, a default value is returned.
+func parseMaxRequests(s string) uint32 {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return defaultMaxRequests
 	}
 	return uint32(v)
 }

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -121,9 +121,9 @@ func (b *Builder) addService(svc *v1.Service, port *v1.ServicePort) *Service {
 		ServicePort: port,
 
 		Protocol:           upstreamProtocol(svc, port),
-		MaxConnections:     parseUInt32(svc.Annotations[annotationMaxConnections]),
+		MaxConnections:     parseMaxConnections(svc.Annotations[annotationMaxConnections]),
 		MaxPendingRequests: parseUInt32(svc.Annotations[annotationMaxPendingRequests]),
-		MaxRequests:        parseUInt32(svc.Annotations[annotationMaxRequests]),
+		MaxRequests:        parseMaxRequests(svc.Annotations[annotationMaxRequests]),
 		MaxRetries:         parseUInt32(svc.Annotations[annotationMaxRetries]),
 		ExternalName:       externalName(svc),
 	}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3189,10 +3189,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
+										Name:           s1a.Name,
+										Namespace:      s1a.Namespace,
+										ServicePort:    &s1a.Spec.Ports[0],
+										Protocol:       "tls",
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -3213,10 +3215,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
+										Name:           s1a.Name,
+										Namespace:      s1a.Namespace,
+										ServicePort:    &s1a.Spec.Ports[0],
+										Protocol:       "tls",
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 									UpstreamValidation: &UpstreamValidation{
 										CACertificate: secret(cert1),
@@ -3241,9 +3245,11 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s10.Name,
-										Namespace:   s10.Namespace,
-										ServicePort: &s10.Spec.Ports[1],
+										Name:           s10.Name,
+										Namespace:      s10.Namespace,
+										ServicePort:    &s10.Spec.Ports[1],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -3443,10 +3449,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3a.Name,
-								Namespace:   s3a.Namespace,
-								ServicePort: &s3a.Spec.Ports[0],
-								Protocol:    "h2c",
+								Name:           s3a.Name,
+								Namespace:      s3a.Namespace,
+								ServicePort:    &s3a.Spec.Ports[0],
+								Protocol:       "h2c",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3463,10 +3471,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3b.Name,
-								Namespace:   s3b.Namespace,
-								ServicePort: &s3b.Spec.Ports[0],
-								Protocol:    "h2",
+								Name:           s3b.Name,
+								Namespace:      s3b.Namespace,
+								ServicePort:    &s3b.Spec.Ports[0],
+								Protocol:       "h2",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3483,10 +3493,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3c.Name,
-								Namespace:   s3c.Namespace,
-								ServicePort: &s3c.Spec.Ports[0],
-								Protocol:    "tls",
+								Name:           s3c.Name,
+								Namespace:      s3c.Namespace,
+								ServicePort:    &s3c.Spec.Ports[0],
+								Protocol:       "tls",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3504,10 +3516,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3a.Name,
-								Namespace:   s3a.Namespace,
-								ServicePort: &s3a.Spec.Ports[0],
-								Protocol:    "h2c",
+								Name:           s3a.Name,
+								Namespace:      s3a.Namespace,
+								ServicePort:    &s3a.Spec.Ports[0],
+								Protocol:       "h2c",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3524,10 +3538,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3b.Name,
-								Namespace:   s3b.Namespace,
-								ServicePort: &s3b.Spec.Ports[0],
-								Protocol:    "h2",
+								Name:           s3b.Name,
+								Namespace:      s3b.Namespace,
+								ServicePort:    &s3b.Spec.Ports[0],
+								Protocol:       "h2",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3544,10 +3560,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3c.Name,
-								Namespace:   s3c.Namespace,
-								ServicePort: &s3c.Spec.Ports[0],
-								Protocol:    "tls",
+								Name:           s3c.Name,
+								Namespace:      s3c.Namespace,
+								ServicePort:    &s3c.Spec.Ports[0],
+								Protocol:       "tls",
+								MaxConnections: 100000,
+								MaxRequests:    100000,
 							}),
 						),
 					),
@@ -3589,17 +3607,21 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("example.com",
 							routeCluster("/a", &Cluster{
 								Upstream: &Service{
-									Name:        s1.Name,
-									Namespace:   s1.Namespace,
-									ServicePort: &s1.Spec.Ports[0],
+									Name:           s1.Name,
+									Namespace:      s1.Namespace,
+									ServicePort:    &s1.Spec.Ports[0],
+									MaxConnections: 100000,
+									MaxRequests:    100000,
 								},
 								Weight: 90,
 							}),
 							routeCluster("/b", &Cluster{
 								Upstream: &Service{
-									Name:        s1.Name,
-									Namespace:   s1.Namespace,
-									ServicePort: &s1.Spec.Ports[0],
+									Name:           s1.Name,
+									Namespace:      s1.Namespace,
+									ServicePort:    &s1.Spec.Ports[0],
+									MaxConnections: 100000,
+									MaxRequests:    100000,
 								},
 								Weight: 60,
 							}),
@@ -3620,16 +3642,20 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/a",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 									Weight: 90,
 								}, &Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 									Weight: 60,
 								},
@@ -4134,10 +4160,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
+										Name:           s1a.Name,
+										Namespace:      s1a.Namespace,
+										ServicePort:    &s1a.Spec.Ports[0],
+										Protocol:       "tls",
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 									UpstreamValidation: &UpstreamValidation{
 										CACertificate: secret(cert1),
@@ -4162,18 +4190,22 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
 							routeCluster("/blog",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										Name:           s4.Name,
+										Namespace:      s4.Namespace,
+										ServicePort:    &s4.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -4194,9 +4226,11 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -4204,9 +4238,11 @@ func TestDAGInsert(t *testing.T) {
 								PathCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										Name:           s4.Name,
+										Namespace:      s4.Namespace,
+										ServicePort:    &s4.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								}},
 							},
@@ -4227,9 +4263,11 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -4237,18 +4275,22 @@ func TestDAGInsert(t *testing.T) {
 								PathCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										Name:           s4.Name,
+										Namespace:      s4.Namespace,
+										ServicePort:    &s4.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								}},
 							},
 							routeCluster("/blog",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										Name:           s4.Name,
+										Namespace:      s4.Namespace,
+										ServicePort:    &s4.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -4256,9 +4298,11 @@ func TestDAGInsert(t *testing.T) {
 								PathCondition: prefix("/blog/it/foo"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s11.Name,
-										Namespace:   s11.Namespace,
-										ServicePort: &s11.Spec.Ports[0],
+										Name:           s11.Name,
+										Namespace:      s11.Namespace,
+										ServicePort:    &s11.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								}},
 							},
@@ -4279,18 +4323,22 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										Name:           s1.Name,
+										Namespace:      s1.Namespace,
+										ServicePort:    &s1.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
 							routeCluster("/kuarder",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										Name:           s2.Name,
+										Namespace:      s2.Namespace,
+										ServicePort:    &s2.Spec.Ports[0],
+										MaxConnections: 100000,
+										MaxRequests:    100000,
 									},
 								},
 							),
@@ -4943,9 +4991,11 @@ func clusters(services ...*Service) (c []*Cluster) {
 
 func service(s *v1.Service) *Service {
 	return &Service{
-		Name:        s.Name,
-		Namespace:   s.Namespace,
-		ServicePort: &s.Spec.Ports[0],
+		Name:           s.Name,
+		Namespace:      s.Namespace,
+		ServicePort:    &s.Spec.Ports[0],
+		MaxConnections: 100000, //default value
+		MaxRequests:    100000, //default value
 	}
 }
 

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -571,6 +571,8 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 				CircuitBreakers: &envoy_cluster.CircuitBreakers{
 					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
 						MaxPendingRequests: protobuf.UInt32(9999),
+						MaxConnections:     protobuf.UInt32(100000),
+						MaxRequests:        protobuf.UInt32(100000),
 					}},
 				},
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
@@ -695,6 +697,12 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 				LbPolicy:       v2.Cluster_RANDOM,
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+						MaxConnections: protobuf.UInt32(100000),
+						MaxRequests:    protobuf.UInt32(100000),
+					}},
+				},
 			},
 			&v2.Cluster{
 				Name:                 "default/kuard/80/8bf87fefba",
@@ -707,6 +715,12 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 				LbPolicy:       v2.Cluster_LEAST_REQUEST,
 				CommonLbConfig: envoy.ClusterCommonLBConfig(),
+				CircuitBreakers: &envoy_cluster.CircuitBreakers{
+					Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+						MaxConnections: protobuf.UInt32(100000),
+						MaxRequests:    protobuf.UInt32(100000),
+					}},
+				},
 			},
 		),
 		TypeUrl: clusterType,
@@ -1010,6 +1024,12 @@ func cluster(name, servicename, statName string) *v2.Cluster {
 		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 		LbPolicy:       v2.Cluster_ROUND_ROBIN,
 		CommonLbConfig: envoy.ClusterCommonLBConfig(),
+		CircuitBreakers: &envoy_cluster.CircuitBreakers{
+			Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+				MaxConnections: protobuf.UInt32(100000),
+				MaxRequests:    protobuf.UInt32(100000),
+			}},
+		},
 	}
 }
 
@@ -1026,6 +1046,12 @@ func externalnamecluster(name, servicename, statName, externalName string, port 
 			Endpoints: envoy.Endpoints(
 				envoy.SocketAddress(externalName, port),
 			),
+		},
+		CircuitBreakers: &envoy_cluster.CircuitBreakers{
+			Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+				MaxConnections: protobuf.UInt32(100000),
+				MaxRequests:    protobuf.UInt32(100000),
+			}},
 		},
 	}
 }

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -18,6 +18,8 @@ package featuretests
 import (
 	"time"
 
+	envoy_api_v2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -47,6 +49,12 @@ func cluster(name, servicename, statName string) *v2.Cluster {
 		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
 		LbPolicy:       v2.Cluster_ROUND_ROBIN,
 		CommonLbConfig: envoy.ClusterCommonLBConfig(),
+		CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+			Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{{
+				MaxConnections: protobuf.UInt32(100000),
+				MaxRequests:    protobuf.UInt32(100000),
+			}},
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes #1192  by setting a default for MaxConnections as well as MaxRequests. Annotating the service will still use a user-defined value so still can be overridden. 

Signed-off-by: Steve Sloka <slokas@vmware.com>