### PR TITLE
Support per-Split header manipulation.

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -152,9 +152,12 @@ type Route struct {
 	//
 	// +kubebuilder:validation:Optional
 	PathRewritePolicy *PathRewritePolicy `json:"pathRewritePolicy,omitempty"`
-	// The policy for managing headers during proxying
+	// The policy for managing request headers during proxying
 	// +kubebuilder:validation:Optional
 	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
+	// The policy for managing response headers during proxying
+	// +kubebuilder:validation:Optional
+	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
 
 func (r *Route) GetPrefixReplacements() []ReplacePrefix {
@@ -201,6 +204,12 @@ type Service struct {
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
 	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
 	Mirror bool `json:"mirror,omitempty"`
+	// The policy for managing request headers during proxying
+	// +kubebuilder:validation:Optional
+	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
+	// The policy for managing response headers during proxying
+	// +kubebuilder:validation:Optional
+	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
 
 // HTTPHealthCheckPolicy defines health checks on the upstream service.
@@ -301,6 +310,9 @@ type HeadersPolicy struct {
 	// Set specifies a list of HTTP header values that will be set in the HTTP header
 	// +kubebuilder:validation:Optional
 	Set []HeaderValue `json:"set,omitempty"`
+	// Remove specifies a list of HTTP header names to remove
+	// +kubebuilder:validation:Optional
+	Remove []string `json:"remove,omitempty"`
 }
 
 // HeaderValue represents a header name/value pair

--- a/apis/projectcontour/v1/zz_generated.deepcopy.go
+++ b/apis/projectcontour/v1/zz_generated.deepcopy.go
@@ -223,6 +223,11 @@ func (in *HeadersPolicy) DeepCopyInto(out *HeadersPolicy) {
 		*out = make([]HeaderValue, len(*in))
 		copy(*out, *in)
 	}
+	if in.Remove != nil {
+		in, out := &in.Remove, &out.Remove
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -375,6 +380,11 @@ func (in *Route) DeepCopyInto(out *Route) {
 		*out = new(HeadersPolicy)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ResponseHeadersPolicy != nil {
+		in, out := &in.ResponseHeadersPolicy, &out.ResponseHeadersPolicy
+		*out = new(HeadersPolicy)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -395,6 +405,16 @@ func (in *Service) DeepCopyInto(out *Service) {
 		in, out := &in.UpstreamValidation, &out.UpstreamValidation
 		*out = new(UpstreamValidation)
 		**out = **in
+	}
+	if in.RequestHeadersPolicy != nil {
+		in, out := &in.RequestHeadersPolicy, &out.RequestHeadersPolicy
+		*out = new(HeadersPolicy)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ResponseHeadersPolicy != nil {
+		in, out := &in.ResponseHeadersPolicy, &out.ResponseHeadersPolicy
+		*out = new(HeadersPolicy)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -659,8 +659,45 @@ spec:
                       block is present.
                     type: boolean
                   requestHeadersPolicy:
-                    description: The policy for managing headers during proxying
+                    description: The policy for managing request headers during proxying
                     properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  responseHeadersPolicy:
+                    description: The policy for managing response headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove
+                        items:
+                          type: string
+                        type: array
                       set:
                         description: Set specifies a list of HTTP header values that
                           will be set in the HTTP header
@@ -715,6 +752,70 @@ spec:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
                           type: integer
+                        requestHeadersPolicy:
+                          description: The policy for managing request headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        responseHeadersPolicy:
+                          description: The policy for managing response headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
                         validation:
                           description: UpstreamValidation defines how to verify the
                             backend service's certificate
@@ -799,6 +900,70 @@ spec:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
                         type: integer
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
                       validation:
                         description: UpstreamValidation defines how to verify the
                           backend service's certificate

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -733,8 +733,45 @@ spec:
                       block is present.
                     type: boolean
                   requestHeadersPolicy:
-                    description: The policy for managing headers during proxying
+                    description: The policy for managing request headers during proxying
                     properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove
+                        items:
+                          type: string
+                        type: array
+                      set:
+                        description: Set specifies a list of HTTP header values that
+                          will be set in the HTTP header
+                        items:
+                          description: HeaderValue represents a header name/value
+                            pair
+                          properties:
+                            name:
+                              description: Name represents a key of a header
+                              minLength: 1
+                              type: string
+                            value:
+                              description: Value represents the value of a header
+                                specified by a key
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  responseHeadersPolicy:
+                    description: The policy for managing response headers during proxying
+                    properties:
+                      remove:
+                        description: Remove specifies a list of HTTP header names
+                          to remove
+                        items:
+                          type: string
+                        type: array
                       set:
                         description: Set specifies a list of HTTP header values that
                           will be set in the HTTP header
@@ -789,6 +826,70 @@ spec:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
                           type: integer
+                        requestHeadersPolicy:
+                          description: The policy for managing request headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        responseHeadersPolicy:
+                          description: The policy for managing response headers during
+                            proxying
+                          properties:
+                            remove:
+                              description: Remove specifies a list of HTTP header
+                                names to remove
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              description: Set specifies a list of HTTP header values
+                                that will be set in the HTTP header
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
                         validation:
                           description: UpstreamValidation defines how to verify the
                             backend service's certificate
@@ -873,6 +974,70 @@ spec:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
                         type: integer
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
                       validation:
                         description: UpstreamValidation defines how to verify the
                           backend service's certificate

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -139,10 +139,19 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 							Action: envoy.UpgradeHTTPS(),
 						})
 					} else {
-						routes = append(routes, &envoy_api_v2_route.Route{
+						rt := &envoy_api_v2_route.Route{
 							Match:  envoy.RouteMatch(route),
 							Action: envoy.RouteRoute(route),
-						})
+						}
+						if route.RequestHeadersPolicy != nil {
+							rt.RequestHeadersToAdd = envoy.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+							rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
+						}
+						if route.ResponseHeadersPolicy != nil {
+							rt.ResponseHeadersToAdd = envoy.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
+							rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
+						}
+						routes = append(routes, rt)
 					}
 				})
 
@@ -161,10 +170,19 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 						return
 					}
 
-					routes = append(routes, &envoy_api_v2_route.Route{
+					rt := &envoy_api_v2_route.Route{
 						Match:  envoy.RouteMatch(route),
 						Action: envoy.RouteRoute(route),
-					})
+					}
+					if route.RequestHeadersPolicy != nil {
+						rt.RequestHeadersToAdd = envoy.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+						rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
+					}
+					if route.ResponseHeadersPolicy != nil {
+						rt.ResponseHeadersToAdd = envoy.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
+						rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
+					}
+					routes = append(routes, rt)
 				})
 				if len(routes) < 1 {
 					return

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/projectcontour/contour/internal/dag"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
@@ -1959,6 +1961,98 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
+				envoy.RouteConfiguration("ingress_https"),
+			),
+		},
+		"httpproxy with route-level header manipulation": {
+			objs: []interface{}{
+				&projcontour.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "simple",
+						Namespace: "default",
+					},
+					Spec: projcontour.HTTPProxySpec{
+						VirtualHost: &projcontour.VirtualHost{
+							Fqdn: "www.example.com",
+						},
+						Routes: []projcontour.Route{{
+							Conditions: []projcontour.Condition{{
+								Prefix: "/",
+							}},
+							Services: []projcontour.Service{{
+								Name: "backend",
+								Port: 80,
+							}},
+							RequestHeadersPolicy: &projcontour.HeadersPolicy{
+								Set: []projcontour.HeaderValue{{
+									Name:  "In-Foo",
+									Value: "bar",
+								}},
+								Remove: []string{
+									"In-Baz",
+								},
+							},
+							ResponseHeadersPolicy: &projcontour.HeadersPolicy{
+								Set: []projcontour.HeaderValue{{
+									Name:  "Out-Foo",
+									Value: "bar",
+								}},
+								Remove: []string{
+									"Out-Baz",
+								},
+							},
+						}},
+					},
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backend",
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{{
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						}},
+					},
+				},
+			},
+			want: routeConfigurations(
+				envoy.RouteConfiguration("ingress_http",
+					envoy.VirtualHost("www.example.com",
+						&envoy_api_v2_route.Route{
+							Match: routePrefix("/"),
+							Action: &envoy_api_v2_route.Route_Route{
+								Route: &envoy_api_v2_route.RouteAction{
+									ClusterSpecifier: &envoy_api_v2_route.RouteAction_Cluster{
+										Cluster: "default/backend/80/da39a3ee5e",
+									},
+								},
+							},
+							RequestHeadersToAdd: []*envoy_api_v2_core.HeaderValueOption{{
+								Header: &envoy_api_v2_core.HeaderValue{
+									Key:   "In-Foo",
+									Value: "bar",
+								},
+								Append: &wrappers.BoolValue{
+									Value: false,
+								},
+							}},
+							RequestHeadersToRemove: []string{"In-Baz"},
+							ResponseHeadersToAdd: []*envoy_api_v2_core.HeaderValueOption{{
+								Header: &envoy_api_v2_core.HeaderValue{
+									Key:   "Out-Foo",
+									Value: "bar",
+								},
+								Append: &wrappers.BoolValue{
+									Value: false,
+								},
+							}},
+							ResponseHeadersToRemove: []string{"Out-Baz"},
+						},
+					),
+				),
 				envoy.RouteConfiguration("ingress_https"),
 			),
 		},

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -684,14 +684,27 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			return nil
 		}
 
