### PR TITLE
internal/dag: refactor builder tests

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -28,8 +28,55 @@ import (
 )
 
 func TestDAGInsert(t *testing.T) {
-	// The DAG is sensitive to ordering, adding an ingress, then a service,
-	// should have the same result as adding a service, then an ingress.
+	type testcase struct {
+		objs                  []interface{}
+		disablePermitInsecure bool
+		want                  []Vertex
+	}
+
+	run := func(t *testing.T, name string, tc testcase) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			builder := Builder{
+				DisablePermitInsecure: tc.disablePermitInsecure,
+				Source: KubernetesCache{
+					FieldLogger: testLogger(t),
+				},
+			}
+
+			for _, o := range tc.objs {
+				builder.Source.Insert(o)
+			}
+
+			dag := builder.Build()
+
+			got := make(map[int]*Listener)
+			dag.Visit(listenerMap(got).Visit)
+
+			want := make(map[int]*Listener)
+
+			for _, v := range tc.want {
+				if l, ok := v.(*Listener); ok {
+					want[l.Port] = l
+				}
+			}
+
+			opts := []cmp.Option{
+				cmp.AllowUnexported(VirtualHost{}),
+			}
+
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Fatal(diff)
+			}
+
+		})
+	}
+
+	// The DAG is insensitive to ordering - adding an ingress,
+	// then a service should have the same result as adding a
+	// service, then an ingress.
 
 	sec1 := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -83,6 +130,7 @@ func TestDAGInsert(t *testing.T) {
 		Spec: v1beta1.IngressSpec{
 			Backend: backend("kuard", intstr.FromInt(8080))},
 	}
+
 	i1a := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -139,6 +187,7 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
 	// i4 is like i1 except it uses a named service port
 	i4 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -148,6 +197,7 @@ func TestDAGInsert(t *testing.T) {
 		Spec: v1beta1.IngressSpec{
 			Backend: backend("kuard", intstr.FromString("http"))},
 	}
+
 	// i5 is functionally identical to i2
 	i5 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -160,6 +210,7 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
 	// i6 contains two named vhosts which point to the same service
 	// one of those has TLS
 	i6 := &v1beta1.Ingress{
@@ -315,6 +366,7 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
 	// i9 is identical to i8 but disables non TLS connections
 	i9 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -617,6 +669,7 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
 	i13b := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{Name: "challenge", Namespace: "nginx-ingress"},
 		Spec: v1beta1.IngressSpec{
@@ -927,114 +980,6 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	// ir1a tcp forwards traffic to default/kuard:8080 by TLS terminating it
-	// first.
-	ir1a := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
-					SecretName: sec1.Name,
-				},
-			},
-			TCPProxy: &ingressroutev1.TCPProxy{
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
-	// ir1b tcp forwards traffic to default/kuard:8080 by TLS pass-throughing
-	// it.
-	ir1b := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			TCPProxy: &ingressroutev1.TCPProxy{
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
-	// ir1c tcp delegates to another ingress route, concretely to
-	// marketing/kuard-tcp. it.
-	ir1c := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			TCPProxy: &ingressroutev1.TCPProxy{
-				Delegate: &ingressroutev1.Delegate{
-					Name:      "kuard-tcp",
-					Namespace: "marketing",
-				},
-			},
-		},
-	}
-
-	// ir1d tcp forwards traffic to default/kuard:8080 by TLS pass-throughing
-	// it.
-	ir1d := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: "marketing",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			TCPProxy: &ingressroutev1.TCPProxy{
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
-	ir1e := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-					HealthCheck: &ingressroutev1.HealthCheck{
-						Path: "/healthz",
-					},
-				}},
-			}},
-		},
-	}
-
 	// ir2 is like ir1 but refers to two backend services
 	ir2 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1058,297 +1003,6 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	// ir3 delegates a route to ir4
-	ir3 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/blog",
-				Delegate: &ingressroutev1.Delegate{
-					Name:      "blog",
-					Namespace: "marketing",
-				},
-			}},
-		},
-	}
-
-	// ir4 is a delegate ingressroute, and itself delegates to another one.
-	ir4 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blog",
-			Namespace: "marketing",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			Routes: []ingressroutev1.Route{{
-				Match: "/blog",
-				Services: []ingressroutev1.Service{{
-					Name: "blog",
-					Port: 8080,
-				}},
-			}, {
-				Match: "/blog/admin",
-				Delegate: &ingressroutev1.Delegate{
-					Name:      "marketing-admin",
-					Namespace: "operations",
-				},
-			}},
-		},
-	}
-
-	// ir5 is a delegate ingressroute
-	ir5 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "marketing-admin",
-			Namespace: "operations",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			Routes: []ingressroutev1.Route{{
-				Match: "/blog/admin",
-				Services: []ingressroutev1.Service{{
-					Name: "blog-admin",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir6 has TLS and does not specify min tls version
-	ir6 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
-					SecretName: sec1.Name,
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir7 has TLS and specifies min tls version of 1.2
-	ir7 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
-					SecretName:             sec1.Name,
-					MinimumProtocolVersion: "1.2",
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir8 has TLS and specifies min tls version of 1.3
-	ir8 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
-					SecretName:             sec1.Name,
-					MinimumProtocolVersion: "1.3",
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir9 has TLS and specifies an invalid min tls version of 0.9999
-	ir9 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
-					SecretName:             sec1.Name,
-					MinimumProtocolVersion: "0.9999",
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir10 has a websocket route
-	ir10 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}, {
-				Match:            "/websocket",
-				EnableWebsockets: true,
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir10 has a websocket route w/multiple upstreams
-	ir10b := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}, {
-				Match:            "/websocket",
-				EnableWebsockets: true,
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}, {
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir11 has a prefix-rewrite route
-	ir11 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}, {
-				Match:         "/websocket",
-				PrefixRewrite: "/",
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// ir13 has two routes to the same service with different
-	// weights
-	ir13 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/a",
-				Services: []ingressroutev1.Service{{
-					Name:   "kuard",
-					Port:   8080,
-					Weight: 90,
-				}},
-			}, {
-				Match: "/b",
-				Services: []ingressroutev1.Service{{Name: "kuard",
-					Port:   8080,
-					Weight: 60,
-				}},
-			}},
-		},
-	}
-	// ir13a has one route to the same service with two different weights
-	ir13a := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/a",
-				Services: []ingressroutev1.Service{{
-					Name:   "kuard",
-					Port:   8080,
-					Weight: 90,
-				}, {
-					Name:   "kuard",
-					Port:   8080,
-					Weight: 60,
-				}},
-			}},
-		},
-	}
-
 	// ir14 has TLS and allows insecure
 	ir14 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1365,141 +1019,6 @@ func TestDAGInsert(t *testing.T) {
 			Routes: []ingressroutev1.Route{{
 				Match:          "/",
 				PermitInsecure: true,
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir15 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				RetryPolicy: &projcontour.RetryPolicy{
-					NumRetries:    6,
-					PerTryTimeout: "10s",
-				},
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir15a := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				RetryPolicy: &projcontour.RetryPolicy{
-					NumRetries:    6,
-					PerTryTimeout: "please",
-				},
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir15b := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				RetryPolicy: &projcontour.RetryPolicy{
-					NumRetries:    0,
-					PerTryTimeout: "10s",
-				},
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir16a := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
-					Request: "peanut",
-				},
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir16b := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
-					Request: "1m30s", // 90 seconds y'all
-				},
-				Services: []ingressroutev1.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	ir16c := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "bar.com",
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
-					Request: "infinite",
-				},
 				Services: []ingressroutev1.Service{{
 					Name: "kuard",
 					Port: 8080,
@@ -1530,6 +1049,7 @@ func TestDAGInsert(t *testing.T) {
 			}},
 		},
 	}
+
 	s5 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog-admin",
@@ -1737,59 +1257,6 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	// ir18 tcp forwards traffic to by TLS pass-throughing
-	// it. It also exposes non HTTP traffic to the the non secure port of the
-	// application so it can give an informational message
-	ir18 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: s10.Namespace,
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: s10.Name,
-					Port: 80, // proxy non secure traffic to port 80
-				}},
-			}},
-			TCPProxy: &ingressroutev1.TCPProxy{
-				Services: []ingressroutev1.Service{{
-					Name: s10.Name,
-					Port: 443, // ssl passthrough to secure port
-				}},
-			},
-		},
-	}
-
-	ir19 := &ingressroutev1.IngressRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app-with-tls-delegation",
-			Namespace: s10.Namespace,
-		},
-		Spec: ingressroutev1.IngressRouteSpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "app-with-tls-delegation.127.0.0.1.nip.io",
-				TLS: &projcontour.TLS{
-					SecretName: "heptio-contour/ssl-cert", // not delegated
-				},
-			},
-			Routes: []ingressroutev1.Route{{
-				Match: "/",
-				Services: []ingressroutev1.Service{{
-					Name: s10.Name,
-					Port: 80,
-				}},
-			}},
-		},
-	}
-
 	proxy1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
@@ -1808,391 +1275,6 @@ func TestDAGInsert(t *testing.T) {
 					Port: 8080,
 				}},
 			}},
