### PR TITLE
Fix default getting started URLs.

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -3,7 +3,7 @@ title: Contour
 email:
 author: Contour Authors
 description: High performance ingress controller for Kubernetes
-url: projectcontour.io
+url: https://projectcontour.io
 logo: Contour.svg
 twitter:
   username: projectcontour

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -40,7 +40,7 @@ If you don't have an application ready to run with Contour, you can explore with
 Run:
 
 ```bash
-kubectl apply -f https://projectcontour.io/examples/kuard.yaml
+kubectl apply -f {{ site.url }}/examples/kuard.yaml
 ```
 
 This example specifies a default backend for all hosts, so that you can test your Contour install. It's recommended for exploration and testing only, however, because it responds to all requests regardless of the incoming DNS that is mapped. You probably want to run with specific Ingress rules for specific hostnames.


### PR DESCRIPTION
When using the Jekyll `site.url` variable, Jekyll doesn't know which
scheme to use, so we have to explicitly add it to the config. In
this case, we need to ensure the `https` scheme is present in the
`kubectl` examples so that `kubectl` can detect that the argument
is a URL.

Signed-off-by: James Peach <jpeach@vmware.com>