### PR TITLE
Add more community info to README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Thanks for taking the time to join our community and start contributing!
 - Please familiarize yourself with the [Code of Conduct](/CODE_OF_CONDUCT.md) before contributing.
 - See [CONTRIBUTING.md](/CONTRIBUTING.md) for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues][3].
+- Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
+- Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
+  - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
+  - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
 ## Changelog
 

--- a/site/_agendas/2019-06-18.md
+++ b/site/_agendas/2019-06-18.md
@@ -1,6 +1,0 @@
----
-title: Contour Community Meeting
-link: https://hackmd.io/2TUlADEcQ6eZZny_d9zy9w?both
-date: 2019-06-18
----
-&nbsp;

--- a/site/_agendas/2019-08-27.md
+++ b/site/_agendas/2019-08-27.md
@@ -1,6 +1,0 @@
----
-title: Contour Community Meeting
-link: https://hackmd.io/qZbCbARMSKSzDIMOqhYMIg?both
-date: 2019-08-27
----
-&nbsp;

--- a/site/_agendas/2019-09-24.md
+++ b/site/_agendas/2019-09-24.md
@@ -1,6 +1,0 @@
----
-title: Contour Community Meeting
-link: https://hackmd.io/vKvLonsgRUCjAOFybTgjGw?both
-date: 2019-09-24
----
-&nbsp;

--- a/site/_agendas/2019-10-15.md
+++ b/site/_agendas/2019-10-15.md
@@ -1,6 +1,0 @@
----
-title: Contour Community Meeting
-link: https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw?both
-date: 2019-10-15
----
-&nbsp;

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -56,8 +56,6 @@ collections:
     output: false
   casestudies:
     output: false
-  agendas:
-    output: false
 
 # Build settings
 permalink: :title/

--- a/site/community.md
+++ b/site/community.md
@@ -12,13 +12,6 @@ If you’re a newcomer, check out the “[Good first issue](https://github.com/p
 
 * Join our Kubernetes Slack channel and talk to over 300 other community members: [#contour​](https://kubernetes.slack.com/messages/C8XRH2R4J/)
 
-* Join the [Contour Community Meetings](https://VMware.zoom.us/j/347232187), every third Tuesday at 6-7PM Eastern Time / 3-4PM Pacific Time / Wednesday at 8-9AM Australian Eastern Time.
-
-## Community Meeting Agendas
-
-Links to past and future community meeting agendas
-
-{% assign agendas = site.agendas | sort: 'date' | reverse %}
-{% for agenda in agendas %}
-- [{{ agenda.title }}]({{ agenda.link }}) _{{ agenda.date | date_to_long_string }}_
-{% endfor %}
+* Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
+  * Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
+  * Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).


### PR DESCRIPTION
This adds links for the community channels and meetings to the README and site.
I updated the single HackMD with all the previous notes, so we can remove those.

Signed-off-by: jonasrosland <jrosland@vmware.com>