### PR TITLE
internal/envoy: switch to Cluster.TransportSocket for upstream TLS

### DIFF
--- a/internal/e2e/cds_test.go
+++ b/internal/e2e/cds_test.go
@@ -1017,7 +1017,9 @@ func externalnamecluster(name, servicename, statName, externalName string, port 
 
 func tlscluster(name, servicename, statsName string, ca []byte, subjectName string) *v2.Cluster {
 	c := cluster(name, servicename, statsName)
-	c.TlsContext = envoy.UpstreamTLSContext(ca, subjectName)
+	c.TransportSocket = envoy.UpstreamTLSTransportSocket(
+		envoy.UpstreamTLSContext(ca, subjectName),
+	)
 	return c
 }
 

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -97,7 +97,9 @@ func Bootstrap(c *BootstrapConfig) *bootstrap.Bootstrap {
 		if !(c.GrpcClientCert != "" && c.GrpcClientKey != "" && c.GrpcCABundle != "") {
 			log.Fatal("You must supply all three TLS parameters - --envoy-cafile, --envoy-cert-file, --envoy-key-file, or none of them.")
 		}
-		b.StaticResources.Clusters[0].TlsContext = upstreamFileTLSContext(c.GrpcCABundle, c.GrpcClientCert, c.GrpcClientKey)
+		b.StaticResources.Clusters[0].TransportSocket = UpstreamTLSTransportSocket(
+			upstreamFileTLSContext(c.GrpcCABundle, c.GrpcClientCert, c.GrpcClientKey),
+		)
 	}
 
 	return b

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -19,7 +19,7 @@ import (
 	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 )
 
 func TestBootstrap(t *testing.T) {
@@ -694,8 +694,11 @@ func TestBootstrap(t *testing.T) {
             "keepalive_interval": 5
           }
         },
-        "tls_context": {
-          "common_tls_context": {
+        "transport_socket": {
+          "name":"tls",
+          "typed_config": {
+            "@type":"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
               "tls_certificates": [
                 {
                   "certificate_chain": {
@@ -715,6 +718,7 @@ func TestBootstrap(t *testing.T) {
                 ]
               }
             }
+          }
         }
       },
       {
@@ -787,9 +791,7 @@ func TestBootstrap(t *testing.T) {
 			got := Bootstrap(&tc.config)
 			want := new(bootstrap.Bootstrap)
 			unmarshal(t, tc.want, want)
-			if diff := cmp.Diff(got, want); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -80,15 +80,20 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 
 	switch c.Upstream.Protocol {
 	case "tls":
-		cluster.TlsContext = UpstreamTLSContext(
-			upstreamValidationCACert(c),
-			upstreamValidationSubjectAltName(c),
+		cluster.TransportSocket = UpstreamTLSTransportSocket(
+			UpstreamTLSContext(
+				upstreamValidationCACert(c),
+				upstreamValidationSubjectAltName(c),
+			),
 		)
 	case "h2":
-		cluster.TlsContext = UpstreamTLSContext(
-			upstreamValidationCACert(c),
-			upstreamValidationSubjectAltName(c),
-			"h2")
+		cluster.TransportSocket = UpstreamTLSTransportSocket(
+			UpstreamTLSContext(
+				upstreamValidationCACert(c),
+				upstreamValidationSubjectAltName(c),
+				"h2",
+			),
+		)
 		fallthrough
 	case "h2c":
 		cluster.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -108,7 +108,9 @@ func TestCluster(t *testing.T) {
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
 				},
-				TlsContext:           UpstreamTLSContext(nil, "", "h2"),
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, "", "h2"),
+				),
 				Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
 			},
 		},
@@ -135,7 +137,9 @@ func TestCluster(t *testing.T) {
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
 				},
-				TlsContext: UpstreamTLSContext(nil, ""),
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, ""),
+				),
 			},
 		},
 		"verify tls upstream with san": {
@@ -164,7 +168,9 @@ func TestCluster(t *testing.T) {
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
 				},
-				TlsContext: UpstreamTLSContext([]byte("cacert"), "foo.bar.io"),
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext([]byte("cacert"), "foo.bar.io"),
+				),
 			},
 		},
 		"projectcontour.io/max-connections": {

--- a/internal/envoy/socket.go
+++ b/internal/envoy/socket.go
@@ -1,0 +1,29 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+// UpstreamTLSTransportSocket returns a custom transport socket using the UpstreamTlsContext provided.
+func UpstreamTLSTransportSocket(tls *envoy_api_v2_auth.UpstreamTlsContext) *envoy_api_v2_core.TransportSocket {
+	return &envoy_api_v2_core.TransportSocket{
+		Name: "tls",
+		ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
+			TypedConfig: toAny(tls),
+		},
+	}
+}

--- a/internal/envoy/socket_test.go
+++ b/internal/envoy/socket_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"testing"
+
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/projectcontour/contour/internal/assert"
+)
+
+func TestUpstreamTLSTransportSocket(t *testing.T) {
+	tests := map[string]struct {
+		ctxt *envoy_api_v2_auth.UpstreamTlsContext
+		want *envoy_api_v2_core.TransportSocket
+	}{
+		"h2": {
+			ctxt: UpstreamTLSContext(nil, "", "h2"),
+			want: &envoy_api_v2_core.TransportSocket{
+				Name: "tls",
+				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
+					TypedConfig: toAny(UpstreamTLSContext(nil, "", "h2")),
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := UpstreamTLSTransportSocket(tc.ctxt)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -70,7 +70,9 @@ func cluster(name, servicename, statName string) *v2.Cluster {
 }
 
 func tlsCluster(c *v2.Cluster, ca []byte, subjectName string, alpnProtocols ...string) *v2.Cluster {
-	c.TlsContext = envoy.UpstreamTLSContext(ca, subjectName, alpnProtocols...)
+	c.TransportSocket = envoy.UpstreamTLSTransportSocket(
+		envoy.UpstreamTLSContext(ca, subjectName, alpnProtocols...),
+	)
 	return c
 }
 


### PR DESCRIPTION
Updates #1351

Envoy 1.12 has deprecated the Cluster.TLSContext field, instead the
UpstreamTLSContext must be provided via a typed config attached to a
TransportSocket.

ref: https://www.envoyproxy.io/docs/envoy/v1.12.0/api-v2/api/v2/cds.proto#envoy-api-field-cluster-tls-context

Signed-off-by: Dave Cheney <dave@cheney.net>