### PR TITLE
site: move getting-started documentation to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy](https://www.envoyproxy.io/) as a reverse proxy and load balancer.
 Contour supports dynamic configuration updates out of the box while maintaining a lightweight profile.
 
-Contour also introduces a new ingress API ([IngressRoute][2]) which is implemented via a Custom Resource Definition (CRD).
+Contour also introduces a new ingress API ([HTTPProxy](/docs/httpproxy.md)) which is implemented via a Custom Resource Definition (CRD).
 Its goal is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
 
 ## Prerequisites
@@ -18,75 +18,12 @@ RBAC must be enabled on your cluster.
 
 ## Get started
 
-You can try out Contour by creating a deployment from a hosted manifest -- no clone or local install necessary.
-
-What you do need:
-
-- A Kubernetes cluster that supports Service objects of `type: LoadBalancer` ([AWS Quickstart cluster](https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/) or Minikube, for example)
-- `kubectl` configured with admin access to your cluster
-
-See the [deployment documentation][1] for more deployment options if you don't meet these requirements.
-
-### Add Contour to your cluster
-
-Run:
-
-```bash
-kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
-```
-
-This command creates:
-
-- A new namespace `projectcontour` with two instances of Contour in the namespace
-- A Service of `type: LoadBalancer` that points to the Contour instances
-- Depending on your configuration, new cloud resources -- for example, ELBs in AWS
-
-See also [TLS support](docs/tls.md) for details on configuring TLS support for the services behind Contour.
-
-For information on configuring TLS for gRPC between Contour and Envoy, see [grpc-tls-howto.md](docs/grpc-tls-howto.md)
-
-#### Example workload
-
-If you don't have an application ready to run with Contour, you can explore with [kuard](https://github.com/kubernetes-up-and-running/kuard).
-
-Run:
-
-```bash
-kubectl apply -f https://projectcontour.io/examples/kuard.yaml
-```
-
-This example specifies a default backend for all hosts, so that you can test your Contour install. It's recommended for exploration and testing only, however, because it responds to all requests regardless of the incoming DNS that is mapped. You probably want to run with specific Ingress rules for specific hostnames.
-
-## Access your cluster
-
-Now you can retrieve the external address of Contour's load balancer:
-
-```bash
-$ kubectl get -n projectcontour service contour -o wide
-NAME      CLUSTER-IP     EXTERNAL-IP                                                                    PORT(S)        AGE       SELECTOR
-contour   10.106.53.14   a47761ccbb9ce11e7b27f023b7e83d33-2036788482.ap-southeast-2.elb.amazonaws.com   80:30274/TCP   3h        app=contour
-```
-
-## Configuring DNS
-
-How you configure DNS depends on your platform:
-
-- On AWS, create a CNAME record that maps the host in your Ingress object to the ELB address.
-- If you have an IP address instead (on GCE, for example), create an A record.
-
-### More information and documentation
-
-For more deployment options, including uninstalling Contour, see the [deployment documentation][1].
-
-See also the Kubernetes documentation for [Services](https://kubernetes.io/docs/concepts/services-networking/service/), [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), and [IngressRoutes][2].
-
-The [detailed documentation](/docs) provides additional information, including an introduction to Envoy and an explanation of how Contour maps key Envoy concepts to Kubernetes.
-
-We've also got [an FAQ](/FAQ.md) for short-answer questions and conceptual stuff that doesn't quite belong in the docs.
+Getting started with Contour is as simple as one command. 
+See the [Getting Started](https://projectcontour.io/getting-started) document.
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting docs](/docs/troubleshooting.md), [file an issue][3], or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
+If you encounter issues, review the [troubleshooting docs](/docs/troubleshooting.md), [file an issue](https://github.com/projectcontour/contour/issue), or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
 
 ## Contributing
 
@@ -99,7 +36,3 @@ Thanks for taking the time to join our community and start contributing!
 ## Changelog
 
 See [the list of releases](https://github.com/projectcontour/contour/releases) to find out about feature changes.
-
-[1]: /docs/deploy-options.md
-[2]: /docs/ingressroute.md
-[3]: https://github.com/projectcontour/contour/issues

--- a/site/README-JEKYLL.md
+++ b/site/README-JEKYLL.md
@@ -20,7 +20,7 @@ If you are running a build on Ubuntu you will need the following packages:
 1. Install Jekyll and plug-ins in one fell swoop. `gem install github-pages`
 This mirrors the plug-ins used by GitHub Pages on your local machine including Jekyll, Sass, etc.
 2. Clone down your own fork, or clone the main repo `git clone https://github.com/projectcontour/contour` and add your own remote.
-3. `cd velero/site`
+3. `cd site`
 4. `rbenv local 2.6.3`
 5. `bundle install`
 6. Serve the site and watch for markup/sass changes `jekyll serve --livereload`. You may need to run `bundle exec jekyll serve --livereload`.

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -14,12 +14,10 @@ markdown: redcarpet
 hero:
   background-color: dark-blue
 footer:
-  title: Getting Started
-  content: To help you get started, see the documentation.
-  cta_title:
-  cta_url: /docs/
-  cta_text: Documentation
-  vm-link: http://vmware.github.io/
+  title: Ready to try Contour?
+  content: Read our getting started documentation.
+  cta_url: /getting-started/
+  cta_text: Getting Started
 
 footer_social_links:
   Twitter:
@@ -47,7 +45,7 @@ defaults:
     values:
       layout: "default"
 
-repository: heptio/contour
+repository: projectcontour/contour
 
 collections:
   - contributors
@@ -87,5 +85,6 @@ exclude:
   - CNAME
   - Runbook.docx
   - '*.sh'
+  - vendor/
 redcarpet:
     extensions: ["no_intra_emphasis", "tables", "autolink", "strikethrough", "with_toc_data"]

--- a/site/_includes/site-header.html
+++ b/site/_includes/site-header.html
@@ -4,6 +4,7 @@
             <a href="/" alt="Homepage"><img src="/img/{{ site.logo }}" class="logo" /></a>
         </div>
         <ul class="nav-menu" id="header-nav">
+            <li class="getting-started"><a href="/getting-started" title="Getting Started">Getting Started<a></li>
             <li class="community"><a href="/community" title="Community">Community</a></li>
             <li class="docs"><a href="/docs/" title="Documentation">Documentation</a></li>
             <li class="resources"><a href="/resources" title="Resources">Resources</a></li>

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: Getting Started
+description: Install Contour in your cluster
+id: getting-started
+---
+
+This page will help you get up and running with Contour.
+
+## Before you start
+
+Before you start you will need:
+
+- A Kubernetes cluster that supports Service objects of `type: LoadBalancer` ([AWS Quickstart cluster](https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/) or Minikube, for example)
+- `kubectl` configured with admin access to your cluster
+- RBAC must be enabled on your cluster.
+
+## Add Contour to your cluster
+
+Run:
+
+```bash
+kubectl apply -f {{ site.url }}/quickstart/contour.yaml
+```
+
+This command creates:
+
+- A new namespace `projectcontour` with two instances of Contour in the namespace
+- A Service of `type: LoadBalancer` that points to the Contour instances
+- Depending on your configuration, new cloud resources -- for example, ELBs in AWS
+
+See also [TLS support][7] for details on configuring TLS support for the services behind Contour.
+
+For information on configuring TLS for gRPC between Contour and Envoy, see [our gRPC TLS documentation][8].
+
+### Example workload
+
+If you don't have an application ready to run with Contour, you can explore with [kuard](https://github.com/kubernetes-up-and-running/kuard).
+
+Run:
+
+```bash
+kubectl apply -f https://projectcontour.io/examples/kuard.yaml
+```
+
+This example specifies a default backend for all hosts, so that you can test your Contour install. It's recommended for exploration and testing only, however, because it responds to all requests regardless of the incoming DNS that is mapped. You probably want to run with specific Ingress rules for specific hostnames.
+
+## Access your cluster
+
+Now you can retrieve the external address of Contour's load balancer:
+
+```bash
+$ kubectl get -n projectcontour service contour -o wide
+NAME      CLUSTER-IP     EXTERNAL-IP                                                                    PORT(S)        AGE       SELECTOR
+contour   10.106.53.14   a47761ccbb9ce11e7b27f023b7e83d33-2036788482.ap-southeast-2.elb.amazonaws.com   80:30274/TCP   3h        app=contour
+```
+
+## Configuring DNS
+
+How you configure DNS depends on your platform:
+
+- On AWS, create a CNAME record that maps the host in your Ingress object to the ELB address.
+- If you have an IP address instead (on GCE, for example), create an A record.
+
+### What's next?
+
+For more deployment options, including uninstalling Contour, see the [deployment documentation][1].
+
+See also the Kubernetes documentation for [Services](https://kubernetes.io/docs/concepts/services-networking/service/), [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), and [HTTPProxy][2].
+
+The [detailed documentation][3] provides additional information, including an introduction to Envoy and an explanation of how Contour maps key Envoy concepts to Kubernetes.
+
+We've also got [a FAQ][4] for short-answer questions and conceptual stuff that doesn't quite belong in the docs.
+
+## Troubleshooting
+
+If you encounter issues, review the [troubleshooting docs][5], [file an issue][6], or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
+
+[1]: {{ site.github.repository_url }}/tree/master/docs/deploy-options.md
+[2]: {{ site.github.repository_url }}/tree/master/docs/httpproxy.md
+[3]: {{ site.github.repository_url }}/tree/master/docs/
+[4]: {{ site.github.repository_url }}/tree/master/docs/FAQ.md
+[5]: {{ site.github.repository_url }}/tree/master/docs/troubleshooting.md
+[6]: {{ site.github.repository_url }}/issues
+[7]: {{ site.github.repository_url }}/tree/master/docs/tls.md
+[8]: {{ site.github.repository_url }}/tree/master/docs/grpc-tls-howto.md

--- a/site/index.html
+++ b/site/index.html
@@ -11,7 +11,7 @@ hero:
   content: Contour is an open source Kubernetes ingress controller providing the control plane for the Envoy edge and service proxy.​ Contour supports dynamic configuration updates and multi-team ingress delegation out of the box while maintaining a lightweight profile.
   cta_link1:
     text: Get Started with Contour
-    url: /docs/
+    url: /getting-started
   cta_link2:
     text: Download Latest Release
     url: https://github.com/projectcontour/contour/releases


### PR DESCRIPTION
Updates #1619

Migrate the getting started section of the README to
projectcontour.io/getting-started.

Signed-off-by: Dave Cheney <dave@cheney.net>