### PR TITLE
TimeoutPolicy GODOC strings and documentation updates

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -212,6 +212,10 @@ type HTTPHealthCheckPolicy struct {
 
 // TimeoutPolicy defines the attributes associated with timeout.
 type TimeoutPolicy struct {
+	// TimeoutPolicy durations are expressed as per the format specified in the ParseDuration documentation: https://godoc.org/time#ParseDuration
+	// Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// The string 'infinity' is also a valid input and specifies no timeout.
+
 	// Timeout for receiving a response from the server after processing a request from client.
 	// If not supplied the timeout duration is undefined.
 	Response string `json:"response"`

--- a/site/_docs_1_0/httpproxy.md
+++ b/site/_docs_1_0/httpproxy.md
@@ -546,6 +546,11 @@ More information can be found in [Envoy's documentation](https://www.envoyproxy.
 The time period of **0s** will also be treated as infinity.
 By default, there is no per-route idle timeout.
 Note that the default connection manager idle timeout of 5 minutes will apply if this is not set.
+
+TimeoutPolicy durations are expressed as per the format specified in the [ParseDuration documentation](https://godoc.org/time#ParseDuration).
+Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+The string 'infinity' is also a valid input and specifies no timeout.
+
 More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout)
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request.
   - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.


### PR DESCRIPTION
Added GODOC strings for httpproxy TimeoutPolicy and updated site documentation to clarify valid input formats with reference to ParseDuration.

Fixes: #1822

Signed-off-by: Brett Johnson <brett@sdbrett.com>