-		},
-	}
-
-	// proxy1a tcp forwards traffic to default/kuard:8080 by TLS pass-through it.
-	proxy1a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-tcp",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
-	proxy1b := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-	proxy1c := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Header: &projcontour.HeaderCondition{
-						Name:    "x-request-id",
-						Present: true,
-					},
-				}, {
-					Prefix: "/kuard",
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:     "e-tag",
-						Contains: "abcdef",
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:        "x-timeout",
-						NotContains: "infinity",
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:  "digest-auth",
-						Exact: "scott",
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:     "digest-password",
-						NotExact: "tiger",
-					},
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy2a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "kubesystem",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Conditions: []projcontour.Condition{{
-					Header: &projcontour.HeaderCondition{
-						Name:    "x-request-id",
-						Present: true,
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:        "x-timeout",
-						NotContains: "infinity",
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:  "digest-auth",
-						Exact: "scott",
-					},
-				}},
-				Name:      "kuard",
-				Namespace: "default",
-			}},
-		},
-	}
-	proxy2b := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/kuard",
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:     "e-tag",
-						Contains: "abcdef",
-					},
-				}, {
-					Header: &projcontour.HeaderCondition{
-						Name:     "digest-password",
-						NotExact: "tiger",
-					},
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy1e := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
-					Path: "/healthz",
-				},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// proxy6 has TLS and does not specify min tls version
-	proxy6 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
-					SecretName: sec1.Name,
-				},
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy17 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-					UpstreamValidation: &projcontour.UpstreamValidation{
-						CACertificate: cert1.Name,
-						SubjectName:   "example.com",
-					},
-				}},
-			}},
-		},
-	}
-
-	// proxy10 has a websocket route
-	proxy10 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}, {
-				Conditions: []projcontour.Condition{{
-					Prefix: "/websocket",
-				}},
-				EnableWebsockets: true,
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	// proxy10b has a websocket route w/multiple upstreams
-	proxy10b := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}, {
-				Conditions: []projcontour.Condition{{
-					Prefix: "/websocket",
-				}},
-				EnableWebsockets: true,
-				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}, {
-					Name: "kuard",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy12 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}, {
-					Name:   s2.Name,
-					Port:   8080,
-					Mirror: true,
-				}},
-			}},
-		},
-	}
-
-	proxy13 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}, {
-					Name:   s2.Name,
-					Port:   8080,
-					Mirror: true,
-				}, {
-					// it is legal to mention a service more that
-					// once, however it is not legal for more than one
-					// service to be marked as mirror.
-					Name:   s2.Name,
-					Port:   8080,
-					Mirror: true,
-				}},
-			}},
-		},
-	}
-
-	// invalid because tcpproxy both includes another and
-	// has a list of services.
-	proxy37 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "roots",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
-					Name:      "foo",
-					Namespace: "roots",
-				},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
-	// Invalid because tcpproxy neither includes another httpproxy
-	// nor has a list of services.
-	proxy37a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "roots",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
-					Passthrough: true,
-				},
-			},
-			TCPProxy: &projcontour.TCPProxy{},
 		},
 	}
 
@@ -2240,21 +1322,6 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy40 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			},
-		},
-	}
-
 	proxy100 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
