### PR TITLE
docs: update metrics documentation

### DIFF
--- a/hack/generate-metrics-doc.go
+++ b/hack/generate-metrics-doc.go
@@ -1,0 +1,81 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/projectcontour/contour/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Collect all the label names for this metric and return them as
+// a comma-deparated string.
+func labels(mf *dto.MetricFamily) string {
+	var l []string
+
+	for _, m := range mf.GetMetric() {
+		for _, pair := range m.GetLabel() {
+			l = append(l, pair.GetName())
+		}
+	}
+
+	return strings.Join(l, ", ")
+}
+
+// Generate a string name for the metric type, linking to the
+// Prometheus docs if we know there is a suitable target.
+func typeof(mf *dto.MetricFamily) string {
+	switch t := mf.GetType(); t {
+	case dto.MetricType_COUNTER, dto.MetricType_GAUGE,
+		dto.MetricType_SUMMARY, dto.MetricType_HISTOGRAM:
+		return fmt.Sprintf(
+			"[%s](https://prometheus.io/docs/concepts/metric_types/#%s)",
+			t.String(), strings.ToLower(t.String()))
+	default:
+		return t.String()
+	}
+}
+
+func main() {
+	registry := prometheus.NewRegistry()
+	m := metrics.NewMetrics(registry)
+
+	m.Zero()
+
+	family, err := registry.Gather()
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	for _, mf := range family {
+		f, err := os.OpenFile(fmt.Sprintf("%s.md", mf.GetName()), os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			log.Fatalf("%s", err)
+		}
+
+		fmt.Fprintf(f, "---\n")
+		fmt.Fprintf(f, "name: '%s'\n", mf.GetName())
+		fmt.Fprintf(f, "type: '%s'\n", typeof(mf))
+		fmt.Fprintf(f, "labels: '%s'\n", labels(mf))
+		fmt.Fprintf(f, "---\n")
+		fmt.Fprintf(f, "\n%s\n", mf.GetHelp())
+
+		f.Close()
+	}
+}

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -59,6 +59,8 @@ collections:
     output: false
   casestudies:
     output: false
+  metrics:
+    output: false
 
 # Build settings
 permalink: :title/

--- a/site/_guides/prometheus.md
+++ b/site/_guides/prometheus.md
@@ -1,7 +1,9 @@
 ---
-title: Prometheus
+title: Collecting Metrics with Prometheus
 layout: page
 ---
+
+<div id="toc"></div>
 
 Contour and Envoy expose metrics that can be scraped with Prometheus. By
 default, annotations to gather them are in all the `deployment` yamls and they
@@ -22,19 +24,7 @@ port `8002`.
 Contour exposes a Prometheus-compatible `/metrics` endpoint on port `8000` with
 the following metrics:
 
-- **contour_ingressroute_total (gauge):** Total number of IngressRoutes objects that exist regardless of status (i.e. Valid / Invalid / Orphaned, etc). This metric should match the sum of `Orphaned` + `Valid` + `Invalid` IngressRoutes.
-  - namespace
-- **contour_ingressroute_orphaned_total (gauge):**  Number of `Orphaned` IngressRoute objects which have no root delegating to them
-  - namespace
-- **contour_ingressroute_root_total (gauge):**  Number of `Root` IngressRoute objects (Note: There will only be a single `Root` IngressRoute per vhost)
-  - namespace
-- **contour_ingressroute_valid_total (gauge):**  Number of `Valid` IngressRoute objects
-  - namespace
-  - vhost
-- **contour_ingressroute_invalid_total (gauge):**  Number of `Invalid` IngressRoute objects
-  - namespace
-  - vhost
-- **contour_ingressroute_dagrebuild_timestamp (gauge):** Timestamp of the last DAG rebuild
+{% include metrics.html %}
 
 ## Sample Deployment
 

