### PR TITLE
Set cluster per-connection-buffer-limit to 32KiB

### DIFF
--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -850,9 +850,10 @@ func serviceWithAnnotations(ns, name string, annotations map[string]string, port
 func cluster(c *v2.Cluster) *v2.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &v2.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		CommonLbConfig: envoy.ClusterCommonLBConfig(),
-		LbPolicy:       v2.Cluster_ROUND_ROBIN,
+		ConnectTimeout:                protobuf.Duration(250 * time.Millisecond),
+		CommonLbConfig:                envoy.ClusterCommonLBConfig(),
+		LbPolicy:                      v2.Cluster_ROUND_ROBIN,
+		PerConnectionBufferLimitBytes: protobuf.UInt32(32768), // 32KiB per connection. Soft limit.
 	}
 
 	proto.Merge(defaults, c)

--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -991,9 +991,10 @@ func streamCDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryRes
 
 func cluster(name, servicename, statName string) *v2.Cluster {
 	return featuretests.DefaultCluster(&v2.Cluster{
-		Name:                 name,
-		ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
-		AltStatName:          statName,
+		Name:                          name,
+		ClusterDiscoveryType:          envoy.ClusterDiscoveryType(v2.Cluster_EDS),
+		AltStatName:                   statName,
+		PerConnectionBufferLimitBytes: protobuf.UInt32(32768), // 32KiB per connection. Soft limit.
 		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
 			EdsConfig:   envoy.ConfigSource("contour"),
 			ServiceName: servicename,

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -35,9 +35,10 @@ const CACertificateKey = "ca.crt"
 
 func clusterDefaults() *v2.Cluster {
 	return &v2.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		CommonLbConfig: ClusterCommonLBConfig(),
-		LbPolicy:       lbPolicy(""),
+		ConnectTimeout:                protobuf.Duration(250 * time.Millisecond),
+		CommonLbConfig:                ClusterCommonLBConfig(),
+		LbPolicy:                      lbPolicy(""),
+		PerConnectionBufferLimitBytes: protobuf.UInt32(32768), // 32KiB per connection. Soft limit.
 	}
 }
 

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -37,9 +37,10 @@ import (
 func DefaultCluster(c *v2.Cluster) *v2.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &v2.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		LbPolicy:       v2.Cluster_ROUND_ROBIN,
-		CommonLbConfig: envoy.ClusterCommonLBConfig(),
+		ConnectTimeout:                protobuf.Duration(250 * time.Millisecond),
+		LbPolicy:                      v2.Cluster_ROUND_ROBIN,
+		CommonLbConfig:                envoy.ClusterCommonLBConfig(),
+		PerConnectionBufferLimitBytes: protobuf.UInt32(32768), // 32KiB per connection. Soft limit.
 	}
 
 	proto.Merge(defaults, c)


### PR DESCRIPTION
Fixes #1408

Shoutout to @jpeach for the cluster default helper, very nice.

Signed-off-by: Nick Young <ynick@vmware.com>