### PR TITLE
Fix error in site-proofing script

### DIFF
--- a/hack/site-proofing/cibuild
+++ b/hack/site-proofing/cibuild
@@ -4,6 +4,8 @@ set -e # halt script on error
 
 # Builds and checks the website for broken links.
 
+cd ./site
+
 gem install bundler
 gem install html-proofer
 gem install jekyll -v 3.8.5


### PR DESCRIPTION
Missing `cd ./site` in `/hack/site-proofing/cibuild` causing travis-ci to fail on site checks.

Signed-off-by: Brett Johnson <brett@sdbrett.com>