+		reqHP, err := headersPolicy(route.RequestHeadersPolicy, true /* allow Host */)
+		if err != nil {
+			sw.SetInvalid(err.Error())
+			return nil
+		}
+
+		respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* allow Host */)
+		if err != nil {
+			sw.SetInvalid(err.Error())
+			return nil
+		}
+
 		r := &Route{
-			PathCondition:        mergePathConditions(conds),
-			HeaderConditions:     mergeHeaderConditions(conds),
-			Websocket:            route.EnableWebsockets,
-			HTTPSUpgrade:         routeEnforceTLS(enforceTLS, route.PermitInsecure && !b.DisablePermitInsecure),
-			TimeoutPolicy:        timeoutPolicy(route.TimeoutPolicy),
-			RetryPolicy:          retryPolicy(route.RetryPolicy),
-			RequestHeadersPolicy: headerPolicy(route.RequestHeadersPolicy),
+			PathCondition:         mergePathConditions(conds),
+			HeaderConditions:      mergeHeaderConditions(conds),
+			Websocket:             route.EnableWebsockets,
+			HTTPSUpgrade:          routeEnforceTLS(enforceTLS, route.PermitInsecure && !b.DisablePermitInsecure),
+			TimeoutPolicy:         timeoutPolicy(route.TimeoutPolicy),
+			RetryPolicy:           retryPolicy(route.RetryPolicy),
+			RequestHeadersPolicy:  reqHP,
+			ResponseHeadersPolicy: respHP,
 		}
 
 		if len(route.GetPrefixReplacements()) > 0 {
@@ -755,12 +768,26 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				}
 			}
 
