### PR TITLE
Add --rm option to docker run commands for site-devel and site-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,11 +215,11 @@ certs/envoycert.pem: certs/CAkey.pem certs/envoykey.pem
 
 .PHONY: site-devel
 site-devel: ## Launch the website in a Docker container
-	docker run --publish $(JEKYLL_PORT):$(JEKYLL_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
+	docker run --rm --publish $(JEKYLL_PORT):$(JEKYLL_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
 		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload"
 
 site-check: ## Test the site's links
-	docker run  -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
+	docker run --rm -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
 		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll build && htmlproofer --assume-extension /site/_site"
 
 .PHONY: metrics-docs


### PR DESCRIPTION
Fixes: #1887

Added `-rm` option to the `docker run` command for site-devel and site-check make targets. This will cause docker to automatically remove containers use for these processes when terminated. Currently they are not removed and the number of stopped containers will build up on the docker host unless manually removed.

Reference: [Clean up (--rm)](https://docs.docker.com/engine/reference/run/#clean-up---rm)

Signed-off-by: Brett Johnson <brett@sdbrett.com>