### PR TITLE
Standardized link insertion

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,5 +1,8 @@
 # site
 
-This directory contains the Jekyll source for [projectcontour.io](https://projectcontour.io/).
+This directory contains the Jekyll source for [projectcontour.io][0].
 
-The site is deployed directly from the [`master`](https://github.com/projectcontour/contour/tree/master/site) branch, copies of the site's source in older tags and branches are non-canonical.
+The site is deployed directly from the [`master`][1] branch, copies of the site's source in older tags and branches are non-canonical.
+
+[0]: https://projectcontour.io/
+[1]: {{site.github.repository_url}}/tree/master/site

--- a/site/_guides/cert-manager.md
+++ b/site/_guides/cert-manager.md
@@ -7,7 +7,7 @@ This tutorial shows you how to securely deploy an HTTPS web application on a Kub
 
 - Kubernetes
 - Contour, as the Ingress controller
-- [JetStack's cert-manager][1] to provision TLS certificates from [the Let's Encrypt project][5]
+- [JetStack's cert-manager][1] to provision TLS certificates from [the Let's Encrypt project][6]
 
 ## Prerequisites
 
@@ -103,7 +103,7 @@ httpbin-67ff6dd458-sfxkb     1/1       Running   0          19d
 
 Then type the DNS name you set up in the previous step into a web browser, for example `http://gke.davecheney.com/`. You should see something like:
 
-![httpbin screenshot][httpbinhomepage]
+![httpbin screenshot][8]
 
 You can delete the httpbin service now, or at any time, by running:
 
@@ -515,12 +515,12 @@ $ curl https://httpbin.davecheney.com/get
 }
 ```
 
-![httpbin.davecheney.com screenshot][httpbin]
+![httpbin.davecheney.com screenshot][9]
 
 ## Making cert-manager work with HTTPProxy
 
 cert-manager currently does not have a way to interact with HTTPProxy objects in order to respond to the HTTP01 challenge correctly.
-(See [#950](https://github.com/projectcontour/contour/issues/950) and [#951](https://github.com/projectcontour/contour/issues/951) for details.)
+(See [#950][10] and [#951][11] for details.)
 cert-manager does this by creating a new, temporary Ingress object that will direct requests from Let's Encrypt to temporary pods called 'solver pods'.
 These pods know how to respond to Let's Encrypt's challenge process for verifying you control the domain you're issuing certificates for.
 This means that cert-manager can't be *directly* used for generating certificates for HTTPProxy configuration.
@@ -601,7 +601,7 @@ $ curl https://httpbinproxy.davecheney.com/get
 
 ### Caveats
 
-This method is a workaround until we can deliver the changes in [#950](https://github.com/projectcontour/contour/issues/950) and [#951](https://github.com/projectcontour/contour/issues/951).
+This method is a workaround until we can deliver the changes in [#950][10] and [#951][11].
 
 The dummy Ingress record exists only to hold the annotations `ingress-shim` requires.
 Because it does not include the `ingress-class: contour` annotation, Contour will not see it and so the configuration of the Ingress does not matter, except that it is valid enough for ingress-shim to use.
@@ -645,13 +645,15 @@ $ curl -v http://httpbin.davecheney.com/get
 * Connection #0 to host httpbin.davecheney.com left intact
 ```
 
-[0]: https://github.com/projectcontour/contour/
+[0]: {{site.github.repository_url}}
 [1]: https://github.com/jetstack/cert-manager
 [2]: https://letsencrypt.org/docs/rate-limits/
 [3]: http://httpbin.org/
 [4]: https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
 [5]: https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
-[httpbinhomepage]: /img/cert-manager/httpbinhomepage.png
-[httpbin]: /img/cert-manager/httpbin.png
-[5]: https://letsencrypt.org/getting-started/
-[7]: {% link docs/v1.0.0/deploy-options.md %}#get-your-hostname-or-ip-address
+[6]: https://letsencrypt.org/getting-started/
+[7]: /docs/{{site.latest}}/deploy-options/#get-your-hostname-or-ip-address
+[8]: {% link /img/cert-manager/httpbinhomepage.png %}
+[9]: {% link /img/cert-manager/httpbin.png %}
+[10]: {{site.github.repository_url}}/issues/950
+[11]: {{site.github.repository_url}}/issues/951

--- a/site/_guides/deploy-aws-nlb.md
+++ b/site/_guides/deploy-aws-nlb.md
@@ -39,6 +39,6 @@ You can now test your NLB.
   - Notice that Envoy fills out `X-Forwarded-For`, because it was the first to see the traffic directly from the browser.
 
 [1]: https://aws.amazon.com/blogs/aws/new-network-load-balancer-effortless-scaling-to-millions-of-requests-per-second/
-[2]: {% link docs/v1.0.0/deploy-options.md %}#testing-your-installation
+[2]: /docs/{{site.latest}}/deploy-options/#testing-your-installation
 [3]: https://github.com/kubernetes/kubernetes/issues/52173
-[4]: {{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/CONTRIBUTING.md
+[4]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/CONTRIBUTING.md

--- a/site/_guides/ingressroute-to-httpproxy.md
+++ b/site/_guides/ingressroute-to-httpproxy.md
@@ -5,13 +5,13 @@ layout: page
 
 This document describes the differences between IngressRoute and HTTPProxy.
 It is intended for Contour users who have existing IngressRoute resources they wish to migrate to HTTPProxy.
-It is not intended a comprehensive documentation of HTTPProxy, for that please see the [`HTTPProxy` documentation](/docs/v1.0.0/httpproxy).
+It is not intended a comprehensive documentation of HTTPProxy, for that please see the [`HTTPProxy` documentation][1].
 
 _Note: IngressRoute is deprecated and will be removed after Contour 1.0 ships in November._
 
 ## Group, Version and Kind changes
 
-As part of the sunseting of the Heptio brand, `HTTPProxy` has moved to the `projectcontour.io` group.
+As part of the sunsetting of the Heptio brand, `HTTPProxy` has moved to the `projectcontour.io` group.
 For Contour 1.0.0-rc.1 the version is `v1`.
 We expect this to change in forthcoming release candidates.
 
@@ -140,7 +140,7 @@ spec:
 
 HTTPProxy offers additional ways to match incoming requests to routes.
 This document covers the conversion between the routing offered in IngressRoute and HTTPProxy.
-For a broader discussion of HTTPProxy routing, see the [Routing section of the HTTPProxy documentation](/docs/v1.0.0/httpproxy).
+For a broader discussion of HTTPProxy routing, see the [HTTPProxy documentation][1].
 
 Before:
 
@@ -375,7 +375,7 @@ As we explored the design of the next revision of IngressRoute the tight couplin
 
 This Gordian Knot was severed by decoupling the inclusion of one document into its parent from the facility to place restrictions on what route matching conditions could be specified in that document.
 The former we call _inclusion_, the latter are known as _conditions_.
-This section discusses conversion from delegation to inclusion, please see the [`HTTPProxy` documentation](/docs/v1.0.0/httpproxy) for a discussion of conditions.
+This section discusses conversion from delegation to inclusion, please see the [HTTPProxy documentation][1] for a discussion of conditions.
 
 Before:
 
@@ -493,3 +493,5 @@ No change.
 ### Status reporting
 
 Status reporting on HTTPProxy objects is similar in scope and function to IngressRoute status.
+
+[1]: {% link /docs/v1.0.0/httpproxy.md %}

--- a/site/_guides/prometheus.md
+++ b/site/_guides/prometheus.md
@@ -37,8 +37,8 @@ A sample deployment of Prometheus and Alertmanager is provided that uses tempora
 
 #### Stateful Deployment
 
- A stateful deployment of Prometheus should use persistent storage with [Persistent Volumes and Persistent Volume Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to maintain a correlation between a data volume and the Prometheus Pod. 
- Persistent volumes can be static or dynamic and depends on the backend storage implementation utilized in environment in which the cluster is deployed. For more information, see the [Kubernetes documentation on types of persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes).
+ A stateful deployment of Prometheus should use persistent storage with [Persistent Volumes and Persistent Volume Claims][1] to maintain a correlation between a data volume and the Prometheus Pod.
+ Persistent volumes can be static or dynamic and depends on the backend storage implementation utilized in environment in which the cluster is deployed. For more information, see the [Kubernetes documentation on types of persistent volumes][2].
 
 #### Quick start
 
@@ -87,3 +87,6 @@ $ kubectl port-forward $(kubectl get pods -l app=grafana -n projectcontour-monit
 
 then go to `http://localhost:3000` in your browser.
 The username and password are from when you defined the Grafana secret in the previous step.
+
+[1]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+[2]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes

--- a/site/_guides/structured-logs.md
+++ b/site/_guides/structured-logs.md
@@ -11,8 +11,8 @@ Contour allows you to choose from a set of JSON fields that will be expanded int
 There is a default set of fields if you enable JSON logging, and you may customize which fields you log.
 Custom fields are not currently possible, however, we welcome PRs on the field list.
 
-The canonical location for the current field list is at [JSONFields]( https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields).
-The default list of fields is available at [DefaultFields](https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields)
+The canonical location for the current field list is at [JSONFields][1].
+The default list of fields is available at [DefaultFields][2]
 
 ## Enabling the feature
 
@@ -24,10 +24,10 @@ To enable the feature you have two options:
 ## Customizing logged fields
 
 To customize the logged fields, add a `json-fields` list of strings to your config file.
-These strings must be options from the [list of default fields](https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields).
-Field names not in that list will be silently dropped. (This is not ideal, watch [#1507](https://github.com/projectcontour/contour/issues/1507) for updates.)
+These strings must be options from the [list of default fields][2].
+Field names not in that list will be silently dropped. (This is not ideal, watch [#1507][3] for updates.)
 
-The [example config file]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/01-contour-config.yaml) contains the full list of fields as well.
+The [example config file][4] contains the full list of fields as well.
 
 ## Sample configuration file
 
@@ -58,3 +58,8 @@ json-fields:
   - "user_agent"
   - "x_forwarded_for"
 ```
+
+[1]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
+[2]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
+[3]: {{site.github.repository_url}}/issues/1507
+[4]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/01-contour-config.yaml

--- a/site/_guides/tls.md
+++ b/site/_guides/tls.md
@@ -13,6 +13,7 @@ Enabling TLS support requires Contour version 0.3 or later. You must also add an
 
 ## Configuring TLS with Contour on an ELB
 
-If you deploy behind an AWS Elastic Load Balancer, see [EC2 ELB PROXY protocol support]({% link _guides/proxy-proto.md %}) for special instructions.
+If you deploy behind an AWS Elastic Load Balancer, see [EC2 ELB PROXY protocol support][2] for special instructions.
 
-[1]: {{ site.github.repository_url }}/blob/master/examples/contour/03-contour.yaml#L45
+[1]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/03-contour.yaml/#L45
+[2]: {% link _guides/proxy-proto.md %}

--- a/site/_includes/blog-community-footer.html
+++ b/site/_includes/blog-community-footer.html
@@ -1,0 +1,8 @@
+<h2 id="join-the-contour-community">Join the Contour Community!</h2>
+
+<ul>
+	<li>Join the <a href="https://projectcontour.io/community/">Contour Community Meetings</a>, every third Tuesday at 6 PM Eastern Time / 3 PM Pacific Time / Wednesday at 8 AM Australian Eastern Time.</li>
+	<li>Get updates on Twitter (<a href="https://twitter.com/projectcontour">@projectcontour</a>)</li>
+	<li>Chat with us in <a href="https://kubernetes.slack.com/messages/contour">#contour on the Kubernetes Slack</a></li>
+	<li>Collaborate with us on <a href="https://github.com/projectcontour/contour">GitHub</a></li>
+</ul>

--- a/site/_layouts/posts.html
+++ b/site/_layouts/posts.html
@@ -36,6 +36,8 @@
           
             <div class="post-single-content">
               {{ content }}
+              <br>
+              {% include blog-community-footer.html %}
             </div>
           </div>
         </div>

--- a/site/_posts/2019-04-22-Routing-Traffic-to-Applications-in-Kubernetes-with-Contour.md
+++ b/site/_posts/2019-04-22-Routing-Traffic-to-Applications-in-Kubernetes-with-Contour.md
@@ -8,7 +8,7 @@ categories: [kubernetes]
 # Tag should match author to drive author pages
 tags: ['Contour Team']
 ---
-One of the most critical needs in running workloads at scale with Kubernetes is efficient and smooth traffic ingress management at the [Layer 7](https://en.wikipedia.org/wiki/OSI_model#Layer_7:_Application_Layer) level. Getting an application up and running is not always the entire story; it may still need a way for users to access it. Filling that operational gap is what Contour was designed to do by providing a way to allow users to access applications within a Kubernetes cluster.
+One of the most critical needs in running workloads at scale with Kubernetes is efficient and smooth traffic ingress management at the [Layer 7][1] level. Getting an application up and running is not always the entire story; it may still need a way for users to access it. Filling that operational gap is what Contour was designed to do by providing a way to allow users to access applications within a Kubernetes cluster.
 Contour is an Ingress controller for Kubernetes that works by deploying the Envoy proxy as a reverse proxy and load balancer. Contour supports dynamic configuration updates out of the box while maintaining a lightweight profile.
 
 Contour offers the following benefits for users:  
@@ -19,7 +19,7 @@ Contour offers the following benefits for users:
  - Dynamic updates to ingress configuration without dropped connections  
 
 ## What is Ingress?
-[Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) is a set of configurations that define how external traffic can be routed to an application inside a Kubernetes cluster. A controller (Contour) watches for changes to objects in the cluster, then wires together the configurations to create a data path for the request to be resolved, implementing the configurations defined. It makes decisions based on the request received (e.g., example.com/blog), provides TLS termination, and performs other functions.
+[Kubernetes Ingress][2] is a set of configurations that define how external traffic can be routed to an application inside a Kubernetes cluster. A controller (Contour) watches for changes to objects in the cluster, then wires together the configurations to create a data path for the request to be resolved, implementing the configurations defined. It makes decisions based on the request received (e.g., example.com/blog), provides TLS termination, and performs other functions.
 
 Ingress is an important component of a cloud native system because it allows for a clean separation between the application and how it’s accessed. A cluster administrator deals with providing access to the controller, and the application engineer just deals with deploying the application. Ingress is the glue that ties the two together.
 
@@ -31,7 +31,7 @@ At the same time a number of web application deployment patterns, such as blue/g
 IngressRoute is designed to provide a sensible home for configuration parameters as well as to share an ingress controller across multiple namespaces and teams in the same Kubernetes cluster. We do this by using a process we call delegation. This delegation concept patterns off of the way a subdomain is delegated from one domain name server to another, and allows for teams to define and self-manage IngressRoute resources safely.
 
 ## Contour 0.10
-Version 0.10 of Contour adds some exciting features to address TLS certificates and how they are referenced. This new version brings a feature called [TLS Certificate Delegation](https://github.com/projectcontour/contour/blob/master/design/tls-certificate-delegation.md). This facility makes it possible for an IngressRoute objects to reference, subject to the appropriate permissions, a Kubernetes Secret object in another namespace. The primary use case for this facility is to allow you, as an administrator, to place a TLS wildcard certificate in a secret object in your own namespace and delegate the permission for Contour to reference that secret from another namespace.
+Version 0.10 of Contour adds some exciting features to address TLS certificates and how they are referenced. This new version brings a feature called [TLS Certificate Delegation][3]. This facility makes it possible for an IngressRoute objects to reference, subject to the appropriate permissions, a Kubernetes Secret object in another namespace. The primary use case for this facility is to allow you, as an administrator, to place a TLS wildcard certificate in a secret object in your own namespace and delegate the permission for Contour to reference that secret from another namespace.
 
 Much like how IngressRoute delegation can limit which namespaces can utilize a host plus path combination, this TLS cert delegation now similarly limits what certificates users can access, further enhancing Contour’s multi-team functionality.
 
@@ -40,15 +40,15 @@ The Contour team would love to hear your feedback on your application requiremen
 
 Contour is also very community driven so please speak up! Many features today (including IngressRoute) were driven from users who needed a better way to solve their current problems.
 
-If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted](https://github.com/projectcontour/contour/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) and work with the team on how to resolve them.
-
-## Join the Contour Community!
-* Get updates on Twitter ([@projectcontour](https://twitter.com/projectcontour))
-* Chat with us on Slack ([#contour](https://kubernetes.slack.com/messages/C8XRH2R4J) on Kubernetes)
-* Collaborate with us on GitHub: [github.com/heptio/contour](https://github.com/projectcontour/contour)
+If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted][4] and work with the team on how to resolve them.
 
 We’re immensely grateful for all of the community contributions that help make Contour even better! For version 0.10, special thanks go out to:
 * @vaamarnath
 * @256dpi
 
 _Previously posted on <https://blogs.vmware.com/cloudnative/2019/03/08/routing-traffic-kubernetes-contour-0-10/>_
+
+[1]: https://en.wikipedia.org/wiki/OSI_model#Layer_7:_Application_Layer
+[2]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[3]: {{site.github.repository_url}}/blob/v0.10.0/design/tls-certificate-delegation.md
+[4]: {{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+

--- a/site/_posts/2019-07-11-kindly-running-contour.md
+++ b/site/_posts/2019-07-11-kindly-running-contour.md
@@ -9,19 +9,19 @@ categories: [kubernetes]
 tags: ['Contour Team', 'Steve Sloka', 'kind']
 ---
 
-[kind](https://github.com/kubernetes-sigs/kind) is a tool for running local Kubernetes clusters using Docker container “nodes.” Primarily designed for testing Kubernetes 1.11 or later, kind is initially targeting the upstream Kubernetes conformance tests, which are run to verify if a cluster meets standard expectations. It is also an excellent tool for creating a Kubernetes cluster locally on many platforms (Linux, macOS, or Windows), especially since it can create multi-node clusters quickly and reliably.
+[kind][1] is a tool for running local Kubernetes clusters using Docker container “nodes.” Primarily designed for testing Kubernetes 1.11 or later, kind is initially targeting the upstream Kubernetes conformance tests, which are run to verify if a cluster meets standard expectations. It is also an excellent tool for creating a Kubernetes cluster locally on many platforms (Linux, macOS, or Windows), especially since it can create multi-node clusters quickly and reliably.
 
 This blog post demonstrates how to install kind, create a cluster, deploy Contour, and deploy a sample application, all locally on your machine which enables running applications locally the same way they are deployed to production. 
 
-![img](/img/posts/kind-contour.png)
+![img][2]
 *Example of a four worker node cluster with a single control plane.*
 
-[![img](/img/posts/kind-contour-video.png)](https://youtu.be/j97MueCYcvc)  
+[![img][3]][4]
 *Here's a quick video demonstration of how to install kind, create a cluster, deploy Contour, and deploy a sample application.*
 
 ## Install Kind
 
-There are a number of ways to [install kind](https://github.com/kubernetes-sigs/kind#installation-and-usage). Here is a simple way to grab the latest release for a Darwin architecture. The following commands downloads the latest binary, makes it executable, and moves it to your local bin path.
+There are a number of ways to [install kind][5]. Here is a simple way to grab the latest release for a Darwin architecture. The following commands downloads the latest binary, makes it executable, and moves it to your local bin path.
 *Note: You may want to update some portions of the commands to match your local operating system and configuration.*
 
 ```bash
@@ -61,12 +61,12 @@ nodes:
 
 After the cluster comes up, you should have two nodes in the cluster, a worker node and a control plane node:
 
-![img](/img/posts/kind-contour2.png)
+![img][6]
 
 
 ## Deploy Contour
 
-Next, we’ll deploy Contour into our freshly created cluster. We are going to use a "split" deployment, which configures [Envoy](https://envoyproxy.io) as a DaemonSet. 
+Next, we’ll deploy Contour into our freshly created cluster. We are going to use a "split" deployment, which configures [Envoy][7] as a DaemonSet.
 
 Contour is the configuration server for Envoy --- Contour, that is, exposes an xDS API for Envoy. Contour watches the Kubernetes cluster for changes to services, end points, secrets, ingress, and HTTPProxies. Contour generates a set of configurations that is streamed to Envoy via the xDS gRPC connection. All data travels through Envoy, which is running on every node in the cluster (a single node in our example).
 
@@ -83,7 +83,7 @@ Since our deployment of kind is binding ports 80 and 443 to our laptop, when we 
 
 ## Deploy the Sample Application
 
-Finally, we’ll deploy a sample application to to verify the network ingress path is functional to an application. By deploying this way, we are matching how we would deploy an application in production within Kubernetes, so any testing done locally inside the `kind` cluster should match how the application will perform once deployed. Since we already cloned the Contour repo in the previous step, let’s deploy the "[kuard](https://github.com/kubernetes-up-and-running/kuard)" sample application, which is an example workload in the repo.
+Finally, we’ll deploy a sample application to to verify the network ingress path is functional to an application. By deploying this way, we are matching how we would deploy an application in production within Kubernetes, so any testing done locally inside the `kind` cluster should match how the application will perform once deployed. Since we already cloned the Contour repo in the previous step, let’s deploy the "[kuard][8]" sample application, which is an example workload in the repo.
 
 Deploy the application:
 
@@ -128,16 +128,19 @@ Let’s create an entry in our local `/etc/hosts` to route `kuard.local` to `127
 ```
 
 Now open a browser and go to: `http://kuard.local`
-![img](/img/posts/kind-contour3.png) 
+![img][9]
 
 What's happening is that the request to `http://kuard.local` is resolved to `127.0.0.1` via the entry the `/etc/hosts` file. That request is then sent to Envoy running on the single Kubernetes worker node in the `kind` cluster. Envoy is configured to send any request to `kuard.local/` to the `kuard` application in the cluster. The request then gets routed to an instance of `kuard` and the response is sent back to the user. 
 
 This blog post helps you enable Contour in your local development environment by allowing you to match the way you'd deploy your application in production. Any testing done locally inside the `kind` cluster should match how the application will perform once deployed reducing the time required testing in production. I hope this blog post better equip your usage of Contour!
 
-## Join the Contour Community!
 
-Please reach out in one of the following ways and let us know how you are using Contour, if you run into a problem, or want to do more:
-
-- Get updates on Twitter [@projectcontour](https://twitter.com/projectcontour)
-- Chat with us in [#contour on the Kubernetes Slack](https://kubernetes.slack.com/messages/contour)
-- Collaborate with us on [GitHub](https://github.com/projectcontour/contour)
+[1]: https://github.com/kubernetes-sigs/kind
+[2]: {% link img/posts/kind-contour.png %}
+[3]: {% link img/posts/kind-contour-video.png %}
+[4]: https://youtu.be/j97MueCYcvc
+[5]: https://github.com/kubernetes-sigs/kind#installation-and-usage
+[6]: {% link img/posts/kind-contour2.png %}
+[7]: https://envoyproxy.io
+[8]: https://github.com/kubernetes-up-and-running/kuard
+[9]: {% link img/posts/kind-contour3.png %}

--- a/site/_posts/2019-07-23-contour-v014.md
+++ b/site/_posts/2019-07-23-contour-v014.md
@@ -15,7 +15,7 @@ There are a few different models that you can implement when you deploy Contour 
 
 However, there are many use cases where this deployment paradigm is less desired. With v0.14, a more secure split deployment model has been added. This style separates Contour’s deployment from Envoy so that they can have different life cycles. 
 
-![img](/img/posts/post-contour-split-deployment.png)
+![img][1]
 *Overview of the split-model deployment.*
 
 Contour’s split model offers the following benefits for users:
@@ -36,30 +36,30 @@ Until Contour release v0.14, the deployment model placed Contour and Envoy in th
 The split model allows Contour and Envoy to scale independently. If a new version of Contour is released, you can now upgrade to the new version without having to restart each instance of Envoy in your cluster. 
 
 A key new feature in Contour v0.14 is that we have secured the communication between Contour and Envoy over the xDS API connection utilizing mutually checked self-signed certificates. There are three ways to generate certificates to secure this connection. 
-The Contour repo includes step-by-step examples of how to generate certificates from a command line if you want to [generate them by hand](https://projectcontour.io/guides/grpc-tls-howto#generating-example-grpc-tls-certificates); the example/contour [example](https://github.com/projectcontour/contour/blob/master/examples/contour) includes a [job](https://github.com/projectcontour/contour/blob/master/examples/contour/02-job-certgen.yaml) which automatically generate the certificates, or you could provide your own based on your IT security requirements.
+The Contour repo includes step-by-step examples of how to generate certificates from a command line if you want to [generate them by hand][2]; the example/contour [example][3] includes a [job][4] which automatically generate the certificates, or you could provide your own based on your IT security requirements.
 
 
 ## More new features in Contour v0.14
 
 Version 0.14 also adds better support for deploying Envoy with various hostnames. Envoy routes traffic at the L7 or HTTP routing level. Previous versions of Contour required requests to be sent over Port 80 or Port 443. Now Contour configures Envoy to route requests without this requirement, allowing for easier deployments within your local laptop or network infrastructure.
 
-We recently wrote a blog post walking through how to deploy Contour to [kind](https://github.com/kubernetes-sigs/kind), which is a tool for creating Kubernetes clusters on your local development machine: [https://projectcontour.io/kindly-running-contour/](https://projectcontour.io/kindly-running-contour/)
+We recently wrote a blog post walking through how to deploy Contour to [kind][5], which is a tool for creating Kubernetes clusters on your local development machine: [https://projectcontour.io/kindly-running-contour/][6]
 
 ## Future Plans
 
 The Contour project is very community driven and the team would love to hear your feedback! Many features (including IngressRoute) were driven by users who needed a better way to solve their problems. We’re working hard to add features to Contour, especially in expanding how we approach routing. Please look out for [design documents](https://github.com/projectcontour/contour/tree/master/design) for the new IngressRoute/v1 routing design which will be a large discussion topic for our next community meeting!
 
-If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted](https://github.com/projectcontour/contour/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) and work with the team on how to resolve them. 
-
-## Join the Contour Community!
-
-Please reach out in one of the following ways and let us know how you are using Contour, if you run into a problem, or want to do more:
-
-- Get updates on Twitter [@projectcontour](https://twitter.com/projectcontour)
-- Chat with us in [#contour on the Kubernetes Slack](https://kubernetes.slack.com/messages/contour)
-- Collaborate with us on [GitHub](https://github.com/projectcontour/contour)
+If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted][7] and work with the team on how to resolve them.
 
 We’re immensely grateful for all the community contributions that help make Contour even better! For version v0.14, special thanks go out to:
 
 - @odacremolbap
 - @mwhittington21
+
+[1]: {% link img/posts/post-contour-split-deployment.png %}
+[2]: {% link docs/v1.0.0/grpc-tls-howto.md %}
+[3]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour
+[4]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/02-job-certgen.yaml
+[5]: https://github.com/kubernetes-sigs/kind
+[6]: {% post_url 2019-07-11-kindly-running-contour %}
+[7]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22

--- a/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
+++ b/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
@@ -7,7 +7,7 @@ categories: [kubernetes]
 tags: ['IngressRoute', 'HTTPProxy', 'ingress', 'Dave Cheney']
 ---
 
-As part of the preparations to deliver Contour 1.0 at KubeCon US, [Contour 1.0.0-beta.1 (available now!)](https://github.com/projectcontour/contour/releases/tag/v1.0.0-beta.1) renamed the [IngressRoute](https://github.com/projectcontour/contour/blob/v1.0.0-beta.1/docs/ingressroute.md) CRD to [HTTPProxy](https://github.com/projectcontour/contour/blob/v1.0.0-beta.1/docs/httpproxy.md).
+As part of the preparations to deliver Contour 1.0 at KubeCon US, [Contour 1.0.0-beta.1 (available now!)][1] renamed the [IngressRoute][2] CRD to [HTTPProxy][3].
 This post explains the path from IngressRoute to HTTPProxy and why the change isn't a revolution but an evolution.
 
 ## IngressRoute is dead, long live HTTPProxy
@@ -38,13 +38,13 @@ Collectively Kubernetes cloud natives might call the configuration for our HTTP 
 The name _HTTPProxy_ reflects the desire to clarify Contour's role in the crowded Kubernetes networking space.
 
 The final issue is addressing the limitations in the IngressRoute--now HTTPProxy--object which we felt could not be solved in an backwards compatible way once we committed to a v1 of the object.
-HTTPProxy brings with it two new concepts--[inclusion](https://github.com/projectcontour/contour/blob/v1.0.0-beta.1/docs/httpproxy.md#httpproxy-inclusion) and [conditions](https://github.com/projectcontour/contour/blob/v1.0.0-beta.1/docs/httpproxy.md#conditions)--which, like the transition from IngressRoute to HTTPProxy, represent the respective evaluations of the delegation model and our limited support for prefix based routing.
+HTTPProxy brings with it two new concepts--[inclusion][4] and [conditions][5]--which, like the transition from IngressRoute to HTTPProxy, represent the respective evaluations of the delegation model and our limited support for prefix based routing.
 
 The intent of making this change now is to prepare HTTPProxy as a stable CRD for Contour users following the same backwards compatibility goals as Contour 1.0.
 With this goal in mind the IngressRoute CRD, having never made it out of beta, should be considered deprecated.
 Contour will continue to support the IngressRoute CRD up to the 1.0 release of Contour in November, however no further enhancements or bug fixes will be made over this period unless absolutely necessary.
 The plan at this stage is to remove support for the IngressRoute CRD after Contour 1.0 ships.
-We've [written a guide]({% link _guides/ingressroute-to-httpproxy.md %}) to help you transition your IngressRoute objects to HTTPProxy.
+We've [written a guide][6] to help you transition your IngressRoute objects to HTTPProxy.
 
 The next blog post in this series will delve into how to use inclusion and conditions.
 Stay tuned for that. 
@@ -54,3 +54,10 @@ Stay tuned for that.
 The final question that should be answered is, with the focus on layer 7 HTTP proxying, what is the future of Contour's TCP proxying feature?
 The short answer is Contour's layer 3/4 TCP proxying feature is not going away.
 Despite the cognitive dissonance, we're committed to supporting and enhancing Contour's TCP proxying abilities via the HTTPProxy CRD for the long term.
+
+[1]: {{site.github.repository_url}}/releases/tag/v1.0.0-beta.1
+[2]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/ingressroute.md
+[3]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md
+[4]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md#httpproxy-inclusion
+[5]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md#conditions
+[6]: {% link _guides/ingressroute-to-httpproxy.md %}

--- a/site/_posts/2019-09-5-contour-v015.md
+++ b/site/_posts/2019-09-5-contour-v015.md
@@ -11,7 +11,7 @@ tags: ['Contour Team', 'Steve Sloka', 'release']
 
 In the previous release of Contour, a split deployment model was improved to secure communication between Envoy and Contour. Now, with our latest release, Contour v0.15, leader election is available to ensure that all instances of Envoy take their configuration from a single Contour instance.
 
-![img](/img/posts/leader-election.png)
+![img][4]
 *Overview of leader election.*
 
 ## Leader Election
@@ -22,7 +22,7 @@ In leader election mode, only one Contour pod in a deployment, the leader, will 
 
 Leader election is currently opt in. In future versions of Contour, we plan to make leader election mode the default.
 
-For more information, please consult the [documentation on upgrading](https://github.com/projectcontour/contour/blob/v0.15.0/docs/upgrading.md#enabling-leader-election).
+For more information, please consult the [documentation on upgrading]().
 
 ## Contour Configuration File
 
@@ -73,24 +73,25 @@ data:
 
 Version 0.15 includes several fixes. It patches several CVEs related to HTTP/2 by upgrading Envoy to v1.11.1. To help with the number and frequency of configuration updates sent to Envoy, Contour now ignores unrelated Secrets and Services that are not referenced by an active Ingress or IngressRoute object.
 
-We recommend reading the full release notes for [Contour v0.15](https://github.com/projectcontour/contour/releases/tag/v0.15.0) as well as digging into the [upgrade guide](https://github.com/projectcontour/contour/blob/v0.15.0/docs/upgrading.md), which outlines some key changes to be aware of when moving from v0.14 to v0.15.
+We recommend reading the full release notes for [Contour v0.15][1] as well as digging into the [upgrade guide][2], which outlines some key changes to be aware of when moving from v0.14 to v0.15.
 
 ## Future Plans
 
 The Contour project is very community driven and the team would love to hear your feedback! Many features (including IngressRoute) were driven by users who needed a better way to solve their problems. We’re working hard to add features to Contour, especially in expanding how we approach routing. 
 
-If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted](https://github.com/projectcontour/contour/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) and work with the team on how to resolve them. 
-
-## Join the Contour Community!
-
-Please reach out in one of the following ways and let us know how you are using Contour, if you run into a problem, or want to do more:
-
-- Get updates on Twitter [@projectcontour](https://twitter.com/projectcontour)
-- Chat with us in [#contour on the Kubernetes Slack](https://kubernetes.slack.com/messages/contour)
-- Collaborate with us on [GitHub](https://github.com/projectcontour/contour)
+If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted][3] and work with the team on how to resolve them.
 
 We’re immensely grateful for all the community contributions that help make Contour even better! For version v0.15, special thanks go out to:
 
-- [@DylanGraham](https://github.com/DylanGraham)
-- [@so0k](https://github.com/so0k)
-- [@mattalberts](https://github.com/mattalberts)
+- [@DylanGraham][7]
+- [@so0k][8]
+- [@mattalberts][9]
+
+[1]: {{site.github.repository_url}}/releases/tag/v0.15.0
+[2]: {{site.github.repository_url}}/blob/v0.15.0/docs/upgrading.md
+[3]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+[4]: {% link img/posts/leader-election.png %}
+[5]: {{site.github.repository_url}}/blob/v0.15.0/docs/upgrading.md#enabling-leader-election
+[7]: https://github.com/DylanGraham
+[8]: https://github.com/so0k
+[9]: https://github.com/mattalberts

--- a/site/_posts/2019-10-23-httpproxy-in-action.md
+++ b/site/_posts/2019-10-23-httpproxy-in-action.md
@@ -9,17 +9,17 @@ categories: [kubernetes]
 tags: ['Contour Team', 'Steve Sloka', 'tutorial']
 ---
 
-In our previous [blog post](https://projectcontour.io/from-ingressroute-to-httpproxy/), Dave Cheney walked through Contour’s evolution from `IngressRoute` to `HTTPProxy` and explained how & why the move happened.
+In our previous [blog post][1], Dave Cheney walked through Contour’s evolution from `IngressRoute` to `HTTPProxy` and explained how & why the move happened.
 
 Now with `HTTPProxy`, Contour allows for additional routing configuration outside of just supporting a `path prefix`.
 
 This post demonstrates a practical implementation of `HTTPProxy` and reviews some examples that explain how you can use it in your cluster today. 
 
-[![img](/img/posts/kind-contour-video.png)](https://youtu.be/YA82A4Rcs_A)  
+[![img][2]][3]
 *Here's a quick video demonstration walking through the rest of the blog post.*
 
 ## Prerequisites
-If you’d like to follow along in your own cluster, you’ll need a working Kubernetes cluster as well as Contour deployed. There are a number of ways to get these up and working. A simple way to test this locally is to use Kubernetes in Docker (Kind); you can check out our previous blog post on how to get this up and running on your local machine: [https://projectcontour.io/kindly-running-contour/][https://projectcontour.io/kindly-running-contour/]
+If you’d like to follow along in your own cluster, you’ll need a working Kubernetes cluster as well as Contour deployed. There are a number of ways to get these up and working. A simple way to test this locally is to use Kubernetes in Docker (Kind); you can check out our previous blog post on how to get this up and running on your local machine: [https://projectcontour.io/kindly-running-contour/][4]
 
 ## Demo Time
 Let’s walk through a simple scenario to quickly demonstrate how these new features work with `HTTPProxy`. This demo will progress through various features of `HTTPProxy` by starting off with a set of prerequisite services and deployments. Then it will move to implement `conditions` on routes to further specify request route matching. Finally, we’ll introduce `includes`, which will allow us to delegate path and header conditions to other `HTTPProxy` resources in different namespaces. 
@@ -350,12 +350,7 @@ Request:
     http://local.projectcontour.io/blog/info
 ```
 
-## Join the Contour Community!
-Please reach out in one of the following ways and let us know how you are using Contour, if you run into a problem, or want to do more:
-
-- Get updates on Twitter [@projectcontour](https://twitter.com/projectcontour)
-- Chat with us in [#contour on the Kubernetes Slack](https://kubernetes.slack.com/messages/contour)
-- Collaborate with us on [GitHub](https://github.com/projectcontour/contour)
-
-
-[https://projectcontour.io/kindly-running-contour/]: https://projectcontour.io/kindly-running-contour/
+[1]: {% post_url 2019-09-27-from-ingressroute-to-httpproxy %}
+[2]: {% link img/posts/kind-contour-video.png %}
+[3]: https://youtu.be/YA82A4Rcs_A
+[4]: {% post_url 2019-07-11-kindly-running-contour %}

--- a/site/_posts/2019-10-25-contour-v100rc2.md
+++ b/site/_posts/2019-10-25-contour-v100rc2.md
@@ -14,16 +14,16 @@ Assuming that no serious issues are found next week we're on track to release Co
 It goes without saying that without the help of the many community contributors this release, nor the 38 that preceded it, would not have been possible.
 Thank you all.
 
-You can read the full [1.0.0-rc.2 release notes](https://github.com/projectcontour/contour/releases/tag/v1.0.0-rc.2) over on GitHub, but as you're here, here are a few highlights. 
+You can read the full [1.0.0-rc.2 release notes][1] over on GitHub, but as you're here, here are a few highlights.
 
 ## Website improvements
 
 As part of the continued preparations for the 1.0 release Contour's documentation has been relocated to the projectcontour.io website. Specifically;
 
-* The Getting Started documentation has moved to [projectcontour.io/getting-started]({% link getting-started.md %})
-* Guides and How-to's have moved to [projectcontour.io/guides]({% link guides.md %})
-* Versioned release documentation has moved to [projectcontour.io/docs](/docs)
-* Project related and non-versioned documentation has moved to [projectcontour.io/resources]({% link resources.md %})  
+* The Getting Started documentation has moved to [projectcontour.io/getting-started][2]
+* Guides and How-to's have moved to [projectcontour.io/guides][3]
+* Versioned release documentation has moved to [projectcontour.io/docs][4]
+* Project related and non-versioned documentation has moved to [projectcontour.io/resources][5]
 
 We're working hard to polish the website content ahead of the 1.0 release. Please pardon our dust.
 
@@ -39,7 +39,7 @@ These schemas are automatically generated from the CRDs themselves and should be
 
 ## TCPProxy delegation
 
-Contour 1.0.0-rc.2 now supports TCPProxy delegation. See the [relevant section](/docs/v1.0.0/httpproxy) in the HTTPProxy documentation.
+Contour 1.0.0-rc.2 now supports TCPProxy delegation. See the [relevant section][6] in the HTTPProxy documentation.
 
 ## Envoy keepalive tuning
 
@@ -53,4 +53,12 @@ This changes reduces the likelihood that Envoy can connect to a Contour instance
 
 ## Upgrading
 
-Please consult the [Upgrading]({% link _resources/upgrading.md %}) document for information on upgrading from Contour 1.0.0-rc.1 to Contour 1.0.0-rc.2.
+Please consult the [Upgrading][7] document for information on upgrading from Contour 1.0.0-rc.1 to Contour 1.0.0-rc.2.
+
+[1]: {{site.github.repository_url}}/releases/tag/v1.0.0-rc.2
+[2]: /getting-started
+[3]: /guides
+[4]: /docs
+[5]: /resources
+[6]: {% link docs/v1.0.0/httpproxy.md %}
+[7]: {% link _resources/upgrading.md %}

--- a/site/_posts/2019-11-01-announcing-contour-1.0.md
+++ b/site/_posts/2019-11-01-announcing-contour-1.0.md
@@ -10,7 +10,7 @@ tags: ['Contour Team', 'release']
 
 _Authored by Dave Cheney, Steve Sloka, Nick Young, and James Peach_
 
-Exactly two years ago, we launched a [new open-source ingress controller](https://github.com/projectcontour/contour/commit/788feabc67c4da76cd1ae3c9ac1998b43cb0e2f3). Contour was the first ingress controller to take advantage of the growing popularity of Envoy to create a layer 7 load-balancing solution for Kubernetes users. Contour was also the first Ingress controller to make use of Envoy’s gRPC API, which allowed changes to be streamed directly from Kubernetes.
+Exactly two years ago, we launched a [new open-source ingress controller][1]. Contour was the first ingress controller to take advantage of the growing popularity of Envoy to create a layer 7 load-balancing solution for Kubernetes users. Contour was also the first Ingress controller to make use of Envoy’s gRPC API, which allowed changes to be streamed directly from Kubernetes.
 
 Today, we are very happy to announce **Contour 1.0**. We’ve come a long way since that first commit two years ago! This blog post takes stock of our journey to Contour 1.0 and describes some of the new features in this milestone release.
 
@@ -57,7 +57,7 @@ We’re also mindful of the ever-present feature backlog we’ve accrued during 
 
 We’re immensely grateful for all the community contributions that help make Contour even better! The lifeblood of any open source project is its community.
 
-![Contour 1.0 stats](/img/contour-1.0/contour-1.0-stats.png)
+![Contour 1.0 stats][2]
 
 The sign of a strong community is how users communicate through Slack and GitHub Issues as well as make contributions back to the project. We couldn’t have made it to 1.0 without you. **Thank you!**
 
@@ -140,9 +140,5 @@ The sign of a strong community is how users communicate through Slack and GitHub
 
 _**Note**: Stats above were taken on  Oct. 31, 2019._
 
-## Join the Contour Community!
-
-* Join the [Contour Community Meetings](https://projectcontour.io/community/), every third Tuesday at 6 PM Eastern Time / 3 PM Pacific Time / Wednesday at 8 AM Australian Eastern Time.
-* Get updates on Twitter ([@projectcontour](https://twitter.com/projectcontour))
-* Chat with us in [#contour on the Kubernetes Slack](https://kubernetes.slack.com/messages/contour)
-* Collaborate with us on [GitHub](https://github.com/projectcontour/contour)
+[1]: {{site.github.repository_url}}/commit/788feabc67c4da76cd1ae3c9ac1998b43cb0e2f3
+[2]: {% link img/contour-1.0/contour-1.0-stats.png %}

--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -28,7 +28,7 @@ This page describes the compatibility matrix of Contour and Envoy versions.
 ## Envoy extensions
 
 Contour requires the following extensions.
-If you are using the image recommended in our [example deployment](https://github.com/projectcontour/contour/tree/{{ site.github.latest_release.tag_name }}/examples/contour) no action is required.
+If you are using the image recommended in our [example deployment][4] no action is required.
 If you are providing your own Envoy it must be compiled with the following extensions:
 
 - `access_loggers`: `envoy.file_access_log`,`envoy.http_grpc_access_log`,`envoy.tcp_grpc_access_log`
@@ -42,3 +42,4 @@ If you are providing your own Envoy it must be compiled with the following exten
 [1]: https://groups.google.com/forum/#!topic/envoy-announce/ZLchtraPYVk
 [2]: https://groups.google.com/forum/#!topic/envoy-announce/Zo3ZEFuPWec
 [3]: https://groups.google.com/d/msg/envoy-announce/3-8S992PUV4/t-egdelVDwAJ
+[4]: {{site.github.repository_url}}/tree/{{site.github.latest_release.tag_name}}/examples/contour

--- a/site/_resources/faq.md
+++ b/site/_resources/faq.md
@@ -25,4 +25,6 @@ Furthermore, as it stands today, the Ingress API is not suitable for clusters th
 
 The HTTPProxy custom resource is an attempt to solve these issues with an API that focuses on providing first-class support for HTTP(S) routing configuration instead of using annotations.
 More importantly, the HTTPProxy CRD is designed with inclusion in mind, a feature that enables administrators to configure top-level ingress settings (for example, which virtual hosts are available to each team), while delegating the lower-level configuration (for example, the mapping between paths and backend services) to each development team.
-More information about the HTTPProxy API can be found [in the HTTPProxy documentation]({% link docs/v1.0.0/httpproxy.md %}).
+More information about the HTTPProxy API can be found [in the HTTPProxy documentation][1].
+
+[1]: {% link docs/v1.0.0/httpproxy.md %}

--- a/site/_resources/how-we-work.md
+++ b/site/_resources/how-we-work.md
@@ -22,7 +22,7 @@ Your aim is to give feedback, not land the as soon as you are asked to review it
 - The smaller the change, the better the PR process works.
 Everything flows from this statement.
 
-- [Talk about what you intend to do, then do the thing you talked about.](https://dave.cheney.net/2019/02/18/talk-then-code)
+- [Talk about what you intend to do, then do the thing you talked about.][1]
 GitHub review tools suck for extended debate, if you find you’re taking past your reviewer, its a sign that more design is needed.
 
 - Log an issue or it didn’t happen. 
@@ -32,4 +32,7 @@ GitHub review tools suck for extended debate, if you find you’re taking past y
 - Before you add a feature, write a test so someone else doesn’t break your feature by accident. 
 
 - You are permitted to refactor as much as you like to achieve these goals.
-As Kent beck said, ["make the change easy, then make the easy change."](https://twitter.com/kentbeck/status/250733358307500032?lang=en)
+As Kent beck said, ["make the change easy, then make the easy change."][2]
+
+[1]: https://dave.cheney.net/2019/02/18/talk-then-code
+[2]: https://twitter.com/kentbeck/status/250733358307500032?lang=en

--- a/site/_resources/support.md
+++ b/site/_resources/support.md
@@ -9,7 +9,7 @@ This document describes which versions of Contour are supported by the Contour t
 
 Only the latest stable release is supported.
 
-The latest stable release is identified by the [Docker tag `:latest`](/docs/v1.0.0/tagging).
+The latest stable release is identified by the [Docker tag `:latest`][1].
 `:latest` is an alias for {{ site.github.latest_release.tag_name }} which is the current stable release.
 
 When required we may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
@@ -19,3 +19,5 @@ For example, prior to a patch release version Contour 1.0.0 was the `:latest` st
 If Contour 1.0.1 is release, the `:latest` tag will move to that version.
 
 No support is offered for major, minor, or patch releases older than the `:latest` stable release.
+
+[1]: {% link docs/v1.0.0/tagging.md %}

--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -17,9 +17,8 @@ Contour 1.0.0 is the current stable release.
 The <code>IngressRoute</code> CRD has been deprecated and will not receive further updates. Contour 1.0.0 continues to support the IngressRoute API, however we anticipate it will be removed in the future.
 <p>
 </p>
-Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a>, which is the successor to <code>IngressRoute</code>.
+Please see the documentation for <a href="{% link docs/v1.0.0/httpproxy.md %}"><code>HTTPProxy</code></a>, which is the successor to <code>IngressRoute</code>.
 You can also read the <a href="{% link _guides/ingressroute-to-httpproxy.md %}">IngressRoute to HTTPProxy upgrade</a> guide.
-</p>
 </div>
 
 &nbsp;
@@ -34,7 +33,7 @@ Ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.11.2`.
 If the following are true for you:
 
  * Your previous installation is in the `projectcontour` namespace.
- * You are using one of the [example]({{ site.github.repository_url }}/blob/v1.0.0/examples/) deployments.
+ * You are using one of the [example][1] deployments.
  * Your cluster can take few minutes of downtime.
 
 Then the simplest way to upgrade is to delete the `projectcontour` namespace and reapply the `examples/contour` sample manifest.
@@ -47,7 +46,7 @@ $ kubectl apply -f examples/contour
 
 This will remove both the Envoy and Contour pods from your cluster and recreate them with the updated configuration.
 If you're using a `LoadBalancer` Service, deleting and recreating may change the public IP assigned by your cloud provider.
-You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address](/docs/v1.0.0/deploy-options).
+You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][2].
 
 ## The less easy way
 
@@ -65,7 +64,7 @@ Contour 1.0.0 ships with updated OpenAPIv3 validation schemas.
 
 Contour 1.0.0 promotes the HTTPProxy CRD to v1.
 HTTPProxy is now considered stable, and there will only be additive, compatible changes in the future.
-See the [HTTPProxy documentation](/docs/v1.0.0/httpproxy) for more information.
+See the [HTTPProxy documentation][3] for more information.
 
 ```
 $ kubectl apply -f examples/contour/01-crds.yaml
@@ -76,7 +75,7 @@ $ kubectl apply -f examples/contour/01-crds.yaml
 All the annotations with the prefix `contour.heptio.com` have been migrated to their respective `projectcontour.io` counterparts.
 The deprecated `contour.heptio.com` annotations will be recognized through the Contour 1.0 release, but are scheduled to be removed after Contour 1.0.
 
-See the [annotation documentation](/docs/v1.0.0/annotations) for more information.
+See the [annotation documentation][4] for more information.
 
 ### Update old `projectcontour.io/v1alpha1` group versions
 
@@ -90,7 +89,7 @@ As part of finalizing the HTTPProxy v1 schema, three breaking changes have been 
 If you are upgrading a cluster that you previously installed a Contour 1.0.0 release candidate, you may need to edit HTTPProxy object to conform to the upgraded schema.
 
 * The per-route prefix rewrite key, `prefixRewrite` has been removed.
-  See [#899](https://github.com/projectcontour/contour/issues/899) for the status of its replacement.
+  See [#899][5] for the status of its replacement.
 
 * The per-service health check key, `healthcheck` has moved to per-route and has been renamed `healthCheckPolicy`.
 
@@ -171,24 +170,24 @@ spec:
 As part of sunsetting the Heptio brand the `heptio-contour` namespace has been renamed to `projectcontour`.
 Contour assumes it will be deployed into the `projectcontour` namespace.
 
-If you deploy Contour into a different namespace you will need to pass `contour bootstrap --namespace=<namespace>` and update the leader election parameters in the [`contour.yaml` configuration](/docs/v1.0.0/configuration)
+If you deploy Contour into a different namespace you will need to pass `contour bootstrap --namespace=<namespace>` and update the leader election parameters in the [`contour.yaml` configuration][6]
 as appropriate.
 
 ### Split deployment/daemonset now the default
 
 We have changed the example installation to use a separate pod installation, where Contour is in a Deployment and Envoy is in a Daemonset.
-Separated pod installations separate the lifecyle of Contour and Envoy, increasing operability.
+Separated pod installations separate the lifecycle of Contour and Envoy, increasing operability.
 Because of this, we are marking the single pod install type as officially deprecated.
-If you are still running a single pod install type, please review the [`contour` example]({{ site.github.repository_url }}/blob/v1.0.0-beta.1/examples/contour/README.md) and either adapt it or use it directly.
+If you are still running a single pod install type, please review the [`contour` example][7] and either adapt it or use it directly.
 
 ### Verify leader election
 
 Contour 1.0.0 enables leader election by default.
-No specific configuration is required if you are using the [example deployment]({{ site.github.repository_url }}/blob/v1.0.0-beta.1/examples/contour/README.md).
+No specific configuration is required if you are using the [example deployment][7].
 
 Leader election requires that Contour have write access to a ConfigMap
 called `leader-elect` in the project-contour namespace.
-This is done with the [contour-leaderelection Role]({{ site.github.repository_url }}/blob/v1.0.0/examples/contour/02-rbac.yaml#L71) in the [example RBAC]({{ site.github.repository_url }}/blob/v1.0.0/examples/contour/02-rbac.yaml).
+This is done with the [contour-leaderelection Role][8] in the [example RBAC][9].
 The namespace and name of the configmap are configurable via the configuration file.
 
 The leader election mechanism no longer blocks serving of gRPC until an instance becomes the leader.
@@ -228,14 +227,14 @@ Contour's `contour serve` now requires that either TLS certificates be available
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.11.2`.
 
-Please see the [Envoy Release Notes](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/version_history) for information about issues fixed in Envoy 1.11.2.
+Please see the [Envoy Release Notes][10] for information about issues fixed in Envoy 1.11.2.
 
 ## The easy way to upgrade
 
 If the following are true for you:
 
  * Your installation is in the `heptio-contour` namespace.
- * You are using one of the [example]({{ site.github.repository_url }}/blob/v0.15.3/examples/) deployments.
+ * You are using one of the [example][11] deployments.
  * Your cluster can take few minutes of downtime.
 
 Then the simplest way to upgrade to 0.15.3 is to delete the `heptio-contour` namespace and reapply one of the example configurations.
@@ -247,7 +246,7 @@ $ kubectl apply -f examples/<your-desired-deployment>
 ```
 
 If you're using a `LoadBalancer` Service, (which most of the examples do) deleting and recreating may change the public IP assigned by your cloud provider.
-You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address](/docs/v1.0.0/deploy-options).
+You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
 **Note:** If you deployed Contour into a different namespace than heptio-contour with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `heptio-contour` and replace it with your preferred name space and apply the updated manifest.
@@ -258,7 +257,7 @@ This section contains information for administrators who wish to apply the Conto
 
 ### Upgrade to Contour 0.15.3
 
-Due to the sun setting on the Heptio brand, from v0.15.0 onwards our images are now served from the docker hub repository [`docker.io/projectcontour/contour`](https://hub.docker.com/r/projectcontour/contour)
+Due to the sun setting on the Heptio brand, from v0.15.0 onwards our images are now served from the docker hub repository [`docker.io/projectcontour/contour`][13]
 
 Change the Contour image version to `docker.io/projectcontour/contour:v0.15.3`.
 
@@ -271,7 +270,7 @@ If you are running using the `ds-hostnet-split` example or a derivative, we stro
 
 There is a Job in the `ds-hostnet-split` directory that will use the new `contour certgen` command to generate a CA and then sign Contour and Envoy keypairs, which can also then be saved directly to Kubernetes as Secrets, ready to be mounted into your Contour and Envoy Deployments and Daemonsets.
 
-If you would like more detail, see [grpc-tls-howto.md](/docs/v1.0.0/grpc-tls-howto), which explains your options.
+If you would like more detail, see [grpc-tls-howto.md][14], which explains your options.
 
 ### Upgrade to Envoy 1.11.2
 
@@ -336,3 +335,18 @@ and checking the annotations that store exact details using
 ```
 $ kubectl get configmap -n heptio-contour -o yaml contour
 ```
+
+[1]: {{site.github.repository_url}}/blob/v1.0.0/examples
+[2]: {% link docs/v1.0.0/deploy-options.md %}
+[3]: {% link docs/v1.0.0/httpproxy.md %}
+[4]: {% link docs/v1.0.0/annotations.md %}
+[5]: {{site.github.repository_url}}/issues/899
+[6]: {% link docs/v1.0.0/configuration.md %}
+[7]: {{site.github.repository_url}}/blob/v1.0.0/examples/contour/README.md
+[8]: {{site.github.repository_url}}/blob/v1.0.0/examples/contour/02-rbac.yaml#L71
+[9]: {{site.github.repository_url}}/blob/v1.0.0/examples/contour/02-rbac.yaml
+[10]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/version_history
+[11]: {{site.github.repository_url}}/blob/v0.15.3/examples/
+[12]: {% link docs/v1.0.0/deploy-options.md %}
+[13]: https://hub.docker.com/r/projectcontour/contour
+[14]: {% link docs/v1.0.0/grpc-tls-howto.md %}

--- a/site/about.md
+++ b/site/about.md
@@ -68,5 +68,3 @@ Envoy provides two mechanisms for reconfiguration: CDS and hot reload. Hot reloa
 ## Security Concerns
 
 Contour implicitly trusts any Ingress object on the API. We are considering a check that the Ingress and Service objects point to valid cluster resources -- in other words, that someone hasn't dumped an Ingress in there to siphon traffic out of the cluster.
-
-

--- a/site/community.md
+++ b/site/community.md
@@ -6,12 +6,20 @@ id: community
 ---
 Do you want to help build Contour?
 
-If you’re a newcomer, check out the “[Good first issue](https://github.com/projectcontour/contour/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22)” and “[Help wanted](https://github.com/projectcontour/contour/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+)” labels in the Contour repository.
+If you’re a newcomer, check out the “[Good first issue][1]” and “[Help wanted][2]” labels in the Contour repository.
 
-* Follow us on Twitter at [@projectcontour](https://twitter.com/projectcontour)
+* Follow us on Twitter at [@projectcontour][3]
 
-* Join our Kubernetes Slack channel and talk to over 300 other community members: [#contour​](https://kubernetes.slack.com/messages/C8XRH2R4J/)
+* Join our Kubernetes Slack channel and talk to over 300 other community members: [#contour​][4]
 
-* Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
-  * Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
-  * Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
+* Join the [Contour Community Meetings][5], every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
+  * Meeting notes can be found [here][6].
+  * Meetings are recorded and can be found [here][7].
+
+[1]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22
+[2]: {{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+
+[3]: {{site.footer_social_links.Twitter.url}}
+[4]: {{site.footer_social_links.Slack.url}}
+[5]: https://vmware.zoom.us/j/347232187
+[6]: https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw
+[7]: https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj

--- a/site/docs/master/README.md
+++ b/site/docs/master/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/projectcontour/contour.svg?branch=master)](https://travis-ci.org/projectcontour/contour) [![Go Report Card](https://goreportcard.com/badge/github.com/projectcontour/contour)](https://goreportcard.com/report/github.com/projectcontour/contour) ![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build Status][1]][2] [![Go Report Card][3]][4] ![GitHub release][5] [![License][6]][7]
 
 ## Overview
-Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy](https://www.envoyproxy.io/) as a reverse proxy and load balancer.
+Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy][8] as a reverse proxy and load balancer.
 Contour supports dynamic configuration updates out of the box while maintaining a lightweight profile.
 
-Contour also introduces a new ingress API ([HTTPProxy](/docs/v1.0.0/httpproxy)) which is implemented via a Custom Resource Definition (CRD).
+Contour also introduces a new ingress API [HTTPProxy][9] which is implemented via a Custom Resource Definition (CRD).
 Its goal is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
 
 ## Prerequisites
@@ -14,4 +14,15 @@ RBAC must be enabled on your cluster.
 
 ## Get started
 Getting started with Contour is as simple as one command.
-See the [Getting Started](https://projectcontour.io/getting-started) document.
+See the [Getting Started][10] document.
+
+[1]: https://travis-ci.org/projectcontour/contour.svg?branch={{page.version}}
+[2]: https://travis-ci.org/projectcontour/contour
+[3]: https://goreportcard.com/badge/github.com/projectcontour/contour
+[4]: https://goreportcard.com/report/github.com/projectcontour/contour
+[5]: https://img.shields.io/github/release/projectcontour/contour.svg
+[6]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+[7]: https://opensource.org/licenses/Apache-2.0
+[8]: https://www.envoyproxy.io/
+[9]: {% link docs/master/httpproxy.md %}
+[10]:{% link getting-started.md %}

--- a/site/docs/master/annotations.md
+++ b/site/docs/master/annotations.md
@@ -2,7 +2,7 @@
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 
-Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API](/docs/v1.0.0/ingressroute), which provides a more robust configuration interface over
+Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API][15], which provides a more robust configuration interface over
 annotations.
 
 However, Contour still supports a number of annotations on the Ingress resources.
@@ -14,25 +14,23 @@ The <code>contour.heptio.com</code> annotations are deprecated, please use the <
 
 ## Standard Kubernetes Ingress annotations
 
-The following Kubernetes annotions are supported on [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/) objects:
+The following Kubernetes annotions are supported on [`Ingress`] objects:
 
  - `kubernetes.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `kubernetes.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
- - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls).
+ - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls][16].
  - `kubernetes.io/ingress.allow-http`: Instructs Contour to not create an Envoy HTTP route for the virtual host. The Ingress exists only for HTTPS requests. Specify `"false"` for Envoy to mark the endpoint as HTTPS only. All other values are ignored.
 
 The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over `kubernetes.io/ingress.allow-http`. If they are set to `"true"` and `"false"` respectively, Contour *will* create an Envoy HTTP route for the Virtual host, and set the `require_tls` virtual host option.
 
 ## Contour specific Ingress annotations
 
-The following Contour annotions are supported on [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/) objects:
-
  - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
- - `projectcontour.io/num-retries`: [The maximum number of retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries) Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
- - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on), if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
- - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout), specified as a [golang duration](https://golang.org/pkg/time/#ParseDuration). By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
- - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on). See also [possible values and their meanings for `retry-on`](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on).
- - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters) the TLS listener should support.
- - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket), the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
+ - `projectcontour.io/num-retries`: [The maximum number of retries][1] Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt][2], if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout][3], specified as a [golang duration][4]. By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
+ - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
+ - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
+ - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
  - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
  - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
  - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
@@ -43,12 +41,12 @@ The following Contour annotions are supported on [`Ingress`](https://kubernetes.
 
 ## Contour specific Service annotations
 
-A [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/) maps to an [Envoy Cluster](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html). Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
+A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
 
-- `projectcontour.io/max-connections`: [The maximum number of connections](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `projectcontour.io/max-pending-requests`: [The maximum number of pending requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `projectcontour.io/max-requests`: [The maximum parallel requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests) a single Envoy instance allows to the Kubernetes Service; defaults to 1024
-- `projectcontour.io/max-retries`: [The maximum number of parallel retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries) a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
+- `projectcontour.io/max-connections`: [The maximum number of connections][11] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-pending-requests`: [The maximum number of pending requests][13] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-requests`: [The maximum parallel requests][13] a single Envoy instance allows to the Kubernetes Service; defaults to 1024
+- `projectcontour.io/max-retries`: [The maximum number of parallel retries][14] a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
 - `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
   - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
 - `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
@@ -58,5 +56,21 @@ A [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/s
 - `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
 
 ## Contour specific IngressRoute annotations
-
 - `contour.heptio.com/ingress.class`: The Ingress class that should interpret and serve the IngressRoute. If not set, then all all Contour instances serve the IngressRoute. If specified as `contour.heptio.com/ingress.class: contour`, then Contour serves the IngressRoute. If any other value, Contour ignores the IngressRoute definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
+
+[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
+[2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[3]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[4]: https://golang.org/pkg/time/#ParseDuration
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on
+[7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters
+[8]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket
+[9]: https://kubernetes.io/docs/concepts/services-networking/service/
+[10]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html
+[11]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections
+[12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
+[13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
+[14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
+[15]: {% link docs/master/ingressroute.md %}
+[16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls

--- a/site/docs/master/configuration.md
+++ b/site/docs/master/configuration.md
@@ -30,4 +30,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{ site.github.repository_url }}/blob/master/examples/contour/01-contour-config.yaml
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/docs/master/deploy-options.md
+++ b/site/docs/master/deploy-options.md
@@ -1,17 +1,17 @@
-The [Getting Started]({% link getting-started.md %}) guide shows you a simple way to get started with Contour on your cluster.
+The [Getting Started][8] guide shows you a simple way to get started with Contour on your cluster.
 This topic explains the details and shows you additional options.
 Most of this covers running Contour using a Kubernetes Service of `Type: LoadBalancer`.
-If you don't have a cluster with that capability see the [Running without a Kubernetes LoadBalancer](#running-without-a-kubernetes-loadbalancer) section.
+If you don't have a cluster with that capability see the [Running without a Kubernetes LoadBalancer][1] section.
 
 ## Installation
 
 ### Recommended installation details
 
 The recommended installation of Contour is Contour running in a Deployment and Envoy in a Daemonset with TLS securing the gRPC communication between them.
-The [`contour` example]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/README.md) will install this for you.
+The [`contour` example][2] will install this for you.
 A Service of `type: LoadBalancer` is also set up to forward traffic to the Envoy instances.
 
-If you wish to use Host Networking, please see the [appropriate section](#host-networking) for the details.
+If you wish to use Host Networking, please see the [appropriate section][3] for the details.
 
 ## Testing your installation
 
@@ -33,7 +33,7 @@ contour   10.106.53.14   a47761ccbb9ce11e7b27f023b7e83d33-2036788482.ap-southeas
 Depending on your cloud provider, the `EXTERNAL-IP` value is an IP address, or, in the case of Amazon AWS, the DNS name of the ELB created for Contour. Keep a record of this value.
 
 Note that if you are running an Elastic Load Balancer (ELB) on AWS, you must add more details to your configuration to get the remote address of your incoming connections.
-See the [instructions for enabling the PROXY protocol.]({% link _guides/proxy-proto.md %}).
+See the [instructions for enabling the PROXY protocol.][9].
 
 #### Minikube
 
@@ -74,7 +74,7 @@ _Note: If you change Envoy's ports to bind to 80/443 then it's possible to add e
 
 ### Test with Ingress
 
-The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard](https://github.com/kubernetes-up-and-running/kuard).
+The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard][5].
 To test your Contour deployment, deploy `kuard` with the following command:
 
 ```bash
@@ -108,7 +108,7 @@ In your browser, navigate your browser to the IP or DNS address of the Contour S
 
 ### Test with IngressRoute
 
-To test your Contour deployment with [IngressRoutes](/docs/v1.0.0/ingressroute), run the following command:
+To test your Contour deployment with [IngressRoutes][6], run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-ingressroute.yaml
@@ -144,7 +144,7 @@ $ curl -H 'Host: kuard.local' ${CONTOUR_IP}
 ```
 ### Test with HTTPProxy
 
-To test your Contour deployment with [HTTPProxy](/docs/v1.0.0/httpproxy), run the following command:
+To test your Contour deployment with [HTTPProxy][9], run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-httpproxy.yaml
@@ -187,7 +187,7 @@ If you can't or don't want to use a Service of `type: LoadBalancer` there are ot
 
 If your cluster doesn't have the capability to configure a Kubernetes LoadBalancer,
 or if you want to configure the load balancer outside Kubernetes,
-you can change the Envoy Service in the [`02-service-envoy.yaml`]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/02-service-envoy.yaml) file and set `type` to `NodePort`.
+you can change the Envoy Service in the [`02-service-envoy.yaml`][7] file and set `type` to `NodePort`.
 
 This will have every node in your cluster listen on the resultant port and forward traffic to Contour.
 That port can be discovered by taking the second number listed in the `PORT` column when listing the service, for example `30274` in `80:30274/TCP`.
@@ -201,7 +201,7 @@ This is done by having the Contour pod run with host networking.
 Do this with `hostNetwork: true` on your pod definition.
 Envoy will listen directly on port 8080 on each host that it is running.
 This is best paired with a DaemonSet (perhaps paired with Node affinity) to ensure that a single instance of Contour runs on each Node.
-See the [AWS NLB tutorial]({% link _guides/deploy-aws-nlb.md %}) as an example.
+See the [AWS NLB tutorial][10] as an example.
 
 ## Running Contour in tandem with another ingress controller
 
@@ -217,3 +217,14 @@ To remove Contour from your cluster, delete the namespace:
 ```bash
 $ kubectl delete ns projectcontour
 ```
+
+[1]: #running-without-a-kubernetes-loadbalancer
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[3]: #host-networking
+[4]: {% link _guides/proxy-proto.md %}
+[5]: https://github.com/kubernetes-up-and-running/kuard
+[6]: /docs/{{page.version}}/ingressroute
+[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[8]: {% link getting-started.md %}
+[9]: {% link docs/master/httpproxy.md %}
+[10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/docs/master/github.md
+++ b/site/docs/master/github.md
@@ -70,9 +70,11 @@ All PRs should reference the issue they relate to either by one of the following
 
 If there is no `Updates` or `Fixes` line in the PR the review will, with the exception of trivial or self evident fixes, be deferred.
 
-[Further reading](https://dave.cheney.net/2019/02/18/talk-then-code)
+[Further reading][1]
 
 ## Help wanted and good first issues
 
 The `help wanted` and `good first issue` tags _may_ be assigned to issues _in the current milestone_.
 To limit the amount of work in progress, `help wanted` and `good first issue` should not be used for issues outside the current milestone.
+
+[1]: https://dave.cheney.net/2019/02/18/talk-then-code

--- a/site/docs/master/grpc-tls-howto.md
+++ b/site/docs/master/grpc-tls-howto.md
@@ -14,7 +14,7 @@ The outcome of this is that we will have three Secrets available in the `project
 
 ### Ways you can get the certificates into your cluster
 
-- Deploy the Job from [certgen.yaml]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/examples/contour/02-job-certgen.yaml).
+- Deploy the Job from [certgen.yaml][1].
 This will run `contour certgen --kube` for you.
 - Run `contour certgen --kube` locally.
 - Run the manual procedure below.
@@ -48,7 +48,7 @@ Then, we need to generate a keypair for Contour. First, we make a new private ke
 $ openssl genrsa -out certs/contourkey.pem 2048
 ```
 
-Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/_integration/cert-contour.ext), which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
+Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext][2], which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
 
 ```
 $ openssl req -new -key certs/contourkey.pem \
@@ -90,7 +90,7 @@ $ openssl x509 -req -in certs/envoy.csr \
     -extfile _integration/cert-envoy.ext
 ```
 
-Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext]({{ site.github.repository_url }}/blob/{{ site.github.latest_release.tag_name }}/_integration/cert-envoy.ext). However, in this case, there are no special names required.
+Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext][3]. However, in this case, there are no special names required.
 
 ### Putting the certs in the cluster
 
@@ -112,4 +112,9 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 # Conclusion
 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
-[examples/contour]({{site.github.repository_url}}/blob/{{ site.github.latest_release.tag_name }}/examples/contour).
+[examples/contour][4].
+
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -1,7 +1,7 @@
 <div id="toc"></div>
 
-The [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
-Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) to express missing properties of HTTP routing.
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
 
 The goal of the `HTTPProxy` (previously `IngressRoute`) Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well addressing the limitations of the latter's use in multi tenent environments.
 
@@ -118,7 +118,7 @@ httpproxy "basic" deleted
 
 ## HTTPProxy API Specification
 
-There are a number of [working examples](https://github.com/projectcontour/contour/tree/v1.0.0/examples/example-workload/httpproxy) of HTTPProxy objects in the `examples/example-workload` directory.
+There are a number of [working examples][3] of HTTPProxy objects in the `examples/example-workload` directory.
 
 We will use these examples as a mechanism to describe HTTPProxy API functionality.
 
@@ -536,12 +536,17 @@ This refers to the time that spans between the point at which complete client re
 The time period of **0s** will also be treated as infinity.
 This timeout covers the time from the *end of the client request* to the *end of the upstream response*.
 By default, Envoy has a 15 second value for this timeout.
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout).
+More information can be found in [Envoy's documentation][4].
 - `timeoutPolicy.idle` This field can be any positive time period or "infinity".
 The time period of **0s** will also be treated as infinity.
 By default, there is no per-route idle timeout.
 Note that the default connection manager idle timeout of 5 minutes will apply if this is not set.
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout)
+
+TimeoutPolicy durations are expressed as per the format specified in the [ParseDuration documentation][5].
+Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+The string 'infinity' is also a valid input and specifies no timeout.
+
+More information can be found in [Envoy's documentation][6]
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request.
   - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
   - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional.
@@ -556,7 +561,7 @@ The following list are the options available to choose from:
 - `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
 - `Random`: The random strategy selects a random healthy Endpoints.
 
-More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview).
+More information on the load balancing strategy can be found in [Envoy's documentation][7].
 
 The following example defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
 Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
@@ -756,7 +761,7 @@ Because the path is not necessarily used as the only key, the route space can be
 
 ### Conditions and Inclusion
 
-Like Routes, Inclusion may specify a set of [conditions](#conditions).
+Like Routes, Inclusion may specify a set of [conditions][8].
 These conditions are added to any conditions on the routes included.
 This process is recursive.
 
@@ -1041,7 +1046,7 @@ The CA certificate bundle for the backend service should be supplied in a Kubern
 The referenced Secret must be of type "Opaque" and have a data key named `ca.crt`.
 This data value must be a PEM-encoded certificate bundle.
 
-In addition to the CA certificate and the subject name, the Kubernetes service must also be annotated with a Contour specific annotation: `projectcontour.io/upstream-protocol.tls: <port>` ([see annotations section](annotations.md))
+In addition to the CA certificate and the subject name, the Kubernetes service must also be annotated with a Contour specific annotation: `projectcontour.io/upstream-protocol.tls: <port>` ([see annotations section][9])
 
 _Note: This annotation is applied to the Service not the Ingress or HTTPProxy object._
 
@@ -1097,3 +1102,13 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Root HTTPProxy does not specify fqdn.
 - Multiple prefixes cannot be specified on the same set of route conditions.
 - Multiple header conditions of type "exact match" with the same header key.
+
+ [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+ [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+ [5]: https://godoc.org/time#ParseDuration
+ [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout
+ [7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+ [8]: #conditions
+ [9]: {% link docs/master/annotations.md %}

--- a/site/docs/master/ingressroute.md
+++ b/site/docs/master/ingressroute.md
@@ -1,7 +1,7 @@
 <div id="toc"></div>
 
-The [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
-Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) to express missing properties of HTTP routing.
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
 
 The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
 
@@ -126,7 +126,7 @@ ingressroute "basic" deleted
 
 ## IngressRoute API Specification
 
-There are a number of [working examples](https://github.com/projectcontour/contour/blob/{{ site.github.latest_release.tag_name }}/examples/example-workload/ingressroute) of IngressRoute objects in the `examples/example-workload` directory.
+There are a number of [working examples][3] of IngressRoute objects in the `examples/example-workload` directory.
 We will use these examples as a mechanism to describe IngressRoute API functionality.
 
 ### Virtual Host Configuration
@@ -482,7 +482,7 @@ This refers to the time that spans between the point at which complete client re
 - `timeoutPolicy.request` This field can be any positive time period or "infinity". 
 The time period of **0s** will also be treated as infinity. 
 By default, Envoy has a 15 second timeout for a backend service to respond.
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout).
+More information can be found in [Envoy's documentation][4].
 
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request. 
     - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
@@ -499,7 +499,7 @@ The following list are the options available to choose from:
 - `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
 - `Random`: The random strategy selects a random healthy Endpoints.
 
-More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview).
+More information on the load balancing strategy can be found in [Envoy's documentation][5].
 
 The following example IngressRoute defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
 Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
@@ -891,7 +891,7 @@ IngressRoutes with a defined `virtualhost` field that are not in one of the allo
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
-An example of this is included in the [examples directory][1] and shows how you might create a namespace called `root-ingressroutes`.
+An example of this is included in the [examples directory][6] and shows how you might create a namespace called `root-ingressroutes`.
 
 > **NOTE: The restricted root namespace feature is only supported for IngressRoute CRDs.
 > `--ingressroute-root-namespaces` does not affect the operation of `v1beta1.Ingress` objects**
@@ -1005,4 +1005,9 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Delegation chain produces a cycle.
 - Root IngressRoute does not specify fqdn.
 
-[1]: {{ site.github.repository_url }}/blob/master/examples/root-rbac
+[1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac

--- a/site/docs/master/start-contributing.md
+++ b/site/docs/master/start-contributing.md
@@ -2,10 +2,14 @@
 
 Thanks for taking the time to join our community and start contributing!
 
-- Please familiarize yourself with the [Code of Conduct](https://github.com/projectcontour/contour/blob/master/CODE_OF_CONDUCT.md) before contributing.
-- See [CONTRIBUTING.md](https://github.com/projectcontour/contour/blob/master/CONTRIBUTING.md) for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
+- Please familiarize yourself with the [Code of Conduct][1] before contributing.
+- See [CONTRIBUTING.md][2] for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues][3].
 - Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
 - Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
+
+[1]: {{site.github.repository_url}}/blob/master/CODE_OF_CONDUCT.md
+[2]: {{site.github.repository_url}}/blob/master/CONTRIBUTING.md
+[3]: {{site.github.repository_url}}/issues

--- a/site/docs/master/tagging.md
+++ b/site/docs/master/tagging.md
@@ -4,7 +4,7 @@ This document describes Contour's image tagging policy.
 
 `docker.io/projectcontour/contour:<SemVer>`
 
-Contour follows the [Semantic Versioning](http://semver.org/) standard for releases.
+Contour follows the [Semantic Versioning][1] standard for releases.
 Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:v1.0.0`
 
 ### Latest
@@ -18,3 +18,5 @@ The `latest` tag follows the most recent stable version of Contour.
 `docker.io/projectcontour/contour:master`
 
 The `master` tag follows the latest commit to land on the `master` branch.
+
+[1]: http://semver.org/

--- a/site/docs/master/troubleshooting.md
+++ b/site/docs/master/troubleshooting.md
@@ -30,7 +30,7 @@ Then navigate to `http://127.0.0.1:9001/` to access the admin interface for the 
 
 ## Accessing Contour's /debug/pprof service
 
-Contour exposes the [net/http/pprof](https://golang.org/pkg/net/http/pprof/) handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
+Contour exposes the [net/http/pprof][1]handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
 This service is useful for profiling Contour.
 To access it from your workstation use `kubectl port-forward` like so,
 
@@ -43,8 +43,8 @@ kubectl -n projectcontour port-forward $CONTOUR_POD 6060
 
 ## Visualizing Contour's internal directed acyclic graph (DAG)
 
-Contour models its configuration using a DAG, which can be visualized through a debug endpoint that outputs the DAG in [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) format.
-To visualize the graph, you must have [`graphviz`](https://graphviz.gitlab.io/) installed on your system.
+Contour models its configuration using a DAG, which can be visualized through a debug endpoint that outputs the DAG in [DOT][2] format.
+To visualize the graph, you must have [`graphviz`][3] installed on your system.
 
 To download the graph and save it as a PNG:
 
@@ -60,7 +60,7 @@ curl localhost:6060/debug/dag | dot -T png > contour-dag.png
 The following is an example of a DAG that maps `http://kuard.local:80/` to the
 `kuard` service in the `default` namespace:
 
-![Sample DAG](/img/kuard-dag.png "Sample DAG")
+![Sample DAG][4]
 
 ## Interrogate Contour's gRPC API
 
@@ -82,4 +82,10 @@ Replace `contour cli lds` with `contour cli rds` for RDS, `contour cli cds` for 
 
 ## I've deployed on Minikube or kind and nothing seems to work
 
-See [the deployment documentation](/docs/v1.0.0/deploy-options) for some tips on using these two deployment options successfully.
+See [the deployment documentation][5] for some tips on using these two deployment options successfully.
+
+[1]: https://golang.org/pkg/net/http/pprof
+[2]: https://en.wikipedia.org/wiki/DOT
+[3]: https://graphviz.gitlab.io/
+[4]: {%link img/kuard-dag.png %}
+[5]: {% link docs/master/deploy-options.md %}

--- a/site/docs/v1.0.0/README.md
+++ b/site/docs/v1.0.0/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/projectcontour/contour.svg?branch=master)](https://travis-ci.org/projectcontour/contour) [![Go Report Card](https://goreportcard.com/badge/github.com/projectcontour/contour)](https://goreportcard.com/report/github.com/projectcontour/contour) ![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build Status][1]][2] [![Go Report Card][3]][4] ![GitHub release][5] [![License][6]][7]
 
 ## Overview
-Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy](https://www.envoyproxy.io/) as a reverse proxy and load balancer.
+Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy][8] as a reverse proxy and load balancer.
 Contour supports dynamic configuration updates out of the box while maintaining a lightweight profile.
 
-Contour also introduces a new ingress API ([HTTPProxy](/docs/v1.0.0/httpproxy)) which is implemented via a Custom Resource Definition (CRD).
+Contour also introduces a new ingress API [HTTPProxy][9] which is implemented via a Custom Resource Definition (CRD).
 Its goal is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
 
 ## Prerequisites
@@ -14,4 +14,15 @@ RBAC must be enabled on your cluster.
 
 ## Get started
 Getting started with Contour is as simple as one command.
-See the [Getting Started](https://projectcontour.io/getting-started) document.
+See the [Getting Started][10] document.
+
+[1]: https://travis-ci.org/projectcontour/contour.svg?branch={{page.version}}
+[2]: https://travis-ci.org/projectcontour/contour
+[3]: https://goreportcard.com/badge/github.com/projectcontour/contour
+[4]: https://goreportcard.com/report/github.com/projectcontour/contour
+[5]: https://img.shields.io/github/release/projectcontour/contour.svg
+[6]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+[7]: https://opensource.org/licenses/Apache-2.0
+[8]: https://www.envoyproxy.io/
+[9]: /docs/{{page.version}}/httpproxy
+[10]: {% link getting-started.md %}

--- a/site/docs/v1.0.0/annotations.md
+++ b/site/docs/v1.0.0/annotations.md
@@ -2,7 +2,7 @@
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 
-Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API](/docs/v1.0.0/ingressroute), which provides a more robust configuration interface over
+Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API][15], which provides a more robust configuration interface over
 annotations.
 
 However, Contour still supports a number of annotations on the Ingress resources.
@@ -15,7 +15,7 @@ The <code>contour.heptio.com</code> annotations are deprecated, please use the <
 ## Standard Kubernetes Ingress annotations
 
  - `kubernetes.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `kubernetes.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
- - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls).
+ - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls][16].
  - `kubernetes.io/ingress.allow-http`: Instructs Contour to not create an Envoy HTTP route for the virtual host. The Ingress exists only for HTTPS requests. Specify `"false"` for Envoy to mark the endpoint as HTTPS only. All other values are ignored.
 
 The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over `kubernetes.io/ingress.allow-http`. If they are set to `"true"` and `"false"` respectively, Contour *will* create an Envoy HTTP route for the Virtual host, and set the `require_tls` virtual host option.
@@ -23,12 +23,12 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
 ## Contour specific Ingress annotations
 
  - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
- - `projectcontour.io/num-retries`: [The maximum number of retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries) Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
- - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on), if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
- - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout), specified as a [golang duration](https://golang.org/pkg/time/#ParseDuration). By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
- - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on). See also [possible values and their meanings for `retry-on`](https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on).
- - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters) the TLS listener should support.
- - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket), the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
+ - `projectcontour.io/num-retries`: [The maximum number of retries][1] Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt][2], if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout][3], specified as a [golang duration][4]. By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
+ - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
+ - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
+ - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
  - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
  - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
  - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
@@ -39,12 +39,12 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
 
 ## Contour specific Service annotations
 
-A [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/) maps to an [Envoy Cluster](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html). Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
+A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
 
-- `projectcontour.io/max-connections`: [The maximum number of connections](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `projectcontour.io/max-pending-requests`: [The maximum number of pending requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests) that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
-- `projectcontour.io/max-requests`: [The maximum parallel requests](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests) a single Envoy instance allows to the Kubernetes Service; defaults to 1024
-- `projectcontour.io/max-retries`: [The maximum number of parallel retries](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries) a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
+- `projectcontour.io/max-connections`: [The maximum number of connections][11] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-pending-requests`: [The maximum number of pending requests][13] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-requests`: [The maximum parallel requests][13] a single Envoy instance allows to the Kubernetes Service; defaults to 1024
+- `projectcontour.io/max-retries`: [The maximum number of parallel retries][14] a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
 - `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
   - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
 - `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
@@ -55,4 +55,19 @@ A [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/s
 
 ## Contour specific IngressRoute annotations
 
-- `contour.heptio.com/ingress.class`: The Ingress class that should interpret and serve the IngressRoute. If not set, then all all Contour instances serve the IngressRoute. If specified as `contour.heptio.com/ingress.class: contour`, then Contour serves the IngressRoute. If any other value, Contour ignores the IngressRoute definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
+[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
+[2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[3]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[4]: https://golang.org/pkg/time/#ParseDuration
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on
+[7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters
+[8]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket
+[9]: https://kubernetes.io/docs/concepts/services-networking/service/
+[10]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html
+[11]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections
+[12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
+[13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
+[14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
+[15]: {% link docs/v1.0.0/ingressroute.md %}
+[16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls

--- a/site/docs/v1.0.0/architecture.md
+++ b/site/docs/v1.0.0/architecture.md
@@ -6,7 +6,7 @@ The Contour Ingress controller is a collaboration between:
 These containers are deployed separately, Contour as a Deployment and Envoy as a Daemonset, although other configurations are possible.
 
 In the Envoy Pods, Contour runs as an initcontainer in `bootstrap` mode and writes a bootstrap configuration to a temporary volume.
-This volume is passed to the Envoy container and directs Envoy to treat Contour as its [management server](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-docs/xds_protocol).
+This volume is passed to the Envoy container and directs Envoy to treat Contour as its [management server][1].
 
 After initialisation is complete, the Envoy container starts, retrieves the bootstrap configuration written by Contour's `bootstrap` mode, and starts to poll Contour for configuration.
 
@@ -22,3 +22,5 @@ These are enabled over the metrics port and are served over http via `/healthz`.
 
 For Contour, a liveness probe checks the `/healthz` running on the Pod's metrics port.
 Readiness probe is a TCP check that the gRPC port is open.
+
+[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-docs/xds_protocol

--- a/site/docs/v1.0.0/configuration.md
+++ b/site/docs/v1.0.0/configuration.md
@@ -28,4 +28,6 @@ data:
       # configmap-namespace: leader-elect
 ```
 
-_Note:_ The default example `contour` includes this [file](https://github.com/projectcontour/contour/blob/v1.0.0/examples/contour/01-contour-config.yaml) for easy deployment of Contour.
+_Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
+
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/docs/v1.0.0/deploy-options.md
+++ b/site/docs/v1.0.0/deploy-options.md
@@ -1,17 +1,17 @@
-The [Getting Started]({% link getting-started.md %}) guide shows you a simple way to get started with Contour on your cluster.
+The [Getting Started][8] guide shows you a simple way to get started with Contour on your cluster.
 This topic explains the details and shows you additional options.
 Most of this covers running Contour using a Kubernetes Service of `Type: LoadBalancer`.
-If you don't have a cluster with that capability see the [Running without a Kubernetes LoadBalancer](#running-without-a-kubernetes-loadbalancer) section.
+If you don't have a cluster with that capability see the [Running without a Kubernetes LoadBalancer][1] section.
 
 ## Installation
 
 ### Recommended installation details
 
 The recommended installation of Contour is Contour running in a Deployment and Envoy in a Daemonset with TLS securing the gRPC communication between them.
-The [`contour` example]({{site.github.repository_url}}/tree/master/examples/contour/README.md) will install this for you.
+The [`contour` example][2] will install this for you.
 A Service of `type: LoadBalancer` is also set up to forward traffic to the Envoy instances.
 
-If you wish to use Host Networking, please see the [appropriate section](#host-networking) for the details.
+If you wish to use Host Networking, please see the [appropriate section][3] for the details.
 
 ## Testing your installation
 
@@ -33,7 +33,7 @@ contour   10.106.53.14   a47761ccbb9ce11e7b27f023b7e83d33-2036788482.ap-southeas
 Depending on your cloud provider, the `EXTERNAL-IP` value is an IP address, or, in the case of Amazon AWS, the DNS name of the ELB created for Contour. Keep a record of this value.
 
 Note that if you are running an Elastic Load Balancer (ELB) on AWS, you must add more details to your configuration to get the remote address of your incoming connections.
-See the [instructions for enabling the PROXY protocol.]({% link _guides/proxy-proto.md %}).
+See the [instructions for enabling the PROXY protocol.][9].
 
 #### Minikube
 
@@ -74,7 +74,7 @@ _Note: If you change Envoy's ports to bind to 80/443 then it's possible to add e
 
 ### Test with Ingress
 
-The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard](https://github.com/kubernetes-up-and-running/kuard).
+The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard][5].
 To test your Contour deployment, deploy `kuard` with the following command:
 
 ```bash
@@ -108,7 +108,7 @@ In your browser, navigate your browser to the IP or DNS address of the Contour S
 
 ### Test with IngressRoute
 
-To test your Contour deployment with [IngressRoutes](/docs/v1.0.0/ingressroute.md), run the following command:
+To test your Contour deployment with [IngressRoutes][6], run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-ingressroute.yaml
@@ -144,7 +144,7 @@ $ curl -H 'Host: kuard.local' ${CONTOUR_IP}
 ```
 ### Test with HTTPProxy
 
-To test your Contour deployment with [HTTPProxy](/docs/v1.0.0/httpproxy), run the following command:
+To test your Contour deployment with [HTTPProxy][9], run the following command:
 
 ```sh
 $ kubectl apply -f https://projectcontour.io/examples/kuard-httpproxy.yaml
@@ -187,7 +187,7 @@ If you can't or don't want to use a Service of `type: LoadBalancer` there are ot
 
 If your cluster doesn't have the capability to configure a Kubernetes LoadBalancer,
 or if you want to configure the load balancer outside Kubernetes,
-you can change the Envoy Service in the [`02-service-envoy.yaml`]({{site.github.repository_url}}/tree/master/examples/contour/02-service-envoy.yaml) file and set `type` to `NodePort`.
+you can change the Envoy Service in the [`02-service-envoy.yaml`][7] file and set `type` to `NodePort`.
 
 This will have every node in your cluster listen on the resultant port and forward traffic to Contour.
 That port can be discovered by taking the second number listed in the `PORT` column when listing the service, for example `30274` in `80:30274/TCP`.
@@ -201,7 +201,7 @@ This is done by having the Contour pod run with host networking.
 Do this with `hostNetwork: true` on your pod definition.
 Envoy will listen directly on port 8080 on each host that it is running.
 This is best paired with a DaemonSet (perhaps paired with Node affinity) to ensure that a single instance of Contour runs on each Node.
-See the [AWS NLB tutorial]({% link _guides/deploy-aws-nlb.md %}) as an example.
+See the [AWS NLB tutorial][10] as an example.
 
 ## Running Contour in tandem with another ingress controller
 
@@ -217,3 +217,14 @@ To remove Contour from your cluster, delete the namespace:
 ```bash
 $ kubectl delete ns projectcontour
 ```
+
+[1]: #running-without-a-kubernetes-loadbalancer
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[3]: #host-networking
+[4]: {% link _guides/proxy-proto.md %}
+[5]: https://github.com/kubernetes-up-and-running/kuard
+[6]: {% link docs/v1.0.0/ingressroute.md %}
+[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[8]: {% link getting-started.md %}
+[9]: {% link docs/v1.0.0/httpproxy.md %}
+[10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/docs/v1.0.0/github.md
+++ b/site/docs/v1.0.0/github.md
@@ -70,9 +70,11 @@ All PRs should reference the issue they relate to either by one of the following
 
 If there is no `Updates` or `Fixes` line in the PR the review will, with the exception of trivial or self evident fixes, be deferred.
 
-[Further reading](https://dave.cheney.net/2019/02/18/talk-then-code)
+[Further reading]
 
 ## Help wanted and good first issues
 
 The `help wanted` and `good first issue` tags _may_ be assigned to issues _in the current milestone_.
 To limit the amount of work in progress, `help wanted` and `good first issue` should not be used for issues outside the current milestone.
+
+[1]: https://dave.cheney.net/2019/02/18/talk-then-code

--- a/site/docs/v1.0.0/grpc-tls-howto.md
+++ b/site/docs/v1.0.0/grpc-tls-howto.md
@@ -14,7 +14,7 @@ The outcome of this is that we will have three Secrets available in the `project
 
 ### Ways you can get the certificates into your cluster
 
-- Deploy the Job from [certgen.yaml]({{ site.github.repository_url }}/tree/master/examples/contour/02-job-certgen.yaml).
+- Deploy the Job from [certgen.yaml][1].
 This will run `contour certgen --kube` for you.
 - Run `contour certgen --kube` locally.
 - Run the manual procedure below.
@@ -48,7 +48,7 @@ Then, we need to generate a keypair for Contour. First, we make a new private ke
 $ openssl genrsa -out certs/contourkey.pem 2048
 ```
 
-Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext]({{ site.github.repository_url }}/tree/master/_integration/cert-contour.ext), which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
+Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext][2], which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
 
 ```
 $ openssl req -new -key certs/contourkey.pem \
@@ -90,7 +90,7 @@ $ openssl x509 -req -in certs/envoy.csr \
     -extfile _integration/cert-envoy.ext
 ```
 
-Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext]({{ site.github.repository_url }}/tree/master/_integration/cert-envoy.ext). However, in this case, there are no special names required.
+Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext][3]. However, in this case, there are no special names required.
 
 ### Putting the certs in the cluster
 
@@ -112,4 +112,9 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 # Conclusion
 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
-[examples/contour]({{site.github.repository_url}}/tree/master/examples/contour).
+[examples/contour][4].
+
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour

--- a/site/docs/v1.0.0/httpproxy.md
+++ b/site/docs/v1.0.0/httpproxy.md
@@ -1,7 +1,7 @@
 <div id="toc"></div>
 
-The [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
-Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) to express missing properties of HTTP routing.
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
 
 The goal of the `HTTPProxy` (previously `IngressRoute`) Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well addressing the limitations of the latter's use in multi tenent environments.
 
@@ -118,7 +118,7 @@ httpproxy "basic" deleted
 
 ## HTTPProxy API Specification
 
-There are a number of [working examples][2] of HTTPProxy objects in the `examples/example-workload` directory.
+There are a number of [working examples][3] of HTTPProxy objects in the `examples/example-workload` directory.
 
 We will use these examples as a mechanism to describe HTTPProxy API functionality.
 
@@ -536,17 +536,17 @@ This refers to the time that spans between the point at which complete client re
 The time period of **0s** will also be treated as infinity.
 This timeout covers the time from the *end of the client request* to the *end of the upstream response*.
 By default, Envoy has a 15 second value for this timeout.
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout).
+More information can be found in [Envoy's documentation][4].
 - `timeoutPolicy.idle` This field can be any positive time period or "infinity".
 The time period of **0s** will also be treated as infinity.
 By default, there is no per-route idle timeout.
 Note that the default connection manager idle timeout of 5 minutes will apply if this is not set.
 
-TimeoutPolicy durations are expressed as per the format specified in the [ParseDuration documentation](https://godoc.org/time#ParseDuration).
+TimeoutPolicy durations are expressed as per the format specified in the [ParseDuration documentation][5].
 Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 The string 'infinity' is also a valid input and specifies no timeout.
 
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout)
+More information can be found in [Envoy's documentation][6]
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request.
   - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
   - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional.
@@ -561,7 +561,7 @@ The following list are the options available to choose from:
 - `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
 - `Random`: The random strategy selects a random healthy Endpoints.
 
-More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview).
+More information on the load balancing strategy can be found in [Envoy's documentation][7].
 
 The following example defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
 Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
@@ -761,7 +761,7 @@ Because the path is not necessarily used as the only key, the route space can be
 
 ### Conditions and Inclusion
 
-Like Routes, Inclusion may specify a set of [conditions](#conditions).
+Like Routes, Inclusion may specify a set of [conditions][8].
 These conditions are added to any conditions on the routes included.
 This process is recursive.
 
@@ -1046,7 +1046,7 @@ The CA certificate bundle for the backend service should be supplied in a Kubern
 The referenced Secret must be of type "Opaque" and have a data key named `ca.crt`.
 This data value must be a PEM-encoded certificate bundle.
 
-In addition to the CA certificate and the subject name, the Kubernetes service must also be annotated with a Contour specific annotation: `projectcontour.io/upstream-protocol.tls: <port>` ([see annotations section](/docs/v1.0.0/annotations))
+In addition to the CA certificate and the subject name, the Kubernetes service must also be annotated with a Contour specific annotation: `projectcontour.io/upstream-protocol.tls: <port>` ([see annotations section][9])
 
 _Note: This annotation is applied to the Service not the Ingress or HTTPProxy object._
 
@@ -1104,5 +1104,12 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Multiple header conditions of type "exact match" with the same header key.
 
 
-[1]: {{ site.github.repository_url }}/blob/master/examples/root-rbac/rbac.yaml
-[2]: {{ site.github.repository_url }}/tree/master/examples/example-workload/httpproxy
+ [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+ [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+ [5]: https://godoc.org/time#ParseDuration
+ [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout
+ [7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+ [8]: #conditions
+ [9]: {% link docs/v1.0.0/annotations.md %}

--- a/site/docs/v1.0.0/ingressroute.md
+++ b/site/docs/v1.0.0/ingressroute.md
@@ -1,7 +1,7 @@
 <div id="toc"></div>
 
-The [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
-Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) to express missing properties of HTTP routing.
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
 
 The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
 
@@ -126,7 +126,7 @@ ingressroute "basic" deleted
 
 ## IngressRoute API Specification
 
-There are a number of [working examples](https://github.com/projectcontour/contour/tree/master/examples/example-workload/ingressroute) of IngressRoute objects in the `examples/example-workload` directory.
+There are a number of [working examples][3] of IngressRoute objects in the `examples/example-workload` directory.
 We will use these examples as a mechanism to describe IngressRoute API functionality.
 
 ### Virtual Host Configuration
@@ -482,7 +482,7 @@ This refers to the time that spans between the point at which complete client re
 - `timeoutPolicy.request` This field can be any positive time period or "infinity". 
 The time period of **0s** will also be treated as infinity. 
 By default, Envoy has a 15 second timeout for a backend service to respond.
-More information can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout).
+More information can be found in [Envoy's documentation][4].
 
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request. 
     - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
@@ -499,7 +499,7 @@ The following list are the options available to choose from:
 - `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
 - `Random`: The random strategy selects a random healthy Endpoints.
 
-More information on the load balancing strategy can be found in [Envoy's documentation](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview).
+More information on the load balancing strategy can be found in [Envoy's documentation][5].
 
 The following example IngressRoute defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
 Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
@@ -891,7 +891,7 @@ IngressRoutes with a defined `virtualhost` field that are not in one of the allo
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
-An example of this is included in the [examples directory](https://github.com/projectcontour/contour/tree/v1.0.0/examples/root-rbac) and shows how you might create a namespace called `root-ingressroutes`.
+An example of this is included in the [examples directory][6] and shows how you might create a namespace called `root-ingressroutes`.
 
 > **NOTE: The restricted root namespace feature is only supported for IngressRoute CRDs.
 > `--ingressroute-root-namespaces` does not affect the operation of `v1beta1.Ingress` objects**
@@ -1004,3 +1004,10 @@ Some examples of invalid configurations that Contour provides statuses for:
 - Orphaned route.
 - Delegation chain produces a cycle.
 - Root IngressRoute does not specify fqdn.
+
+[1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac

--- a/site/docs/v1.0.0/start-contributing.md
+++ b/site/docs/v1.0.0/start-contributing.md
@@ -2,10 +2,14 @@
 
 Thanks for taking the time to join our community and start contributing!
 
-- Please familiarize yourself with the [Code of Conduct](https://github.com/projectcontour/contour/blob/master/CODE_OF_CONDUCT.md) before contributing.
-- See [CONTRIBUTING.md](https://github.com/projectcontour/contour/blob/master/CONTRIBUTING.md) for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
+- Please familiarize yourself with the [Code of Conduct][1] before contributing.
+- See [CONTRIBUTING.md][2] for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues][3].
 - Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
 - Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
+
+[1]: {{site.github.repository_url}}/blob/master/CODE_OF_CONDUCT.md
+[2]: {{site.github.repository_url}}/blob/master/CONTRIBUTING.md
+[3]: {{site.github.repository_url}}/issues

--- a/site/docs/v1.0.0/tagging.md
+++ b/site/docs/v1.0.0/tagging.md
@@ -4,7 +4,7 @@ This document describes Contour's image tagging policy.
 
 `docker.io/projectcontour/contour:<SemVer>`
 
-Contour follows the [Semantic Versioning](http://semver.org/) standard for releases.
+Contour follows the [Semantic Versioning][1] standard for releases.
 Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:v1.0.0`
 
 ### Latest
@@ -18,3 +18,5 @@ The `latest` tag follows the most recent stable version of Contour.
 `docker.io/projectcontour/contour:master`
 
 The `master` tag follows the latest commit to land on the `master` branch.
+
+[1]: http://semver.org/

--- a/site/docs/v1.0.0/troubleshooting.md
+++ b/site/docs/v1.0.0/troubleshooting.md
@@ -30,7 +30,7 @@ Then navigate to `http://127.0.0.1:9001/` to access the admin interface for the 
 
 ## Accessing Contour's /debug/pprof service
 
-Contour exposes the [net/http/pprof](https://golang.org/pkg/net/http/pprof/) handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
+Contour exposes the [net/http/pprof][1]handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
 This service is useful for profiling Contour.
 To access it from your workstation use `kubectl port-forward` like so,
 
@@ -43,8 +43,8 @@ kubectl -n projectcontour port-forward $CONTOUR_POD 6060
 
 ## Visualizing Contour's internal directed acyclic graph (DAG)
 
-Contour models its configuration using a DAG, which can be visualized through a debug endpoint that outputs the DAG in [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) format.
-To visualize the graph, you must have [`graphviz`](https://graphviz.gitlab.io/) installed on your system.
+Contour models its configuration using a DAG, which can be visualized through a debug endpoint that outputs the DAG in [DOT][2] format.
+To visualize the graph, you must have [`graphviz`][3] installed on your system.
 
 To download the graph and save it as a PNG:
 
@@ -60,7 +60,7 @@ curl localhost:6060/debug/dag | dot -T png > contour-dag.png
 The following is an example of a DAG that maps `http://kuard.local:80/` to the
 `kuard` service in the `default` namespace:
 
-![Sample DAG](/img/kuard-dag.png "Sample DAG")
+![Sample DAG][4]
 
 ## Interrogate Contour's gRPC API
 
@@ -82,4 +82,10 @@ Replace `contour cli lds` with `contour cli rds` for RDS, `contour cli cds` for 
 
 ## I've deployed on Minikube or kind and nothing seems to work
 
-See [the deployment documentation](/docs/v1.0.0/deploy-options) for some tips on using these two deployment options successfully.
+See [the deployment documentation][5] for some tips on using these two deployment options successfully.
+
+[1]: https://golang.org/pkg/net/http/pprof
+[2]: https://en.wikipedia.org/wiki/DOT
+[3]: https://graphviz.gitlab.io/
+[4]: {% link img/kuard-dag.png %}
+[5]: {% link docs/v1.0.0/deploy-options.md %}

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -11,7 +11,7 @@ This page will help you get up and running with Contour.
 
 Before you start you will need:
 
-- A Kubernetes cluster that supports Service objects of `type: LoadBalancer` ([AWS Quickstart cluster](https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/) or Minikube, for example)
+- A Kubernetes cluster that supports Service objects of `type: LoadBalancer` ([AWS Quickstart cluster][0] or Minikube, for example)
 - `kubectl` configured with admin access to your cluster
 - RBAC must be enabled on your cluster.
 
@@ -35,7 +35,7 @@ For information on configuring TLS for gRPC between Contour and Envoy, see [our 
 
 ### Example workload
 
-If you don't have an application ready to run with Contour, you can explore with [kuard](https://github.com/kubernetes-up-and-running/kuard).
+If you don't have an application ready to run with Contour, you can explore with [kuard][9].
 
 Run:
 
@@ -66,7 +66,7 @@ How you configure DNS depends on your platform:
 
 For more deployment options, including uninstalling Contour, see the [deployment documentation][1].
 
-See also the Kubernetes documentation for [Services](https://kubernetes.io/docs/concepts/services-networking/service/), [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/), and [HTTPProxy][2].
+See also the Kubernetes documentation for [Services][10], [Ingress][11], and [HTTPProxy][2].
 
 The [detailed documentation][3] provides additional information, including an introduction to Envoy and an explanation of how Contour maps key Envoy concepts to Kubernetes.
 
@@ -74,13 +74,18 @@ We've also got [a FAQ][4] for short-answer questions and conceptual stuff that d
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting docs][5], [file an issue][6], or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
+If you encounter issues, review the [troubleshooting docs][5], [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
 
-[1]: /docs/v1.0.0/deploy-options
-[2]: /docs/v1.0.0/httpproxy
+[0]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes
+[1]: {% link docs/v1.0.0/deploy-options.md %}
+[2]: {% link docs/v1.0.0/httpproxy.md %}
 [3]: /docs
 [4]: {% link _resources/faq.md %}
-[5]: /docs/v1.0.0/troubleshooting
-[6]: {{ site.github.repository_url }}/issues
-[7]: /guides/tls
-[8]: /docs/v1.0.0/grpc-tls-howto
+[5]: {% link docs/v1.0.0/troubleshooting.md %}
+[6]: {{site.github.repository_url}}/issues
+[7]: {% link _guides/tls.md %}
+[8]: {% link docs/v1.0.0/grpc-tls-howto.md %}
+[9]: https://github.com/kubernetes-up-and-running/kuard
+[10]:https://kubernetes.io/docs/concepts/services-networking/service
+[11]:https://kubernetes.io/docs/concepts/services-networking/ingress
+[12]: {{site.footer_social_links.Slack.url}}


### PR DESCRIPTION
Updates: #1891 

Updated posts to place links on the bottom of the page instead of inline where possibe to simplify finding links used on a page.
    
Internal links configured to use either `{% link %}` or `{% post_url %}` as default options.
    
Links that require section links do not use the above convention due to Jekyll limitation.
    
Project Github links set to use `{{site.github.repository_url}}`

Created a footer with community links to be standardize across blog posts. Also provides a single place to update improving consistency.
    
Signed-off-by: Brett Johnson <brett@sdbrett.com>