### PR TITLE
RFC: hoist DAG test fixtures.

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -28,17 +28,21 @@ import (
 )
 
 func TestDAGInsert(t *testing.T) {
+	f := NewFixtures()
+
 	// The DAG is sensitive to ordering, adding an ingress, then a service,
 	// should have the same result as adding a service, then an ingress.
 
-	sec1 := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "secret",
-			Namespace: "default",
-		},
-		Type: v1.SecretTypeTLS,
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
-	}
+	sec1 := f.Secret("sec1")
+
+	// sec1 := &v1.Secret{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      "secret",
+	// 		Namespace: "default",
+	// 	},
+	// 	Type: v1.SecretTypeTLS,
+	// 	Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+	// }
 
 	// Invalid cert in the secret
 	sec2 := &v1.Secret{

--- a/internal/dag/fixtures_test.go
+++ b/internal/dag/fixtures_test.go
@@ -1,0 +1,58 @@
+package dag
+
+import (
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Fixtures struct {
+	secrets       map[string]*v1.Secret
+	services      map[string]*v1.Service
+	ingresses     map[string]*v1beta1.Ingress
+	ingressRoutes map[string]*ingressroutev1.IngressRoute
+	httpProxies   map[string]*projcontour.HTTPProxy
+}
+
+func (f *Fixtures) Secret(s string) *v1.Secret {
+	return f.secrets[s]
+}
+
+func (f *Fixtures) Service(s string) *v1.Service {
+	return f.services[s]
+}
+
+func (f *Fixtures) Ingress(s string) *v1beta1.Ingress {
+	return f.ingresses[s]
+}
+
+func (f *Fixtures) IngressRoute(s string) *ingressroutev1.IngressRoute {
+	return f.ingressRoutes[s]
+}
+
+func (f *Fixtures) HTTPProxy(s string) *projcontour.HTTPProxy {
+	return f.httpProxies[s]
+}
+
+func NewFixtures() *Fixtures {
+	f := Fixtures{
+		secrets:       map[string]*v1.Secret{},
+		services:      map[string]*v1.Service{},
+		ingresses:     map[string]*v1beta1.Ingress{},
+		ingressRoutes: map[string]*ingressroutev1.IngressRoute{},
+		httpProxies:   map[string]*projcontour.HTTPProxy{},
+	}
+
+	f.secrets["sec1"] = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret",
+			Namespace: "default",
+		},
+		Type: v1.SecretTypeTLS,
+		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+	}
+
+	return &f
+}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -26,14 +26,18 @@ import (
 )
 
 func TestDAGIngressRouteStatus(t *testing.T) {
-	sec1 := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ssl-cert",
-			Namespace: "roots",
-		},
-		Type: v1.SecretTypeTLS,
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
-	}
+	f := NewFixtures()
+
+	sec1 := f.Secret("sec1")
+
+	// sec1 := &v1.Secret{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      "ssl-cert",
+	// 		Namespace: "roots",
+	// 	},
+	// 	Type: v1.SecretTypeTLS,
+	// 	Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+	// }
 
 	sec2 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This commit hoists test fixtures out of DAG tests into a commit
fixture store.

There are other approaches to this problem, so posting this as an
RFC to get consensus before I go too far down this path.

This updates #1449.

Signed-off-by: James Peach <jpeach@vmware.com>