### PR TITLE
.github: remove environment section from feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -1,21 +1,7 @@
 ---
 name: Feature enhancement request
 about: Suggest an idea for this project
-
 ---
 
-**Describe the solution you'd like**
-[A clear and concise description of what you want to happen.]
-
-
-**Anything else you would like to add:**
-[Miscellaneous information that will assist in solving the issue.]
-
-
-**Environment:**
-
-- Contour version:
-- Kubernetes version: (use `kubectl version`):
-- Kubernetes installer & version:
-- Cloud provider or hardware configuration:
-- OS (e.g. from `/etc/os-release`):
+**Please describe the problem you have**
+[A clear, concise, description of the problem you are facing. What is the _problem_ that feature X would solve for you?]


### PR DESCRIPTION
Remove the environment second from the feature request issue template,
it is redundant.

Also, try to guide the author towards describing the problem they have
not the specific feature they want us to add.

Signed-off-by: Dave Cheney <dave@cheney.net>