### PR TITLE
Cleanup travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/heptio/contour
+
 go:
   - 1.13.x
 


### PR DESCRIPTION
Removed needed line go-import from travis-ci configuration file.

Signed-off-by: Brett Johnson <brett@sdbrett.com>