### PR TITLE
site: update quickstart redirect for release-1.0

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,3 +1,3 @@
 # redirect /quickstart/contour.yaml to the deployment that matches :latest
 # kubectl apply https://projectcontour.io/quickstart/contour.yaml
-/quickstart/contour.yaml	https://raw.githubusercontent.com/projectcontour/contour/release-0.15/examples/render/deployment-rbac.yaml	302
+/quickstart/contour.yaml	https://raw.githubusercontent.com/projectcontour/contour/release-1.0/examples/render/contour.yaml	302


### PR DESCRIPTION
Update the quickstart redirect to point to the rendered version of
/examples/contour on release-1.0

Signed-off-by: Dave Cheney <dave@cheney.net>