### PR TITLE
cmd/contour: Fix bootstrap command where defer with check threw errors

### DIFF
--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -56,7 +56,7 @@ func doBootstrap(ctx *bootstrapContext) {
 		f, err := os.Create(ctx.path)
 		check(err)
 
-		defer check(f.Close())
+		defer f.Close()
 		out = f
 	}
 


### PR DESCRIPTION
Fixes #1669 by removing the `check()` from the file close defer.

Signed-off-by: Steve Sloka <slokas@vmware.com>