### PR TITLE
internal/dag: reject a TCPProxy without services or includes

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -890,7 +890,9 @@ func (b *Builder) processIngressRouteTCPProxy(sw *ObjectStatusWriter, ir *ingres
 	}
 
 	if tcpproxy.Delegate == nil {
-		// not a delegate tcpproxy
+		// Not a delegate tcpproxy. Note that we allow a TCPProxy to be
+		// empty (no services and no delegates) for IngressRoute backwards
+		// compatibility. This is not allowed in HTTPProxy.
 		return
 	}
 
@@ -961,8 +963,9 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 	}
 
 	if tcpproxy.Include == nil {
-		// no includes, we're done.
-		return true
+		// We don't allow an empty TCPProxy object.
+		sw.SetInvalid("tcpproxy: either services or inclusion must be specified")
+		return false
 	}
 
 	namespace := tcpproxy.Include.Namespace

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2178,6 +2178,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	// Invalid because tcpproxy neither includes another httpproxy
+	// nor has a list of services.
+	proxy37a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "roots",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "passthrough.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			TCPProxy: &projcontour.TCPProxy{},
+		},
+	}
+
 	// proxy38 is invalid when combined with proxy39
 	// as the latter is a root.
 	proxy38 := &projcontour.HTTPProxy{
@@ -4708,6 +4726,10 @@ func TestDAGInsert(t *testing.T) {
 		},
 		"insert httpproxy with invalid tcpproxy": {
 			objs: []interface{}{proxy37, s1},
+			want: listeners(),
+		},
+		"insert httpproxy with empty tcpproxy": {
+			objs: []interface{}{proxy37a, s1},
 			want: listeners(),
 		},
 		"insert httpproxy w/ tcpproxy w/ missing include": {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1469,6 +1469,24 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 	}
 
+	// Invalid because tcpproxy neither includes another httpproxy
+	// nor has a list of services.
+	proxy37a := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: "roots",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "passthrough.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			TCPProxy: &projcontour.TCPProxy{},
+		},
+	}
+
 	// proxy38 is invalid when combined with proxy39 as the latter
 	// is a root httpproxy.
 	proxy38 := &projcontour.HTTPProxy{
@@ -2065,6 +2083,17 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 					Object:      proxy37,
 					Status:      "invalid",
 					Description: "tcpproxy: cannot specify services and include in the same httpproxy",
+					Vhost:       "passthrough.example.com",
+				},
+			},
+		},
+		"httpproxy with empty tcpproxy": {
+			objs: []interface{}{proxy37a, s1},
+			want: map[Meta]Status{
+				{name: proxy37a.Name, namespace: proxy37a.Namespace}: {
+					Object:      proxy37a,
+					Status:      "invalid",
+					Description: "tcpproxy: either services or inclusion must be specified",
 					Vhost:       "passthrough.example.com",
 				},
 			},


### PR DESCRIPTION
If a `TCPProxy` object doesn't have any `Services` and does not
`Include` a delegate, then it's an empty no-op. Reject it with a
status message in this case.

This fixes #1776.

Signed-off-by: James Peach <jpeach@vmware.com>