@@ -2283,88 +1350,3358 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "marketingwww",
-			Namespace: "marketing",
+	run(t, "insert ingress w/ default backend w/o matching service", testcase{
+		objs: []interface{}{
+			i1,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
-					Name: "blog",
-					Port: 8080,
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ default backend", testcase{
+		objs: []interface{}{
+			i1,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ single unnamed backend w/o matching service", testcase{
+		objs: []interface{}{
+			i2,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ single unnamed backend", testcase{
+		objs: []interface{}{
+			i2,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress with missing spec.rule.http key", testcase{
+		objs: []interface{}{
+			i2a,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ host name and single backend w/o matching service", testcase{
+		objs: []interface{}{
+			i3,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ host name and single backend", testcase{
+		objs: []interface{}{
+			i3,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("kuard.example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert non matching service then ingress w/ default backend", testcase{
+		objs: []interface{}{
+			s2,
+			i1,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ default backend then matching service with wrong port", testcase{
+		objs: []interface{}{
+			i1,
+			s3,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert unnamed ingress w/ single backend then matching service with wrong port", testcase{
+		objs: []interface{}{
+			i2,
+			s3,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingress w/ default backend then matching service w/ named port", testcase{
+		objs: []interface{}{
+			i4,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert service w/ named port then ingress w/ default backend", testcase{
+		objs: []interface{}{
+			s1,
+			i4,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ single unnamed backend w/ named service port then service", testcase{
+		objs: []interface{}{
+			i5,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert service then ingress w/ single unnamed backend w/ named service port", testcase{
+		objs: []interface{}{
+			s1,
+			i5,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert secret", testcase{
+		objs: []interface{}{
+			sec1,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert secret then ingress w/o tls", testcase{
+		objs: []interface{}{
+			sec1,
+			i1,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert service, secret then ingress w/o tls", testcase{
+		objs: []interface{}{
+			s1,
+			sec1,
+			i1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert secret then ingress w/ tls", testcase{
+		objs: []interface{}{
+			sec1,
+			i3,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert service, secret then ingress w/ tls", testcase{
+		objs: []interface{}{
+			s1,
+			sec1,
+			i3,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("kuard.example.com", prefixroute("/", service(s1))),
+				),
+			},
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("kuard.example.com", sec1, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert service w/ secret with w/ blank ca.crt", testcase{
+		objs: []interface{}{
+			s1,
+			sec3, // issue 1644
+			i3,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("kuard.example.com", prefixroute("/", service(s1))),
+				),
+			},
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("kuard.example.com", sec3, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert invalid secret then ingress w/o tls", testcase{
+		objs: []interface{}{
+			sec2,
+			i1,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert service, invalid secret then ingress w/o tls", testcase{
+		objs: []interface{}{
+			s1,
+			sec2,
+			i1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert invalid secret then ingress w/ tls", testcase{
+		objs: []interface{}{
+			sec2,
+			i3,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert service, invalid secret then ingress w/ tls", testcase{
+		objs: []interface{}{
+			s1,
+			sec2,
+			i3,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("kuard.example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ two vhosts", testcase{
+		objs: []interface{}{
+			i6,
+		},
+		want: nil, // no matching service
+	})
+
+	run(t, "insert ingress w/ two vhosts then matching service", testcase{
+		objs: []interface{}{
+			i6,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("a.example.com", prefixroute("/", service(s1))),
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert service then ingress w/ two vhosts", testcase{
+		objs: []interface{}{
+			s1,
+			i6,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("a.example.com", prefixroute("/", service(s1))),
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ two vhosts then service then secret", testcase{
+		objs: []interface{}{
+			i6,
+			s1,
+			sec1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("a.example.com", prefixroute("/", service(s1))),
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert service then secret then ingress w/ two vhosts", testcase{
+		objs: []interface{}{
+			s1,
+			sec1,
+			i6,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("a.example.com", prefixroute("/", service(s1))),
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ two paths then one service", testcase{
+		objs: []interface{}{
+			i7,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com",
+						prefixroute("/", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ two paths then services", testcase{
+		objs: []interface{}{
+			i7,
+			s2,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com",
+						prefixroute("/", service(s1)),
+						prefixroute("/kuarder", service(s2)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert two services then ingress w/ two ingress rules", testcase{
+		objs: []interface{}{
+			s1, s2, i8,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com",
+						prefixroute("/", service(s1)),
+						prefixroute("/kuarder", service(s2)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ two paths httpAllowed: false", testcase{
+		objs: []interface{}{
+			i9,
+		},
+		want: []Vertex{},
+	})
+
+	run(t, "insert ingress w/ two paths httpAllowed: false then tls and service", testcase{
+		objs: []interface{}{
+			i9,
+			sec1,
+			s1, s2,
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1,
+						prefixroute("/", service(s1)),
+						prefixroute("/kuarder", service(s2)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert default ingress httpAllowed: false", testcase{
+		objs: []interface{}{
+			i1a,
+		},
+		want: []Vertex{},
+	})
+
+	run(t, "insert default ingress httpAllowed: false then tls and service", testcase{
+		objs: []interface{}{
+			i1a, sec1, s1,
+		},
+		want: []Vertex{}, // default ingress cannot be tls
+	})
+
+	run(t, "insert ingress w/ two vhosts httpAllowed: false", testcase{
+		objs: []interface{}{
+			i6a,
+		},
+		want: []Vertex{},
+	})
+
+	run(t, "insert ingress w/ two vhosts httpAllowed: false then tls and service", testcase{
+		objs: []interface{}{
+			i6a, sec1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ force-ssl-redirect: true", testcase{
+		objs: []interface{}{
+			i6b, sec1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ force-ssl-redirect: true and allow-http: false", testcase{
+		objs: []interface{}{
+			i6c, sec1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute", testcase{
+		objs: []interface{}{
+			ir1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ healthcheck", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+							HealthCheck: &ingressroutev1.HealthCheck{
+								Path: "/healthz",
+							},
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/", &Cluster{
+							Upstream: service(s1),
+							HealthCheckPolicy: &HealthCheckPolicy{
+								Path: "/healthz",
+							},
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with websocket route", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}, {
+						Match:         "/websocket",
+						PrefixRewrite: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+						routeRewrite("/websocket", "/", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with tcp forward with TLS termination", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			// This tcp forwards traffic to default/kuard:8080 by TLS terminating it first.
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard-tcp",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "kuard.example.com",
+						TLS: &projcontour.TLS{
+							SecretName: sec1.Name,
+						},
+					},
+					TCPProxy: &ingressroutev1.TCPProxy{
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "kuard.example.com",
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s1),
+							),
+						},
+						Secret:          secret(sec1),
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with tcp forward without TLS termination w/ passthrough", testcase{
+		objs: []interface{}{
+			s1,
+			// This tcp forwards traffic to default/kuard:8080 by TLS pass-throughing it.
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard-tcp",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "kuard.example.com",
+						TLS: &projcontour.TLS{
+							Passthrough: true,
+						},
+					},
+					TCPProxy: &ingressroutev1.TCPProxy{
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "kuard.example.com",
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s1),
+							),
+						},
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert root ingress route and delegate ingress route for a tcp proxy", testcase{
+		objs: []interface{}{
+			s6,
+			// This tcp delegates to another ingress route, concretely to
+			// marketing/kuard-tcp.
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard-tcp",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "kuard.example.com",
+						TLS: &projcontour.TLS{
+							Passthrough: true,
+						},
+					},
+					TCPProxy: &ingressroutev1.TCPProxy{
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "kuard-tcp",
+							Namespace: "marketing",
+						},
+					},
+				},
+			},
+
+			// This tcp forwards traffic to default/kuard:8080 by TLS pass-through.
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard-tcp",
+					Namespace: "marketing",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					TCPProxy: &ingressroutev1.TCPProxy{
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "kuard.example.com",
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s6),
+							),
+						},
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with prefix rewrite route", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}, {
+						Match:            "/websocket",
+						EnableWebsockets: true,
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+						routeWebsocket("/websocket", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with multiple upstreams prefix rewrite route, websocket routes are dropped", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}, {
+						Match:            "/websocket",
+						EnableWebsockets: true,
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}, {
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute and service", testcase{
+		objs: []interface{}{
+			ir1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	// IngressRoute has TLS and does not specify min TLS version.
+	run(t, "insert ingressroute without tls version", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "foo.com",
+						TLS: &projcontour.TLS{
+							SecretName: sec1.Name,
+						},
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with TLS one insecure", testcase{
+		objs: []interface{}{
+			ir14, s1, sec1,
+		},
+		disablePermitInsecure: false,
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", prefixroute("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("foo.com", sec1, prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with TLS one insecure - disablePermitInsecure=true", testcase{
+		objs: []interface{}{
+			ir14, s1, sec1,
+		},
+		disablePermitInsecure: true,
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	// IngressRoute has TLS and specifies min tls version of 1.2
+	run(t, "insert ingressroute with tls version 1.2", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "foo.com",
+						TLS: &projcontour.TLS{
+							SecretName:             sec1.Name,
+							MinimumProtocolVersion: "1.2",
+						},
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "foo.com",
+							routes: routes(
+								routeUpgrade("/", service(s1)),
+							),
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
+						Secret:          secret(sec1),
+					},
+				),
+			},
+		),
+	})
+
+	// IngressRoute has TLS and specifies min tls version of 1.3
+	run(t, "insert ingressroute with tls version 1.3", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "foo.com",
+						TLS: &projcontour.TLS{
+							SecretName:             sec1.Name,
+							MinimumProtocolVersion: "1.3",
+						},
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "foo.com",
+							routes: routes(
+								routeUpgrade("/", service(s1)),
+							),
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
+						Secret:          secret(sec1),
+					},
+				),
+			},
+		),
+	})
+
+	// IngressRoute has TLS and specifies an invalid min tls version of 0.9999
+	run(t, "insert ingressroute with invalid tls version", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "foo.com",
+						TLS: &projcontour.TLS{
+							SecretName:             sec1.Name,
+							MinimumProtocolVersion: "0.9999",
+						},
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute referencing two backends, one missing", testcase{
+		objs: []interface{}{
+			ir2, s2,
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert ingressroute referencing two backends", testcase{
+		objs: []interface{}{
+			ir2, s1, s2,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1), service(s2))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ tls min proto annotation", testcase{
+		objs: []interface{}{
+			i10a,
+			sec1,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "b.example.com",
+							routes: routes(
+								prefixroute("/", service(s1)),
+							),
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
+						Secret:          secret(sec1),
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ legacy tls min proto annotation", testcase{
+		objs: []interface{}{
+			i10b,
+			sec1,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("b.example.com", prefixroute("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "b.example.com",
+							routes: routes(
+								prefixroute("/", service(s1)),
+							),
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
+						Secret:          secret(sec1),
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ websocket route annotation", testcase{
+		objs: []interface{}{
+			i11,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", service(s1)),
+						routeWebsocket("/ws1", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ invalid legacy timeout annotation", testcase{
+		objs: []interface{}{
+			i12a,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ invalid timeout annotation", testcase{
+		objs: []interface{}{
+			i12d,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ invalid timeoutpolicy", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
+							Request: "peanut",
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ valid legacy timeout annotation", testcase{
+		objs: []interface{}{
+			i12b,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: 90 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ valid timeout annotation", testcase{
+		objs: []interface{}{
+			i12e,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: 90 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ valid timeoutpolicy", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
+							Request: "1m30s", // 90 seconds y'all
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: 90 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ legacy infinite timeout annotation", testcase{
+		objs: []interface{}{
+			i12c,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress w/ infinite timeout annotation", testcase{
+		objs: []interface{}{
+			i12f,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ infinite timeoutpolicy", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						TimeoutPolicy: &ingressroutev1.TimeoutPolicy{
+							Request: "infinite",
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						TimeoutPolicy: &TimeoutPolicy{
+							ResponseTimeout: -1,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ missing tls annotation", testcase{
+		objs: []interface{}{
+			cert1, ir17, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute w/ missing certificate", testcase{
+		objs: []interface{}{
+			ir17, s1a,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1a.Name,
+									Namespace:   s1a.Namespace,
+									ServicePort: &s1a.Spec.Ports[0],
+									Protocol:    "tls",
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute expecting verification", testcase{
+		objs: []interface{}{
+			cert1, ir17, s1a,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1a.Name,
+									Namespace:   s1a.Namespace,
+									ServicePort: &s1a.Spec.Ports[0],
+									Protocol:    "tls",
+								},
+								UpstreamValidation: &UpstreamValidation{
+									CACertificate: secret(cert1),
+									SubjectName:   "example.com",
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	// ir18 tcp forwards traffic to by TLS pass-throughing
+	// it. It also exposes non HTTP traffic to the the non secure port of the
+	// application so it can give an informational message
+	ir18 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard-tcp",
+			Namespace: s10.Namespace,
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "kuard.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/",
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 80, // proxy non secure traffic to port 80
 				}},
+			}},
+			TCPProxy: &ingressroutev1.TCPProxy{
+				Services: []ingressroutev1.Service{{
+					Name: s10.Name,
+					Port: 443, // ssl passthrough to secure port
+				}},
+			},
+		},
+	}
+
+	run(t, "insert ingressroute routing and tcpproxying", testcase{
+		objs: []interface{}{
+			s10, ir18,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost(ir18.Spec.VirtualHost.Fqdn,
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s10.Name,
+									Namespace:   s10.Namespace,
+									ServicePort: &s10.Spec.Ports[1],
+								},
+							},
+						),
+					),
+				),
+			},
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: ir18.Spec.VirtualHost.Fqdn,
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(service(s10)),
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLS_AUTO, // tls passthrough does not specify a TLS version; that's the domain of the backend
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with missing tls delegation should not present port 80", testcase{
+		objs: []interface{}{
+			s10,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-with-tls-delegation",
+					Namespace: s10.Namespace,
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "app-with-tls-delegation.127.0.0.1.nip.io",
+						TLS: &projcontour.TLS{
+							SecretName: "heptio-contour/ssl-cert", // not delegated
+						},
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: s10.Name,
+							Port: 80,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(), // no listeners, the ingressroute is invalid
+	})
+
+	// ir3 delegates a route to ir4
+	ir3 := &ingressroutev1.IngressRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: ingressroutev1.IngressRouteSpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Routes: []ingressroutev1.Route{{
+				Match: "/blog",
+				Delegate: &ingressroutev1.Delegate{
+					Name:      "blog",
+					Namespace: "marketing",
+				},
 			}},
 		},
 	}
 
-	proxy100b := &projcontour.HTTPProxy{
+	// ir4 is a delegate ingressroute, and itself delegates to another one.
+	ir4 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "marketingwww",
+			Name:      "blog",
 			Namespace: "marketing",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/infotech",
-				}},
-				Services: []projcontour.Service{{
-					Name: "blog",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy100c := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "marketingwww",
-			Namespace: "marketing",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Includes: []projcontour.Include{{
-				Name:      "marketingit",
-				Namespace: "it",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/it",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/infotech",
-				}},
-				Services: []projcontour.Service{{
+		Spec: ingressroutev1.IngressRouteSpec{
+			Routes: []ingressroutev1.Route{{
+				Match: "/blog",
+				Services: []ingressroutev1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
 			}, {
-				Services: []projcontour.Service{{
-					Name: "blog",
-					Port: 8080,
-				}},
+				Match: "/blog/admin",
+				Delegate: &ingressroutev1.Delegate{
+					Name:      "marketing-admin",
+					Namespace: "operations",
+				},
 			}},
 		},
 	}
 
-	proxy100d := &projcontour.HTTPProxy{
+	// ir5 is a delegate ingressroute
+	ir5 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "marketingit",
-			Namespace: "it",
+			Name:      "marketing-admin",
+			Namespace: "operations",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/foo",
-				}},
-				Services: []projcontour.Service{{
-					Name: "blog",
+		Spec: ingressroutev1.IngressRouteSpec{
+			Routes: []ingressroutev1.Route{{
+				Match: "/blog/admin",
+				Services: []ingressroutev1.Service{{
+					Name: "blog-admin",
 					Port: 8080,
 				}},
 			}},
 		},
 	}
 
-	// proxy101 and proxy101a test inclusion without a specified namespace.
+	run(t, "insert root ingress route and delegate ingress route", testcase{
+		objs: []interface{}{
+			ir5, s4, ir4, s5, ir3,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/blog", service(s4)),
+						prefixroute("/blog/admin", service(s5)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress with retry annotations", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						RetryPolicy: &projcontour.RetryPolicy{
+							NumRetries:    6,
+							PerTryTimeout: "10s",
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "5xx",
+							NumRetries:    6,
+							PerTryTimeout: 10 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress with invalid perTryTimeout", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						RetryPolicy: &projcontour.RetryPolicy{
+							NumRetries:    6,
+							PerTryTimeout: "please",
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "5xx",
+							NumRetries:    6,
+							PerTryTimeout: 0,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress with zero retry count", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "bar.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						RetryPolicy: &projcontour.RetryPolicy{
+							NumRetries:    0,
+							PerTryTimeout: "10s",
+						},
+						Services: []ingressroutev1.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("bar.com", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "5xx",
+							NumRetries:    1,
+							PerTryTimeout: 10 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with retrypolicy", testcase{
+		objs: []interface{}{
+			i14a,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "gateway-error",
+							NumRetries:    6,
+							PerTryTimeout: 10 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with legacy retrypolicy", testcase{
+		objs: []interface{}{
+			i14b,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "gateway-error",
+							NumRetries:    6,
+							PerTryTimeout: 10 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with timeout policy", testcase{
+		objs: []interface{}{
+			i14c,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: prefix("/"),
+						Clusters:      clustermap(s1),
+						RetryPolicy: &RetryPolicy{
+							RetryOn:       "gateway-error",
+							NumRetries:    6,
+							PerTryTimeout: 10 * time.Second,
+						},
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress with regex route", testcase{
+		objs: []interface{}{
+			i15,
+			s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", &Route{
+						PathCondition: regex("/[^/]+/invoices(/.*|/?)"),
+						Clusters:      clustermap(s1),
+					}),
+				),
+			},
+		),
+	})
+
+	// issue 1234
+	run(t, "insert ingress with wildcard hostnames", testcase{
+		objs: []interface{}{
+			s1,
+			i16,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress overlay", testcase{
+		objs: []interface{}{
+			i13a, i13b, sec13, s13a, s13b,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeUpgrade("/", service(s13a)),
+						prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
+					),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("example.com", sec13,
+						routeUpgrade("/", service(s13a)),
+						prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "deprecated h2c service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3a,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3a.Name,
+							Namespace:   s3a.Namespace,
+							ServicePort: &s3a.Spec.Ports[0],
+							Protocol:    "h2c",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "deprecated h2 service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3b,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3b.Name,
+							Namespace:   s3b.Namespace,
+							ServicePort: &s3b.Spec.Ports[0],
+							Protocol:    "h2",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "deprecated tls service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3c,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3c.Name,
+							Namespace:   s3c.Namespace,
+							ServicePort: &s3c.Spec.Ports[0],
+							Protocol:    "tls",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "h2c service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3d,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3a.Name,
+							Namespace:   s3a.Namespace,
+							ServicePort: &s3a.Spec.Ports[0],
+							Protocol:    "h2c",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "h2 service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3e,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3b.Name,
+							Namespace:   s3b.Namespace,
+							ServicePort: &s3b.Spec.Ports[0],
+							Protocol:    "h2",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "tls service annotation", testcase{
+		objs: []interface{}{
+			i3a, s3f,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:        s3c.Name,
+							Namespace:   s3c.Namespace,
+							ServicePort: &s3c.Spec.Ports[0],
+							Protocol:    "tls",
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingress then service w/ upstream annotations", testcase{
+		objs: []interface{}{
+			i1,
+			s1b,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*",
+						prefixroute("/", &Service{
+							Name:               s1b.Name,
+							Namespace:          s1b.Namespace,
+							ServicePort:        &s1b.Spec.Ports[0],
+							MaxConnections:     9000,
+							MaxPendingRequests: 4096,
+							MaxRequests:        404,
+							MaxRetries:         7,
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	// Two routes to the same service with different weights.
+	run(t, "insert ingressroute with two routes to the same service", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/a",
+						Services: []ingressroutev1.Service{{
+							Name:   "kuard",
+							Port:   8080,
+							Weight: 90,
+						}},
+					}, {
+						Match: "/b",
+						Services: []ingressroutev1.Service{{Name: "kuard",
+							Port:   8080,
+							Weight: 60,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/a", &Cluster{
+							Upstream: &Service{
+								Name:        s1.Name,
+								Namespace:   s1.Namespace,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+							Weight: 90,
+						}),
+						routeCluster("/b", &Cluster{
+							Upstream: &Service{
+								Name:        s1.Name,
+								Namespace:   s1.Namespace,
+								ServicePort: &s1.Spec.Ports[0],
+							},
+							Weight: 60,
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert ingressroute with one routes to the same service with two different weights", testcase{
+		objs: []interface{}{
+			s1,
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/a",
+						Services: []ingressroutev1.Service{{
+							Name:   "kuard",
+							Port:   8080,
+							Weight: 90,
+						}, {
+							Name:   "kuard",
+							Port:   8080,
+							Weight: 60,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/a",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+								Weight: 90,
+							}, &Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+								Weight: 60,
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "ingressroute delegated to non existent object", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-com",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/finance",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "non-existent",
+							Namespace: "non-existent",
+						},
+					}},
+				},
+			},
+		},
+		want: nil, // no listener created
+	})
+
+	run(t, "ingressroute delegates to itself", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-com",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/finance",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "example-com",
+							Namespace: "default",
+						},
+					}},
+				},
+			},
+		},
+		want: nil, // no listener created
+	})
+
+	run(t, "ingressroute delegates to incorrect prefix", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-com",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/finance",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "finance-root",
+							Namespace: "finance",
+						},
+					}},
+				},
+			},
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "finance",
+					Name:      "finance-root",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					Routes: []ingressroutev1.Route{{
+						Match: "/prefixDoesntMatch",
+						Services: []ingressroutev1.Service{{
+							Name: "home",
+						}},
+					}},
+				},
+			},
+		},
+		want: nil, // no listener created
+	})
+
+	run(t, "ingressroute delegate to prefix, but no matching path in delegate", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-com",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/foo",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "finance-root",
+							Namespace: "finance",
+						},
+					}},
+				},
+			},
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "finance",
+					Name:      "finance-root",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					Routes: []ingressroutev1.Route{{
+						Match: "/foobar",
+						Services: []ingressroutev1.Service{{
+							Name: "home",
+						}},
+					}, {
+						Match: "/foo/bar",
+						Services: []ingressroutev1.Service{{
+							Name: "home",
+						}},
+					}},
+				},
+			},
+		},
+		want: nil, // no listener created
+	})
+
+	run(t, "ingressroute cycle", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "example-com",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/finance",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "finance-root",
+							Namespace: "finance",
+						},
+					}},
+				},
+			},
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "finance",
+					Name:      "finance-root",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					Routes: []ingressroutev1.Route{{
+						Match: "/finance",
+						Services: []ingressroutev1.Service{{
+							Name: "home",
+							Port: 8080,
+						}},
+					}, {
+						Match: "/finance/stocks",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "example-com",
+							Namespace: "default",
+						},
+					}},
+				},
+			},
+			s7,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/finance", service(s7))),
+				),
+			},
+		),
+	})
+
+	run(t, "ingressroute root delegates to another ingressroute root", testcase{
+		objs: []interface{}{
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "root-blog",
+					Namespace: "roots",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "blog.containersteve.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Delegate: &ingressroutev1.Delegate{
+							Name:      "blog",
+							Namespace: "marketing",
+						},
+					}},
+				},
+			},
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "blog",
+					Namespace: "marketing",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "www.containersteve.com",
+					},
+					Routes: []ingressroutev1.Route{{
+						Match: "/",
+						Services: []ingressroutev1.Service{{
+							Name: "green",
+							Port: 80,
+						}},
+					}},
+				},
+			},
+			s8,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("www.containersteve.com", prefixroute("/", service(s8))),
+				),
+			},
+		),
+	})
+
+	// issue 1399
+	run(t, "service shared across ingress and ingressroute tcpproxy", testcase{
+		objs: []interface{}{
+			sec1,
+			s9,
+			&v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{{
+						Hosts:      []string{"example.com"},
+						SecretName: s1.Name,
+					}},
+					Rules: []v1beta1.IngressRule{{
+						Host:             "example.com",
+						IngressRuleValue: ingressrulevalue(backend(s9.Name, intstr.FromInt(80))),
+					}},
+				},
+			},
+			&ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: ingressroutev1.IngressRouteSpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+						TLS: &projcontour.TLS{
+							SecretName: sec1.Name,
+						},
+					},
+					TCPProxy: &ingressroutev1.TCPProxy{
+						Services: []ingressroutev1.Service{{
+							Name: s9.Name,
+							Port: 80,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s9))),
+				),
+			},
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "example.com",
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+						Secret:          secret(sec1),
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(service(s9)),
+						},
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert httproxy", testcase{
+		objs: []interface{}{
+			proxy1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httproxy w/o condition", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httproxy w/ conditions", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Header: &projcontour.HeaderCondition{
+								Name:    "x-request-id",
+								Present: true,
+							},
+						}, {
+							Prefix: "/kuard",
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:     "e-tag",
+								Contains: "abcdef",
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:        "x-timeout",
+								NotContains: "infinity",
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:  "digest-auth",
+								Exact: "scott",
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:     "digest-password",
+								NotExact: "tiger",
+							},
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", &Route{
+						PathCondition: &PrefixCondition{Prefix: "/kuard"},
+						HeaderConditions: []HeaderCondition{
+							{Name: "x-request-id", MatchType: "present"},
+							{Name: "e-tag", Value: "abcdef", MatchType: "contains"},
+							{Name: "x-timeout", Value: "infinity", MatchType: "contains", Invert: true},
+							{Name: "digest-auth", Value: "scott", MatchType: "exact"},
+							{Name: "digest-password", Value: "tiger", MatchType: "exact", Invert: true},
+						},
+						Clusters: clusters(service(s1)),
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httproxy w/ included conditions", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "kubesystem",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Includes: []projcontour.Include{{
+						Conditions: []projcontour.Condition{{
+							Header: &projcontour.HeaderCondition{
+								Name:    "x-request-id",
+								Present: true,
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:        "x-timeout",
+								NotContains: "infinity",
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:  "digest-auth",
+								Exact: "scott",
+							},
+						}},
+						Name:      "kuard",
+						Namespace: "default",
+					}},
+				},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/kuard",
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:     "e-tag",
+								Contains: "abcdef",
+							},
+						}, {
+							Header: &projcontour.HeaderCondition{
+								Name:     "digest-password",
+								NotExact: "tiger",
+							},
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", &Route{
+						PathCondition: &PrefixCondition{Prefix: "/kuard"},
+						HeaderConditions: []HeaderCondition{
+							{Name: "x-request-id", MatchType: "present"},
+							{Name: "x-timeout", Value: "infinity", MatchType: "contains", Invert: true},
+							{Name: "digest-auth", Value: "scott", MatchType: "exact"},
+							{Name: "e-tag", Value: "abcdef", MatchType: "contains"},
+							{Name: "digest-password", Value: "tiger", MatchType: "exact", Invert: true},
+						},
+						Clusters: clusters(service(s1)),
+					}),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy w/ healthcheck", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
+							Path: "/healthz",
+						},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/", &Cluster{
+							Upstream: service(s1),
+							HealthCheckPolicy: &HealthCheckPolicy{
+								Path: "/healthz",
+							},
+						}),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with mirroring route", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}, {
+							Name:   s2.Name,
+							Port:   8080,
+							Mirror: true,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						withMirror(prefixroute("/", service(s1)), service(s2)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with two mirrors", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}, {
+							Name:   s2.Name,
+							Port:   8080,
+							Mirror: true,
+						}, {
+							// It is legal to mention a service more that
+							// once, however it is not legal for more than one
+							// service to be marked as mirror.
+							Name:   s2.Name,
+							Port:   8080,
+							Mirror: true,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert httpproxy with websocket route", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}, {
+						Conditions: []projcontour.Condition{{
+							Prefix: "/websocket",
+						}},
+						EnableWebsockets: true,
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+						routeWebsocket("/websocket", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with multiple upstreams prefix rewrite route, websocket routes are dropped", testcase{
+		objs: []interface{}{
+			s1,
+			// This proxy has a websocket route w/multiple upstreams.
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}, {
+						Conditions: []projcontour.Condition{{
+							Prefix: "/websocket",
+						}},
+						EnableWebsockets: true,
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}, {
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						prefixroute("/", service(s1)),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy and service", testcase{
+		objs: []interface{}{
+			proxy1, s1,
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	// Inserting a proxy that has TLS and does not specify min tls version
+	// should succeed.
+	run(t, "insert httpproxy without tls version", testcase{
+		objs: []interface{}{
+			s1, sec1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "foo.com",
+						TLS: &projcontour.TLS{
+							SecretName: sec1.Name,
+						},
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("foo.com", routeUpgrade("/", service(s1))),
+				),
+			}, &Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy expecting verification", testcase{
+		objs: []interface{}{
+			cert1, s1a,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+							UpstreamValidation: &projcontour.UpstreamValidation{
+								CACertificate: cert1.Name,
+								SubjectName:   "example.com",
+							},
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1a.Name,
+									Namespace:   s1a.Namespace,
+									ServicePort: &s1a.Spec.Ports[0],
+									Protocol:    "tls",
+								},
+								UpstreamValidation: &UpstreamValidation{
+									CACertificate: secret(cert1),
+									SubjectName:   "example.com",
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	// Invalid because tcpproxy both includes another and
+	// has a list of services.
+	run(t, "insert httpproxy with invalid tcpproxy", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "roots",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "passthrough.example.com",
+						TLS: &projcontour.TLS{
+							Passthrough: true,
+						},
+					},
+					TCPProxy: &projcontour.TCPProxy{
+						Include: &projcontour.TCPProxyInclude{
+							Name:      "foo",
+							Namespace: "roots",
+						},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(),
+	})
+
+	// Invalid because tcpproxy neither includes another httpproxy
+	// nor has a list of services.
+	run(t, "insert httpproxy with empty tcpproxy", testcase{
+		objs: []interface{}{
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "roots",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "passthrough.example.com",
+						TLS: &projcontour.TLS{
+							Passthrough: true,
+						},
+					},
+					TCPProxy: &projcontour.TCPProxy{},
+				},
+			},
+		},
+		want: listeners(),
+	})
+
+	run(t, "insert httpproxy w/ tcpproxy w/ missing include", testcase{
+		objs: []interface{}{proxy38, s1},
+		want: listeners(),
+	})
+
+	run(t, "insert httpproxy w/ tcpproxy w/ includes another root", testcase{
+		objs: []interface{}{proxy38, proxy39, s1},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "www.example.com", // this is proxy39, not proxy38
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s1),
+							),
+						},
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy w/ tcpproxy w/ includes valid child", testcase{
+		objs: []interface{}{
+			proxy38, s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					TCPProxy: &projcontour.TCPProxy{
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "passthrough.example.com",
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s1),
+							),
+						},
+					},
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with pathPrefix include", testcase{
+		objs: []interface{}{
+			proxy100, s1, s4,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "marketingwww",
+					Namespace: "marketing",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Services: []projcontour.Service{{
+							Name: "blog",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							},
+						),
+						routeCluster("/blog",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s4.Name,
+									Namespace:   s4.Namespace,
+									ServicePort: &s4.Spec.Ports[0],
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with pathPrefix include, child adds to pathPrefix", testcase{
+		objs: []interface{}{
+			proxy100, s1, s4,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "marketingwww",
+					Namespace: "marketing",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/infotech",
+						}},
+						Services: []projcontour.Service{{
+							Name: "blog",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							},
+						),
+						&Route{
+							PathCondition: prefix("/blog/infotech"),
+							Clusters: []*Cluster{{
+								Upstream: &Service{
+									Name:        s4.Name,
+									Namespace:   s4.Namespace,
+									ServicePort: &s4.Spec.Ports[0],
+								},
+							}},
+						},
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with pathPrefix include, child adds to pathPrefix, delegates again", testcase{
+		objs: []interface{}{
+			proxy100, s1, s4, s11,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "marketingit",
+					Namespace: "it",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/foo",
+						}},
+						Services: []projcontour.Service{{
+							Name: "blog",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "marketingwww",
+					Namespace: "marketing",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Includes: []projcontour.Include{{
+						Name:      "marketingit",
+						Namespace: "it",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/it",
+						}},
+					}},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/infotech",
+						}},
+						Services: []projcontour.Service{{
+							Name: "blog",
+							Port: 8080,
+						}},
+					}, {
+						Services: []projcontour.Service{{
+							Name: "blog",
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							},
+						),
+						&Route{
+							PathCondition: prefix("/blog/infotech"),
+							Clusters: []*Cluster{{
+								Upstream: &Service{
+									Name:        s4.Name,
+									Namespace:   s4.Namespace,
+									ServicePort: &s4.Spec.Ports[0],
+								},
+							}},
+						},
+						routeCluster("/blog",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s4.Name,
+									Namespace:   s4.Namespace,
+									ServicePort: &s4.Spec.Ports[0],
+								},
+							},
+						),
+						&Route{
+							PathCondition: prefix("/blog/it/foo"),
+							Clusters: []*Cluster{{
+								Upstream: &Service{
+									Name:        s11.Name,
+									Namespace:   s11.Namespace,
+									ServicePort: &s11.Spec.Ports[0],
+								},
+							}},
+						},
+					),
+				),
+			},
+		),
+	})
+
+	// proxy101 tests inclusion without a specified namespace.
 	proxy101 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
