### PR TITLE
internal/dag: do not generate ingress_https route for tcpproxy vhost

### DIFF
--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -661,14 +661,8 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 					upgradeHTTPS(routePrefix("/")),
 				),
 			),
-			// BUG(dfc): issue 1954, the route should not be present if tcpproxy is in use
-			envoy.RouteConfiguration("ingress_https",
-				envoy.VirtualHost("kuard-tcp.example.com",
-					envoy.Route(routePrefix("/"),
-						routeCluster("default/backend/80/da39a3ee5e"),
-					),
-				),
-			),
+			// no route should not be present as tcpproxy is in use
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -775,14 +769,8 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 					),
 				),
 			),
-			// BUG(dfc) issue 1954, the route should not be present if tcpproxy is in use
-			envoy.RouteConfiguration("ingress_https",
-				envoy.VirtualHost("kuard-tcp.example.com",
-					envoy.Route(routePrefix("/"),
-						routeCluster("default/backend/80/da39a3ee5e"),
-					),
-				),
-			),
+			// no route should not be present as tcpproxy is in use
+			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})


### PR DESCRIPTION
Fixes #1954

Prior to the change the builder would generate suprious route on the
secure virtual host connected to a HTTPProxy in tcpproxy mode. This route
would not have been accessible because there is no http connection manager
attached to the filter chain for that secure virtual host however the route was
still present in RDS.

Signed-off-by: Dave Cheney <dave@cheney.net>