### PR TITLE
Dockerfile: update to Go 1.13.3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /hack
 /contour
 *.test
+/site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1 AS build
+FROM golang:1.13.3 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Also, add /site to .dockerignore.

Signed-off-by: Dave Cheney <dave@cheney.net>