### PR TITLE
internal/envoy: use common_http_protocol_options.idletimeout

### DIFF
--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -99,6 +99,12 @@ func HTTPConnectionManager(routename string, accesslogger []*accesslog.AccessLog
 				}, {
 					Name: wellknown.Router,
 				}},
+				CommonHttpProtocolOptions: &envoy_api_v2_core.HttpProtocolOptions{
+					// Sets the idle timeout for HTTP connections to 60 seconds.
+					// This is chosen as a rough default to stop idle connections wasting resources,
+					// without stopping slow connections from being terminated too quickly.
+					IdleTimeout: protobuf.Duration(60 * time.Second),
+				},
 				HttpProtocolOptions: &envoy_api_v2_core.Http1ProtocolOptions{
 					// Enable support for HTTP/1.0 requests that carry
 					// a Host: header. See #537.
@@ -107,11 +113,7 @@ func HTTPConnectionManager(routename string, accesslogger []*accesslog.AccessLog
 				AccessLog:        accesslogger,
 				UseRemoteAddress: protobuf.Bool(true),
 				NormalizePath:    protobuf.Bool(true),
-				// Sets the idle timeout for HTTP connections to 60 seconds.
-				// This is chosen as a rough default to stop idle connections wasting resources,
-				// without stopping slow connections from being terminated too quickly.
-				IdleTimeout:    protobuf.Duration(60 * time.Second),
-				RequestTimeout: ptypes.DurationProto(requestTimeout),
+				RequestTimeout:   protobuf.Duration(requestTimeout),
 
 				// issue #1487 pass through X-Request-Id if provided.
 				PreserveExternalRequestId: true,

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -247,10 +247,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 							// a Host: header. See #537.
 							AcceptHttp_10: true,
 						},
+						CommonHttpProtocolOptions: &envoy_api_v2_core.HttpProtocolOptions{
+							IdleTimeout: protobuf.Duration(60 * time.Second),
+						},
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						IdleTimeout:               protobuf.Duration(60 * time.Second),
 						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 					}),
@@ -297,10 +299,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 							// a Host: header. See #537.
 							AcceptHttp_10: true,
 						},
+						CommonHttpProtocolOptions: &envoy_api_v2_core.HttpProtocolOptions{
+							IdleTimeout: protobuf.Duration(60 * time.Second),
+						},
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						IdleTimeout:               protobuf.Duration(60 * time.Second),
 						RequestTimeout:            protobuf.Duration(10 * time.Second),
 						PreserveExternalRequestId: true,
 					}),


### PR DESCRIPTION
Updates #1351

HttpConnectionManager.IdleTimeout was deprecated in 1.11.2. Switch to
HttpConnectionManager.CommonHttpProtocolOptions.IdleTimeout.

Also, there was one case where ptypes.DurationProtocol was being used
where all the other cases uses protobuf.Duration. Make that the same as
everywhere else.

Signed-off-by: Dave Cheney <dave@cheney.net>