### PR TITLE
Add TCP Keepalives for Envoy->Contour xDS comms

### DIFF
--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -49,6 +49,13 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 						SocketAddress(c.xdsAddress(), c.xdsGRPCPort()),
 					),
 				},
+				UpstreamConnectionOptions: &api.UpstreamConnectionOptions{
+					TcpKeepalive: &envoy_api_v2_core.TcpKeepalive{
+						KeepaliveProbes:   protobuf.UInt32(3),
+						KeepaliveTime:     protobuf.UInt32(30),
+						KeepaliveInterval: protobuf.UInt32(5),
+					},
+				},
 				Http2ProtocolOptions: new(envoy_api_v2_core.Http2ProtocolOptions), // enables http2
 				CircuitBreakers: &clusterv2.CircuitBreakers{
 					Thresholds: []*clusterv2.CircuitBreakers_Thresholds{{

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -73,7 +73,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {}
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
       },
       {
         "name": "service-stats",
@@ -189,7 +196,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {}
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
       },
       {
         "name": "service-stats",
@@ -304,7 +318,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {}
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
       },
       {
         "name": "service-stats",
@@ -420,7 +441,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {}
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
       },
       {
         "name": "service-stats",
@@ -534,7 +562,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {}
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
       },
       {
         "name": "service-stats",
@@ -652,6 +687,13 @@ func TestBootstrap(t *testing.T) {
           ]
         },
         "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        },
         "tls_context": {
           "common_tls_context": {
               "tls_certificates": [


### PR DESCRIPTION
Fixes #1744.

Note that this only adds this to the xDS setup in `contour bootstrap`. No other upstreams will be affected, although it sees like it's worth investigating.

Signed-off-by: Nick Young <ynick@vmware.com>