### PR TITLE
contour/serve: fix Endpoints event handling

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -205,7 +205,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		FieldLogger: log.WithField("context", "endpointstranslator"),
 	}
 
-	informers = registerEventHandler(informers, coreInformers.Core().V1().Endpoints().Informer(), eh)
+	informers = registerEventHandler(informers, coreInformers.Core().V1().Endpoints().Informer(), et)
 
 	// step 6. setup workgroup runner and register informers.
 	var g workgroup.Group


### PR DESCRIPTION
Fix a regression where the Endpoints informer was getting the wrong
event handler.

Signed-off-by: James Peach <jpeach@vmware.com>