### PR TITLE
Highlight selected header menu item

### DIFF
--- a/site/_includes/site-header.html
+++ b/site/_includes/site-header.html
@@ -4,12 +4,12 @@
             <a href="/" aria-label="Contour homepage"><img src="/img/{{ site.logo }}" alt="Homepage" class="logo" /></a>
         </div>
         <ul class="nav-menu" id="header-nav">
-		<li><a href="{% link getting-started.md %}" title="Getting Started">Getting Started</a></li>
-		<li><a href="{% link guides.md %}" title="Guides">Guides</a></li>
-		<li><a href="{% link community.md %}" title="Community">Community</a></li>
-            <li class="docs"><a href="/docs/{{ site.latest }}" title="Documentation">Documentation</a></li>
-		<li><a href="{% link resources.md %}" title="Resources">Resources</a></li>
-		<li><a href="{% link blog.html %}" title="Blog Posts">Blog</a></li>
+		<li class="getting-started"><a href="{% link getting-started.md %}" title="Getting Started">Getting Started</a></li>
+		<li class="guides"><a href="{% link guides.md %}" title="Guides">Guides</a></li>
+		<li class="community"><a href="{% link community.md %}" title="Community">Community</a></li>
+        <li class="docs"><a href="/docs/{{ site.latest }}" title="Documentation">Documentation</a></li>
+		<li class="resources"><a href="{% link resources.md %}" title="Resources">Resources</a></li>
+		<li class="blog"><a href="{% link blog.html %}" title="Blog Posts">Blog</a></li>
         </ul>
         <div class="nav-mobile-link">
             <a href="javascript:void(0);" id="nav-mobile-toggle" aria-label="Toggle mobile site"></a>

--- a/site/guides.md
+++ b/site/guides.md
@@ -2,6 +2,7 @@
 layout: page
 title: Guides
 description: Contour Resources
+id: guides
 ---
 ## Getting things done with Contour
 


### PR DESCRIPTION
Fixes: #1911

Added classes to `<li>`  elements for header menu to match body class id tag in relevant page markdown file.

Added body class id tag for guides page

Signed-off-by: Brett Johnson <brett@sdbrett.com>