### PR TITLE
internal/featuretests: add status check machinery

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -158,7 +158,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		},
 		HoldoffDelay:    100 * time.Millisecond,
 		HoldoffMaxDelay: 500 * time.Millisecond,
-		CRDStatus: &k8s.CRDStatus{
+		StatusClient: &k8s.StatusWriter{
 			Client: contourClient,
 		},
 		Builder: dag.Builder{

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
 github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
@@ -287,6 +285,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v0.0.0-20180122172545-ddea229ff1df/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -386,6 +385,7 @@ gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485 h1:OB/uP/Puiu5vS5QMRPrXCDW
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
+google.golang.org/api v0.4.0 h1:KKgc1aqhV8wDPbDzlDtpvyjZFY3vjz85FP7p4wcQUyI=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -40,7 +40,7 @@ type EventHandler struct {
 
 	HoldoffDelay, HoldoffMaxDelay time.Duration
 
-	CRDStatus *k8s.CRDStatus
+	StatusClient k8s.StatusClient
 
 	*metrics.Metrics
 
@@ -242,7 +242,7 @@ func (e *EventHandler) setStatus(statuses map[dag.Meta]dag.Status) {
 	for _, st := range statuses {
 		switch obj := st.Object.(type) {
 		case *ingressroutev1.IngressRoute:
-			err := e.CRDStatus.SetStatus(st.Status, st.Description, obj)
+			err := e.StatusClient.SetStatus(st.Status, st.Description, obj)
 			if err != nil {
 				e.WithError(err).
 					WithField("status", st.Status).
@@ -252,7 +252,7 @@ func (e *EventHandler) setStatus(statuses map[dag.Meta]dag.Status) {
 					Error("failed to set status")
 			}
 		case *projcontour.HTTPProxy:
-			err := e.CRDStatus.SetStatus(st.Status, st.Description, obj)
+			err := e.StatusClient.SetStatus(st.Status, st.Description, obj)
 			if err != nil {
 				e.WithError(err).
 					WithField("status", st.Status).

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/projectcontour/contour/internal/k8s"
+
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
@@ -436,11 +438,11 @@ func TestAnnotationKindValidation(t *testing.T) {
 	// Trivially check that everything specified in the global
 	// table is valid.
 	for _, kind := range []string{
-		toKind(&v1.Service{}),
-		toKind(&v1beta1.Ingress{}),
-		toKind(&extensionsv1beta1.Ingress{}),
-		toKind(&ingressroutev1.IngressRoute{}),
-		toKind(&projectcontour.HTTPProxy{}),
+		k8s.KindOf(&v1.Service{}),
+		k8s.KindOf(&v1beta1.Ingress{}),
+		k8s.KindOf(&extensionsv1beta1.Ingress{}),
+		k8s.KindOf(&ingressroutev1.IngressRoute{}),
+		k8s.KindOf(&projectcontour.HTTPProxy{}),
 	} {
 		for key := range annotationsByKind[kind] {
 			t.Run(fmt.Sprintf("%s is known and valid for %s", key, kind),
@@ -456,7 +458,7 @@ func TestAnnotationKindValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for k, s := range tc.annotations {
 				assert.Equal(t, s.known, annotationIsKnown(k))
-				assert.Equal(t, s.valid, validAnnotationForKind(toKind(tc.obj), k))
+				assert.Equal(t, s.valid, validAnnotationForKind(k8s.KindOf(tc.obj), k))
 			}
 		})
 	}

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/projectcontour/contour/apis/generated/clientset/versioned/fake"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
@@ -93,10 +92,8 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 				FieldLogger: log,
 			},
 		},
-		CacheHandler: ch,
-		CRDStatus: &k8s.CRDStatus{
-			Client: fake.NewSimpleClientset(),
-		},
+		CacheHandler:    ch,
+		StatusClient:    &k8s.StatusCacher{},
 		Metrics:         ch.Metrics,
 		FieldLogger:     log,
 		Sequence:        make(chan int, 1),

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -1,0 +1,50 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	v1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+)
+
+// KindOf returns the kind string for the given Kubernetes object.
+//
+// The API machinery doesn't populate the metav1.TypeMeta field for
+// objects, so we have to use a type assertion to detect kinds that
+// we care about.
+func KindOf(obj interface{}) string {
+	switch obj.(type) {
+	case *v1.Secret:
+		return "Secret"
+	case *v1.Service:
+		return "Service"
+	case *v1beta1.Ingress:
+		return "Ingress"
+	case *extensionsv1beta1.Ingress:
+		return "Ingress"
+	case *ingressroutev1.IngressRoute:
+		return "IngressRoute"
+	case *projectcontour.HTTPProxy:
+		return "HTTPProxy"
+	case *ingressroutev1.TLSCertificateDelegation:
+		return "TLSCertificateDelegation"
+	case *projectcontour.TLSCertificateDelegation:
+		return "TLSCertificateDelegation"
+	default:
+		return ""
+	}
+}

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -96,7 +96,7 @@ func TestSetStatus(t *testing.T) {
 					return true, tc.existing, nil
 				}
 			})
-			irs := CRDStatus{
+			irs := StatusWriter{
 				Client: client,
 			}
 			if err := irs.SetStatus(tc.msg, tc.desc, tc.existing); err != nil {


### PR DESCRIPTION
Add a Kubernetes object status cache that can be used to assert
object status in feature tests. Status can be `Equals()` (all
fields must match) or `Like()` (only specified fields need to
match). The assertion functions return a `*Contour` to that a
fluent style can be used.

Sample usage:

```Go
c.Request().Equals(
        ...
).Status().Equals(
        ...
)
```