### PR TITLE
Add an option to emit bootstrap config to stdout.

### DIFF
--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"io"
 	"os"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -27,7 +28,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *bootstrap
 	var ctx bootstrapContext
 
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
-	bootstrap.Arg("path", "Configuration file.").Required().StringVar(&ctx.path)
+	bootstrap.Arg("path", "Configuration file ('-' for standard output)").Required().StringVar(&ctx.path)
 	bootstrap.Flag("admin-address", "Envoy admin interface address").StringVar(&ctx.config.AdminAddress)
 	bootstrap.Flag("admin-port", "Envoy admin interface port").IntVar(&ctx.config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address").StringVar(&ctx.config.XDSAddress)
@@ -46,11 +47,21 @@ type bootstrapContext struct {
 
 // doBootstrap writes an Envoy bootstrap configuration file to the supplied path.
 func doBootstrap(ctx *bootstrapContext) {
-	f, err := os.Create(ctx.path)
-	check(err)
+	var out io.Writer
+
+	switch ctx.path {
+	case "-":
+		out = os.Stdout
+	default:
+		f, err := os.Create(ctx.path)
+		check(err)
+
+		defer check(f.Close())
+		out = f
+	}
+
 	bs := envoy.Bootstrap(&ctx.config)
 	m := &jsonpb.Marshaler{OrigName: true}
-	err = m.Marshal(f, bs)
+	err := m.Marshal(out, bs)
 	check(err)
-	check(f.Close())
 }

--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -21,7 +21,7 @@ import (
 	"text/template"
 )
 
-// A ConfigWriter knows how to write a bootstap Envoy configuration in YAML format.
+// A ConfigWriter knows how to write a bootstrap Envoy configuration in YAML format.
 type ConfigWriter struct {
 	// AdminAccessLogPath is the path to write the access log for the administration server.
 	// Defaults to /dev/null.


### PR DESCRIPTION
Add bootstrap subcommand support emissing the bootstrap JSON to
standard output by specifying the output file as `-`. The required
invocation to use this then becomes:

```
$ contour bootstrap -- -
```

Signed-off-by: James Peach <jpeach@vmware.com>