### PR TITLE
Implement wildcard path prefix for HTTPProxy conditions

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -1927,6 +1927,22 @@ func TestSortLongestRouteFirst(t *testing.T) {
 				Match: envoy.RoutePrefix("/"),
 			}},
 		},
+		"prefix sorts before regex wildcard": {
+			routes: []*envoy_api_v2_route.Route{{
+				Match: envoy.RouteRegex("/api/[0-9a-zA-Z-]*/secure.*"),
+			}, {
+				Match: envoy.RoutePrefix("/api/something/secure"),
+			}, {
+				Match: envoy.RoutePrefix("/"),
+			}},
+			want: []*envoy_api_v2_route.Route{{
+				Match: envoy.RoutePrefix("/api/something/secure"),
+			}, {
+				Match: envoy.RouteRegex("/api/[0-9a-zA-Z-]*/secure.*"),
+			}, {
+				Match: envoy.RoutePrefix("/"),
+			}},
+		},
 		"more headers sort before less": {
 			routes: []*envoy_api_v2_route.Route{{
 				Match: envoy.RoutePrefix("/"),

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -74,11 +74,11 @@ func pathConditionsValid(sw *ObjectStatusWriter, conds []projcontour.Condition, 
 				}
 			case "route":
 				if strings.HasSuffix(cond.Prefix, "*") {
-					sw.SetInvalid(fmt.Sprintf("Cannot specify trailing wilcard character, '%s' was supplied", cond.Prefix))
+					sw.SetInvalid(fmt.Sprintf("Cannot specify trailing wildcard character, '%s' was supplied", cond.Prefix))
 					return false
 				}
 				if strings.HasPrefix(cond.Prefix, "/*") {
-					sw.SetInvalid(fmt.Sprintf("Cannot specify '/*' as leading wilcard character pattern, '%s' was supplied", cond.Prefix))
+					sw.SetInvalid(fmt.Sprintf("Cannot specify '/*' as leading wildcard character pattern, '%s' was supplied", cond.Prefix))
 					return false
 				}
 				if strings.Contains(cond.Prefix, "**") {

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -83,6 +83,48 @@ func TestPathCondition(t *testing.T) {
 			}},
 			want: &PrefixCondition{Prefix: "/"},
 		},
+		"wildcard condition": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/foo/*/bar",
+			}},
+			want: &WildcardPrefixCondition{Prefix: "/foo/*/bar"},
+		},
+		"wildcard condition with multiple wildcards": {
+			conditions: []projcontour.Condition{{
+				Prefix: "/foo/*/bar/*/zed",
+			}},
+			want: &WildcardPrefixCondition{Prefix: "/foo/*/bar/*/zed"},
+		},
+		"wildcard condition with prefix conditions": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "/api",
+				},
+				{
+					Prefix: "/foo/*/bar",
+				},
+			},
+			want: &WildcardPrefixCondition{Prefix: "/api/foo/*/bar"},
+		},
+		"wildcard trailing slash": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "/foo/*/bar/",
+				},
+			},
+			want: &WildcardPrefixCondition{Prefix: "/foo/*/bar/"},
+		},
+		"wildcard trailing slash on second prefix condition": {
+			conditions: []projcontour.Condition{
+				{
+					Prefix: "/api",
+				},
+				{
+					Prefix: "/foo/*/bar/",
+				},
+			},
+			want: &WildcardPrefixCondition{Prefix: "/api/foo/*/bar/"},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -81,6 +81,14 @@ func (hc *HeaderCondition) String() string {
 	return "header: " + hc.Name
 }
 
+type WildcardPrefixCondition struct {
+	Prefix string
+}
+
+func (pc *WildcardPrefixCondition) String() string {
+	return "wildcard path: " + pc.Prefix
+}
+
 // Route defines the properties of a route to a Cluster.
 type Route struct {
 

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -80,7 +80,7 @@ func sanitizeRegex(prefix string) string {
 	prefix = strings.ReplaceAll(regexp.QuoteMeta(prefix), "\\*", "*")
 
 	// Replace all "*" with the match-all regex
-	return fmt.Sprintf("%s.*", strings.ReplaceAll(prefix, "*", "[0-9a-zA-Z-]*"))
+	return fmt.Sprintf("%s.*", strings.ReplaceAll(prefix, "*", "[0-9a-zA-Z-]+"))
 }
 
 // RoutePrefix returns a prefix matcher.


### PR DESCRIPTION
Fixes #1457 
Fixes #1179 

Adds wildcard path prefix support for HTTPProxy

Signed-off-by: Steve Sloka <slokas@vmare.com>