### PR TITLE
examples: Add shortname (tlscerts) to TLSCertificateDelegation

### DIFF
--- a/apis/projectcontour/v1/tlscertificatedelegation.go
+++ b/apis/projectcontour/v1/tlscertificatedelegation.go
@@ -42,6 +42,8 @@ type CertificateDelegation struct {
 
 // TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
 // See design/tls-certificate-delegation.md for details.
+// +k8s:openapi-gen=true
+// +kubebuilder:resource:path=tlscertificatedelegations,shortName=tlscerts,singular=tlscertificatedelegation
 type TLSCertificateDelegation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -840,8 +840,10 @@ spec:
     kind: TLSCertificateDelegation
     listKind: TLSCertificateDelegationList
     plural: tlscertificatedelegations
+    shortNames:
+    - tlscerts
     singular: tlscertificatedelegation
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -914,8 +914,10 @@ spec:
     kind: TLSCertificateDelegation
     listKind: TLSCertificateDelegationList
     plural: tlscertificatedelegations
+    shortNames:
+    - tlscerts
     singular: tlscertificatedelegation
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.


### PR DESCRIPTION
Fixes #1739 by adding a shortname `tlscerts` to the TLSCertificateDelegation CRD.

Signed-off-by: Steve Sloka <slokas@vmware.com>