### PR TITLE
Fixed unclosed <a> element in site header.

### DIFF
--- a/site/_includes/site-header.html
+++ b/site/_includes/site-header.html
@@ -4,7 +4,7 @@
             <a href="/" alt="Homepage"><img src="/img/{{ site.logo }}" class="logo" /></a>
         </div>
         <ul class="nav-menu" id="header-nav">
-		<li><a href="{% link getting-started.md %}" title="Getting Started">Getting Started<a></li>
+		<li><a href="{% link getting-started.md %}" title="Getting Started">Getting Started</a></li>
 		<li><a href="{% link guides.md %}" title="Guides">Guides</a></li>
 		<li><a href="{% link community.md %}" title="Community">Community</a></li>
 		<li><a href="{% link docs.md %}" title="Documentation">Documentation</a></li>


### PR DESCRIPTION
The unclosed element caused the site to render without <li> elements in the site header which could negatively impact site users who use a screen reader. Reference: https://dequeuniversity.com/rules/axe/3.1/list?application=lighthouse

Signed-off-by: Brett Johnson <brett@sdbrett.com>