### PR TITLE
Remove Heptio branding from the CLI help.

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -38,13 +38,13 @@ func init() {
 
 func main() {
 	log := logrus.StandardLogger()
-	app := kingpin.New("contour", "Heptio Contour Kubernetes ingress controller.")
+	app := kingpin.New("contour", "Contour Kubernetes ingress controller.")
 
 	bootstrap, bootstrapCtx := registerBootstrap(app)
 
 	certgenApp, certgenConfig := registerCertGen(app)
 
-	cli := app.Command("cli", "A CLI client for the Heptio Contour Kubernetes ingress controller.")
+	cli := app.Command("cli", "A CLI client for the Contour Kubernetes ingress controller.")
 	var client Client
 	cli.Flag("contour", "contour host:port.").Default("127.0.0.1:8001").StringVar(&client.ContourAddr)
 	cli.Flag("cafile", "CA bundle file for connecting to a TLS-secured Contour").Envar("CLI_CAFILE").StringVar(&client.CAFile)


### PR DESCRIPTION
Signed-off-by: James Peach <jpeach@vmware.com>