### PR TITLE
Improve link colour to help distinguish from regular text

### DIFF
--- a/site/_scss/site/objects/_section.scss
+++ b/site/_scss/site/objects/_section.scss
@@ -8,6 +8,9 @@
   &.section-grey {
     color: $body-color-darkest;
     background: $section-grey-background;
+    a {
+      color: $darkest-blue;
+    }
   }
 
   &.section-card {

--- a/site/_scss/site/settings/_variables.scss
+++ b/site/_scss/site/settings/_variables.scss
@@ -23,7 +23,7 @@ $card-border-color: $border-color;
 $font-family-base: "Metropolis", Helvetica, Arial, sans-serif;
 $font-size-base: 1.125rem; // 18px
 
-$link-color: #004C70;
+$link-color: #007AB8;
 $link-decoration: none;
 $link-hover-color: $link-color;
 $link-hover-decoration: underline;


### PR DESCRIPTION
Minor change to improve link colour in text based on feedback that they did not stand out enough and where easy to miss.

Added link colour for section.grey as lighter links do not have enough contrast ratio with the grey background. This is used on the home page.

Signed-off-by: Brett Johnson <brett@sdbrett.com>