### PR TITLE
certgen: parametrize gRPC certificate expiry

### DIFF
--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -35,7 +35,8 @@ func registerCertGen(app *kingpin.Application) (*kingpin.CmdClause, *certgenConf
 	certgenApp.Flag("incluster", "use in cluster configuration.").BoolVar(&certgenConfig.InCluster)
 	certgenApp.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&certgenConfig.KubeConfig)
 	certgenApp.Flag("namespace", "Kubernetes namespace, used for Kube objects").Default("projectcontour").Envar("CONTOUR_NAMESPACE").StringVar(&certgenConfig.Namespace)
-	certgenApp.Flag("expirydays", "Duration in days how long the certificates shall be valid").Default("365").UintVar(&certgenConfig.ExpiryDays)
+	// --certificate-lifetime can be used to accept Duration string once certificate rotation is supported
+	certgenApp.Flag("certificate-lifetime", "Duration in days how long the certificates shall be valid").Default("365").UintVar(&certgenConfig.Lifetime)
 	certgenApp.Arg("outputdir", "Directory to output any files to").Default("certs").StringVar(&certgenConfig.OutputDir)
 	return certgenApp, &certgenConfig
 }
@@ -64,15 +65,15 @@ type certgenConfig struct {
 	// OutputPEM means that the certs generated will be output as PEM files in the current directory.
 	OutputPEM bool
 
-	// ExpiryDays is the duration in days how long certificates will be valid.
-	ExpiryDays uint
+	// Lifetime is the number of days how long certificates will be valid.
+	Lifetime uint
 }
 
 // GenerateCerts performs the actual cert generation steps and then returns the certs for the output function.
 func GenerateCerts(certConfig *certgenConfig) (map[string][]byte, error) {
 
 	now := time.Now()
-	expiry := now.Add(24 * time.Duration(certConfig.ExpiryDays) * time.Hour)
+	expiry := now.Add(24 * time.Duration(certConfig.Lifetime) * time.Hour)
 	caCertPEM, caKeyPEM, err := certgen.NewCA("Project Contour", expiry)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Introduced new parameter `--certificate-lifetime` to set the validity duration
of gRPC certificates for the TLS connection between Contour and Envoy.

Closes: #2017

Signed-off-by: Tero Saarni <tero.saarni@est.tech>

> Commit message from old proposal:

> Currently there is no automatic rotation of gRPC certificates for the TLS
> connection between Contour and Envoy.  It is safer to issue certificates
> that will never expire than to depend on all users to manage life-cycle of
> these certificates.
> 
> Closes: #2017
> 
> Signed-off-by: Tero Saarni <tero.saarni@est.tech>