### PR TITLE
Enable bundler caching to decrease local site testing time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,10 @@ node_modules
 _site
 .jekyll
 .jekyll-metadata
+.jekyll-cache
 .bundle
 .vscode
-
+bundler
 *.log
 *.js.map
 *.css.map

--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,11 @@ certs/envoycert.pem: certs/CAkey.pem certs/envoykey.pem
 .PHONY: site-devel
 site-devel: ## Launch the website in a Docker container
 	docker run --publish $(JEKYLL_PORT):$(JEKYLL_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
-		bash -c "cd /site && bundle install && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload"
+		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload"
 
 site-check: ## Test the site's links
 	docker run  -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
-		bash -c "cd /site && bundle install && bundle exec jekyll build && htmlproofer --assume-extension /site/_site"
+		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll build && htmlproofer --assume-extension /site/_site"
 
 .PHONY: metrics-docs
 metrics-docs: ## Regenerate documentation for metrics

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -120,6 +120,12 @@ exclude:
   - Runbook.docx
   - '*.sh'
   - vendor
+  - bundler/bundle/
+  - bundler/cache/
+  - bundler/gems/
+  - bundler/ruby/
+  - node_modules
+
 redcarpet:
     extensions: ["no_intra_emphasis", "tables", "autolink", "strikethrough", "with_toc_data"]
 


### PR DESCRIPTION
Fixes: #1852 

Added --path option to bunder install commands for site-devel and site-check make targets and added path to .gitignore.

First time running make site-devel or make site-check will install gems to site/bundler/cache. Each subsequent run will use the local cache instead of downloading and installing gems. Changes to the Gemfile and Gemfile.lock will install new / updated gem versions to the cache.

This approach also means that system gems will not be used, only those in the cache location and can provide more consistent results across local testing.

Bundler cache path has been added to .gitignore and Jekyll excludes

Bundler command options: https://bundler.io/v2.0/bundle_install.html
Jekyll excludes reference: https://jekyllrb.com/docs/troubleshooting/#configuration-problems

Signed-off-by: Brett Johnson <brett@sdbrett.com>