### PR TITLE
Fixes broken link to SITE_CONTRIBUTION.md

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -4,7 +4,7 @@ This directory contains the Jekyll source for [projectcontour.io][0].
 
 The site is deployed directly from the [`master`][1] branch, copies of the site's source in older tags and branches are non-canonical.
 
-Site specific contribution information can be found at [/SITE_CONTRIBUTION.md][2].
+Site specific contribution information can be found at [SITE_CONTRIBUTION.md][2].
 
 [0]: https://projectcontour.io/
 [1]: https://github.com/projectcontour/contour/

--- a/site/README.md
+++ b/site/README.md
@@ -4,7 +4,8 @@ This directory contains the Jekyll source for [projectcontour.io][0].
 
 The site is deployed directly from the [`master`][1] branch, copies of the site's source in older tags and branches are non-canonical.
 
-Site specific contribution information can be found at [/contour/SITE_CONTRIBUTION.md](/contour/SITE_CONTRIBUTION.md).
+Site specific contribution information can be found at [/SITE_CONTRIBUTION.md][2].
 
 [0]: https://projectcontour.io/
-[1]: {{site.github.repository_url}}/tree/master/site
+[1]: https://github.com/projectcontour/contour/
+[2]: https://github.com/projectcontour/contour/blob/master/SITE_CONTRIBUTION.md


### PR DESCRIPTION
Fixes: #1990

Liquid link for master work when site is build but are broken if used from github repo.

Link to SITE_CONTRIBUTION.md worked through github but not on live site.

Signed-off-by: Brett Johnson <brett@sdbrett.com>