@@ -2392,2799 +4729,545 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy101a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuarder",
-			Namespace: proxy101.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
-					Name: s2.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy102 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/v1",
-				}, {
-					Prefix: "/api",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy103 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Name:      "www",
-				Namespace: "teama",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/v1",
-				}, {
-					Prefix: "/api",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy103a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "www",
-			Namespace: "teama",
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/v1",
-				}, {
-					Prefix: "/api",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy104 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Name: "kuarder",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/kuarder",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy104a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuarder",
-			Namespace: proxy104.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
-					Name: s2.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy105 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Name: "kuarder",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/kuarder",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy105a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuarder",
-			Namespace: proxy105.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s2.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy106 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Name: "kuarder",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/kuarder/",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy106a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuarder",
-			Namespace: proxy105.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s2.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy107 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-com",
-			Namespace: s1.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "example.com",
-			},
-			Includes: []projcontour.Include{{
-				Name: "kuarder",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/kuarder",
-				}},
-			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/",
-				}},
-				Services: []projcontour.Service{{
-					Name: s1.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	proxy107a := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuarder",
-			Namespace: proxy105.Namespace,
-		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.Condition{{
-					Prefix: "/withavengeance",
-				}},
-				Services: []projcontour.Service{{
-					Name: s2.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-	tests := map[string]struct {
-		objs                  []interface{}
-		disablePermitInsecure bool
-		want                  []Vertex
-	}{
-		"insert ingress w/ default backend w/o matching service": {
-			objs: []interface{}{
-				i1,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ default backend": {
-			objs: []interface{}{
-				i1,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ single unnamed backend w/o matching service": {
-			objs: []interface{}{
-				i2,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ single unnamed backend": {
-			objs: []interface{}{
-				i2,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress with missing spec.rule.http key": {
-			objs: []interface{}{
-				i2a,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ host name and single backend w/o matching service": {
-			objs: []interface{}{
-				i3,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ host name and single backend": {
-			objs: []interface{}{
-				i3,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert non matching service then ingress w/ default backend": {
-			objs: []interface{}{
-				s2,
-				i1,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ default backend then matching service with wrong port": {
-			objs: []interface{}{
-				i1,
-				s3,
-			},
-			want: listeners(),
-		},
-		"insert unnamed ingress w/ single backend then matching service with wrong port": {
-			objs: []interface{}{
-				i2,
-				s3,
-			},
-			want: listeners(),
-		},
-		"insert ingress w/ default backend then matching service w/ named port": {
-			objs: []interface{}{
-				i4,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert service w/ named port then ingress w/ default backend": {
-			objs: []interface{}{
-				s1,
-				i4,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ single unnamed backend w/ named service port then service": {
-			objs: []interface{}{
-				i5,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert service then ingress w/ single unnamed backend w/ named service port": {
-			objs: []interface{}{
-				s1,
-				i5,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert secret": {
-			objs: []interface{}{
-				sec1,
-			},
-			want: listeners(),
-		},
-		"insert secret then ingress w/o tls": {
-			objs: []interface{}{
-				sec1,
-				i1,
-			},
-			want: listeners(),
-		},
-		"insert service, secret then ingress w/o tls": {
-			objs: []interface{}{
-				s1,
-				sec1,
-				i1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert secret then ingress w/ tls": {
-			objs: []interface{}{
-				sec1,
-				i3,
-			},
-			want: listeners(),
-		},
-		"insert service, secret then ingress w/ tls": {
-			objs: []interface{}{
-				s1,
-				sec1,
-				i3,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
-					),
-				},
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("kuard.example.com", sec1, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert service w/ secret with w/ blank ca.crt": {
-			objs: []interface{}{
-				s1,
-				sec3, // issue 1644
-				i3,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
-					),
-				},
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("kuard.example.com", sec3, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert invalid secret then ingress w/o tls": {
-			objs: []interface{}{
-				sec2,
-				i1,
-			},
-			want: listeners(),
-		},
-		"insert service, invalid secret then ingress w/o tls": {
-			objs: []interface{}{
-				s1,
-				sec2,
-				i1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert invalid secret then ingress w/ tls": {
-			objs: []interface{}{
-				sec2,
-				i3,
-			},
-			want: listeners(),
-		},
-		"insert service, invalid secret then ingress w/ tls": {
-			objs: []interface{}{
-				s1,
-				sec2,
-				i3,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ two vhosts": {
-			objs: []interface{}{
-				i6,
-			},
-			want: nil, // no matching service
-		},
-		"insert ingress w/ two vhosts then matching service": {
-			objs: []interface{}{
-				i6,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("a.example.com", prefixroute("/", service(s1))),
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert service then ingress w/ two vhosts": {
-			objs: []interface{}{
-				s1,
-				i6,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("a.example.com", prefixroute("/", service(s1))),
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ two vhosts then service then secret": {
-			objs: []interface{}{
-				i6,
-				s1,
-				sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("a.example.com", prefixroute("/", service(s1))),
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert service then secret then ingress w/ two vhosts": {
-			objs: []interface{}{
-				s1,
-				sec1,
-				i6,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("a.example.com", prefixroute("/", service(s1))),
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ two paths then one service": {
-			objs: []interface{}{
-				i7,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com",
-							prefixroute("/", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingress w/ two paths then services": {
-			objs: []interface{}{
-				i7,
-				s2,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com",
-							prefixroute("/", service(s1)),
-							prefixroute("/kuarder", service(s2)),
-						),
-					),
-				},
-			),
-		},
-		"insert two services then ingress w/ two ingress rules": {
-			objs: []interface{}{
-				s1, s2, i8,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com",
-							prefixroute("/", service(s1)),
-							prefixroute("/kuarder", service(s2)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingress w/ two paths httpAllowed: false": {
-			objs: []interface{}{
-				i9,
-			},
-			want: []Vertex{},
-		},
-		"insert ingress w/ two paths httpAllowed: false then tls and service": {
-			objs: []interface{}{
-				i9,
-				sec1,
-				s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1,
-							prefixroute("/", service(s1)),
-							prefixroute("/kuarder", service(s2)),
-						),
-					),
-				},
-			),
-		},
-		"insert default ingress httpAllowed: false": {
-			objs: []interface{}{
-				i1a,
-			},
-			want: []Vertex{},
-		},
-		"insert default ingress httpAllowed: false then tls and service": {
-			objs: []interface{}{
-				i1a, sec1, s1,
-			},
-			want: []Vertex{}, // default ingress cannot be tls
-		},
-		"insert ingress w/ two vhosts httpAllowed: false": {
-			objs: []interface{}{
-				i6a,
-			},
-			want: []Vertex{},
-		},
-		"insert ingress w/ two vhosts httpAllowed: false then tls and service": {
-			objs: []interface{}{
-				i6a, sec1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ force-ssl-redirect: true": {
-			objs: []interface{}{
-				i6b, sec1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-
-		"insert ingress w/ force-ssl-redirect: true and allow-http: false": {
-			objs: []interface{}{
-				i6c, sec1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute": {
-			objs: []interface{}{
-				ir1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute w/ healthcheck": {
-			objs: []interface{}{
-				ir1e, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/", &Cluster{
-								Upstream: service(s1),
-								HealthCheckPolicy: &HealthCheckPolicy{
-									Path: "/healthz",
-								},
-							}),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute with websocket route": {
-			objs: []interface{}{
-				ir11, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-							routeRewrite("/websocket", "/", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute with tcp forward with TLS termination": {
-			objs: []interface{}{
-				ir1a, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s1),
-								),
-							},
-							Secret:          secret(sec1),
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
-						},
-					),
-				},
-			),
-		},
-		"insert ingressroute with tcp forward without TLS termination w/ passthrough": {
-			objs: []interface{}{
-				ir1b, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s1),
-								),
-							},
-						},
-					),
-				},
-			),
-		},
-		"insert root ingress route and delegate ingress route for a tcp proxy": {
-			objs: []interface{}{
-				ir1d, s6, ir1c,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s6),
-								),
-							},
-						},
-					),
-				},
-			),
-		},
-		"insert ingressroute with prefix rewrite route": {
-			objs: []interface{}{
-				ir10, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-							routeWebsocket("/websocket", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute with multiple upstreams prefix rewrite route, websocket routes are dropped": {
-			objs: []interface{}{
-				ir10b, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute and service": {
-			objs: []interface{}{
-				ir1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute without tls version": {
-			objs: []interface{}{
-				ir6, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute with TLS one insecure": {
-			objs: []interface{}{
-				ir14, s1, sec1,
-			},
-			disablePermitInsecure: false,
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", prefixroute("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("foo.com", sec1, prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute with TLS one insecure - disablePermitInsecure=true": {
-			objs: []interface{}{
-				ir14, s1, sec1,
-			},
-			disablePermitInsecure: true,
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute with tls version 1.2": {
-			objs: []interface{}{
-				ir7, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "foo.com",
-								routes: routes(
-									routeUpgrade("/", service(s1)),
-								),
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
-							Secret:          secret(sec1),
-						},
-					),
-				},
-			),
-		},
-		"insert ingressroute with tls version 1.3": {
-			objs: []interface{}{
-				ir8, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "foo.com",
-								routes: routes(
-									routeUpgrade("/", service(s1)),
-								),
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
-							Secret:          secret(sec1),
-						},
-					),
-				},
-			),
-		},
-		"insert ingressroute with invalid tls version": {
-			objs: []interface{}{
-				ir9, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingressroute referencing two backends, one missing": {
-			objs: []interface{}{
-				ir2, s2,
-			},
-			want: listeners(),
-		},
-		"insert ingressroute referencing two backends": {
-			objs: []interface{}{
-				ir2, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1), service(s2))),
-					),
-				},
-			),
-		},
-		"insert ingress w/ tls min proto annotation": {
-			objs: []interface{}{
-				i10a,
-				sec1,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "b.example.com",
-								routes: routes(
-									prefixroute("/", service(s1)),
-								),
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
-							Secret:          secret(sec1),
-						},
-					),
-				},
-			),
-		},
-		"insert ingress w/ legacy tls min proto annotation": {
-			objs: []interface{}{
-				i10b,
-				sec1,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("b.example.com", prefixroute("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "b.example.com",
-								routes: routes(
-									prefixroute("/", service(s1)),
-								),
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
-							Secret:          secret(sec1),
-						},
-					),
-				},
-			),
-		},
-		"insert ingress w/ websocket route annotation": {
-			objs: []interface{}{
-				i11,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", service(s1)),
-							routeWebsocket("/ws1", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingress w/ invalid legacy timeout annotation": {
-			objs: []interface{}{
-				i12a,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress w/ invalid timeout annotation": {
-			objs: []interface{}{
-				i12d,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
-						}),
-					),
-				},
-			),
-		},
-
-		"insert ingressroute w/ invalid timeoutpolicy": {
-			objs: []interface{}{
-				ir16a,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1, // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress w/ valid legacy timeout annotation": {
-			objs: []interface{}{
-				i12b,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: 90 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress w/ valid timeout annotation": {
-			objs: []interface{}{
-				i12e,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: 90 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-
-		"insert ingressroute w/ valid timeoutpolicy": {
-			objs: []interface{}{
-				ir16b,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: 90 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress w/ legacy infinite timeout annotation": {
-			objs: []interface{}{
-				i12c,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress w/ infinite timeout annotation": {
-			objs: []interface{}{
-				i12f,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1,
-							},
-						}),
-					),
-				},
-			),
-		},
-
-		"insert ingressroute w/ infinite timeoutpolicy": {
-			objs: []interface{}{
-				ir16c,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							TimeoutPolicy: &TimeoutPolicy{
-								ResponseTimeout: -1,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingressroute w/ missing tls annotation": {
-			objs: []interface{}{
-				cert1, ir17, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute w/ missing certificate": {
-			objs: []interface{}{
-				ir17, s1a,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute expecting verification": {
-			objs: []interface{}{
-				cert1, ir17, s1a,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
-									},
-									UpstreamValidation: &UpstreamValidation{
-										CACertificate: secret(cert1),
-										SubjectName:   "example.com",
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute routing and tcpproxying": {
-			objs: []interface{}{
-				s10, ir18,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost(ir18.Spec.VirtualHost.Fqdn,
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s10.Name,
-										Namespace:   s10.Namespace,
-										ServicePort: &s10.Spec.Ports[1],
-									},
-								},
-							),
-						),
-					),
-				},
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: ir18.Spec.VirtualHost.Fqdn,
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(service(s10)),
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLS_AUTO, // tls passthrough does not specify a TLS version; that's the domain of the backend
-						},
-					),
-				},
-			),
-		},
-		"insert ingressroute with missing tls delegation should not present port 80": {
-			objs: []interface{}{
-				s10, ir19,
-			},
-			want: listeners(), // no listeners, ir19 is invalid
-		},
-		"insert root ingress route and delegate ingress route": {
-			objs: []interface{}{
-				ir5, s4, ir4, s5, ir3,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/blog", service(s4)),
-							prefixroute("/blog/admin", service(s5)),
-						),
-					),
-				},
-			),
-		},
-		"insert ingress with retry annotations": {
-			objs: []interface{}{
-				ir15,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "5xx",
-								NumRetries:    6,
-								PerTryTimeout: 10 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress with invalid perTryTimeout": {
-			objs: []interface{}{
-				ir15a,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "5xx",
-								NumRetries:    6,
-								PerTryTimeout: 0,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingress with zero retry count": {
-			objs: []interface{}{
-				ir15b,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "5xx",
-								NumRetries:    1,
-								PerTryTimeout: 10 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingressroute with retrypolicy": {
-			objs: []interface{}{
-				i14a,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "gateway-error",
-								NumRetries:    6,
-								PerTryTimeout: 10 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingressroute with legacy retrypolicy": {
-			objs: []interface{}{
-				i14b,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "gateway-error",
-								NumRetries:    6,
-								PerTryTimeout: 10 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-		"insert ingressroute with timeout policy": {
-			objs: []interface{}{
-				i14c,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: prefix("/"),
-							Clusters:      clustermap(s1),
-							RetryPolicy: &RetryPolicy{
-								RetryOn:       "gateway-error",
-								NumRetries:    6,
-								PerTryTimeout: 10 * time.Second,
-							},
-						}),
-					),
-				},
-			),
-		},
-
-		"insert ingress with regex route": {
-			objs: []interface{}{
-				i15,
-				s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", &Route{
-							PathCondition: regex("/[^/]+/invoices(/.*|/?)"),
-							Clusters:      clustermap(s1),
-						}),
-					),
-				},
-			),
-		},
-		// issue 1234
-		"insert ingress with wildcard hostnames": {
-			objs: []interface{}{
-				s1,
-				i16,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert ingress overlay": {
-			objs: []interface{}{
-				i13a, i13b, sec13, s13a, s13b,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeUpgrade("/", service(s13a)),
-							prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
-						),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("example.com", sec13,
-							routeUpgrade("/", service(s13a)),
-							prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
-						),
-					),
-				},
-			),
-		},
-		"deprecated h2c service annotation": {
-			objs: []interface{}{
-				i3a, s3a,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3a.Name,
-								Namespace:   s3a.Namespace,
-								ServicePort: &s3a.Spec.Ports[0],
-								Protocol:    "h2c",
-							}),
-						),
-					),
-				},
-			),
-		},
-		"deprecated h2 service annotation": {
-			objs: []interface{}{
-				i3a, s3b,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3b.Name,
-								Namespace:   s3b.Namespace,
-								ServicePort: &s3b.Spec.Ports[0],
-								Protocol:    "h2",
-							}),
-						),
-					),
-				},
-			),
-		},
-		"deprecated tls service annotation": {
-			objs: []interface{}{
-				i3a, s3c,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3c.Name,
-								Namespace:   s3c.Namespace,
-								ServicePort: &s3c.Spec.Ports[0],
-								Protocol:    "tls",
-							}),
-						),
-					),
-				},
-			),
-		},
-
-		"h2c service annotation": {
-			objs: []interface{}{
-				i3a, s3d,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3a.Name,
-								Namespace:   s3a.Namespace,
-								ServicePort: &s3a.Spec.Ports[0],
-								Protocol:    "h2c",
-							}),
-						),
-					),
-				},
-			),
-		},
-		"h2 service annotation": {
-			objs: []interface{}{
-				i3a, s3e,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3b.Name,
-								Namespace:   s3b.Namespace,
-								ServicePort: &s3b.Spec.Ports[0],
-								Protocol:    "h2",
-							}),
-						),
-					),
-				},
-			),
-		},
-		"tls service annotation": {
-			objs: []interface{}{
-				i3a, s3f,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:        s3c.Name,
-								Namespace:   s3c.Namespace,
-								ServicePort: &s3c.Spec.Ports[0],
-								Protocol:    "tls",
-							}),
-						),
-					),
-				},
-			),
-		},
-		"insert ingress then service w/ upstream annotations": {
-			objs: []interface{}{
-				i1,
-				s1b,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("*",
-							prefixroute("/", &Service{
-								Name:               s1b.Name,
-								Namespace:          s1b.Namespace,
-								ServicePort:        &s1b.Spec.Ports[0],
-								MaxConnections:     9000,
-								MaxPendingRequests: 4096,
-								MaxRequests:        404,
-								MaxRetries:         7,
-							}),
-						),
-					),
-				},
-			),
-		},
-		"insert ingressroute with two routes to the same service": {
-			objs: []interface{}{
-				ir13, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/a", &Cluster{
+	run(t, "insert httpproxy with no namespace for include", testcase{
+		objs: []interface{}{
+			proxy101, s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuarder",
+					Namespace: proxy101.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Services: []projcontour.Service{{
+							Name: s2.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
 								Upstream: &Service{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 								},
-								Weight: 90,
-							}),
-							routeCluster("/b", &Cluster{
+							},
+						),
+						routeCluster("/kuarder",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s2.Name,
+									Namespace:   s2.Namespace,
+									ServicePort: &s2.Spec.Ports[0],
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with include, no prefix condition on included proxy", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Includes: []projcontour.Include{{
+						Name: "kuarder",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/kuarder",
+						}},
+					}},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuarder",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Services: []projcontour.Service{{
+							Name: s2.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
 								Upstream: &Service{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
 									ServicePort: &s1.Spec.Ports[0],
 								},
-								Weight: 60,
-							}),
+							},
 						),
