### PR TITLE
internal/dag: reject HTTPProxy with missing include

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -286,12 +286,6 @@ func TestIngressRouteMetrics(t *testing.T) {
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
-				Name: "delegated",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/prefix",
-				}},
-			}},
 			Routes: []projcontour.Route{{
 				Conditions: []projcontour.Condition{{
 					Prefix: "/foo",
@@ -969,11 +963,11 @@ func TestIngressRouteMetrics(t *testing.T) {
 			wantIR: nil,
 			wantProxy: &metrics.RouteMetric{
 				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
+					{Namespace: "roots"}:                       1,
+					{Namespace: "roots", VHost: "example.com"}: 1,
 				},
 				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-					{Namespace: "roots"}:                       1,
+					{Namespace: "roots"}: 1,
 				},
 				Orphaned: map[metrics.Meta]int{},
 				Root: map[metrics.Meta]int{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -542,24 +542,28 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			namespace = proxy.Namespace
 		}
 
-		if delegate, ok := b.Source.httpproxies[Meta{name: include.Name, namespace: namespace}]; ok {
-			if delegate.Spec.VirtualHost != nil {
-				sw.SetInvalid("root httpproxy cannot delegate to another root httpproxy")
-				return nil
-			}
-
-			if !pathConditionsValid(sw, include.Conditions, "include") {
-				return nil
-			}
-
-			sw, commit := b.WithObject(delegate)
-			routes = append(routes, b.computeRoutes(sw, delegate, append(conditions, include.Conditions...), visited, enforceTLS)...)
-			commit()
-
-			// dest is not an orphaned httpproxy, as there is an httpproxy that points to it
-			delete(b.orphaned, Meta{name: delegate.Name, namespace: delegate.Namespace})
+		delegate, ok := b.Source.httpproxies[Meta{name: include.Name, namespace: namespace}]
+		if !ok {
+			sw.SetInvalid(fmt.Sprintf("include %s/%s not found", namespace, include.Name))
+			return nil
 		}
+		if delegate.Spec.VirtualHost != nil {
+			sw.SetInvalid("root httpproxy cannot delegate to another root httpproxy")
+			return nil
+		}
+
+		if !pathConditionsValid(sw, include.Conditions, "include") {
+			return nil
+		}
+
+		sw, commit := b.WithObject(delegate)
+		routes = append(routes, b.computeRoutes(sw, delegate, append(conditions, include.Conditions...), visited, enforceTLS)...)
+		commit()
+
+		// dest is not an orphaned httpproxy, as there is an httpproxy that points to it
+		delete(b.orphaned, Meta{name: delegate.Name, namespace: delegate.Namespace})
 	}
+
 	for _, route := range proxy.Spec.Routes {
 		if len(route.Services) > 1 && route.EnableWebsockets {
 			sw.SetInvalid("route: cannot specify multiple services and enable websockets")

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -796,13 +796,6 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
-				Name:      "delegated",
-				Namespace: "roots",
-				Conditions: []projcontour.Condition{{
-					Prefix: "/prefix",
-				}},
-			}},
 			Routes: []projcontour.Route{{
 				Conditions: []projcontour.Condition{{
 					Prefix: "/foo",
@@ -1733,6 +1726,22 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 		},
 	}
 
+	// proxy44's include is missing
+	proxy44 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "roots",
+			Name:      "example",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Includes: []projcontour.Include{{
+				Name: "child",
+			}},
+		},
+	}
+
 	tests := map[string]struct {
 		objs []interface{}
 		want map[Meta]Status
@@ -2351,6 +2360,17 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 					Status:      "valid",
 					Description: "valid HTTPProxy",
 					Vhost:       "passthrough.example.com",
+				},
+			},
+		},
+		"httpproxy w/ missing include": {
+			objs: []interface{}{proxy44, s1},
+			want: map[Meta]Status{
+				{name: proxy44.Name, namespace: proxy44.Namespace}: {
+					Object:      proxy44,
+					Status:      "invalid",
+					Description: "include roots/child not found",
+					Vhost:       "example.com",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #1904

This change causes the builder to reject HTTPProxies that include
missing documents.

Signed-off-by: Dave Cheney <dave@cheney.net>