### PR TITLE
manifests: Run contour & cert-gen job as non-root

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -65,6 +65,10 @@ spec:
               fieldPath: metadata.namespace
       restartPolicy: Never
       serviceAccountName: contour-certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
   parallelism: 1
   completions: 1
   backoffLimit: 1

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -85,6 +85,10 @@ spec:
               fieldPath: metadata.name
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       volumes:
         - name: contourcert
           secret:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1072,6 +1072,10 @@ spec:
               fieldPath: metadata.namespace
       restartPolicy: Never
       serviceAccountName: contour-certgen
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
   parallelism: 1
   completions: 1
   backoffLimit: 1
@@ -1320,6 +1324,10 @@ spec:
               fieldPath: metadata.name
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       volumes:
         - name: contourcert
           secret:


### PR DESCRIPTION
This commit adds `securityContext` to pods that don't need to run as
root, viz. certgen job and the contour deployment.