### PR TITLE
Update metrics for HTTPProxy as well as dashboard to match

### DIFF
--- a/examples/grafana/02-grafana-configmap.yaml
+++ b/examples/grafana/02-grafana-configmap.yaml
@@ -6,837 +6,1611 @@ metadata:
   name: grafana-dashs
   namespace: projectcontour-monitoring
 data:
-  contour.json: | 
+  contour-ingressroute.json: |
     {
-      "__inputs": [
-        {
-          "name": "DS_PROMETHEUS",
-          "label": "prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        }
-      ],
-      "__requires": [
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "5.0.4"
-        },
-        {
-          "type": "panel",
-          "id": "graph",
-          "name": "Graph",
-          "version": "5.0.0"
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "5.0.0"
-        }
-      ],
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-          }
-        ]
-      },
-      "editable": false,
-      "gnetId": null,
-      "graphTooltip": 0,
-      "id": null,
-      "iteration": 1532630524651,
-      "links": [],
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 0,
-            "y": 0
-          },
-          "id": 2,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(contour_ingressroute_total{namespace=~\"$Namespace\"}) by (namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Namespace: {{ namespace }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Total IngressRoutes",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
+        "__inputs": [{
+            "name": "DS_PROMETHEUS",
+            "label": "prometheus",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+        }],
+        "__requires": [{
+                "type": "grafana",
+                "id": "grafana",
+                "name": "Grafana",
+                "version": "5.0.4"
             },
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 0
-          },
-          "id": 6,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(contour_ingressroute_orphaned_total{namespace=~\"$Namespace\"}) by (namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Namespace: {{ namespace }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Orphaned IngressRoutes",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
+                "type": "panel",
+                "id": "graph",
+                "name": "Graph",
+                "version": "5.0.0"
             },
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
+                "type": "datasource",
+                "id": "prometheus",
+                "name": "Prometheus",
+                "version": "5.0.0"
             }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 12,
-            "y": 0
-          },
-          "id": 4,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(contour_ingressroute_valid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Valid IngressRoutes",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 0
-          },
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(contour_ingressroute_invalid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Invalid IngressRoutes",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 0,
-            "y": 8
-          },
-          "id": 5,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(contour_ingressroute_root_total{namespace=~\"$Namespace\"}) by (namespace)",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Namespace: {{ namespace }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Root IngressRoutes",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 0,
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 8
-          },
-          "id": 10,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "envoy_listener_manager_lds_update_failure",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (failure)",
-              "refId": "A"
-            },
-            {
-              "expr": "envoy_listener_manager_lds_update_success",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (success)",
-              "refId": "B"
-            },
-            {
-              "expr": "envoy_listener_manager_lds_update_rejected",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (rejected)",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Contour LDS Updates",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 12,
-            "y": 8
-          },
-          "id": 8,
-          "legend": {
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "envoy_cluster_manager_cds_update_success",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Success)",
-              "refId": "A"
-            },
-            {
-              "expr": "envoy_cluster_manager_cds_update_failure",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Failure)",
-              "refId": "B"
-            },
-            {
-              "expr": "envoy_cluster_manager_cds_update_rejected",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Contour CDS Updates",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 8
-          },
-          "id": 11,
-          "legend": {
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "envoy_http_rds_ingress_http_update_success",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Success)",
-              "refId": "A"
-            },
-            {
-              "expr": "envoy_http_rds_ingress_http_update_failure",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Failure)",
-              "refId": "B"
-            },
-            {
-              "expr": "envoy_http_rds_ingress_http_update_rejected",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Contour RDS Updates",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        }
-      ],
-      "refresh": "10s",
-      "schemaVersion": 16,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-        "list": [
-          {
-            "allValue": ".*",
-            "current": {},
-            "datasource": "prometheus",
-            "hide": 0,
-            "includeAll": true,
-            "label": null,
-            "multi": true,
-            "name": "Namespace",
-            "options": [],
-            "query": "label_values(namespace)",
-            "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": ".*",
-            "current": {},
-            "datasource": "prometheus",
-            "hide": 0,
-            "includeAll": true,
-            "label": null,
-            "multi": true,
-            "name": "VHost",
-            "options": [],
-            "query": "label_values(vhost)",
-            "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          }
-        ]
-      },
-      "time": {
-        "from": "now-30m",
-        "to": "now"
-      },
-      "timepicker": {
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
         ],
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ]
-      },
-      "timezone": "",
-      "title": "Contour",
-      "uid": "KYcCfvKik",
-      "version": 1
+        "annotations": {
+            "list": [{
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": null,
+        "iteration": 1532630524651,
+        "links": [],
+        "panels": [{
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 0,
+                    "y": 0
+                },
+                "id": 2,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_ingressroute_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Total IngressRoutes",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 6,
+                    "y": 0
+                },
+                "id": 6,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_ingressroute_orphaned_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Orphaned IngressRoutes",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 12,
+                    "y": 0
+                },
+                "id": 4,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_ingressroute_valid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Valid IngressRoutes",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 18,
+                    "y": 0
+                },
+                "id": 3,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_ingressroute_invalid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Invalid IngressRoutes",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 0,
+                    "y": 8
+                },
+                "id": 5,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_ingressroute_root_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Root IngressRoutes",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 6,
+                    "y": 8
+                },
+                "id": 10,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_listener_manager_lds_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (failure)",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "envoy_listener_manager_lds_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (success)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_listener_manager_lds_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour LDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 12,
+                    "y": 8
+                },
+                "id": 8,
+                "legend": {
+                    "avg": false,
+                    "current": true,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_cluster_manager_cds_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Success)",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "envoy_cluster_manager_cds_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Failure)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_cluster_manager_cds_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour CDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 18,
+                    "y": 8
+                },
+                "id": 11,
+                "legend": {
+                    "avg": false,
+                    "current": true,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_http_rds_ingress_http_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Success)",
+                        "refId": "A"
+                    }, {
+                        "expr": "envoy_http_rds_ingress_http_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Failure)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_http_rds_ingress_http_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour RDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            }
+        ],
+        "refresh": "10s",
+        "schemaVersion": 16,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [{
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "Namespace",
+                    "options": [],
+                    "query": "label_values(namespace)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "VHost",
+                    "options": [],
+                    "query": "label_values(vhost)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-30m",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "",
+        "title": "Contour - IngressRoute",
+        "uid": "KYcCfvKid",
+        "version": 1
+    }
+  contour-proxy.json: |
+    {
+        "__inputs": [{
+            "name": "DS_PROMETHEUS",
+            "label": "prometheus",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+        }],
+        "__requires": [{
+                "type": "grafana",
+                "id": "grafana",
+                "name": "Grafana",
+                "version": "5.0.4"
+            },
+            {
+                "type": "panel",
+                "id": "graph",
+                "name": "Graph",
+                "version": "5.0.0"
+            },
+            {
+                "type": "datasource",
+                "id": "prometheus",
+                "name": "Prometheus",
+                "version": "5.0.0"
+            }
+        ],
+        "annotations": {
+            "list": [{
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": null,
+        "iteration": 1532630524651,
+        "links": [],
+        "panels": [{
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 0,
+                    "y": 0
+                },
+                "id": 2,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_httpproxy_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Total HTTProxies",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 6,
+                    "y": 0
+                },
+                "id": 6,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_httpproxy_orphaned_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Orphaned HTTProxies",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 12,
+                    "y": 0
+                },
+                "id": 4,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_httpproxy_valid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Valid HTTProxies",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 18,
+                    "y": 0
+                },
+                "id": 3,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_httpproxy_invalid_total{namespace=~\"$Namespace\",vhost=~\"$VHost\"}) by (namespace,vhost)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }} ({{ vhost }})",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Invalid HTTProxies",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 0,
+                    "y": 8
+                },
+                "id": 5,
+                "legend": {
+                    "alignAsTable": true,
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": true,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                    "expr": "avg(contour_httpproxy_root_total{namespace=~\"$Namespace\"}) by (namespace)",
+                    "format": "time_series",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Namespace: {{ namespace }}",
+                    "refId": "A"
+                }],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Root HTTProxies",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "decimals": 0,
+                        "format": "short",
+                        "label": "",
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 6,
+                    "y": 8
+                },
+                "id": 10,
+                "legend": {
+                    "avg": false,
+                    "current": false,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_listener_manager_lds_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (failure)",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "envoy_listener_manager_lds_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (success)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_listener_manager_lds_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour LDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 12,
+                    "y": 8
+                },
+                "id": 8,
+                "legend": {
+                    "avg": false,
+                    "current": true,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_cluster_manager_cds_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Success)",
+                        "refId": "A"
+                    },
+                    {
+                        "expr": "envoy_cluster_manager_cds_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Failure)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_cluster_manager_cds_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour CDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            },
+            {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "prometheus",
+                "fill": 1,
+                "gridPos": {
+                    "h": 8,
+                    "w": 6,
+                    "x": 18,
+                    "y": 8
+                },
+                "id": 11,
+                "legend": {
+                    "avg": false,
+                    "current": true,
+                    "max": false,
+                    "min": false,
+                    "show": false,
+                    "total": false,
+                    "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [{
+                        "expr": "envoy_http_rds_ingress_http_update_success",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Success)",
+                        "refId": "A"
+                    }, {
+                        "expr": "envoy_http_rds_ingress_http_update_failure",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Failure)",
+                        "refId": "B"
+                    },
+                    {
+                        "expr": "envoy_http_rds_ingress_http_update_rejected",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "{{kubernetes_pod_name}} (Rejected)",
+                        "refId": "C"
+                    }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Contour RDS Updates",
+                "tooltip": {
+                    "shared": true,
+                    "sort": 0,
+                    "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                    "buckets": null,
+                    "mode": "time",
+                    "name": null,
+                    "show": true,
+                    "values": []
+                },
+                "yaxes": [{
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    },
+                    {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": true
+                    }
+                ]
+            }
+        ],
+        "refresh": "10s",
+        "schemaVersion": 16,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+            "list": [{
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "Namespace",
+                    "options": [],
+                    "query": "label_values(namespace)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                },
+                {
+                    "allValue": ".*",
+                    "current": {},
+                    "datasource": "prometheus",
+                    "hide": 0,
+                    "includeAll": true,
+                    "label": null,
+                    "multi": true,
+                    "name": "VHost",
+                    "options": [],
+                    "query": "label_values(vhost)",
+                    "refresh": 2,
+                    "regex": "",
+                    "sort": 0,
+                    "tagValuesQuery": "",
+                    "tags": [],
+                    "tagsQuery": "",
+                    "type": "query",
+                    "useTags": false
+                }
+            ]
+        },
+        "time": {
+            "from": "now-30m",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+                "5s",
+                "10s",
+                "30s",
+                "1m",
+                "5m",
+                "15m",
+                "30m",
+                "1h",
+                "2h",
+                "1d"
+            ],
+            "time_options": [
+                "5m",
+                "15m",
+                "1h",
+                "6h",
+                "12h",
+                "24h",
+                "2d",
+                "7d",
+                "30d"
+            ]
+        },
+        "timezone": "",
+        "title": "Contour - HTTPProxy",
+        "uid": "KYcCfvKik",
+        "version": 1
     }
   envoy.json: |
     {

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -227,8 +227,9 @@ func (e *EventHandler) updateDAG() {
 		statuses := dag.Statuses()
 		e.setStatus(statuses)
 
-		metrics := calculateIngressRouteMetric(statuses)
+		metrics, proxymetrics := calculateRouteMetric(statuses)
 		e.Metrics.SetIngressRouteMetric(metrics)
+		e.Metrics.SetHTTPProxyMetric(proxymetrics)
 	default:
 		e.Debug("skipping status update: not the leader")
 	}

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -18,41 +18,63 @@ package contour
 
 import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/metrics"
 )
 