-					),
-				},
-			),
-		},
-		"insert ingressroute with one routes to the same service with two different weights": {
-			objs: []interface{}{
-				ir13a, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/a",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-									Weight: 90,
-								}, &Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-									Weight: 60,
+						routeCluster("/kuarder",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s2.Name,
+									Namespace:   s2.Namespace,
+									ServicePort: &s2.Spec.Ports[0],
 								},
-							),
+							},
 						),
 					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with include, / on included proxy", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
 				},
-			),
-		},
-		"ingressroute delegated to non existent object": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "example-com",
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
 					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/finance",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "non-existent",
-								Namespace: "non-existent",
-							},
+					Includes: []projcontour.Include{{
+						Name: "kuarder",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/kuarder",
 						}},
-					},
+					}},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					}},
 				},
 			},
-			want: nil, // no listener created
-		},
-		"ingressroute delegates to itself": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "example-com",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/finance",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "example-com",
-								Namespace: "default",
-							},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuarder",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
 						}},
-					},
+						Services: []projcontour.Service{{
+							Name: s2.Name,
+							Port: 8080,
+						}},
+					}},
 				},
 			},
-			want: nil, // no listener created
 		},
-		"ingressroute delegates to incorrect prefix": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "example-com",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/finance",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "finance-root",
-								Namespace: "finance",
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
 							},
