### PR TITLE
Add site development Docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
 PHONY = gencerts
 
+# The version of Jekyll is pinned in site/Gemfile.lock.
+# https://docs.netlify.com/configure-builds/common-configurations/#jekyll
+JEKYLL_IMAGE := jekyll/jekyll:3.8.5
+JEKYLL_PORT := 4000
+
 TAG_LATEST ?= false
 # Used to supply a local Envoy docker container an IP to connect to that is running
 # 'contour serve'. On MacOS this will work, but may not on other OSes. Defining
@@ -202,6 +207,11 @@ certs/envoycert.pem: certs/CAkey.pem certs/envoykey.pem
 		-out certs/envoycert.pem \
 		-days 1825 -sha256 \
 		-extfile _integration/cert-envoy.ext
+
+.PHONY: site-devel
+site-devel: ## Launch the website in a Docker container
+	docker run --publish $(JEKYLL_PORT):$(JEKYLL_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
+		bash -c "cd /site && bundle install && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload"
 
 help: ## Display this help
 	@echo Contour high performance Ingress controller for Kubernetes

--- a/site/README-JEKYLL.md
+++ b/site/README-JEKYLL.md
@@ -15,9 +15,8 @@ If you are running a build on Ubuntu you will need the following packages:
 * zlib1g-dev
 * nginx (or apache2)
 
-
 # Local Development
-1. Install Jekyll and plug-ins in one fell swoop. `gem install github-pages`
+1. Install [Jekyll](https://jekyllrb.com) and plug-ins in one fell swoop. `gem install github-pages`
 This mirrors the plug-ins used by GitHub Pages on your local machine including Jekyll, Sass, etc.
 2. Clone down your own fork, or clone the main repo `git clone https://github.com/projectcontour/contour` and add your own remote.
 3. `cd site`
@@ -27,3 +26,7 @@ This mirrors the plug-ins used by GitHub Pages on your local machine including J
 7. View your website at http://127.0.0.1:4000/
 8. Commit any changes and push everything to your fork.
 9. Once you're ready, submit a PR of your changes. Netlify will automatically generate a preview of your changes.
+
+The top-level [Makefile](../Makefile) has a `site-devel` target and
+runs a [Jekyll](https://jekyllrb.com) development server in Docker,
+which is useful for checking local documentation changes..


### PR DESCRIPTION
Add a Dockerfile and make target that can be used for hacking on
the Contour website. This removes the need to deal with installing
Ruby and Jekyll locally.

Signed-off-by: James Peach <jpeach@vmware.com>