### PR TITLE
docs: Update HTTPProxy docs for TLS Cert Delegation to all namespaces

### DIFF
--- a/site/_docs_1_0/httpproxy.md
+++ b/site/_docs_1_0/httpproxy.md
@@ -297,6 +297,10 @@ Status:
 In order to support wildcard certificates, TLS certificates for a `*.somedomain.com`, which are stored in a namespace controlled by the cluster administrator, Contour supports a facility known as TLS Certificate Delegation.
 This facility allows the owner of a TLS certificate to delegate, for the purposes of referencing the TLS certificate, permission to Contour to read the Secret object from another namespace.
 
+The `TLSCertificateDelegation` resource defines a set of `delegations` in the `spec`.
+Each delegation references a `secretName` from the namespace where the `TLSCertificateDelegation` is created as well as describing a set of `targetNamespaces` in which the certificate can be referenced.
+If all namespaces should be able to reference the secret, then set `"*"` as the value of `targetNamespaces` (see example below).
+
 ```yaml
 apiVersion: projectcontour.io/v1
 kind: TLSCertificateDelegation
@@ -307,7 +311,10 @@ spec:
   delegations:
     - secretName: example-com-wildcard
       targetNamespaces:
-      - example-com
+      - example-com 
+    - secretName: another-com-wildcard
+      targetNamespaces:
+      - "*"
 ---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -326,6 +333,7 @@ spec:
 ```
 
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
+Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
 ### Conditions
 


### PR DESCRIPTION
Fixes #1645 by updating docs to show how secrets can be delegated to all namespaces.

Signed-off-by: Steve Sloka <slokas@vmware.com>