-						}},
-					},
+						),
+						routeCluster("/kuarder/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s2.Name,
+									Namespace:   s2.Namespace,
+									ServicePort: &s2.Spec.Ports[0],
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with include, full prefix on included proxy", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
 				},
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "finance",
-						Name:      "finance-root",
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
 					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						Routes: []ingressroutev1.Route{{
-							Match: "/prefixDoesntMatch",
-							Services: []ingressroutev1.Service{{
-								Name: "home",
-							}},
+					Includes: []projcontour.Include{{
+						Name: "kuarder",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/kuarder",
 						}},
-					},
+					}},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					}},
 				},
 			},
-			want: nil, // no listener created
-		},
-		"ingressroute delegate to prefix, but no matching path in delegate": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "example-com",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/foo",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "finance-root",
-								Namespace: "finance",
-							},
-						}},
-					},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuarder",
+					Namespace: s1.Namespace,
 				},
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "finance",
-						Name:      "finance-root",
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/withavengeance",
+						}},
+						Services: []projcontour.Service{{
+							Name: s2.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							},
+						),
+						routeCluster("/kuarder/withavengeance",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s2.Name,
+									Namespace:   s2.Namespace,
+									ServicePort: &s2.Spec.Ports[0],
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with include ending with /, / on included proxy", testcase{
+		objs: []interface{}{
+			s1, s2,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
 					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						Routes: []ingressroutev1.Route{{
-							Match: "/foobar",
-							Services: []ingressroutev1.Service{{
-								Name: "home",
-							}},
+					Includes: []projcontour.Include{{
+						Name: "kuarder",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/kuarder/",
+						}},
+					}},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuarder",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/",
+						}},
+						Services: []projcontour.Service{{
+							Name: s2.Name,
+							Port: 8080,
+						}},
+					}},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com",
+						routeCluster("/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s1.Name,
+									Namespace:   s1.Namespace,
+									ServicePort: &s1.Spec.Ports[0],
+								},
+							},
+						),
+						routeCluster("/kuarder/",
+							&Cluster{
+								Upstream: &Service{
+									Name:        s2.Name,
+									Namespace:   s2.Namespace,
+									ServicePort: &s2.Spec.Ports[0],
+								},
+							},
+						),
+					),
+				),
+			},
+		),
+	})
+
+	run(t, "insert httpproxy with multiple prefix conditions on route", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+					},
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/v1",
 						}, {
-							Match: "/foo/bar",
-							Services: []ingressroutev1.Service{{
-								Name: "home",
-							}},
+							Prefix: "/api",
 						}},