--- a/site/_includes/metrics.html
+++ b/site/_includes/metrics.html
@@ -1,0 +1,21 @@
+<table class="table table-sm">
+{% for m in site.metrics %}
+<tr>
+    <td class="font-weight-bold table-active">Name</td>
+    <td class="font-weight-bold table-active">{{ m.name }}</td>
+</tr>
+<tr>
+    <td class="font-weight-bold table-active">Type</td>
+    <!-- Strip the <p> that the redcarpet markdown processor wraps around everything. -->
+    <td>{{ m.type | markdownify | remove: "<p>" | remove: "</p>" }}</td>
+</tr>
+<tr>
+    <td class="font-weight-bold table-active">Labels</td>
+    <td>{{ m.labels | markdownify | remove: "<p>" | remove: "</p>" }}</td>
+</tr>
+<tr>
+    <td class="font-weight-bold table-active">Description</td>
+    <td>{{ m.content | markdownify | remove: "<p>" | remove: "</p>" }}</td>
+</tr>
+{% endfor %}
+</table>

--- a/site/_metrics/contour_cachehandler_onupdate_duration_seconds.md
+++ b/site/_metrics/contour_cachehandler_onupdate_duration_seconds.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_cachehandler_onupdate_duration_seconds'
+type: '[SUMMARY](https://prometheus.io/docs/concepts/metric_types/#summary)'
+labels: ''
+---
+
+Histogram for the runtime of xDS cache regeneration.

--- a/site/_metrics/contour_dagrebuild_timestamp.md
+++ b/site/_metrics/contour_dagrebuild_timestamp.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_dagrebuild_timestamp'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: ''
+---
+
+Timestamp of the last DAG rebuild.

--- a/site/_metrics/contour_httpproxy_invalid_total.md
+++ b/site/_metrics/contour_httpproxy_invalid_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_httpproxy_invalid_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace, vhost'
+---
+
+Total number of invalid HTTPProxies.

--- a/site/_metrics/contour_httpproxy_orphaned_total.md
+++ b/site/_metrics/contour_httpproxy_orphaned_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_httpproxy_orphaned_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of orphaned HTTPProxies which have no root delegating to them.

--- a/site/_metrics/contour_httpproxy_root_total.md
+++ b/site/_metrics/contour_httpproxy_root_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_httpproxy_root_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of root HTTPProxies. Note there will only be a single root HTTPProxy per vhost.

--- a/site/_metrics/contour_httpproxy_total.md
+++ b/site/_metrics/contour_httpproxy_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_httpproxy_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of HTTPProxies that exist regardless of status.

--- a/site/_metrics/contour_httpproxy_valid_total.md
+++ b/site/_metrics/contour_httpproxy_valid_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_httpproxy_valid_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace, vhost'
+---
+
+Total number of valid HTTPProxies.

--- a/site/_metrics/contour_ingressroute_invalid_total.md
+++ b/site/_metrics/contour_ingressroute_invalid_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_ingressroute_invalid_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace, vhost'
+---
+
+Total number of invalid IngressRoutes.

--- a/site/_metrics/contour_ingressroute_orphaned_total.md
+++ b/site/_metrics/contour_ingressroute_orphaned_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_ingressroute_orphaned_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of orphaned IngressRoutes which have no root delegating to them.

--- a/site/_metrics/contour_ingressroute_root_total.md
+++ b/site/_metrics/contour_ingressroute_root_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_ingressroute_root_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of root IngressRoutes. Note there will only be a single root IngressRoute per vhost.

--- a/site/_metrics/contour_ingressroute_total.md
+++ b/site/_metrics/contour_ingressroute_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_ingressroute_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace'
+---
+
+Total number of IngressRoutes that exist regardless of status

--- a/site/_metrics/contour_ingressroute_valid_total.md
+++ b/site/_metrics/contour_ingressroute_valid_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_ingressroute_valid_total'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'namespace, vhost'
+---
+
+Total number of valid IngressRoutes.


### PR DESCRIPTION
Move the metrics documentation from the "resources" section to the
"guides" section. Add build machinery to generate metrics reference
documentation from the Contour sources.

This updates #1750.

Signed-off-by: James Peach <jpeach@vmware.com>