+			reqHP, err := headersPolicy(service.RequestHeadersPolicy, false /* allow Host */)
+			if err != nil {
+				sw.SetInvalid(err.Error())
+				return nil
+			}
+
+			respHP, err := headersPolicy(service.ResponseHeadersPolicy, false /* allow Host */)
+			if err != nil {
+				sw.SetInvalid(err.Error())
+				return nil
+			}
+
 			c := &Cluster{
-				Upstream:           s,
-				LoadBalancerPolicy: loadBalancerPolicy(route.LoadBalancerPolicy),
-				Weight:             service.Weight,
-				HealthCheckPolicy:  healthCheckPolicy(route.HealthCheckPolicy),
-				UpstreamValidation: uv,
+				Upstream:              s,
+				LoadBalancerPolicy:    loadBalancerPolicy(route.LoadBalancerPolicy),
+				Weight:                service.Weight,
+				HealthCheckPolicy:     healthCheckPolicy(route.HealthCheckPolicy),
+				UpstreamValidation:    uv,
+				RequestHeadersPolicy:  reqHP,
+				ResponseHeadersPolicy: respHP,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				sw.SetInvalid("only one service per route may be nominated as mirror")
@@ -781,6 +808,12 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 
 	sw.SetValid()
 	return routes
+}
+
+func escapeHeaderValue(value string) string {
+	// Envoy supports %-encoded variables, so literal %'s in the header's value must be escaped.  See:
+	// https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers
+	return strings.Replace(value, "%", "%%", -1)
 }
 
 func includeConditionsIdentical(includes []projcontour.Include) bool {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -14,6 +14,7 @@
 package dag
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -2993,6 +2994,46 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	// proxy109 has a route that rewrites headers.
+	proxy109 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-com",
+			Namespace: "default",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: []projcontour.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+				RequestHeadersPolicy: &projcontour.HeadersPolicy{
+					Set: []projcontour.HeaderValue{{
+						Name:  "In-Foo",
+						Value: "bar",
+					}},
+					Remove: []string{
+						"In-Baz",
+					},
+				},
+				ResponseHeadersPolicy: &projcontour.HeadersPolicy{
+					Set: []projcontour.HeaderValue{{
+						Name:  "Out-Foo",
+						Value: "bar",
+					}},
+					Remove: []string{
+						"Out-Baz",
+					},
+				},
+			}},
+		},
+	}
+
 	tests := map[string]struct {
 		objs                  []interface{}
 		disablePermitInsecure bool
@@ -5479,6 +5520,26 @@ func TestDAGInsert(t *testing.T) {
 			),
 		},
 
