### PR TITLE
Fix upstream validation error in IngressRoute

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -804,6 +804,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 					uv, err = b.lookupUpstreamValidation(route.Match, service.Name, service.UpstreamValidation, ir.Namespace)
 					if err != nil {
 						sw.SetInvalid(err.Error())
+						return
 					}
 				}
 				r.Clusters = append(r.Clusters, &Cluster{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3830,25 +3830,7 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{
 				ir17, s1a,
 			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com",
-							routeCluster("/",
-								&Cluster{
-									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
-										Protocol:    "tls",
-									},
-								},
-							),
-						),
-					),
-				},
-			),
+			want: listeners(), // no listeners, missing certificate
 		},
 		"insert ingressroute expecting verification": {
 			objs: []interface{}{


### PR DESCRIPTION
Fixes: #1924
Fixes: #1925

Processing IngressRoute did not stop to an error when validation.caSecret
referred to a non-existing secret.  As result, IngressRoute was considered
valid and upstream validation was skipped.

Stop processing IngressRoute and indicate invalid status when upstream
validation is defined but cannot be done due to error in configuration.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>