-					},
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
+						}},
+					}},
 				},
 			},
-			want: nil, // no listener created
 		},
-		"ingressroute cycle": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "default",
-						Name:      "example-com",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/finance",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "finance-root",
-								Namespace: "finance",
-							},
-						}},
-					},
+		want: listeners(),
+	})
+
+	run(t, "insert httpproxy with multiple prefix conditions on include", testcase{
+		objs: []interface{}{
+			s1,
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-com",
+					Namespace: s1.Namespace,
 				},
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "finance",
-						Name:      "finance-root",
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
 					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						Routes: []ingressroutev1.Route{{
-							Match: "/finance",
-							Services: []ingressroutev1.Service{{
-								Name: "home",
-								Port: 8080,
-							}},
+					Includes: []projcontour.Include{{
+						Name:      "www",
+						Namespace: "teama",
+						Conditions: []projcontour.Condition{{
+							Prefix: "/v1",
 						}, {
-							Match: "/finance/stocks",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "example-com",
-								Namespace: "default",
-							},
+							Prefix: "/api",
 						}},
-					},
-				},
-				s7,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/finance", service(s7))),
-					),
-				},
-			),
-		},
-		"ingressroute root delegates to another ingressroute root": {
-			objs: []interface{}{
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "root-blog",
-						Namespace: "roots",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "blog.containersteve.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/",
-							Delegate: &ingressroutev1.Delegate{
-								Name:      "blog",
-								Namespace: "marketing",
-							},
+					}},
+					Routes: []projcontour.Route{{
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
 						}},
-					},
+					}},
 				},
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "blog",
-						Namespace: "marketing",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "www.containersteve.com",
-						},
-						Routes: []ingressroutev1.Route{{
-							Match: "/",
-							Services: []ingressroutev1.Service{{
-								Name: "green",
-								Port: 80,
-							}},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "www",
+					Namespace: "teama",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					Routes: []projcontour.Route{{
+						Conditions: []projcontour.Condition{{
+							Prefix: "/v1",
+						}, {
+							Prefix: "/api",
 						}},
-					},
-				},
-				s8,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("www.containersteve.com", prefixroute("/", service(s8))),
-					),
-				},
-			),
-		},
-		// issue 1399
-		"service shared across ingress and ingressroute tcpproxy": {
-			objs: []interface{}{
-				sec1,
-				s9,
-				&v1beta1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
-					},
-					Spec: v1beta1.IngressSpec{
-						TLS: []v1beta1.IngressTLS{{
-							Hosts:      []string{"example.com"},
-							SecretName: s1.Name,
+						Services: []projcontour.Service{{
+							Name: s1.Name,
+							Port: 8080,
 						}},
-						Rules: []v1beta1.IngressRule{{
-							Host:             "example.com",
-							IngressRuleValue: ingressrulevalue(backend(s9.Name, intstr.FromInt(80))),
-						}},
-					},
-				},
-				&ingressroutev1.IngressRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
-					},
-					Spec: ingressroutev1.IngressRouteSpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
-								SecretName: sec1.Name,
-							},
-						},
-						TCPProxy: &ingressroutev1.TCPProxy{
-							Services: []ingressroutev1.Service{{
-								Name: s9.Name,
-								Port: 80,
-							}},
-						},
-					},
+					}},
 				},
 			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s9))),
-					),
-				},
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "example.com",
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
-							Secret:          secret(sec1),
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(service(s9)),
-							},
-						},
-					),
-				},
-			),
 		},
