### PR TITLE
internal/dag: enforce that HTTPProxy must produce routes

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -890,11 +890,10 @@ func TestIngressRouteMetrics(t *testing.T) {
 			wantIR: nil,
 			wantProxy: &metrics.RouteMetric{
 				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
+					{Namespace: "roots"}:                       1,
 					{Namespace: "roots", VHost: "example.com"}: 1,
 				},
+				Valid:    map[metrics.Meta]int{},
 				Orphaned: map[metrics.Meta]int{},
 				Root: map[metrics.Meta]int{
 					{Namespace: "roots"}: 1,

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -514,6 +514,16 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 		secure := b.lookupSecureVirtualHost(host)
 		addRoutes(secure, routes)
 	}
+
+	// HTTPProxy object must have either a TCPProxy spec, or
+	// some combination of Include and Route specs that result
+	// routes being generated.
+	if sw.IsValid() {
+		if proxy.Spec.TCPProxy == nil && len(routes) == 0 {
+			sw.SetInvalid("Spec does not produce any routes")
+			return
+		}
+	}
 }
 
 type vhost interface {

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -94,6 +94,10 @@ func (osw *ObjectStatusWriter) SetInvalid(desc string) {
 	osw.WithValue("description", desc).WithValue("status", StatusInvalid)
 }
 
+func (osw *ObjectStatusWriter) IsValid() bool {
+	return osw.values["status"] == StatusValid
+}
+
 func (osw *ObjectStatusWriter) SetValid() {
 	switch osw.obj.(type) {
 	case *projcontour.HTTPProxy:

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2136,8 +2136,8 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 			want: map[Meta]Status{
 				{name: proxy7.Name, namespace: proxy7.Namespace}: {
 					Object:      proxy7,
-					Status:      "valid",
-					Description: "valid HTTPProxy",
+					Status:      "invalid",
+					Description: "Spec does not produce any routes",
 					Vhost:       "example.com",
 				},
 				{name: proxy8.Name, namespace: proxy8.Namespace}: {

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -359,8 +359,8 @@ For `header` conditions there is one required field, `name`, and five operator f
 
 ### Routes
 
-HTTPProxy must have at least one route or include defined.
-Paths defined are matched using prefix conditions.
+HTTPProxy must have either a [TCPProxy](#tcp-proxying) field, or at least one Routes or [Includes](#httpproxy-inclusion) field.
+HTTP request paths can be matched to Routes using prefix conditions.
 In this example, any requests to `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*` will be routed to the Service `s2`.
 All other requests to the host `multi-path.bar.com` will be routed to the Service `s1`.
 


### PR DESCRIPTION
A HTTPProxy must have either a TCPProxy spec, or enough valid Routes
and Includes specs to actually emit Envouy routes. If there are no
Envoy routes, that is logically similar to having an Include that
doesn't resolve, so mark the HTTPProxy as invalid.

This fixes #1988 

Signed-off-by: James Peach <jpeach@vmware.com>