### PR TITLE
internal/featuretest: add RetryPolicy tests

### DIFF
--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -81,6 +81,19 @@ func withMirrorPolicy(route *envoy_api_v2_route.Route_Route, mirror string) *env
 	return route
 }
 
+func withRetryPolicy(route *envoy_api_v2_route.Route_Route, retryOn string, numRetries uint32, perTryTimeout time.Duration) *envoy_api_v2_route.Route_Route {
+	route.Route.RetryPolicy = &envoy_api_v2_route.RetryPolicy{
+		RetryOn: retryOn,
+	}
+	if numRetries > 0 {
+		route.Route.RetryPolicy.NumRetries = protobuf.UInt32(numRetries)
+	}
+	if perTryTimeout > 0 {
+		route.Route.RetryPolicy.PerTryTimeout = protobuf.Duration(perTryTimeout)
+	}
+	return route
+}
+
 func withWebsocket(route *envoy_api_v2_route.Route_Route) *envoy_api_v2_route.Route_Route {
 	route.Route.UpgradeConfigs = append(route.Route.UpgradeConfigs,
 		&envoy_api_v2_route.RouteAction_UpgradeConfig{

--- a/internal/featuretests/retrypolicy_test.go
+++ b/internal/featuretests/retrypolicy_test.go
@@ -1,0 +1,174 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuretests
+
+import (
+	"testing"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/envoy"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestRetryPolicy(t *testing.T) {
+	rh, c, done := setup(t)
+	defer done()
+
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+	rh.OnAdd(s1)
+
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hello",
+			Namespace: s1.Namespace,
+			Annotations: map[string]string{
+				"contour.heptio.com/retry-on":        "5xx,gateway-error",
+				"contour.heptio.com/num-retries":     "7",
+				"contour.heptio.com/per-try-timeout": "120ms",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend(s1),
+		},
+	}
+	rh.OnAdd(i1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx,gateway-error", 7, 120*time.Millisecond)),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+
+	i2 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hello", Namespace: "default",
+			Annotations: map[string]string{
+				"contour.heptio.com/retry-on":        "5xx,gateway-error",
+				"projectcontour.io/num-retries":      "7",
+				"contour.heptio.com/per-try-timeout": "120ms",
+			},
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: backend(s1),
+		},
+	}
+	rh.OnUpdate(i1, i2)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(envoy.RoutePrefix("/"), withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx,gateway-error", 7, 120*time.Millisecond)),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+
+	rh.OnDelete(i2)
+
+	ir1 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: s1.Namespace,
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				RetryPolicy: &projcontour.RetryPolicy{
+					NumRetries:    6,
+					PerTryTimeout: "125ms",
+				},
+				Services: []ingressroutev1.Service{{
+					Name: s1.Name,
+					Port: 80,
+				}},
+			}},
+		},
+	}
+	rh.OnAdd(ir1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(ir1.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx", 6, 125*time.Millisecond)),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+
+	rh.OnDelete(ir1)
+
+	hp1 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{Fqdn: "test3.test.com"},
+			Routes: []projcontour.Route{{
+				RetryPolicy: &projcontour.RetryPolicy{
+					NumRetries:    5,
+					PerTryTimeout: "105s",
+				},
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 80,
+				}},
+			}},
+		},
+	}
+	rh.OnAdd(hp1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost(hp1.Spec.VirtualHost.Fqdn,
+					envoy.Route(envoy.RoutePrefix("/"), withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx", 5, 105*time.Second)),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+}


### PR DESCRIPTION
Updates #1506

This is a followup to #1661. Move and consolidate the feature tests for
RetryPolicy acorss Ingress, IngressRoute and HTTPProxy.

Signed-off-by: Dave Cheney <dave@cheney.net>