### PR TITLE
docs: condense heptio annotation documentation

### DIFF
--- a/site/_docs_1_0/annotations.md
+++ b/site/_docs_1_0/annotations.md
@@ -28,18 +28,18 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
 ## Contour specific Ingress annotations
 
  - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
- - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
- - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout), specified as a [golang duration](https://golang.org/pkg/time/#ParseDuration). By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
- - `contour.heptio.com/request-timeout`: deprecated form of `projectcontour.io/response-timeout`. _note_ this is **response-timeout**.
- - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on). See also [possible values and their meanings for `retry-on`](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on).
- - `contour.heptio.com/retry-on`:  deprecated form of `projectcontour.io/retry-on`.
  - `projectcontour.io/num-retries`: [The maximum number of retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries) Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
- - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
  - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on), if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
- - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
+ - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout), specified as a [golang duration](https://golang.org/pkg/time/#ParseDuration). By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
+ - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on). See also [possible values and their meanings for `retry-on`](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on).
  - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters) the TLS listener should support.
- - `contour.heptio.com/tls-minimum-protocol-version`: deprecated form of `projectcontour.io/tls-minimum-protocol-version`.
  - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket), the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`. The IngressRoute API has [first-class support for websockets](ingressroute.md#websocket-support).
+ - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
+ - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
+ - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
+ - `contour.heptio.com/request-timeout`: deprecated form of `projectcontour.io/response-timeout`. _Note_ this is **response-timeout**.
+ - `contour.heptio.com/retry-on`:  deprecated form of `projectcontour.io/retry-on`.
+ - `contour.heptio.com/tls-minimum-protocol-version`: deprecated form of `projectcontour.io/tls-minimum-protocol-version`.
  - `contour.heptio.com/websocket-routes`: deprecated form of `projectcontour.io/websocket-routes`.
 
 ## Contour specific Service annotations
@@ -47,16 +47,16 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
 A [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/) maps to an [Envoy Cluster](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html). Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
 
 - `projectcontour.io/max-connections`: [The maximum number of connections](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
 - `projectcontour.io/max-pending-requests`: [The maximum number of pending requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `contour.heptio.com/max-pending-requests`: deprecated form of `projectcontour.io/max-pending-requests`.
 - `projectcontour.io/max-requests`: [The maximum parallel requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests) a single Envoy instance allows to the Kubernetes Service; defaults to 1024
-- `contour.heptio.com/max-requests`: deprecated form of `projectcontour.io/max-requests`.
 - `projectcontour.io/max-retries`: [The maximum number of parallel retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries) a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
-- `contour.heptio.com/max-retries`: deprecated form of `projectcontour.io/max-retries`.
 - `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
-- `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
   - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
+- `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
+- `contour.heptio.com/max-pending-requests`: deprecated form of `projectcontour.io/max-pending-requests`.
+- `contour.heptio.com/max-requests`: deprecated form of `projectcontour.io/max-requests`.
+- `contour.heptio.com/max-retries`: deprecated form of `projectcontour.io/max-retries`.
+- `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
 
 ## Contour specific IngressRoute annotations
 


### PR DESCRIPTION
Move the heptio annotation references to the end of the list so
that the reader doesn't have to work through a lot of clutter
of deprecated annotations.

Signed-off-by: James Peach <jpeach@vmware.com>