### PR TITLE
internal/envoy: enable Envoy ADS support

### DIFF
--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -37,6 +37,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *bootstrap
 	bootstrap.Flag("envoy-cert-file", "gRPC Client cert filename for Envoy to load.").Envar("ENVOY_CERT_FILE").StringVar(&ctx.config.GrpcClientCert)
 	bootstrap.Flag("envoy-key-file", "gRPC Client key filename for Envoy to load.").Envar("ENVOY_KEY_FILE").StringVar(&ctx.config.GrpcClientKey)
 	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&ctx.config.Namespace)
+	bootstrap.Flag("disable-ads", "Enable the Envoy Aggregated Discovery Service.").BoolVar(&ctx.config.DisableADS)
 	return bootstrap, &ctx
 }
 

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -28,8 +28,11 @@ func TestBootstrap(t *testing.T) {
 		want   string
 	}{
 		"default configuration": {
-			config: BootstrapConfig{Namespace: "testing-ns"},
-			want: `{
+			config: BootstrapConfig{
+				Namespace: "testing-ns",
+			},
+			want: `
+{
   "static_resources": {
     "clusters": [
       {
@@ -89,8 +92,8 @@ func TestBootstrap(t *testing.T) {
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
-          "endpoints": [   
-            {                          
+          "endpoints": [
+            {
               "lb_endpoints": [
                 {
                   "endpoint": {
@@ -98,11 +101,11 @@ func TestBootstrap(t *testing.T) {
                       "socket_address": {
                         "address": "127.0.0.1",
                         "port_value": 9001
-                      }    
-                    }     
+                      }
+                    }
                   }
-                }          
-              ]                        
+                }
+              ]
             }
           ]
         }
@@ -111,28 +114,20 @@ func TestBootstrap(t *testing.T) {
   },
   "dynamic_resources": {
     "lds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      }
+      "ads": {}
     },
     "cds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
+      "ads": {}
+    },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "contour"
           }
-        ]
-      }
+        }
+      ]
     }
   },
   "admin": {
@@ -146,8 +141,9 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"--admin-address=8.8.8.8 --admin-port=9200": {
+		"--admin-address=8.8.8.8 --admin-port=9200 --disable-ads": {
 			config: BootstrapConfig{
+				DisableADS:   true,
 				AdminAddress: "8.8.8.8",
 				AdminPort:    9200,
 				Namespace:    "testing-ns",
@@ -269,8 +265,9 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"AdminAccessLogPath": { // TODO(dfc) doesn't appear to be exposed via contour bootstrap
+		"AdminAccessLogPath --disable-ads": { // TODO(dfc) doesn't appear to be exposed via contour bootstrap
 			config: BootstrapConfig{
+				DisableADS:         true,
 				AdminAccessLogPath: "/var/log/admin.log",
 				Namespace:          "testing-ns",
 			},
@@ -391,8 +388,9 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"--xds-address=8.8.8.8 --xds-port=9200": {
+		"--xds-address=8.8.8.8 --xds-port=9200 --disable-ads": {
 			config: BootstrapConfig{
+				DisableADS:  true,
 				XDSAddress:  "8.8.8.8",
 				XDSGRPCPort: 9200,
 				Namespace:   "testing-ns",
@@ -514,9 +512,10 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"--stats-address=8.8.8.8 --stats-port=9200": {
+		"--stats-address=8.8.8.8 --stats-port=9200 --disable-ads": {
 			config: BootstrapConfig{
-				Namespace: "testing-ns",
+				DisableADS: true,
+				Namespace:  "testing-ns",
 			},
 			want: `{
   "static_resources": {
@@ -635,8 +634,9 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"--envoy-cafile=CA.cert --envoy-client-cert=client.cert --envoy-client-key=client.key": {
+		"--envoy-cafile=CA.cert --envoy-client-cert=client.cert --envoy-client-key=client.key --disable-ads": {
 			config: BootstrapConfig{
+				DisableADS:     true,
 				Namespace:      "testing-ns",
 				GrpcCABundle:   "CA.cert",
 				GrpcClientCert: "client.cert",

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -307,6 +307,16 @@ func ConfigSource(cluster string) *envoy_api_v2_core.ConfigSource {
 	}
 }
 
+// ConfigSourceADS returns a *envoy_api_v2_core.ConfigSource that
+// directs the resource to ADS.
+func ConfigSourceADS() *envoy_api_v2_core.ConfigSource {
+	return &envoy_api_v2_core.ConfigSource{
+		ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+			Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+		},
+	}
+}
+
 // ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
 func ClusterDiscoveryType(t v2.Cluster_DiscoveryType) *v2.Cluster_Type {
 	return &v2.Cluster_Type{Type: t}

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -39,16 +39,23 @@ func NewAPI(log logrus.FieldLogger, resources map[string]Resource, registry *pro
 		},
 		grpc_prometheus.NewServerMetrics(),
 	}
+
 	registry.MustRegister(s.metrics)
+
 	opts = append(opts, grpc.StreamInterceptor(s.metrics.StreamServerInterceptor()),
 		grpc.UnaryInterceptor(s.metrics.UnaryServerInterceptor()))
+
 	g := grpc.NewServer(opts...)
+
 	v2.RegisterClusterDiscoveryServiceServer(g, s)
 	v2.RegisterEndpointDiscoveryServiceServer(g, s)
 	v2.RegisterListenerDiscoveryServiceServer(g, s)
 	v2.RegisterRouteDiscoveryServiceServer(g, s)
 	discovery.RegisterSecretDiscoveryServiceServer(g, s)
+	discovery.RegisterAggregatedDiscoveryServiceServer(g, s)
+
 	s.metrics.InitializeMetrics(g)
+
 	return g
 }
 
@@ -110,6 +117,10 @@ func (s *grpcServer) DeltaRoutes(v2.RouteDiscoveryService_DeltaRoutesServer) err
 	return status.Errorf(codes.Unimplemented, "IncrementalRoutes unimplemented")
 }
 
+func (s *grpcServer) DeltaAggregatedResources(srv discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	return status.Errorf(codes.Unimplemented, "DeltaAggregatedResources unimplemented")
+}
+
 func (s *grpcServer) StreamListeners(srv v2.ListenerDiscoveryService_StreamListenersServer) error {
 	return s.stream(srv)
 }
@@ -119,5 +130,9 @@ func (s *grpcServer) StreamRoutes(srv v2.RouteDiscoveryService_StreamRoutesServe
 }
 
 func (s *grpcServer) StreamSecrets(srv discovery.SecretDiscoveryService_StreamSecretsServer) error {
+	return s.stream(srv)
+}
+
+func (s *grpcServer) StreamAggregatedResources(srv discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return s.stream(srv)
 }


### PR DESCRIPTION
Since the Contour GRPC server already multiplexes Envoy requests
using the resource type URL, we can support ADS simply by enabling
it in the bootstrap configuration.

Signed-off-by: James Peach <jpeach@vmware.com>