### PR TITLE
Add tests to cover override behaviour for IngressRoute and HTTPProxy

### DIFF
--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2472,6 +2472,13 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				},
 			},
 		},
+		"ingressroute first, then identical httpproxy": {
+			objs: []interface{}{ir1, proxy1, s4},
+			want: map[Meta]Status{
+				{name: ir1.Name, namespace: ir1.Namespace}:       {Object: ir1, Status: "valid", Description: "valid IngressRoute", Vhost: "example.com"},
+				{name: proxy1.Name, namespace: proxy1.Namespace}: {Object: proxy1, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
+			},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Fixes #1949

Issue #1949 is about ensuring that HTTPProxy objects will override IngressRoute
ones when they match on {FQDN, path} tuple. Turns out this is already the case,
this PR adds tests to assert this behaviour.

The tests have an Ingress, IngressRoute, and HTTPProxy that are identical aside from the service where the traffic is routed to, and assert that the override behaviour holds based on which service ends up chosen.

Note that routes that are not exactly the same (on FQDN, path tuple), will just be additive, no matter where they come from. This is why the cert-manager ingress-shim thing works.

Signed-off-by: Nick Young <ynick@vmware.com>