### PR TITLE
site: add README to direct users to the master branch

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,5 @@
+# site
+
+This directory contains the Jekyll source for [projectcontour.io](https://projectcontour.io/).
+
+The site is deployed directly from the [`master`](https://github.com/projectcontour/contour/tree/master/site) branch, copies of the site's source in older tags and branches are non-canonical.


### PR DESCRIPTION
Add a short README to direct users to the master branch for the
canonical source of the site.

Signed-off-by: Dave Cheney <dave@cheney.net>