### PR TITLE
internal/dag: 301 upgrade insecure routes irrespective of tcpproxying

### DIFF
--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -863,12 +863,11 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http",
-				// BUG(dfc) issue 1952, route: / is not marked permitInsecure: true
-				// this should be a 301 upgrade
+				// 301 upgrade because permitInsecure is false, thus
+				// the route is present on port 80, but unconditionally
+				// upgrades to HTTPS.
 				envoy.VirtualHost("kuard-tcp.example.com",
-					envoy.Route(routePrefix("/"),
-						routeCluster("default/backend/80/da39a3ee5e"),
-					),
+					upgradeHTTPS(routePrefix("/")),
 				),
 			),
 			// ingress_https should be empty.


### PR DESCRIPTION
Fixes #1952

Clean the HTTPProxy spec.virtualhost.tls validation logic and fix the
last issue with HTTPProxy TCPProxy logic.

If a HTTPProxy is using TCP proxying then its secure port is forwarded
according to the spec.tcpproxy schema. The insecure port, port 80 is not
tcp forwarded and remains connected to a L7 http connection manager.
Because by definition a HTTPProxy using TCP proxying must supply a valid
spec.virtualhost.tls block, our 301 upgrade logic applies. Thus, after
this change, if a route on the insecure listener is not using
permitInsecure: true, it will by 301 upgraded.

Signed-off-by: Dave Cheney <dave@cheney.net>