### PR TITLE
internal/envoy: switch to safe regex for path match

### DIFF
--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -255,27 +255,23 @@ func (l longestRouteFirst) Less(i, j int) bool {
 				return true
 			case -1:
 				return false
-			case 0:
+			default:
 				return longestRouteByHeaders(l[i], l[j])
 			}
-
-			panic("bad compare")
 		}
-	case *envoy_api_v2_route.RouteMatch_Regex:
+	case *envoy_api_v2_route.RouteMatch_SafeRegex:
 		switch b := l[j].Match.PathSpecifier.(type) {
-		case *envoy_api_v2_route.RouteMatch_Regex:
-			cmp := strings.Compare(a.Regex, b.Regex)
+		case *envoy_api_v2_route.RouteMatch_SafeRegex:
+			cmp := strings.Compare(a.SafeRegex.Regex, b.SafeRegex.Regex)
 			switch cmp {
 			case 1:
 				// Sort longest regex first.
 				return true
 			case -1:
 				return false
-			case 0:
+			default:
 				return longestRouteByHeaders(l[i], l[j])
 			}
-
-			panic("bad compare")
 		case *envoy_api_v2_route.RouteMatch_Prefix:
 			return true
 		}

--- a/internal/envoy/regex.go
+++ b/internal/envoy/regex.go
@@ -1,0 +1,32 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// SafeRegexMatch retruns a matcher.RegexMatcher for the supplied regex.
+// SafeRegexMatch does not escape regex meta characters.
+func SafeRegexMatch(regex string) *matcher.RegexMatcher {
+	return &matcher.RegexMatcher{
+		EngineType: &matcher.RegexMatcher_GoogleRe2{
+			GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+				MaxProgramSize: protobuf.UInt32(uint32(len(regex))),
+			},
+		},
+		Regex: regex,
+	}
+}

--- a/internal/envoy/regex_test.go
+++ b/internal/envoy/regex_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+func TestSafeRegexMatch(t *testing.T) {
+	tests := map[string]struct {
+		regex string
+		want  *matcher.RegexMatcher
+	}{
+		"blank regex": {
+			regex: "",
+			want: &matcher.RegexMatcher{
+				EngineType: &matcher.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+						MaxProgramSize: protobuf.UInt32(0),
+					},
+				},
+			},
+		},
+		"simple": {
+			regex: "chrome",
+			want: &matcher.RegexMatcher{
+				EngineType: &matcher.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+						MaxProgramSize: protobuf.UInt32(6),
+					},
+				},
+				Regex: "chrome",
+			},
+		},
+		"regex meta": {
+			regex: "[a-z]+$",
+			want: &matcher.RegexMatcher{
+				EngineType: &matcher.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+						MaxProgramSize: protobuf.UInt32(7),
+					},
+				},
+				Regex: "[a-z]+$", // meta characters are not escaped.
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := SafeRegexMatch(tc.regex)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -20,7 +20,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -620,14 +619,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{
-								GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-									MaxProgramSize: protobuf.UInt32(15),
-								},
-							},
-							Regex: ".*11-22-33-44.*",
-						},
+						SafeRegexMatch: SafeRegexMatch(".*11-22-33-44.*"),
 					},
 				}},
 			},
@@ -646,14 +638,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{
-								GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-									MaxProgramSize: protobuf.UInt32(18),
-								},
-							},
-							Regex: ".*11\\.22\\.33\\.44.*",
-						},
+						SafeRegexMatch: SafeRegexMatch(".*11\\.22\\.33\\.44.*"),
 					},
 				}},
 			},
@@ -672,14 +657,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{
-								GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-									MaxProgramSize: protobuf.UInt32(24),
-								},
-							},
-							Regex: ".*11\\.\\[22\\]\\.\\*33\\.44.*",
-						},
+						SafeRegexMatch: SafeRegexMatch(".*11\\.\\[22\\]\\.\\*33\\.44.*"),
 					},
 				}},
 			},
@@ -703,11 +681,11 @@ func TestRouteMatch(t *testing.T) {
 				},
 			},
 			want: &envoy_api_v2_route.RouteMatch{
-				PathSpecifier: &envoy_api_v2_route.RouteMatch_Regex{
+				PathSpecifier: &envoy_api_v2_route.RouteMatch_SafeRegex{
 					// note, unlike header conditions this is not a quoted regex because
 					// the value comes directly from the Ingress.Paths.Path value which
 					// is permitted to be a bare regex.
-					Regex: "/v.1/*",
+					SafeRegex: SafeRegexMatch("/v.1/*"),
 				},
 			},
 		},


### PR DESCRIPTION
Updates #1351
Fixes #1513

Switch path regex matching to safe regex. Refactor matcher.RegexMatcher
code to its own file and helper so it can be reused across
internal/envoy and internal/contour.

Also of note, internal/contour longestRouteFirst comparator has intimate
knowledge of RouteMatch_SafeRegex which is probably not ideal.

Signed-off-by: Dave Cheney <dave@cheney.net>