### PR TITLE
site: add navigation class to the TOC

### DIFF
--- a/site/_guides/prometheus.md
+++ b/site/_guides/prometheus.md
@@ -3,7 +3,7 @@ title: Collecting Metrics with Prometheus
 layout: page
 ---
 
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 Contour and Envoy expose metrics that can be scraped with Prometheus. By
 default, annotations to gather them are in all the `deployment` yamls and they

--- a/site/docs/master/annotations.md
+++ b/site/docs/master/annotations.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
 Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.

--- a/site/docs/master/ingressroute.md
+++ b/site/docs/master/ingressroute.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
 Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.

--- a/site/docs/v1.0.0/annotations.md
+++ b/site/docs/v1.0.0/annotations.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 

--- a/site/docs/v1.0.0/httpproxy.md
+++ b/site/docs/v1.0.0/httpproxy.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
 Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.

--- a/site/docs/v1.0.0/ingressroute.md
+++ b/site/docs/v1.0.0/ingressroute.md
@@ -1,4 +1,4 @@
-<div id="toc"></div>
+<div id="toc" class="navigation"></div>
 
 The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
 Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.


### PR DESCRIPTION
Add the "navigation" class to the in-page TOC elements so that it
can be used consistently with CSS selectors.

Signed-off-by: James Peach <jpeach@vmware.com>