### PR TITLE
internal/featuretests: move externalname test to featuretests

### DIFF
--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -2075,20 +2075,6 @@ func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
 	}
 }
 
-func externalnameservice(ns, name, externalname string, ports ...v1.ServicePort) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-		},
-		Spec: v1.ServiceSpec{
-			Ports:        ports,
-			ExternalName: externalname,
-			Type:         v1.ServiceTypeExternalName,
-		},
-	}
-}
-
 func TestRDSHTTPProxyOutsideRootNamespaces(t *testing.T) {
 	rh, cc, done := setup(t, func(reh *contour.EventHandler) {
 		reh.Builder.Source.RootNamespaces = []string{"roots"}

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -44,7 +44,20 @@ func DefaultCluster(c *v2.Cluster) *v2.Cluster {
 
 	proto.Merge(defaults, c)
 	return defaults
+}
 
+func externalNameCluster(name, servicename, statName, externalName string, port int) *v2.Cluster {
+	return DefaultCluster(&v2.Cluster{
+		Name:                 name,
+		ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_STRICT_DNS),
+		AltStatName:          statName,
+		LoadAssignment: &v2.ClusterLoadAssignment{
+			ClusterName: servicename,
+			Endpoints: envoy.Endpoints(
+				envoy.SocketAddress(externalName, port),
+			),
+		},
+	})
 }
 
 func routeCluster(cluster string) *envoy_api_v2_route.Route_Route {

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -1,0 +1,126 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuretests
+
+import (
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/envoy"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Assert that services of type v1.ServiceTypeExternalName can be
+// referenced by an Ingress, IngressRoute, or HTTPProxy document.
+func TestExternalNameService(t *testing.T) {
+	rh, c, done := setup(t)
+	defer done()
+
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+			ExternalName: "foo.io",
+			Type:         v1.ServiceTypeExternalName,
+		},
+	}
+
+	i1 := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: s1.Namespace,
+		},
+		Spec: v1beta1.IngressSpec{
+			Backend: &v1beta1.IngressBackend{
+				ServiceName: s1.Name,
+				ServicePort: intstr.FromInt(80),
+			},
+		},
+	}
+	rh.OnAdd(s1)
+	rh.OnAdd(i1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("*",
+					envoy.Route(
+						routePrefix("/"),
+						routeCluster("default/kuard/80/da39a3ee5e"),
+					),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+		),
+		TypeUrl: clusterType,
+	})
+
+	rh.OnDelete(i1)
+
+	hp1 := &projcontour.HTTPProxy{
+		ObjectMeta: i1.ObjectMeta,
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "kuard.projectcontour.io",
+			},
+			Routes: []projcontour.Route{{
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 80,
+				}},
+			}},
+		},
+	}
+	rh.OnAdd(hp1)
+
+	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			envoy.RouteConfiguration("ingress_http",
+				envoy.VirtualHost("kuard.projectcontour.io",
+					envoy.Route(
+						routePrefix("/"),
+						routeCluster("default/kuard/80/da39a3ee5e"),
+					),
+				),
+			),
+			envoy.RouteConfiguration("ingress_https"),
+		),
+		TypeUrl: routeType,
+	})
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
+		Resources: resources(t,
+			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+		),
+		TypeUrl: clusterType,
+	})
+}


### PR DESCRIPTION
Updates #1431

Migrate tests for external name Services to featuretests.

Signed-off-by: Dave Cheney <dave@cheney.net>