### PR TITLE
examples: Fix prometheus / grafana examples for apps/v1 api groups

### DIFF
--- a/examples/grafana/01-namespace.yaml
+++ b/examples/grafana/01-namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: contour-monitoring
+  name: projectcontour-monitoring
   labels:
-    app: contour-monitoring
+    app: projectcontour-monitoring

--- a/examples/grafana/02-grafana-configmap.yaml
+++ b/examples/grafana/02-grafana-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: grafana
   name: grafana-dashs
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   contour.json: | 
     {
@@ -2372,7 +2372,7 @@ metadata:
   labels:
     app: grafana
   name: grafana-config
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   grafana.ini: |
     ; instance_name = ${HOSTNAME}
@@ -2503,7 +2503,7 @@ metadata:
   labels:
     app: grafana
   name: grafana-dash-provider
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   providers.yaml: |
     apiVersion: 1
@@ -2523,7 +2523,7 @@ metadata:
   labels:
     app: grafana
   name: grafana-datasources-provider
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   providers.yaml: |
     apiVersion: 1

--- a/examples/grafana/03-grafana-deployment.yaml
+++ b/examples/grafana/03-grafana-deployment.yaml
@@ -5,8 +5,11 @@ metadata:
   labels:
     app: grafana
   name: grafana
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: grafana
   replicas: 1
   template:
     metadata:

--- a/examples/grafana/03-grafana-service.yaml
+++ b/examples/grafana/03-grafana-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: grafana
   name: grafana
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
   ports:
     - name: http

--- a/examples/prometheus/01-namespace.yaml
+++ b/examples/prometheus/01-namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: contour-monitoring
+  name: projectcontour-monitoring
   labels:
-    app: contour-monitoring
+    app: projectcontour-monitoring

--- a/examples/prometheus/02-prometheus-alertmanager-configmap.yaml
+++ b/examples/prometheus/02-prometheus-alertmanager-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-alertmanager
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   alertmanager.yml: |-
     global:

--- a/examples/prometheus/02-prometheus-alertrules-configmap.yaml
+++ b/examples/prometheus/02-prometheus-alertrules-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-alert-rules
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   alert.rules: |-
     groups:

--- a/examples/prometheus/02-prometheus-configmap.yaml
+++ b/examples/prometheus/02-prometheus-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 data:
   prometheus.yml: |-
     # A scrape configuration for running Prometheus on a Kubernetes cluster.
@@ -316,7 +316,7 @@ data:
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         relabel_configs:
         - source_labels: [__meta_kubernetes_namespace]
-          regex: contour-monitoring
+          regex: projectcontour-monitoring
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_app]
           regex: prometheus

--- a/examples/prometheus/03-prometheus-alertmanager-deployment.yaml
+++ b/examples/prometheus/03-prometheus-alertmanager-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: prometheus
     component: alertmanager
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
   name: prometheus-alertmanager
 ---
 apiVersion: v1
@@ -14,7 +14,7 @@ metadata:
     app: prometheus
     component: alertmanager
   name: prometheus-alertmanager
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
   ports:
     - name: http
@@ -33,8 +33,12 @@ metadata:
     app: prometheus
     component: alertmanager
   name: prometheus-alertmanager
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      component: alertmanager
   replicas: 1
   template:
     metadata:

--- a/examples/prometheus/03-prometheus-deployment.yaml
+++ b/examples/prometheus/03-prometheus-deployment.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -36,7 +36,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 ---
 apiVersion: v1
 kind: Service
@@ -44,7 +44,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   name: prometheus
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
   ports:
   - protocol: TCP
@@ -58,7 +58,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
   labels:
     app: prometheus
     component: server

--- a/examples/prometheus/03-prometheus-node-exporter.yaml
+++ b/examples/prometheus/03-prometheus-node-exporter.yaml
@@ -6,8 +6,12 @@ metadata:
     app: prometheus
     component: node-exporter
   name: prometheus-node-exporter
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
 spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      component: node-exporter
   updateStrategy:
     type: OnDelete
   template:
@@ -48,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-node-exporter
-  namespace: contour-monitoring
+  namespace: projectcontour-monitoring
   annotations:
     prometheus.io/scrape: "true"
   labels:

--- a/site/_resources/prometheus.md
+++ b/site/_resources/prometheus.md
@@ -60,7 +60,7 @@ $ kubectl apply -f examples/prometheus
 #### Access the Prometheus web UI
 
 ```sh
-$ kubectl -n contour-monitoring port-forward $(kubectl -n contour-monitoring get pods -l app=prometheus -l component=server -o jsonpath='{.items[0].metadata.name}') 9090:9090
+$ kubectl -n projectcontour-monitoring port-forward $(kubectl -n projectcontour-monitoring get pods -l app=prometheus -l component=server -o jsonpath='{.items[0].metadata.name}') 9090:9090
 ```
 
 then go to [http://localhost:9090](http://localhost:9090) in your browser.
@@ -68,7 +68,7 @@ then go to [http://localhost:9090](http://localhost:9090) in your browser.
 #### Access the Alertmanager web UI
 
 ```sh
-$ kubectl -n contour-monitoring port-forward $(kubectl -n contour-monitoring get pods -l app=prometheus -l component=alertmanager -o jsonpath='{.items[0].metadata.name}') 9093:9093
+$ kubectl -n projectcontour-monitoring port-forward $(kubectl -n projectcontour-monitoring get pods -l app=prometheus -l component=alertmanager -o jsonpath='{.items[0].metadata.name}') 9093:9093
 ```
 
 then go to [http://localhost:9093](http://localhost:9093) in your browser.
@@ -84,7 +84,7 @@ A sample deployment of Grafana is provided that uses temporary storage.
 $ kubectl apply -f examples/grafana/
 
 # Create secret with grafana credentials
-$ kubectl create secret generic grafana -n contour-monitoring \
+$ kubectl create secret generic grafana -n projectcontour-monitoring \
     --from-literal=grafana-admin-password=admin \
     --from-literal=grafana-admin-user=admin
 ```
@@ -92,7 +92,7 @@ $ kubectl create secret generic grafana -n contour-monitoring \
 #### Access the Grafana UI
 
 ```sh
-$ kubectl port-forward $(kubectl get pods -l app=grafana -n contour-monitoring -o jsonpath='{.items[0].metadata.name}') 3000 -n contour-monitoring
+$ kubectl port-forward $(kubectl get pods -l app=grafana -n projectcontour-monitoring -o jsonpath='{.items[0].metadata.name}') 3000 -n projectcontour-monitoring
 ```
 
 then go to [http://localhost:3000](http://localhost:3000) in your browser.


### PR DESCRIPTION
Fix prometheus / grafana examples for apps/v1 api groups as well as rename sample namespace of `contour-monitoring` to `projectcontour-monitoring`. 

Signed-off-by: Steve Sloka <slokas@vmware.com>