### PR TITLE
api: mark all timeoutPolicy parameters optional

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -231,11 +231,13 @@ type TimeoutPolicy struct {
 
 	// Timeout for receiving a response from the server after processing a request from client.
 	// If not supplied the timeout duration is undefined.
-	Response string `json:"response"`
+	// +optional
+	Response string `json:"response,omitempty"`
 
-	// Timeout after which if there are no active requests, the connection between Envoy and the
-	// backend will be closed.
-	Idle string `json:"idle"`
+	// Timeout after which if there are no active requests for this route, the connection between
+	// Envoy and the backend will be closed. If not specified, there is no per-route idle timeout.
+	// +optional
+	Idle string `json:"idle,omitempty"`
 }
 
 // RetryPolicy defines the attributes associated with retrying policy.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -720,17 +720,16 @@ spec:
                     description: The timeout policy for this route.
                     properties:
                       idle:
-                        description: Timeout after which if there are no active requests,
-                          the connection between Envoy and the backend will be closed.
+                        description: Timeout after which if there are no active requests
+                          for this route, the connection between Envoy and the backend
+                          will be closed. If not specified, there is no per-route
+                          idle timeout.
                         type: string
                       response:
                         description: Timeout for receiving a response from the server
                           after processing a request from client. If not supplied
                           the timeout duration is undefined.
                         type: string
-                    required:
-                    - idle
-                    - response
                     type: object
                 type: object
               type: array

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -794,17 +794,16 @@ spec:
                     description: The timeout policy for this route.
                     properties:
                       idle:
-                        description: Timeout after which if there are no active requests,
-                          the connection between Envoy and the backend will be closed.
+                        description: Timeout after which if there are no active requests
+                          for this route, the connection between Envoy and the backend
+                          will be closed. If not specified, there is no per-route
+                          idle timeout.
                         type: string
                       response:
                         description: Timeout for receiving a response from the server
                           after processing a request from client. If not supplied
                           the timeout duration is undefined.
                         type: string
-                    required:
-                    - idle
-                    - response
                     type: object
                 type: object
               type: array


### PR DESCRIPTION
Fixes #1993

Mark timeoutPolicy.request and timeoutPolicy.idle +optional (for schema
generation) and omitempty (for JSON encoding). This permits the user to
create a timeoutPolicy without having to specify both fields. We have
test coverage in internal/envoy and internal/dag for these scenarios.

Signed-off-by: Dave Cheney <dave@cheney.net>