### PR TITLE
Fix minimumProtocolVersion in migration doc

### DIFF
--- a/docs/ingressroute-to-httpproxy.md
+++ b/docs/ingressroute-to-httpproxy.md
@@ -69,7 +69,7 @@ spec:
     fqdn: example.com
     tls:
       secretName: tlssecret
-      minimumProtocolVersion: 1.3
+      minimumProtocolVersion: "1.3"
 ```
 
 ### Upstream TLS validation


### PR DESCRIPTION
`minimumProtocolVersion` is of type string. This prevents an unmarshalling error, potentially leading to an endless loop in Contour.

Signed-off-by: Michael Gasch <mgasch@vmware.com>