### PR TITLE
Add namespace env var to certgen job

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -58,6 +58,11 @@ spec:
         - certgen
         - --incluster
         - --kube
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       restartPolicy: Never
       serviceAccountName: contour-certgen
   parallelism: 1

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1038,6 +1038,11 @@ spec:
         - certgen
         - --incluster
         - --kube
+        env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       restartPolicy: Never
       serviceAccountName: contour-certgen
   parallelism: 1


### PR DESCRIPTION
This makes it easier to deploy examples/render/contour.yaml to a different namespace, via kustomization.yaml for example.
Without this change contour certgen will try to create a secret in the namespace projectcontour, which will not be accessable(, iff deoployed to different namespace).

The contour bootstrap initcontainer also has this namespace env, there should be no reason for certgen to not have it. :)