### PR TITLE
internal/dag: validate each pem block

### DIFF
--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -80,6 +80,30 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert secret referenced by ingress with multiple pem blocks": {
+			pre: []interface{}{
+				&v1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "www",
+						Namespace: "default",
+					},
+					Spec: v1beta1.IngressSpec{
+						TLS: []v1beta1.IngressTLS{{
+							SecretName: "secret",
+						}},
+					},
+				},
+			},
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeTLS,
+				Data: secretdata(EC_CERTIFICATE, EC_PRIVATE_KEY),
+			},
+			want: true,
+		},
 		"insert secret w/ wrong type referenced by ingress": {
 			pre: []interface{}{
 				&v1beta1.Ingress{

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -15,9 +15,8 @@ package dag
 
 import v1 "k8s.io/api/core/v1"
 
-// sample data from https://8gwifi.org/PemParserFunctions.jsp
-
 const (
+	// sample data from https://8gwifi.org/PemParserFunctions.jsp
 	CERTIFICATE = `-----BEGIN CERTIFICATE-----
 MIIFtTCCA52gAwIBAgIJAO0cq2lJPZZJMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
 BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
@@ -103,6 +102,30 @@ KMkcE4BT8IZIHQ+wIMhmYLAdSQCVVv8x78jN0sZCC0fjqVuyPdYQ8sIc3OHsJZcW
 lzewFW72lfsiB/RxWZ/XwXONXeW5Quf+XwbGGboTofyzTxzsYSwn1U9Kt8iaY8zr
 z7Z5SQCSf2Js9V9lJcodYswWlxrdtoRKA/WgrvQkZhGGAePTUVoO5Lab29M8
 -----END RSA PRIVATE KEY-----`
+
+	// sample elliptical curve data generated
+	// openssl ecparam -name prime256v1 -genkey -out ec_key.pem
+	// openssl req -new -x509 -key ec_key.pem -out ec_crt.pem -days 3650
+	EC_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIIBbjCCARQCCQCPA0hmRaqduTAKBggqhkjOPQQDAjA/MQswCQYDVQQGEwJVUzEL
+MAkGA1UECAwCQ0ExEjAQBgNVBAcMCVBhbG8gQWx0bzEPMA0GA1UECgwGVk1XYXJl
+MB4XDTE5MTAxNTAzMzkzM1oXDTI5MTAxMjAzMzkzM1owPzELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgMAkNBMRIwEAYDVQQHDAlQYWxvIEFsdG8xDzANBgNVBAoMBlZNV2Fy
+ZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFUOHv4hnLcopcYdjojx2j/FmFX6
+MOLVVNsNpZ4SpmcGKN2zGp0SyAQgNhY0gGojC0g+VVYrh8X3GQAXYdvIjfMwCgYI
+KoZIzj0EAwIDSAAwRQIhAJudFacSiwcRtyQ2aNYAPbDJnnwbUTXRCVRlgLysgP5G
+AiALPSbO8d0wa24Z0AU2oXocuNkDaH8qEyp2yhL5LKI3Dw==
+-----END CERTIFICATE-----
+`
+	EC_PRIVATE_KEY = `-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIOlYOKzXGQTYlKDkuM62/U84DjxEOa8T3XGYlVmycFJroAoGCCqGSM49
+AwEHoUQDQgAEVQ4e/iGctyilxh2OiPHaP8WYVfow4tVU2w2lnhKmZwYo3bManRLI
+BCA2FjSAaiMLSD5VViuHxfcZABdh28iN8w==
+-----END EC PRIVATE KEY-----
+`
 )
 
 func secretdata(cert, key string) map[string][]byte {


### PR DESCRIPTION
During certificate validation, walk the PEM and validate each
appropriate block.

closes #1702

Signed-off-by: Matt Alberts <malberts@cloudflare.com>