-		"insert httproxy": {
-			objs: []interface{}{
-				proxy1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert httproxy w/o condition": {
-			objs: []interface{}{
-				proxy1b, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert httproxy w/ conditions": {
-			objs: []interface{}{
-				proxy1c, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", &Route{
-							PathCondition: &PrefixCondition{Prefix: "/kuard"},
-							HeaderConditions: []HeaderCondition{
-								{Name: "x-request-id", MatchType: "present"},
-								{Name: "e-tag", Value: "abcdef", MatchType: "contains"},
-								{Name: "x-timeout", Value: "infinity", MatchType: "contains", Invert: true},
-								{Name: "digest-auth", Value: "scott", MatchType: "exact"},
-								{Name: "digest-password", Value: "tiger", MatchType: "exact", Invert: true},
-							},
-							Clusters: clusters(service(s1)),
-						}),
-					),
-				},
-			),
-		},
-		"insert httproxy w/ included conditions": {
-			objs: []interface{}{
-				proxy2a, proxy2b, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", &Route{
-							PathCondition: &PrefixCondition{Prefix: "/kuard"},
-							HeaderConditions: []HeaderCondition{
-								{Name: "x-request-id", MatchType: "present"},
-								{Name: "x-timeout", Value: "infinity", MatchType: "contains", Invert: true},
-								{Name: "digest-auth", Value: "scott", MatchType: "exact"},
-								{Name: "e-tag", Value: "abcdef", MatchType: "contains"},
-								{Name: "digest-password", Value: "tiger", MatchType: "exact", Invert: true},
-							},
-							Clusters: clusters(service(s1)),
-						}),
-					),
-				},
-			),
-		},
-		"insert httpproxy w/ healthcheck": {
-			objs: []interface{}{
-				proxy1e, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/", &Cluster{
-								Upstream: service(s1),
-								HealthCheckPolicy: &HealthCheckPolicy{
-									Path: "/healthz",
-								},
-							}),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with mirroring route": {
-			objs: []interface{}{
-				proxy12, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							withMirror(prefixroute("/", service(s1)), service(s2)),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with two mirrors": {
-			objs: []interface{}{
-				proxy13, s1, s2,
-			},
-			want: listeners(),
-		},
-		"insert httpproxy with prefix rewrite route": {
-			objs: []interface{}{
-				proxy10, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-							routeWebsocket("/websocket", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with multiple upstreams prefix rewrite route, websocket routes are dropped": {
-			objs: []interface{}{
-				proxy10b, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							prefixroute("/", service(s1)),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy and service": {
-			objs: []interface{}{
-				proxy1, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert httpproxy without tls version": {
-			objs: []interface{}{
-				proxy6, s1, sec1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("foo.com", routeUpgrade("/", service(s1))),
-					),
-				}, &Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
-					),
-				},
-			),
-		},
-		"insert httpproxy expecting verification": {
-			objs: []interface{}{
-				cert1, proxy17, s1a,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
-									},
-									UpstreamValidation: &UpstreamValidation{
-										CACertificate: secret(cert1),
-										SubjectName:   "example.com",
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with invalid tcpproxy": {
-			objs: []interface{}{proxy37, s1},
-			want: listeners(),
-		},
-		"insert httpproxy with empty tcpproxy": {
-			objs: []interface{}{proxy37a, s1},
-			want: listeners(),
-		},
-		"insert httpproxy w/ tcpproxy w/ missing include": {
-			objs: []interface{}{proxy38, s1},
-			want: listeners(),
-		},
-		"insert httpproxy w/ tcpproxy w/ includes another root": {
-			objs: []interface{}{proxy38, proxy39, s1},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "www.example.com", // this is proxy39, not proxy38
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s1),
-								),
-							},
-						},
-					),
-				},
-			),
-		},
-		"insert httpproxy w/ tcpproxy w/ includes valid child": {
-			objs: []interface{}{proxy38, proxy40, s1},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "passthrough.example.com",
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s1),
-								),
-							},
-						},
-					),
-				},
-			),
-		},
-		"insert httpproxy with pathPrefix include": {
-			objs: []interface{}{
-				proxy100, proxy100a, s1, s4,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/blog",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with pathPrefix include, child adds to pathPrefix": {
-			objs: []interface{}{
-				proxy100, proxy100b, s1, s4,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							&Route{
-								PathCondition: prefix("/blog/infotech"),
-								Clusters: []*Cluster{{
-									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
-									},
-								}},
-							},
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with pathPrefix include, child adds to pathPrefix, delegates again": {
-			objs: []interface{}{
-				proxy100, proxy100c, proxy100d, s1, s4, s11,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							&Route{
-								PathCondition: prefix("/blog/infotech"),
-								Clusters: []*Cluster{{
-									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
-									},
-								}},
-							},
-							routeCluster("/blog",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
-									},
-								},
-							),
-							&Route{
-								PathCondition: prefix("/blog/it/foo"),
-								Clusters: []*Cluster{{
-									Upstream: &Service{
-										Name:        s11.Name,
-										Namespace:   s11.Namespace,
-										ServicePort: &s11.Spec.Ports[0],
-									},
-								}},
-							},
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with no namespace for include": {
-			objs: []interface{}{
-				proxy101, proxy101a, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/kuarder",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with include, no prefix condition on included proxy": {
-			objs: []interface{}{
-				proxy104, proxy104a, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/kuarder",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with include, / on included proxy": {
-			objs: []interface{}{
-				proxy105, proxy105a, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/kuarder/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with include, full prefix on included proxy": {
-			objs: []interface{}{
-				proxy107, proxy107a, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/kuarder/withavengeance",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with include ending with /, / on included proxy": {
-			objs: []interface{}{
-				proxy106, proxy106a, s1, s2,
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
-									},
-								},
-							),
-							routeCluster("/kuarder/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
-									},
-								},
-							),
-						),
-					),
-				},
-			),
-		},
-		"insert httpproxy with multiple prefix conditions on route": {
-			objs: []interface{}{
-				proxy102, s1,
-			},
-			want: listeners(),
-		},
-		"insert httpproxy with multiple prefix conditions on include": {
-			objs: []interface{}{
-				proxy103, proxy103a, s1,
-			},
-			want: listeners(),
-		},
-		"insert proxy with tcp forward without TLS termination w/ passthrough": {
-			objs: []interface{}{
-				proxy1a, s1,
-			},
-			want: listeners(
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
-							},
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(
-									service(s1),
-								),
-							},
-						},
-					),
-				},
-			),
-		},
-		// issue 1399
-		"service shared across ingress and httpproxy tcpproxy": {
-			objs: []interface{}{
-				sec1,
-				s9,
-				&v1beta1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
-					},
-					Spec: v1beta1.IngressSpec{
-						TLS: []v1beta1.IngressTLS{{
-							Hosts:      []string{"example.com"},
-							SecretName: s1.Name,
-						}},
-						Rules: []v1beta1.IngressRule{{
-							Host:             "example.com",
-							IngressRuleValue: ingressrulevalue(backend(s9.Name, intstr.FromInt(80))),
-						}},
-					},
-				},
-				&projcontour.HTTPProxy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nginx",
-						Namespace: "default",
-					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
-							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
-								SecretName: sec1.Name,
-							},
-						},
-						TCPProxy: &projcontour.TCPProxy{
-							Services: []projcontour.Service{{
-								Name: s9.Name,
-								Port: 80,
-							}},
-						},
-					},
-				},
-			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", prefixroute("/", service(s9))),
-					),
-				},
-				&Listener{
-					Port: 443,
-					VirtualHosts: virtualhosts(
-						&SecureVirtualHost{
-							VirtualHost: VirtualHost{
-								Name: "example.com",
-							},
-							MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
-							Secret:          secret(sec1),
-							TCPProxy: &TCPProxy{
-								Clusters: clusters(service(s9)),
-							},
-						},
-					),
-				},
-			),
-		},
-	}
+		want: listeners(),
+	})
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			builder := Builder{
-				DisablePermitInsecure: tc.disablePermitInsecure,
-				Source: KubernetesCache{
-					FieldLogger: testLogger(t),
+	run(t, "insert proxy with tcp forward without TLS termination w/ passthrough", testcase{
+		objs: []interface{}{
+			s1,
+			// Forwards traffic to default/kuard:8080 by TLS pass-through.
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard-tcp",
+					Namespace: "default",
 				},
-			}
-			for _, o := range tc.objs {
-				builder.Source.Insert(o)
-			}
-			dag := builder.Build()
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "kuard.example.com",
+						TLS: &projcontour.TLS{
+							Passthrough: true,
+						},
+					},
+					TCPProxy: &projcontour.TCPProxy{
+						Services: []projcontour.Service{{
+							Name: "kuard",
+							Port: 8080,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "kuard.example.com",
+						},
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(
+								service(s1),
+							),
+						},
+					},
+				),
+			},
+		),
+	})
 
-			got := make(map[int]*Listener)
-			dag.Visit(listenerMap(got).Visit)
-
-			want := make(map[int]*Listener)
-			for _, v := range tc.want {
-				if l, ok := v.(*Listener); ok {
-					want[l.Port] = l
-				}
-			}
-			opts := []cmp.Option{
-				cmp.AllowUnexported(VirtualHost{}),
-			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
+	// issue 1399
+	run(t, "service shared across ingress and httpproxy tcpproxy", testcase{
+		objs: []interface{}{
+			sec1,
+			s9,
+			&v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: v1beta1.IngressSpec{
+					TLS: []v1beta1.IngressTLS{{
+						Hosts:      []string{"example.com"},
+						SecretName: s1.Name,
+					}},
+					Rules: []v1beta1.IngressRule{{
+						Host:             "example.com",
+						IngressRuleValue: ingressrulevalue(backend(s9.Name, intstr.FromInt(80))),
+					}},
+				},
+			},
+			&projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+				Spec: projcontour.HTTPProxySpec{
+					VirtualHost: &projcontour.VirtualHost{
+						Fqdn: "example.com",
+						TLS: &projcontour.TLS{
+							SecretName: sec1.Name,
+						},
+					},
+					TCPProxy: &projcontour.TCPProxy{
+						Services: []projcontour.Service{{
+							Name: s9.Name,
+							Port: 80,
+						}},
+					},
+				},
+			},
+		},
+		want: listeners(
+			&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("example.com", prefixroute("/", service(s9))),
+				),
+			},
+			&Listener{
+				Port: 443,
+				VirtualHosts: virtualhosts(
+					&SecureVirtualHost{
+						VirtualHost: VirtualHost{
+							Name: "example.com",
+						},
+						MinProtoVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+						Secret:          secret(sec1),
+						TCPProxy: &TCPProxy{
+							Clusters: clusters(service(s9)),
+						},
+					},
+				),
+			},
+		),
+	})
 }
 
 type listenerMap map[int]*Listener


### PR DESCRIPTION
Refactor the Builder tests to use local helpers rather than direct
table-driven test cases. This preserved the benefits of test cases
(getting a useful name and test case structure), but also keeps
test inputs and outputs close together, removes the need for many
local fixture variables and improves test failure reporting (you
get a useful line number).

This updates #1499.

Signed-off-by: James Peach <jpeach@vmware.com>