+		"insert httpproxy with route-level header manipulation": {
+			objs: []interface{}{
+				proxy109, s1,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeHeaders("/", map[string]string{
+								"In-Foo": "bar",
+							}, []string{"In-Baz"}, map[string]string{
+								"Out-Foo": "bar",
+							}, []string{"Out-Baz"}, service(s1)),
+						),
+					),
+				},
+			),
+		},
+
 		// issue 1399
 		"service shared across ingress and httpproxy tcpproxy": {
 			objs: []interface{}{
@@ -5743,6 +5804,10 @@ func TestDAGInsert(t *testing.T) {
 							Clusters:      clustermap(s9),
 							RequestHeadersPolicy: &HeadersPolicy{
 								HostRewrite: "bar.com",
+								Set: map[string]string{
+									"X-Header": "bar.com",
+									"Y-Header": "zed.com",
+								},
 							},
 						}),
 					),
@@ -5759,9 +5824,13 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
-							PathCondition:        prefix("/"),
-							Clusters:             clustermap(s9),
-							RequestHeadersPolicy: nil, // No header policy since only Host is supported
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s9),
+							RequestHeadersPolicy: &HeadersPolicy{
+								Set: map[string]string{
+									"X-Header": "bar.com",
+								},
+							},
 						}),
 					),
 				},
@@ -5777,9 +5846,13 @@ func TestDAGInsert(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
-							PathCondition:        prefix("/"),
-							Clusters:             clustermap(s9),
-							RequestHeadersPolicy: nil, // No header policy since only Host is supported
+							PathCondition: prefix("/"),
+							Clusters:      clustermap(s9),
+							RequestHeadersPolicy: &HeadersPolicy{
+								Set: map[string]string{
+									"X-Header": "",
+								},
+							},
 						}),
 					),
 				},
@@ -6272,6 +6345,7 @@ func TestHttpPaths(t *testing.T) {
 		})
 	}
 }
