### PR TITLE
internal/envoy: default the cluster connection buffer to 32K

### DIFF
--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -33,25 +33,71 @@ import (
 // CACertificateKey stores the key for the TLS validation secret cert
 const CACertificateKey = "ca.crt"
 
+// DefaultCluster returns an anonymous Cluster struct with default
+// configuration settings.
+func DefaultCluster() *v2.Cluster {
+	return &v2.Cluster{
+		ConnectTimeout:                protobuf.Duration(250 * time.Millisecond),
+		PerConnectionBufferLimitBytes: protobuf.UInt32(32768), // 32KiB
+		CommonLbConfig:                ClusterCommonLBConfig(),
+		LbPolicy:                      lbPolicy(""),
+	}
+}
+
 // Cluster creates new v2.Cluster from dag.Cluster.
 func Cluster(c *dag.Cluster) *v2.Cluster {
-	cl := cluster(c)
+	service := c.Upstream
+	cluster := DefaultCluster()
+
+	cluster.Name = Clustername(c)
+	cluster.AltStatName = altStatName(service)
+	cluster.LbPolicy = lbPolicy(c.LoadBalancerPolicy)
+	cluster.HealthChecks = edshealthcheck(c)
+
+	switch len(service.ExternalName) {
+	case 0:
+		// external name not set, cluster will be discovered via EDS
+		cluster.ClusterDiscoveryType = ClusterDiscoveryType(v2.Cluster_EDS)
+		cluster.EdsClusterConfig = edsconfig("contour", service)
+	default:
+		// external name set, use hard coded DNS name
+		cluster.ClusterDiscoveryType = ClusterDiscoveryType(v2.Cluster_STRICT_DNS)
+		cluster.LoadAssignment = StaticClusterLoadAssignment(service)
+	}
+
+	// Drain connections immediately if using healthchecks and the endpoint is known to be removed
+	if c.HealthCheckPolicy != nil {
+		cluster.DrainConnectionsOnHostRemoval = true
+	}
+
+	if anyPositive(service.MaxConnections, service.MaxPendingRequests, service.MaxRequests, service.MaxRetries) {
+		cluster.CircuitBreakers = &envoy_cluster.CircuitBreakers{
+			Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
+				MaxConnections:     u32nil(service.MaxConnections),
+				MaxPendingRequests: u32nil(service.MaxPendingRequests),
+				MaxRequests:        u32nil(service.MaxRequests),
+				MaxRetries:         u32nil(service.MaxRetries),
+			}},
+		}
+	}
+
 	switch c.Upstream.Protocol {
 	case "tls":
-		cl.TlsContext = UpstreamTLSContext(
+		cluster.TlsContext = UpstreamTLSContext(
 			upstreamValidationCACert(c),
 			upstreamValidationSubjectAltName(c),
 		)
 	case "h2":
-		cl.TlsContext = UpstreamTLSContext(
+		cluster.TlsContext = UpstreamTLSContext(
 			upstreamValidationCACert(c),
 			upstreamValidationSubjectAltName(c),
 			"h2")
 		fallthrough
 	case "h2c":
-		cl.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}
+		cluster.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}
 	}
-	return cl
+
+	return cluster
 }
 
 func upstreamValidationCACert(c *dag.Cluster) []byte {
@@ -68,46 +114,6 @@ func upstreamValidationSubjectAltName(c *dag.Cluster) string {
 		return ""
 	}
 	return c.UpstreamValidation.SubjectName
-}
-
-func cluster(cluster *dag.Cluster) *v2.Cluster {
-	service := cluster.Upstream
-	c := &v2.Cluster{
-		Name:           Clustername(cluster),
-		AltStatName:    altStatName(service),
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		LbPolicy:       lbPolicy(cluster.LoadBalancerPolicy),
-		CommonLbConfig: ClusterCommonLBConfig(),
-		HealthChecks:   edshealthcheck(cluster),
-	}
-
-	switch len(service.ExternalName) {
-	case 0:
-		// external name not set, cluster will be discovered via EDS
-		c.ClusterDiscoveryType = ClusterDiscoveryType(v2.Cluster_EDS)
-		c.EdsClusterConfig = edsconfig("contour", service)
-	default:
-		// external name set, use hard coded DNS name
-		c.ClusterDiscoveryType = ClusterDiscoveryType(v2.Cluster_STRICT_DNS)
-		c.LoadAssignment = StaticClusterLoadAssignment(service)
-	}
-
-	// Drain connections immediately if using healthchecks and the endpoint is known to be removed
-	if cluster.HealthCheckPolicy != nil {
-		c.DrainConnectionsOnHostRemoval = true
-	}
-
-	if anyPositive(service.MaxConnections, service.MaxPendingRequests, service.MaxRequests, service.MaxRetries) {
-		c.CircuitBreakers = &envoy_cluster.CircuitBreakers{
-			Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
-				MaxConnections:     u32nil(service.MaxConnections),
-				MaxPendingRequests: u32nil(service.MaxPendingRequests),
-				MaxRequests:        u32nil(service.MaxRequests),
-				MaxRetries:         u32nil(service.MaxRetries),
-			}},
-		}
-	}
-	return c
 }
 
 // StaticClusterLoadAssignment creates a *v2.ClusterLoadAssignment pointing to the external DNS address of the service

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -23,6 +23,7 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -40,18 +41,21 @@ func routeCluster(cluster string) *envoy_api_v2_route.Route_Route {
 }
 
 func cluster(name, servicename, statName string) *v2.Cluster {
-	return &v2.Cluster{
-		Name:                 name,
-		ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
-		AltStatName:          statName,
-		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-			EdsConfig:   envoy.ConfigSource("contour"),
-			ServiceName: servicename,
-		},
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		LbPolicy:       v2.Cluster_ROUND_ROBIN,
-		CommonLbConfig: envoy.ClusterCommonLBConfig(),
-	}
+	c := envoy.DefaultCluster()
+
+	proto.Merge(c,
+		&v2.Cluster{
+			Name:                 name,
+			ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
+			AltStatName:          statName,
+			EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
+				EdsConfig:   envoy.ConfigSource("contour"),
+				ServiceName: servicename,
+			},
+			LbPolicy: v2.Cluster_ROUND_ROBIN,
+		})
+
+	return c
 }
 
 func tlsCluster(c *v2.Cluster, ca []byte, subjectName string, alpnProtocols ...string) *v2.Cluster {


### PR DESCRIPTION
Introduce a `DefaultCluster()` convenience API that returns a Envoy
`v2.Cluster` struct that has only the Contour internal default
fields initialized. This gives us a single place where clusters get
default settings.

Add the 32K default for `per_connection_buffer_limit_bytes`.

Update all the tests to merge their Cluster spec into the default
Cluster struct. This makes the tests insensitive to changes in the
envoy Cluster defaults.

This fixes #1407.

Signed-off-by: James Peach <jpeach@vmware.com>