### PR TITLE
site: style deprecation blocks as warnings

### DIFF
--- a/site/_scss/site/objects/_deprecated.scss
+++ b/site/_scss/site/objects/_deprecated.scss
@@ -1,5 +1,5 @@
 .alert-deprecation {
-    @extend .alert-danger;
+    @extend .alert-warning;
     border-radius: 5px;
     padding-left: 10px;
     padding-right: 10px;


### PR DESCRIPTION
Style the deprecation class as a warning (yellow) rather than an
error (red). The red is a bit too alarming.

Signed-off-by: James Peach <jpeach@vmware.com>