### PR TITLE
Add PSP to the contour configuration

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -5,6 +5,78 @@ metadata:
   name: contour-certgen
   namespace: projectcontour
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: contour-certgen
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  # Allow core volume types.
+  volumes:
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-certgen
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - contour-certgen
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-certgen
+  namespace: projectcontour
+roleRef:
+  kind: ClusterRole
+  name: contour-certgen
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: contour-certgen
+  namespace: projectcontour
+# Make sure that the policy is available for contour pods as well
+- kind: ServiceAccount
+  name: contour
+  namespace: projectcontour
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -65,6 +65,10 @@ spec:
               fieldPath: metadata.namespace
       restartPolicy: Never
       serviceAccountName: contour-certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
   parallelism: 1
   completions: 1
   backoffLimit: 1

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -85,6 +85,10 @@ spec:
               fieldPath: metadata.name
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       volumes:
         - name: contourcert
           secret:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -1,4 +1,58 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
+  namespace: projectcontour
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  creationTimestamp: null
+  name: contour-envoy
+spec:
+  hostPorts:
+  - min: 80
+    max: 80
+  - min: 443
+    max: 443
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - emptyDir
+  - secret
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-envoy
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - contour-envoy
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-envoy
+  namespace: projectcontour
+roleRef:
+  kind: ClusterRole
+  name: contour-envoy
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: envoy
+  namespace: projectcontour
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -161,7 +161,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      automountServiceAccountToken: false
+      serviceAccountName: envoy
       volumes:
         - name: envoy-config
           emptyDir: {}


### PR DESCRIPTION
* Add PSP for envoy daemonset
    
  * Add a new service account for envoy daemonset.
  
  * This also adds a PSP which will allow the envoy pods to do privileged work like binding port 80 and 443.
    
* Add a PSP which will be used for workloads of certgen job and the contour pods.
    
* Run contour & cert-gen job as non-root
    
  * Add `securityContext` to pods that don't need to run as root, viz. certgen job and the contour deployment.
    
* Use the SA `envoy` for `envoy` DS

Fixes #1896 