### PR TITLE
site: add site to misspell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ misspell:
 		-i clas \
 		-locale US \
 		-error \
-		cmd/* internal/* docs/* design/* *.md
+		cmd/* internal/* docs/* design/* site/*.md site/_{guides,posts,resources} *.md
 
 unconvert:
 	go install github.com/mdempsky/unconvert

--- a/site/_posts/2019-09-17-projectcontour.md
+++ b/site/_posts/2019-09-17-projectcontour.md
@@ -1,6 +1,6 @@
 ---
-title: New GitHub Organisation, Who Dis?
-excerpt: Contour has moved to a new GitHub organisation
+title: New GitHub Organization, Who Dis?
+excerpt: Contour has moved to a new GitHub organization
 author_name: Dave Cheney
 author_avatar: /img/contributors/dave-cheney.png
 categories: [kubernetes]

--- a/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
+++ b/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
@@ -13,7 +13,7 @@ This post explains the path from IngressRoute to HTTPProxy and why the change is
 ## IngressRoute is dead, long live HTTPProxy
 
 More than a year ago Contour 0.6 introduced a new CRD, IngressRoute.
-IngressRoute was our attempt to address the issues preventing Kubernetes developers from utilising modern web deployment patterns in multi tenant Kubernetes clusters.
+IngressRoute was our attempt to address the issues preventing Kubernetes developers from utilizing modern web deployment patterns in multi tenant Kubernetes clusters.
 
 Fast forward to July of this year where plans to move Contour out of the _0.whatever_ doldrums were being set in motion.
 We knew that stamping a 1.0 release on Contour required us to do the same for IngressRoute, which had at that point been in beta for a period of time that would make a Google product blush.

--- a/site/_posts/2019-10-25-contour-v100rc2.md
+++ b/site/_posts/2019-10-25-contour-v100rc2.md
@@ -11,7 +11,7 @@ tags: ['Contour Team', 'release']
 Contour 1.0.0-rc.2 is the second, and hopefully final, release candidate on the path to Contour 1.0.
 Assuming that no serious issues are found next week we're on track to release Contour 1.0 on November 1st.
 
-It goes without saying that without the help of the many community contributors this release, nor the 38 that preceeded it, would not have been possible.
+It goes without saying that without the help of the many community contributors this release, nor the 38 that preceded it, would not have been possible.
 Thank you all.
 
 You can read the full [1.0.0-rc.2 release notes](https://github.com/projectcontour/contour/releases/tag/v1.0.0-rc.2) over on GitHub, but as you're here, here are a few highlights. 
@@ -49,7 +49,7 @@ This helps Contour and Envoy work better with overlay networks which drop long r
 ## Contour now waits for a full cache before talking to Envoy.
 
 Contour now delays serving traffic to Envoy until each of the API informers caught up to the API server.
-This changes reduces the likelyhood that Envoy can connect to a Contour instance in the process of startup and thus observe an incomplete view of the cluster.
+This changes reduces the likelihood that Envoy can connect to a Contour instance in the process of startup and thus observe an incomplete view of the cluster.
 
 ## Upgrading
 


### PR DESCRIPTION
Add site to misspell target and address issues.

Signed-off-by: Dave Cheney <dave@cheney.net>