### PR TITLE
Add site proofing checks to travis-ci process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,32 @@
-language: go
+matrix:
+  include:
+    - language: go
+      name: test make process
+      go:
+        - 1.13.x
+      sudo: false
+      cache:
+        directories:
+          - /home/travis/.cache/go-build
+          - /home/travis/gopath/pkg/mod
+      env:
+        - GOPROXY=https://proxy.golang.org/
+      script:
+        - make check
 
-go:
-  - 1.13.x
-
-sudo: false
-
-cache:
-  directories:
-  - /home/travis/.cache/go-build
-  - /home/travis/gopath/pkg/mod
-
-env:
-  - GOPROXY=https://proxy.golang.org/
-
-script:
-  - make check
+    - language: ruby
+      rvm: 2.6
+      name: Site Proofing
+      sudo: false # route your build to the container-based infrastructure for a faster build
+      cache: bundler
+      env:
+        - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+        - SEARCH_DIRECTORIES="site"
+      addons:
+        apt:
+          packages:
+            - libcurl4-openssl-dev
+      install:
+        - ./hack/travis/travis-check-files-changed.sh $SEARCH_DIRECTORIES ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
+      script:
+        - ./hack/site-proofing/cibuild

--- a/hack/site-proofing/cibuild
+++ b/hack/site-proofing/cibuild
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+# Builds and checks the website for broken links.
+
+readonly HERE="$(cd $(dirname $0) && pwd)"
+cd ${HERE}/../../site
+
+gem install bundler
+gem install html-proofer
+gem install jekyll -v 3.8.5
+bundle install
+bundle exec jekyll build
+htmlproofer ./_site \
+    --empty-alt-ignore \
+    --assume-extension \
+    --allow-missing-href \
+    --allow-hash-href

--- a/hack/travis/travis-check-files-changed.sh
+++ b/hack/travis/travis-check-files-changed.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Checks if the files changed in the last commit are contained within specifed directories.
+# This is used to determine if a job should run based on changes within a commit
+# PATHS_TO_SEARCH can be a single path "site" or multipl paths "site hack", response if for any path specified.
+# Add to a job within .travis.yml
+#      env:
+#        - SEARCH_DIRECTORIES="site"
+#      install:
+#        - ./hack/travis/travis-check-files-changed.sh $SEARCH_DIRECTORIES ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
+
+set -e # halt script on error
+
+# 1. Make sure the paths to search are not empty
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+# 2. Get the latest commit
+LATEST_COMMIT=$(git rev-parse HEAD)
+
+# 3. Get the latest commit in the searched paths
+LATEST_COMMIT_IN_PATH=$(git log -1 --format=format:%H --full-diff "$@")
+
+if [ $LATEST_COMMIT != $LATEST_COMMIT_IN_PATH ]; then
+    echo "Exiting this job because code in the following paths have not changed:"
+    echo $@
+    exit 137
+fi
+
+echo "Changes detected in the following paths:"
+echo $@
+exit 0


### PR DESCRIPTION
Added site proofing process to travis-ci process.

Added script to detect if files within a directory have changes as part of a commit. Adds capability to determine only run travis jobs relevant to the files changed.

Travis matrix used to enable build tasks to be run in parallel and independently off each other.

Signed-off-by: Brett Johnson <brett@sdbrett.com>