### PR TITLE
Resolve header foreground selected colour

### DIFF
--- a/site/_scss/site/settings/_variables.scss
+++ b/site/_scss/site/settings/_variables.scss
@@ -46,8 +46,8 @@ $container-max-width: 1440px;
 // Header
 
 $header-background: $white;
-$header-foreground: #000;
-$header-foreground-selected: $white;
+$header-foreground: $black;
+$header-foreground-selected: $black;
 
 // Footer
 $footer-foreground: #808080;


### PR DESCRIPTION
Fixes: #1892

Corrected colour setting for $header-foreground-selected
Changed $header-foreground from #000 to $black for consistency

Signed-off-by: Brett Johnson brett@sdbrett.com