### PR TITLE
doc: move HTTPProxy migration docs to the guides

### DIFF
--- a/site/_docs_1_0/ingressroute.md
+++ b/site/_docs_1_0/ingressroute.md
@@ -7,7 +7,7 @@ layout: page
 
 `IngressRoute` has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for [`HTTPProxy`](./httpproxy.md) the successor to `IngressRoute`.
-You can also read the [IngressRoute to HTTPProxy upgrade guide](./ingressroute-to-httpproxy.md).
+You can also read the [IngressRoute to HTTPProxy upgrade guide]({% link _guides/ingressroute-to-httpproxy.md %}).
 
 </hr>
 

--- a/site/_guides/ingressroute-to-httpproxy.md
+++ b/site/_guides/ingressroute-to-httpproxy.md
@@ -1,5 +1,5 @@
 ---
-title: IngressRoute to HTTPProxy
+title: Migrating from IngressRoute to HTTPProxy
 layout: page
 ---
 
@@ -16,6 +16,7 @@ For Contour 1.0.0-rc.1 the version is `v1`.
 We expect this to change in forthcoming release candidates.
 
 Before:
+
 ```yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
@@ -45,6 +46,7 @@ spec:
     tls:
       secretName: tlssecret
 ```
+
 After:
 
 ```yaml
@@ -161,6 +163,7 @@ spec:
         - name: s2
           port: 80
 ```
+
 After:
 
 ```yaml
@@ -216,6 +219,7 @@ spec:
     - name: s1
       port: 80
 ```
+
 After:
 
 ```yaml
@@ -269,6 +273,7 @@ spec:
           port: 80
           strategy: WeightedLeastRequest
 ```
+
 After:
 
 ```yaml
@@ -323,6 +328,7 @@ spec:
         - name: s2-health  # no health-check defined for this service
           port: 80
 ```
+
 After:
 
 ```yaml
@@ -410,6 +416,7 @@ spec:
         - name: blog
           port: 80
 ```
+
 After:
 
 ```yaml

--- a/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
+++ b/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
@@ -44,7 +44,7 @@ The intent of making this change now is to prepare HTTPProxy as a stable CRD for
 With this goal in mind the IngressRoute CRD, having never made it out of beta, should be considered deprecated.
 Contour will continue to support the IngressRoute CRD up to the 1.0 release of Contour in November, however no further enhancements or bug fixes will be made over this period unless absolutely necessary.
 The plan at this stage is to remove support for the IngressRoute CRD after Contour 1.0 ships.
-We've [written a guide](https://github.com/projectcontour/contour/blob/v1.0.0-beta.1/docs/ingressroute-to-httpproxy.md) to help you transition your IngressRoute objects to HTTPProxy.
+We've [written a guide]({% link _guides/ingressroute-to-httpproxy.md %}) to help you transition your IngressRoute objects to HTTPProxy.
 
 The next blog post in this series will delve into how to use inclusion and conditions.
 Stay tuned for that. 


### PR DESCRIPTION
This updates #1750.

Signed-off-by: James Peach <jpeach@vmware.com>