### PR TITLE
internal/contour: only write status updates if we're the leader

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -37,6 +37,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
 	coreinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/leaderelection"
 )
 
 // registerServe registers the serve subcommand and flags
@@ -242,8 +243,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// step 11. if enabled, register leader election
 	if !ctx.DisableLeaderElection {
-		log := log.WithField("context", "leaderelection")
-		le, _, deposed := newLeaderElector(log, ctx, client, coordinationClient)
+		var le *leaderelection.LeaderElector
+		var deposed chan struct{}
+		le, eh.IsLeader, deposed = newLeaderElector(log, ctx, client, coordinationClient)
 
 		g.AddContext(func(electionCtx context.Context) {
 			log.WithFields(logrus.Fields{
@@ -253,6 +255,25 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 			le.Run(electionCtx)
 			log.Info("stopped")
+		})
+
+		g.Add(func(stop <-chan struct{}) error {
+			log := log.WithField("context", "leaderelection-elected")
+			leader := eh.IsLeader
+			for {
+				select {
+				case <-stop:
+					// shut down
+					log.Info("stopped")
+					return nil
+				case <-leader:
+					log.Info("elected as leader, triggering rebuild")
+					eh.UpdateNow()
+
+					// disable this case
+					leader = nil
+				}
+			}
 		})
 
 		g.Add(func(stop <-chan struct{}) error {
@@ -269,6 +290,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		})
 	} else {
 		log.Info("Leader election disabled")
+
+		// leadership election disabled, hardwire IsLeader to be always readable.
+		leader := make(chan struct{})
+		close(leader)
+		eh.IsLeader = leader
 	}
 
 	// step 12. register our custom metrics and plumb into cache handler


### PR DESCRIPTION
Fixes #1425
Fixes #1385
Updates #499

This PR threads the leader elected signal throught to
contour.EventHandler allowing it to skip writing status back to the API
unless it is currently the leader.

This should fixes #1425 by removing the condition where several Contours
would fight to update status. This updates #499 by continuing to reduce
the number of updates that Contour generates, thereby processes.

This PR does create a condition where during startup no Contour may be
the leader and the xDS tables reach steady state before anyone is
elected. This would mean the status of an object would be stale until
the next update from the API server after leadership was established.
To address this a mechanism to force a rebuild of the dag is added to
the EventHandler and wired to election success.

Signed-off-by: Dave Cheney <dave@cheney.net>