### PR TITLE
site: use {% link in top nav

### DIFF
--- a/site/_includes/site-header.html
+++ b/site/_includes/site-header.html
@@ -4,12 +4,12 @@
             <a href="/" alt="Homepage"><img src="/img/{{ site.logo }}" class="logo" /></a>
         </div>
         <ul class="nav-menu" id="header-nav">
-            <li class="getting-started"><a href="/getting-started" title="Getting Started">Getting Started<a></li>
-            <li class="guides"><a href="/guides" title="Guides">Guides</a></li>
-            <li class="community"><a href="/community" title="Community">Community</a></li>
-            <li class="docs"><a href="/docs/" title="Documentation">Documentation</a></li>
-            <li class="resources"><a href="/resources" title="Resources">Resources</a></li>
-            <li class="blog"><a href="/blog" title="Blog Posts">Blog</a></li>
+		<li><a href="{% link getting-started.md %}" title="Getting Started">Getting Started<a></li>
+		<li><a href="{% link guides.md %}" title="Guides">Guides</a></li>
+		<li><a href="{% link community.md %}" title="Community">Community</a></li>
+		<li><a href="{% link docs.md %}" title="Documentation">Documentation</a></li>
+		<li><a href="{% link resources.md %}" title="Resources">Resources</a></li>
+		<li><a href="{% link blog.html %}" title="Blog Posts">Blog</a></li>
         </ul>
         <div class="nav-mobile-link">
             <a href="javascript:void(0);" id="nav-mobile-toggle"></a>


### PR DESCRIPTION
Use {% link consistently throughout the top navigation. This will
prevent the site from building if we remove/rename one of those pages
and has the added benefit that {% link generates the correct link rather
than bouncing through a 301 redirect to append a / to the url.

Lastly, remove the unused class tags on the li element.

Signed-off-by: Dave Cheney <dave@cheney.net>