+
 func TestEnforceRoute(t *testing.T) {
 	tests := map[string]struct {
 		tlsEnabled     bool
@@ -6362,6 +6436,113 @@ func TestSplitSecret(t *testing.T) {
 	}
 }
 
+func TestValidateHeaderAlteration(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      *projcontour.HeadersPolicy
+		want    *HeadersPolicy
+		wantErr error
+	}{{
+		name: "empty is fine",
+	}, {
+		name: "set two, remove one",
+		in: &projcontour.HeadersPolicy{
+			Set: []projcontour.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "bar",
+			}, {
+				Name:  "k-baz", // This gets canonicalized
+				Value: "blah",
+			}},
+			Remove: []string{"K-Nada"},
+		},
+		want: &HeadersPolicy{
+			Set: map[string]string{
+				"K-Foo": "bar",
+				"K-Baz": "blah",
+			},
+			Remove: []string{"K-Nada"},
+		},
+	}, {
+		name: "duplicate set",
+		in: &projcontour.HeadersPolicy{
+			Set: []projcontour.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "bar",
+			}, {
+				Name:  "k-foo", // This gets canonicalized
+				Value: "blah",
+			}},
+		},
+		wantErr: errors.New(`duplicate header addition: "K-Foo"`),
+	}, {
+		name: "duplicate remove",
+		in: &projcontour.HeadersPolicy{
+			Remove: []string{"K-Foo", "k-foo"},
+		},
+		wantErr: errors.New(`duplicate header removal: "K-Foo"`),
+	}, {
+		name: "invalid set header",
+		in: &projcontour.HeadersPolicy{
+			Set: []projcontour.HeaderValue{{
+				Name:  "  K-Foo",
+				Value: "bar",
+			}},
+		},
+		wantErr: errors.New(`invalid set header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
+	}, {
+		name: "invalid remove header",
+		in: &projcontour.HeadersPolicy{
+			Remove: []string{"  K-Foo"},
+		},
+		wantErr: errors.New(`invalid remove header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
+	}, {
+		name: "invalid set header (special headers)",
+		in: &projcontour.HeadersPolicy{
+			Set: []projcontour.HeaderValue{{
+				Name:  "Host",
+				Value: "bar",
+			}},
+		},
+		wantErr: errors.New(`rewriting "Host" header is not supported`),
+	}, {
+		name: "percents are escaped",
+		in: &projcontour.HeadersPolicy{
+			Set: []projcontour.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "100%",
+			}, {
+				Name:  "Lot-Of-Percents",
+				Value: "%%%%%",
+			}, {
+				Name:  "k-baz", // This gets canonicalized
+				Value: "%DOWNSTREAM_LOCAL_ADDRESS%",
+			}},
+		},
+		want: &HeadersPolicy{
+			Set: map[string]string{
+				"K-Foo":           "100%%",
+				"K-Baz":           "%%DOWNSTREAM_LOCAL_ADDRESS%%",
+				"Lot-Of-Percents": "%%%%%%%%%%",
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotErr := headersPolicy(test.in, false)
+			if !cmp.Equal(test.want, got) {
+				t.Errorf("set (-want, +got) = %s", cmp.Diff(test.want, got))
+			}
+			if (test.wantErr != nil) != (gotErr != nil) {
+				t.Errorf("err = %v, wanted %v", gotErr, test.wantErr)
+			} else if test.wantErr != nil && gotErr != nil && test.wantErr.Error() != gotErr.Error() {
+				t.Errorf("err = %v, wanted %v", gotErr, test.wantErr)
+			}
+		})
+	}
+}
+
 func routes(routes ...*Route) map[string]*Route {
 	if len(routes) == 0 {
 		return nil
@@ -6403,6 +6584,19 @@ func routeRewrite(prefix, rewrite string, first *Service, rest ...*Service) *Rou
 func routeWebsocket(prefix string, first *Service, rest ...*Service) *Route {
 	r := prefixroute(prefix, first, rest...)
 	r.Websocket = true
+	return r
+}
+
+func routeHeaders(prefix string, requestSet map[string]string, requestRemove []string, responseSet map[string]string, responseRemove []string, first *Service, rest ...*Service) *Route {
+	r := prefixroute(prefix, first, rest...)
+	r.RequestHeadersPolicy = &HeadersPolicy{
+		Set:    requestSet,
+		Remove: requestRemove,
+	}
+	r.ResponseHeadersPolicy = &HeadersPolicy{
+		Set:    responseSet,
+		Remove: responseRemove,
+	}
 	return r
 }
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -116,6 +116,9 @@ type Route struct {
 
 	// RequestHeadersPolicy defines how headers are managed during forwarding
 	RequestHeadersPolicy *HeadersPolicy
+
+	// ResponseHeadersPolicy defines how headers are managed during forwarding
+	ResponseHeadersPolicy *HeadersPolicy
 }
 
 // HasPathPrefix returns whether this route has a PrefixPathCondition.
@@ -166,6 +169,9 @@ type MirrorPolicy struct {
 type HeadersPolicy struct {
 	// HostRewrite defines if a host should be rewritten on upstream requests
 	HostRewrite string
+
+	Set    map[string]string
+	Remove []string
 }
 
 type HeaderValue struct {
@@ -369,6 +375,12 @@ type Cluster struct {
 
 	// Cluster health check policy.
 	*HealthCheckPolicy
+
+	// RequestHeadersPolicy defines how headers are managed during forwarding
+	RequestHeadersPolicy *HeadersPolicy
+
+	// ResponseHeadersPolicy defines how headers are managed during forwarding
+	ResponseHeadersPolicy *HeadersPolicy
 }
 
 func (c Cluster) Visit(f func(Vertex)) {

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -14,7 +14,9 @@
 package featuretests
 
 import (
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
 
@@ -81,7 +83,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	// Unsupported header (i.e. not `Host`)
+	// Non-Host header
 	rh.OnAdd(&projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
@@ -111,6 +113,15 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/svc1/80/da39a3ee5e"),
+						RequestHeadersToAdd: []*envoy_api_v2_core.HeaderValueOption{{
+							Header: &envoy_api_v2_core.HeaderValue{
+								Key:   "X-Header",
+								Value: "goodbye.planet",
+							},
+							Append: &wrappers.BoolValue{
+								Value: false,
+							},
+						}},
 					},
 				),
 			),

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -623,7 +623,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#projectcontour.io/v1.Route">Route</a>)
+<a href="#projectcontour.io/v1.Route">Route</a>, 
+<a href="#projectcontour.io/v1.Service">Service</a>)
 </p>
 <p>
 <p>HeadersPolicy defines how headers are managed during forwarding</p>
@@ -647,6 +648,17 @@ string
 </td>
 <td>
 <p>Set specifies a list of HTTP header values that will be set in the HTTP header</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>remove</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Remove specifies a list of HTTP header names to remove</p>
 </td>
 </tr>
 </tbody>
@@ -1016,7 +1028,20 @@ HeadersPolicy
 </em>
 </td>
 <td>
-<p>The policy for managing headers during proxying</p>
+<p>The policy for managing request headers during proxying</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>responseHeadersPolicy</code></br>
+<em>
+<a href="#projectcontour.io/v1.HeadersPolicy">
+HeadersPolicy
+</a>
+</em>
+</td>
+<td>
+<p>The policy for managing response headers during proxying</p>
 </td>
 </tr>
 </tbody>
@@ -1097,6 +1122,32 @@ bool
 </td>
 <td>
 <p>If Mirror is true the Service will receive a read only mirror of the traffic for this route.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>requestHeadersPolicy</code></br>
+<em>
+<a href="#projectcontour.io/v1.HeadersPolicy">
+HeadersPolicy
+</a>
+</em>
+</td>
+<td>
+<p>The policy for managing request headers during proxying</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>responseHeadersPolicy</code></br>
+<em>
+<a href="#projectcontour.io/v1.HeadersPolicy">
+HeadersPolicy
+</a>
+</em>
+</td>
+<td>
+<p>The policy for managing response headers during proxying</p>
 </td>
 </tr>
 </tbody>

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -268,7 +268,7 @@ metadata:
   name: secure-backend
 spec:
   virtualhost:
-    fqdn: www.example.com  
+    fqdn: www.example.com
   routes:
     - services:
         - name: service
@@ -308,7 +308,7 @@ spec:
   delegations:
     - secretName: example-com-wildcard
       targetNamespaces:
-      - example-com 
+      - example-com
     - secretName: another-com-wildcard
       targetNamespaces:
       - "*"
@@ -476,6 +476,72 @@ HTTPProxy weighting follows some specific rules:
 - If no weights are specified for a given route, it's assumed even distribution across the Services.
 - Weights are relative and do not need to add up to 100. If all weights for a route are specified, then the "total" weight is the sum of those specified. As an example, if weights are 20, 30, 20 for three upstreams, the total weight would be 70. In this example, a weight of 30 would receive approximately 42.9% of traffic (30/70 = .4285).
 - If some weights are specified but others are not, then it's assumed that upstreams without weights have an implicit weight of zero, and thus will not receive traffic.
+
+#### Request and Response Header Policies
+
+Manipulating headers is also supported per-Service or per-Route.  Headers can be set or
+removed from the request or response as follows:
+
+per-Service:
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: header-manipulation
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: headers.bar.com
+  routes:
+    - services:
+        - name: s1
+          port: 80
+          requestHeaderPolicy:
+            set:
+              - name: X-Foo
+                value: bar
+            remove:
+              - X-Baz
+          responseHeaderPolicy:
+            set:
+              - name: X-Service-Name
+                value: s1
+            remove:
+              - X-Internal-Secret
+```
+
+
+per-Route
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: header-manipulation
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: headers.bar.com
+  routes:
+    - services:
+        - name: s1
+          port: 80
+      requestHeadersPolicy:
+        set:
+          - name: X-Foo
+            value: bar
+        remove:
+          - X-Baz
+      responseHeadersPolicy:
+        set:
+          - name: X-Service-Name
+            value: s1
+        remove:
+          - X-Internal-Secret
+```
+
+In these examples we are setting the header `X-Foo` with value `baz` on requests
+and stripping `X-Baz`.  We are then setting `X-Service-Name` on the response with
+value `s1`, and removing `X-Internal-Secret`.
 
 #### Traffic mirroring
 


### PR DESCRIPTION
This changes adds support for adding and removing request or response headers
for each service target in a Contour HTTPProxy resource.

The structure differs from the originally proposed shape in the linked issue
for two reasons:
1. A desire to support response-header manipulation.
2. A desire to support split-specific header manipulation (needed by Knative).

The resulting shape looks like:

```yaml
spec:
  virtualhost:
    fqdn: foo.default.mattmoor.io
  routes:
  - services:
    - name: foo
      port: 80
      requestHeaders:
        add:
        - name: Foo
          value: bar
        remove:
        - Baz
      responseHeaders:
        add:
        - name: Ugh
          value: tedious
        remove:
        - Secret-Stuff
```

Fixes: https://github.com/projectcontour/contour/issues/70