### PR TITLE
site: point to latest github release tag where possible

### DIFF
--- a/site/_docs_1_0/ingressroute.md
+++ b/site/_docs_1_0/ingressroute.md
@@ -131,7 +131,7 @@ ingressroute "basic" deleted
 
 ## IngressRoute API Specification
 
-There are a number of [working examples](https://github.com/projectcontour/contour/tree/master/examples/example-workload/ingressroute) of IngressRoute objects in the `examples/example-workload` directory.
+There are a number of [working examples](https://github.com/projectcontour/contour/blob/{{ site.github.latest_release.tag_name }}/examples/example-workload/ingressroute) of IngressRoute objects in the `examples/example-workload` directory.
 We will use these examples as a mechanism to describe IngressRoute API functionality.
 
 ### Virtual Host Configuration

--- a/site/_guides/deploy-aws-nlb.md
+++ b/site/_guides/deploy-aws-nlb.md
@@ -41,4 +41,4 @@ You can now test your NLB.
 [1]: https://aws.amazon.com/blogs/aws/new-network-load-balancer-effortless-scaling-to-millions-of-requests-per-second/
 [2]: {% link _guides/deploy-options.md %}#testing-your-installation
 [3]: https://github.com/kubernetes/kubernetes/issues/52173
-[4]: {{ site.github.repository_url }}/tree/master/CONTRIBUTING.md
+[4]: {{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/CONTRIBUTING.md

--- a/site/_guides/deploy-options.md
+++ b/site/_guides/deploy-options.md
@@ -13,7 +13,7 @@ If you don't have a cluster with that capability see the [Running without a Kube
 ### Recommended installation details
 
 The recommended installation of Contour is Contour running in a Deployment and Envoy in a Daemonset with TLS securing the gRPC communication between them.
-The [`contour` example]({{site.github.repository_url}}/tree/master/examples/contour/README.md) will install this for you.
+The [`contour` example]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/README.md) will install this for you.
 A Service of `type: LoadBalancer` is also set up to forward traffic to the Envoy instances.
 
 If you wish to use Host Networking, please see the [appropriate section](#host-networking) for the details.
@@ -113,7 +113,7 @@ In your browser, navigate your browser to the IP or DNS address of the Contour S
 
 ### Test with IngressRoute
 
-To test your Contour deployment with [IngressRoutes]({{site.github.repository_url}}/tree/master/docs/ingressroute.md), run the following command:
+To test your Contour deployment with [IngressRoutes]({% link _docs_1_0/ingressroute.md %}), run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-ingressroute.yaml
@@ -149,7 +149,7 @@ $ curl -H 'Host: kuard.local' ${CONTOUR_IP}
 ```
 ### Test with HTTPProxy
 
-To test your Contour deployment with [HTTPProxy]({{site.github.repository_url}}/tree/master/docs/httpproxy.md), run the following command:
+To test your Contour deployment with [HTTPProxy]({% link _docs_1_0/httpproxy.md %}), run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-httpproxy.yaml
@@ -192,7 +192,7 @@ If you can't or don't want to use a Service of `type: LoadBalancer` there are ot
 
 If your cluster doesn't have the capability to configure a Kubernetes LoadBalancer,
 or if you want to configure the load balancer outside Kubernetes,
-you can change the Envoy Service in the [`02-service-envoy.yaml`]({{site.github.repository_url}}/tree/master/examples/contour/02-service-envoy.yaml) file and set `type` to `NodePort`.
+you can change the Envoy Service in the [`02-service-envoy.yaml`]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/02-service-envoy.yaml) file and set `type` to `NodePort`.
 
 This will have every node in your cluster listen on the resultant port and forward traffic to Contour.
 That port can be discovered by taking the second number listed in the `PORT` column when listing the service, for example `30274` in `80:30274/TCP`.

--- a/site/_guides/grpc-tls-howto.md
+++ b/site/_guides/grpc-tls-howto.md
@@ -14,7 +14,7 @@ The outcome of this is that we will have three Secrets available in the `project
 
 ### Ways you can get the certificates into your cluster
 
-- Deploy the Job from [certgen.yaml]({{ site.github.repository_url }}/tree/master/examples/contour/02-job-certgen.yaml).
+- Deploy the Job from [certgen.yaml]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/02-job-certgen.yaml).
 This will run `contour certgen --kube` for you.
 - Run `contour certgen --kube` locally.
 - Run the manual procedure below.
@@ -48,7 +48,7 @@ Then, we need to generate a keypair for Contour. First, we make a new private ke
 $ openssl genrsa -out certs/contourkey.pem 2048
 ```
 
-Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext]({{ site.github.repository_url }}/tree/master/_integration/cert-contour.ext), which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
+Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/_integration/cert-contour.ext), which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
 
 ```
 $ openssl req -new -key certs/contourkey.pem \
@@ -90,7 +90,7 @@ $ openssl x509 -req -in certs/envoy.csr \
     -extfile _integration/cert-envoy.ext
 ```
 
-Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext]({{ site.github.repository_url }}/tree/master/_integration/cert-envoy.ext). However, in this case, there are no special names required.
+Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/_integration/cert-envoy.ext). However, in this case, there are no special names required.
 
 ### Putting the certs in the cluster
 
@@ -112,4 +112,4 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 # Conclusion
 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
-[examples/contour]({{site.github.repository_url}}/tree/master/examples/contour).
+[examples/contour]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour).

--- a/site/_guides/proxy-proto.md
+++ b/site/_guides/proxy-proto.md
@@ -41,7 +41,7 @@ spec:
 ...
 spec:
   containers:
-  - image: docker.io/projectcontour/contour:master
+  - image: docker.io/projectcontour/contour:{{ site.github.latest_release.tag_name }}
     imagePullPolicy: Always
     name: contour
     command: ["contour"]

--- a/site/_guides/structured-logs.md
+++ b/site/_guides/structured-logs.md
@@ -27,7 +27,7 @@ To customize the logged fields, add a `json-fields` list of strings to your conf
 These strings must be options from the [list of default fields](https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields).
 Field names not in that list will be silently dropped. (This is not ideal, watch [#1507](https://github.com/projectcontour/contour/issues/1507) for updates.)
 
-The [example config file]({{site.github.repository_url}}/tree/master/examples/contour/01-contour-config.yaml) contains the full list of fields as well.
+The [example config file]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/01-contour-config.yaml) contains the full list of fields as well.
 
 ## Sample configuration file
 

--- a/site/_resources/support.md
+++ b/site/_resources/support.md
@@ -9,6 +9,7 @@ This document describes which versions of Contour are supported by the Contour t
 
 Only the latest stable release is supported.
 The latest stable release is identified by the [Docker tag `:latest`]({% link _resources/tagging.md %}).
+`:latest` is an alias for {{ site.github.latest_release.tag_name }} which is the current stable release.
 
 When required we may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
 At that point the patch release will become the :latest stable release.

--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -184,7 +184,7 @@ If you are still running a single pod install type, please review the [`contour`
 ### Verify leader election
 
 Contour 1.0.0 enables leader election by default.
-No additional configuration is required if you are using the [example deployment](../examples/contour/README.md).
+No specific configuration is required if you are using the [example deployment]({{ site.github.repository_url }}/blob/v1.0.0-beta.1/examples/contour/README.md).
 
 Leader election requires that Contour have write access to a ConfigMap
 called `leader-elect` in the project-contour namespace.


### PR DESCRIPTION
Fixes #1619

For 1.0 the plan of record is to keep the examples on GitHub. This is
due to the difficulty in doing directory index style static resources
from projectcontour.io.

To support this weave the name of the current github release through the
website.

Note that at the present, in the rc.2 timeframe, this will break a lot
of links so this PR is targeted for 1.0 (or shortly after) which will
bring the guides, resources, and release documentation in line with the
latest released tag on GitHub.

Signed-off-by: Dave Cheney <dave@cheney.net>