### PR TITLE
Change prefix condition merge logic to not use path.Join()

### DIFF
--- a/docs/httpproxy.md
+++ b/docs/httpproxy.md
@@ -58,7 +58,7 @@ spec:
 **Line 6-7**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
 
-**Lines 8-9**: Each HTTPProxy must have one or more `routes`, each of which must have a condition to match against (e.g. `prefix: /`) and then one or more `services` which will handle the HTTP traffic.
+**Lines 8-9**: Each HTTPProxy **must** have one or more routes, each of which **must** have one or more services which will handle the HTTP traffic. In addition, each route **may** have one or more conditions to match against.
 
 **Lines 10-12**: The `services` field is an array of named Service & Port combinations that will be used for this HTTPProxy path.
 HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
@@ -326,11 +326,18 @@ In this example, the permission for Contour to reference the Secret `example-com
 
 ### Conditions
 
-Each Route entry in a HTTPProxy may contain one or more conditions.
+Each Route entry in a HTTPProxy **may** contain one or more conditions.
 These conditions are combined with an AND operator on the route passed to Envoy.
 
 Conditions can be either a `prefix` or a `header` condition.
+
+#### Prefix conditions
+
 For `prefix`, this adds a path prefix.
+
+Up to one prefix condition may be present in any condition block.
+
+Prefix conditions **must** start with a `/` if they are present.
 
 #### Header conditions
 
@@ -771,7 +778,7 @@ Because the path is not necessarily used as the only key, the route space can be
 
 ### Conditions and Inclusion
 
-Like Routes, Inclusion may specify a set of [conditions](#conditions.
+Like Routes, Inclusion may specify a set of [conditions](#conditions).
 These conditions are added to any conditions on the routes included.
 This process is recursive.
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -570,8 +570,8 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 		}
 
 		r := &Route{
-			PathCondition:    pathCondition(conds),
-			HeaderConditions: headerConditions(conds),
+			PathCondition:    mergePathConditions(conds),
+			HeaderConditions: mergeHeaderConditions(conds),
 			Websocket:        route.EnableWebsockets,
 			HTTPSUpgrade:     routeEnforceTLS(enforceTLS, route.PermitInsecure && !b.DisablePermitInsecure),
 			PrefixRewrite:    route.PrefixRewrite,

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2351,6 +2351,182 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	proxy104 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name: "kuarder",
+				Conditions: []projcontour.Condition{{
+					Prefix: "/kuarder",
+				}},
+			}},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy104a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: proxy104.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			Routes: []projcontour.Route{{
+				Services: []projcontour.Service{{
+					Name: s2.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy105 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name: "kuarder",
+				Conditions: []projcontour.Condition{{
+					Prefix: "/kuarder",
+				}},
+			}},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy105a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: proxy105.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s2.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy106 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name: "kuarder",
+				Conditions: []projcontour.Condition{{
+					Prefix: "/kuarder/",
+				}},
+			}},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy106a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: proxy105.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s2.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy107 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name: "kuarder",
+				Conditions: []projcontour.Condition{{
+					Prefix: "/kuarder",
+				}},
+			}},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	proxy107a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuarder",
+			Namespace: proxy105.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/withavengeance",
+				}},
+				Services: []projcontour.Service{{
+					Name: s2.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
 	tests := map[string]struct {
 		objs                  []interface{}
 		disablePermitInsecure bool
@@ -4522,6 +4698,134 @@ func TestDAGInsert(t *testing.T) {
 								},
 							),
 							routeCluster("/kuarder",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s2.Name,
+										Namespace:   s2.Namespace,
+										ServicePort: &s2.Spec.Ports[0],
+									},
+								},
+							),
+						),
+					),
+				},
+			),
+		},
+		"insert httpproxy with include, no prefix condition on included proxy": {
+			objs: []interface{}{
+				proxy104, proxy104a, s1, s2,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeCluster("/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s1.Name,
+										Namespace:   s1.Namespace,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								},
+							),
+							routeCluster("/kuarder",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s2.Name,
+										Namespace:   s2.Namespace,
+										ServicePort: &s2.Spec.Ports[0],
+									},
+								},
+							),
+						),
+					),
+				},
+			),
+		},
+		"insert httpproxy with include, / on included proxy": {
+			objs: []interface{}{
+				proxy105, proxy105a, s1, s2,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeCluster("/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s1.Name,
+										Namespace:   s1.Namespace,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								},
+							),
+							routeCluster("/kuarder/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s2.Name,
+										Namespace:   s2.Namespace,
+										ServicePort: &s2.Spec.Ports[0],
+									},
+								},
+							),
+						),
+					),
+				},
+			),
+		},
+		"insert httpproxy with include, full prefix on included proxy": {
+			objs: []interface{}{
+				proxy107, proxy107a, s1, s2,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeCluster("/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s1.Name,
+										Namespace:   s1.Namespace,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								},
+							),
+							routeCluster("/kuarder/withavengeance",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s2.Name,
+										Namespace:   s2.Namespace,
+										ServicePort: &s2.Spec.Ports[0],
+									},
+								},
+							),
+						),
+					),
+				},
+			),
+		},
+		"insert httpproxy with include ending with /, / on included proxy": {
+			objs: []interface{}{
+				proxy106, proxy106a, s1, s2,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeCluster("/",
+								&Cluster{
+									Upstream: &Service{
+										Name:        s1.Name,
+										Namespace:   s1.Namespace,
+										ServicePort: &s1.Spec.Ports[0],
+									},
+								},
+							),
+							routeCluster("/kuarder/",
 								&Cluster{
 									Upstream: &Service{
 										Name:        s2.Name,

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -56,8 +56,26 @@ func TestPathCondition(t *testing.T) {
 			conditions: []projcontour.Condition{{
 				Prefix: "/a/",
 			}},
-			// TODO(dfc) issue 1597
-			want: &PrefixCondition{Prefix: "/a"},
+			want: &PrefixCondition{Prefix: "/a/"},
+		},
+		"trailing slash on second prefix condition": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/a",
+			},
+				{
+					Prefix: "/b/",
+				}},
+			want: &PrefixCondition{Prefix: "/a/b/"},
+		},
+		"nothing but slashes": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "///",
+				},
+				{
+					Prefix: "/",
+				}},
+			want: &PrefixCondition{Prefix: "/"},
 		},
 		"header condition": {
 			conditions: []projcontour.Condition{{
@@ -69,7 +87,7 @@ func TestPathCondition(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := pathCondition(tc.conditions)
+			got := mergePathConditions(tc.conditions)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -220,7 +238,7 @@ func TestHeaderConditions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := headerConditions(tc.conditions)
+			got := mergeHeaderConditions(tc.conditions)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
Fixes #1597.

Also clarify the documentation language around prefix condtions
to make the requirements clear.

Signed-off-by: Nick Young <ynick@vmware.com>