-func calculateIngressRouteMetric(statuses map[dag.Meta]dag.Status) metrics.IngressRouteMetric {
-	metricTotal := make(map[metrics.Meta]int)
-	metricValid := make(map[metrics.Meta]int)
-	metricInvalid := make(map[metrics.Meta]int)
-	metricOrphaned := make(map[metrics.Meta]int)
-	metricRoots := make(map[metrics.Meta]int)
+func calculateRouteMetric(statuses map[dag.Meta]dag.Status) (metrics.RouteMetric, metrics.RouteMetric) {
+	irMetricTotal := make(map[metrics.Meta]int)
+	irMetricValid := make(map[metrics.Meta]int)
+	irMetricInvalid := make(map[metrics.Meta]int)
+	irMetricOrphaned := make(map[metrics.Meta]int)
+	irMetricRoots := make(map[metrics.Meta]int)
+
+	proxyMetricTotal := make(map[metrics.Meta]int)
+	proxyMetricValid := make(map[metrics.Meta]int)
+	proxyMetricInvalid := make(map[metrics.Meta]int)
+	proxyMetricOrphaned := make(map[metrics.Meta]int)
+	proxyMetricRoots := make(map[metrics.Meta]int)
 
 	for _, v := range statuses {
-		switch v.Status {
-		case dag.StatusValid:
-			metricValid[metrics.Meta{VHost: v.Vhost, Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
-		case dag.StatusInvalid:
-			metricInvalid[metrics.Meta{VHost: v.Vhost, Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
-		case dag.StatusOrphaned:
-			metricOrphaned[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
-		}
-
 		switch o := v.Object.(type) {
 		case *ingressroutev1.IngressRoute:
+			calcMetrics(v, irMetricValid, irMetricInvalid, irMetricOrphaned, irMetricRoots, irMetricTotal)
 			if o.Spec.VirtualHost != nil {
-				metricRoots[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
+				irMetricRoots[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
+			}
+		case *projcontour.HTTPProxy:
+			calcMetrics(v, proxyMetricValid, proxyMetricInvalid, proxyMetricOrphaned, proxyMetricRoots, proxyMetricTotal)
+			if o.Spec.VirtualHost != nil {
+				proxyMetricRoots[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
 			}
 		}
-		metricTotal[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
 	}
 
-	return metrics.IngressRouteMetric{
-		Invalid:  metricInvalid,
-		Valid:    metricValid,
-		Orphaned: metricOrphaned,
-		Total:    metricTotal,
-		Root:     metricRoots,
+	return metrics.RouteMetric{
+			Invalid:  irMetricInvalid,
+			Valid:    irMetricValid,
+			Orphaned: irMetricOrphaned,
+			Total:    irMetricTotal,
+			Root:     irMetricRoots,
+		},
+		metrics.RouteMetric{
+			Invalid:  proxyMetricInvalid,
+			Valid:    proxyMetricValid,
+			Orphaned: proxyMetricOrphaned,
+			Total:    proxyMetricTotal,
+			Root:     proxyMetricRoots,
+		}
+}
+
+func calcMetrics(v dag.Status, metricValid map[metrics.Meta]int, metricInvalid map[metrics.Meta]int, metricOrphaned map[metrics.Meta]int, metricRoots map[metrics.Meta]int, metricTotal map[metrics.Meta]int) {
+	switch v.Status {
+	case dag.StatusValid:
+		metricValid[metrics.Meta{VHost: v.Vhost, Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
+	case dag.StatusInvalid:
+		metricInvalid[metrics.Meta{VHost: v.Vhost, Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
+	case dag.StatusOrphaned:
+		metricOrphaned[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
 	}
+	metricTotal[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -28,22 +28,29 @@ import (
 
 // Metrics provide Prometheus metrics for the app
 type Metrics struct {
-	ingressRouteTotalGauge      *prometheus.GaugeVec
-	ingressRouteRootTotalGauge  *prometheus.GaugeVec
-	ingressRouteInvalidGauge    *prometheus.GaugeVec
-	ingressRouteValidGauge      *prometheus.GaugeVec
-	ingressRouteOrphanedGauge   *prometheus.GaugeVec
-	ingressRouteDAGRebuildGauge *prometheus.GaugeVec
+	ingressRouteTotalGauge     *prometheus.GaugeVec
+	ingressRouteRootTotalGauge *prometheus.GaugeVec
+	ingressRouteInvalidGauge   *prometheus.GaugeVec
+	ingressRouteValidGauge     *prometheus.GaugeVec
+	ingressRouteOrphanedGauge  *prometheus.GaugeVec
 
+	proxyTotalGauge     *prometheus.GaugeVec
+	proxyRootTotalGauge *prometheus.GaugeVec
+	proxyInvalidGauge   *prometheus.GaugeVec
+	proxyValidGauge     *prometheus.GaugeVec
+	proxyOrphanedGauge  *prometheus.GaugeVec
+
+	dagRebuildGauge             *prometheus.GaugeVec
 	CacheHandlerOnUpdateSummary prometheus.Summary
 	ResourceEventHandlerSummary *prometheus.SummaryVec
 
 	// Keep a local cache of metrics for comparison on updates
-	metricCache *IngressRouteMetric
+	ingressRouteMetricCache *RouteMetric
+	proxyMetricCache        *RouteMetric
 }
 
-// IngressRouteMetric stores various metrics for IngressRoute objects
-type IngressRouteMetric struct {
+// RouteMetric stores various metrics for IngressRoute objects
+type RouteMetric struct {
 	Total    map[Meta]int
 	Valid    map[Meta]int
 	Invalid  map[Meta]int
@@ -57,13 +64,19 @@ type Meta struct {
 }
 
 const (
-	IngressRouteTotalGauge      = "contour_ingressroute_total"
-	IngressRouteRootTotalGauge  = "contour_ingressroute_root_total"
-	IngressRouteInvalidGauge    = "contour_ingressroute_invalid_total"
-	IngressRouteValidGauge      = "contour_ingressroute_valid_total"
-	IngressRouteOrphanedGauge   = "contour_ingressroute_orphaned_total"
-	IngressRouteDAGRebuildGauge = "contour_ingressroute_dagrebuild_timestamp"
+	IngressRouteTotalGauge     = "contour_ingressroute_total"
+	IngressRouteRootTotalGauge = "contour_ingressroute_root_total"
+	IngressRouteInvalidGauge   = "contour_ingressroute_invalid_total"
+	IngressRouteValidGauge     = "contour_ingressroute_valid_total"
+	IngressRouteOrphanedGauge  = "contour_ingressroute_orphaned_total"
 
+	HTTPProxyTotalGauge     = "contour_httpproxy_total"
+	HTTPProxyRootTotalGauge = "contour_httpproxy_root_total"
+	HTTPProxyInvalidGauge   = "contour_httpproxy_invalid_total"
+	HTTPProxyValidGauge     = "contour_httpproxy_valid_total"
+	HTTPProxyOrphanedGauge  = "contour_httpproxy_orphaned_total"
+
+	DAGRebuildGauge             = "contour_dagrebuild_timestamp"
 	cacheHandlerOnUpdateSummary = "contour_cachehandler_onupdate_duration_seconds"
 	resourceEventHandlerSummary = "contour_resourceeventhandler_duration_seconds"
 )
@@ -72,7 +85,8 @@ const (
 // the supplied registry.
 func NewMetrics(registry *prometheus.Registry) *Metrics {
 	m := Metrics{
-		metricCache: &IngressRouteMetric{},
+		ingressRouteMetricCache: &RouteMetric{},
+		proxyMetricCache:        &RouteMetric{},
 		ingressRouteTotalGauge: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: IngressRouteTotalGauge,
@@ -108,9 +122,44 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 			},
 			[]string{"namespace"},
 		),
-		ingressRouteDAGRebuildGauge: prometheus.NewGaugeVec(
+		proxyTotalGauge: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: IngressRouteDAGRebuildGauge,
+				Name: HTTPProxyTotalGauge,
+				Help: "Total number of HTTPProxies",
+			},
+			[]string{"namespace"},
+		),
+		proxyRootTotalGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: HTTPProxyRootTotalGauge,
+				Help: "Total number of root HTTPProxies",
+			},
+			[]string{"namespace"},
+		),
+		proxyInvalidGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: HTTPProxyInvalidGauge,
+				Help: "Total number of invalid HTTPProxies",
+			},
+			[]string{"namespace", "vhost"},
+		),
+		proxyValidGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: HTTPProxyValidGauge,
+				Help: "Total number of valid HTTPProxies",
+			},
+			[]string{"namespace", "vhost"},
+		),
+		proxyOrphanedGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: HTTPProxyOrphanedGauge,
+				Help: "Total number of orphaned HTTPProxies",
+			},
+			[]string{"namespace"},
+		),
+		dagRebuildGauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: DAGRebuildGauge,
 				Help: "Timestamp of the last DAG rebuild",
 			},
 			[]string{},
@@ -140,7 +189,12 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 		m.ingressRouteInvalidGauge,
 		m.ingressRouteValidGauge,
 		m.ingressRouteOrphanedGauge,
-		m.ingressRouteDAGRebuildGauge,
+		m.proxyTotalGauge,
+		m.proxyRootTotalGauge,
+		m.proxyInvalidGauge,
+		m.proxyValidGauge,
+		m.proxyOrphanedGauge,
+		m.dagRebuildGauge,
 		m.CacheHandlerOnUpdateSummary,
 		m.ResourceEventHandlerSummary,
 	)
@@ -148,52 +202,101 @@ func (m *Metrics) register(registry *prometheus.Registry) {
 
 // SetDAGLastRebuilt records the last time the DAG was rebuilt.
 func (m *Metrics) SetDAGLastRebuilt(ts time.Time) {
-	m.ingressRouteDAGRebuildGauge.WithLabelValues().Set(float64(ts.Unix()))
+	m.dagRebuildGauge.WithLabelValues().Set(float64(ts.Unix()))
 }
 
 // SetIngressRouteMetric sets metric values for a set of IngressRoutes
-func (m *Metrics) SetIngressRouteMetric(metrics IngressRouteMetric) {
+func (m *Metrics) SetIngressRouteMetric(metrics RouteMetric) {
 	// Process metrics
 	for meta, value := range metrics.Total {
 		m.ingressRouteTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		delete(m.metricCache.Total, meta)
+		delete(m.ingressRouteMetricCache.Total, meta)
 	}
 	for meta, value := range metrics.Invalid {
 		m.ingressRouteInvalidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
-		delete(m.metricCache.Invalid, meta)
+		delete(m.ingressRouteMetricCache.Invalid, meta)
 	}
 	for meta, value := range metrics.Orphaned {
 		m.ingressRouteOrphanedGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		delete(m.metricCache.Orphaned, meta)
+		delete(m.ingressRouteMetricCache.Orphaned, meta)
 	}
 	for meta, value := range metrics.Valid {
 		m.ingressRouteValidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
-		delete(m.metricCache.Valid, meta)
+		delete(m.ingressRouteMetricCache.Valid, meta)
 	}
 	for meta, value := range metrics.Root {
 		m.ingressRouteRootTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
-		delete(m.metricCache.Root, meta)
+		delete(m.ingressRouteMetricCache.Root, meta)
 	}
 
 	// All metrics processed, now remove what's left as they are not needed
-	for meta := range m.metricCache.Total {
+	for meta := range m.ingressRouteMetricCache.Total {
 		m.ingressRouteTotalGauge.DeleteLabelValues(meta.Namespace)
 	}
-	for meta := range m.metricCache.Invalid {
+	for meta := range m.ingressRouteMetricCache.Invalid {
 		m.ingressRouteInvalidGauge.DeleteLabelValues(meta.Namespace, meta.VHost)
 	}
-	for meta := range m.metricCache.Orphaned {
+	for meta := range m.ingressRouteMetricCache.Orphaned {
 		m.ingressRouteOrphanedGauge.DeleteLabelValues(meta.Namespace)
 	}
-	for meta := range m.metricCache.Valid {
+	for meta := range m.ingressRouteMetricCache.Valid {
 		m.ingressRouteValidGauge.DeleteLabelValues(meta.Namespace, meta.VHost)
 	}
-	for meta := range m.metricCache.Root {
+	for meta := range m.ingressRouteMetricCache.Root {
 		m.ingressRouteRootTotalGauge.DeleteLabelValues(meta.Namespace)
 	}
 
-	// copier.Copy(&m.metricCache, metrics)
-	m.metricCache = &IngressRouteMetric{
+	m.ingressRouteMetricCache = &RouteMetric{
+		Total:    metrics.Total,
+		Invalid:  metrics.Invalid,
+		Valid:    metrics.Valid,
+		Orphaned: metrics.Orphaned,
+		Root:     metrics.Root,
+	}
+}
+
+// SetHTTPProxyMetric sets metric values for a set of HTTPProxies
+func (m *Metrics) SetHTTPProxyMetric(metrics RouteMetric) {
+	// Process metrics
+	for meta, value := range metrics.Total {
+		m.proxyTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
+		delete(m.proxyMetricCache.Total, meta)
+	}
+	for meta, value := range metrics.Invalid {
+		m.proxyInvalidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
+		delete(m.proxyMetricCache.Invalid, meta)
+	}
+	for meta, value := range metrics.Orphaned {
+		m.proxyOrphanedGauge.WithLabelValues(meta.Namespace).Set(float64(value))
+		delete(m.proxyMetricCache.Orphaned, meta)
+	}
+	for meta, value := range metrics.Valid {
+		m.proxyValidGauge.WithLabelValues(meta.Namespace, meta.VHost).Set(float64(value))
+		delete(m.proxyMetricCache.Valid, meta)
+	}
+	for meta, value := range metrics.Root {
+		m.proxyRootTotalGauge.WithLabelValues(meta.Namespace).Set(float64(value))
+		delete(m.proxyMetricCache.Root, meta)
+	}
+
+	// All metrics processed, now remove what's left as they are not needed
+	for meta := range m.proxyMetricCache.Total {
+		m.proxyTotalGauge.DeleteLabelValues(meta.Namespace)
+	}
+	for meta := range m.proxyMetricCache.Invalid {
+		m.proxyInvalidGauge.DeleteLabelValues(meta.Namespace, meta.VHost)
+	}
+	for meta := range m.proxyMetricCache.Orphaned {
+		m.proxyOrphanedGauge.DeleteLabelValues(meta.Namespace)
+	}
+	for meta := range m.proxyMetricCache.Valid {
+		m.proxyValidGauge.DeleteLabelValues(meta.Namespace, meta.VHost)
+	}
+	for meta := range m.proxyMetricCache.Root {
+		m.proxyRootTotalGauge.DeleteLabelValues(meta.Namespace)
+	}
+
+	m.proxyMetricCache = &RouteMetric{
 		Total:    metrics.Total,
 		Invalid:  metrics.Invalid,
 		Valid:    metrics.Valid,


### PR DESCRIPTION
Fixes #1709 by adding `HTTPPRoxy` metrics to Contour's prometheus endpoint as well as updating the dashboard to match. 

Signed-off-by: Steve Sloka <slokas@vmware.com>