### PR TITLE
doc: add line numbers to CRD references

### DIFF
--- a/site/_docs_1_0/httpproxy.md
+++ b/site/_docs_1_0/httpproxy.md
@@ -39,7 +39,7 @@ spec:
 This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.
 Implementing similar behavior using an HTTPProxy looks like this:
 
-```yaml
+{% highlight yaml linenos %}
 # httpproxy.yaml
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
@@ -54,16 +54,16 @@ spec:
       services:
         - name: s1
           port: 80
-```
+{% endhighlight %}
 
-**Lines 1-4**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
 
-**Line 6-7**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
+**Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
 
-**Lines 8-9**: Each HTTPProxy **must** have one or more routes, each of which **must** have one or more services which will handle the HTTP traffic. In addition, each route **may** have one or more conditions to match against.
+**Lines 9-14**: Each HTTPProxy **must** have one or more routes, each of which **must** have one or more services which will handle the HTTP traffic. In addition, each route **may** have one or more conditions to match against.
 
-**Lines 10-12**: The `services` field is an array of named Service & Port combinations that will be used for this HTTPProxy path.
+**Lines 12-14**: The `services` field is an array of named Service & Port combinations that will be used for this HTTPProxy path.
 HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
 
 ## Interacting with HTTPProxies

--- a/site/_docs_1_0/ingressroute.md
+++ b/site/_docs_1_0/ingressroute.md
@@ -49,7 +49,7 @@ spec:
 This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.
 Implementing similar behavior using an IngressRoute looks like this:
 
-```yaml
+{% highlight yaml linenos %}
 # ingressroute.yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
@@ -63,16 +63,16 @@ spec:
       services:
         - name: s1
           port: 80
-```
+{% endhighlight %}
 
-**Lines 1-4**: As with all other Kubernetes objects, an IngressRoute needs apiVersion, kind, and metadata fields. Note that the IngressRoute API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an IngressRoute needs apiVersion, kind, and metadata fields. Note that the IngressRoute API is currently considered beta.
 
-**Line 6-7**: The presence of the `virtualhost` field indicates that this is a root IngressRoute that is the top level entry point for this domain.
+**Line 7-8**: The presence of the `virtualhost` field indicates that this is a root IngressRoute that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
 
-**Lines 8-9**: IngressRoutes must have one or more `routes`, each of which must have a path to match against (e.g. `/blog`) and then one or more `services` which will handle the HTTP traffic.
+**Lines 9-13**: IngressRoutes must have one or more `routes`, each of which must have a path to match against (e.g. `/blog`) and then one or more `services` which will handle the HTTP traffic.
 
-**Lines 10-12**: The `services` field is an array of named Service & Port combinations that will be used for this IngressRoute path.
+**Lines 11-13**: The `services` field is an array of named Service & Port combinations that will be used for this IngressRoute path.
 Ingress HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
 
 ## Interacting with IngressRoutes


### PR DESCRIPTION
Add automatic line numbering to the HTTPProxy and IngressRoute
reference documention. This makes is easier for the reader to
follow the description of the YAML fields.

See also https://jekyllrb.com/docs/liquid/tags/#line-numbers

Signed-off-by: James Peach <jpeach@vmware.com>