### PR TITLE
all: migrate to networking/v1beta1.Ingress

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -98,6 +98,15 @@ type serveContext struct {
 
 	// RequestTimeout sets the client request timeout globally for Contour.
 	RequestTimeout time.Duration `yaml:"request-timeout,omitempty"`
+
+	// Should Contour fall back to registering an informer for the deprecated
+	// extensions/v1beta1.Ingress type.
+	// By default this value is false, meaning Contour will register an informer for
+	// networking/v1beta1.Ingress and expect the API server to rewrite extensions/v1beta1.Ingress
+	// objects transparently.
+	// If the value is true, Contour will register for extensions/v1beta1.Ingress type and do
+	// the rewrite itself.
+	UseExtensionsV1beta1Ingress bool `yaml:"-"`
 }
 
 // newServeContext returns a serveContext initialized to defaults.
@@ -153,6 +162,7 @@ func newServeContext() *serveContext {
 			Namespace:     "projectcontour",
 			Name:          "leader-elect",
 		},
+		UseExtensionsV1beta1Ingress: false,
 	}
 }
 

--- a/examples/contour/02-rbac.yaml
+++ b/examples/contour/02-rbac.yaml
@@ -49,6 +49,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
   verbs:

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -37,6 +37,7 @@ spec:
       - args:
         - serve
         - --incluster
+        - --use-extensions-v1beta1-ingress
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -327,6 +327,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
   verbs:
@@ -465,6 +473,7 @@ spec:
       - args:
         - serve
         - --incluster
+        - --use-extensions-v1beta1-ingress
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 // compatAnnotation checks the Object for the given annotation, first with the

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/projectcontour/contour/internal/assert"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -22,7 +22,7 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,8 +14,12 @@
 package dag
 
 import (
+	"bytes"
+	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
@@ -105,6 +109,16 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		}
 		kc.ingresses[m] = obj
 		return true
+	case *extensionsv1beta1.Ingress:
+		ingress := new(v1beta1.Ingress)
+		if err := transposeIngress(obj, ingress); err != nil {
+			om := obj.GetObjectMeta()
+			kc.WithField("name", om.GetName()).
+				WithField("namespace", om.GetNamespace()).
+				Error(err)
+			return false
+		}
+		return kc.Insert(ingress)
 	case *ingressroutev1.IngressRoute:
 		class := ingressClass(obj)
 		if class != "" && class != kc.ingressClass() {
@@ -179,6 +193,11 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		delete(kc.services, m)
 		return ok
 	case *v1beta1.Ingress:
+		m := toMeta(obj)
+		_, ok := kc.ingresses[m]
+		delete(kc.ingresses, m)
+		return ok
+	case *extensionsv1beta1.Ingress:
 		m := toMeta(obj)
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
@@ -390,4 +409,16 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 	}
 
 	return false
+}
+
+// transposeIngress transposes extensionis/v1beta1.Ingress objects into
+// networking/v1beta1.Ingress objects.
+func transposeIngress(src *extensionsv1beta1.Ingress, dst *v1beta1.Ingress) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(src); err != nil {
+		return nil
+	}
+	dec := json.NewDecoder(&buf)
+	return dec.Decode(dst)
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -20,7 +20,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -18,7 +18,7 @@ import (
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 func retryPolicy(rp *projcontour.RetryPolicy) *RetryPolicy {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -20,7 +20,7 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -20,7 +20,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/e2e/sds_test.go
+++ b/internal/e2e/sds_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/featuretests/kubernetes.go
+++ b/internal/featuretests/kubernetes.go
@@ -17,7 +17,7 @@ package featuretests
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/internal/featuretests/retrypolicy_test.go
+++ b/internal/featuretests/retrypolicy_test.go
@@ -22,7 +22,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/featuretests/timeoutpolicy_test.go
+++ b/internal/featuretests/timeoutpolicy_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/featuretests/tlsprotocolversion_test.go
+++ b/internal/featuretests/tlsprotocolversion_test.go
@@ -22,7 +22,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/featuretests/upstreamprotocol_test.go
+++ b/internal/featuretests/upstreamprotocol_test.go
@@ -18,7 +18,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/featuretests/websockets_test.go
+++ b/internal/featuretests/websockets_test.go
@@ -21,7 +21,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/site/examples/kuard.yaml
+++ b/site/examples/kuard.yaml
@@ -34,7 +34,7 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kuard


### PR DESCRIPTION
Fixes #1633

This PR changes Contour to use the networking/v1beta1.Ingress version of
the Ingress object. Contour uses this object internally and relies on
the API server to convert the older extensions/v1beta1 form to the current
networking/v1beta1 form.  Where this translation is not possible because
the cluster is too old, Contour performs this translation internally.

The catch is when relying on this translation mechanism, registering for
*both* extensions/v1beta1 and networking/v1beta1 causes objects that are
natively in the former format to appear twice. Thus, contour can only
subscribe to one of extensions/v1beta1 or networking/v1beta1. Thus
this PR provides a new flag, --use-extensions-v1beta1-ingress to
subscribe to the older form in pre 1.13 clusters.

Signed-off-by: Dave Cheney <dave@cheney.net>