### PR TITLE
site: add v1.0.1 documentation

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -54,6 +54,11 @@ defaults:
     values:
       version: v1.0.0
       layout: "docs"
+  - scope:
+      path: docs/v1.0.1
+    values:
+      version: v1.0.1
+      layout: "docs"
 
 repository: projectcontour/contour
 
@@ -73,10 +78,11 @@ collections:
     output: false
 
 versioning: true
-latest: v1.0.0
+latest: v1.0.1
 versions:
   - master
   - v1.0.0
+  - v1.0.1
 
 # Build settings
 permalink: :title/

--- a/site/_data/toc-mapping.yml
+++ b/site/_data/toc-mapping.yml
@@ -4,3 +4,4 @@
 
 master: master-toc
 v1.0.0: v1-0-0-toc
+v1.0.1: v1-0-1-toc

--- a/site/docs/v1.0.1/README.md
+++ b/site/docs/v1.0.1/README.md
@@ -1,0 +1,28 @@
+[![Build Status][1]][2] [![Go Report Card][3]][4] ![GitHub release][5] [![License][6]][7]
+
+## Overview
+Contour is an Ingress controller for Kubernetes that works by deploying the [Envoy proxy][8] as a reverse proxy and load balancer.
+Contour supports dynamic configuration updates out of the box while maintaining a lightweight profile.
+
+Contour also introduces a new ingress API [HTTPProxy][9] which is implemented via a Custom Resource Definition (CRD).
+Its goal is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
+
+## Prerequisites
+Contour is tested with Kubernetes clusters running version 1.10 and later, but should work with earlier versions where Custom Resource Definitions are supported (Kubernetes 1.7+).
+
+RBAC must be enabled on your cluster.
+
+## Get started
+Getting started with Contour is as simple as one command.
+See the [Getting Started][10] document.
+
+[1]: https://travis-ci.org/projectcontour/contour.svg?branch={{page.version}}
+[2]: https://travis-ci.org/projectcontour/contour
+[3]: https://goreportcard.com/badge/github.com/projectcontour/contour
+[4]: https://goreportcard.com/report/github.com/projectcontour/contour
+[5]: https://img.shields.io/github/release/projectcontour/contour.svg
+[6]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+[7]: https://opensource.org/licenses/Apache-2.0
+[8]: https://www.envoyproxy.io/
+[9]: /docs/{{page.version}}/httpproxy
+[10]: {% link getting-started.md %}

--- a/site/docs/v1.0.1/annotations.md
+++ b/site/docs/v1.0.1/annotations.md
@@ -1,0 +1,73 @@
+<div id="toc" class="navigation"></div>
+
+Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
+
+Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API][15], which provides a more robust configuration interface over
+annotations.
+
+However, Contour still supports a number of annotations on the Ingress resources.
+
+<p class="alert-deprecation">
+<b>Deprecation Notice</b></br>
+The <code>contour.heptio.com</code> annotations are deprecated, please use the <code>projectcontour.io</code> form going forward.
+</p>
+
+## Standard Kubernetes Ingress annotations
+
+ - `kubernetes.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `kubernetes.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
+ - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls][16].
+ - `kubernetes.io/ingress.allow-http`: Instructs Contour to not create an Envoy HTTP route for the virtual host. The Ingress exists only for HTTPS requests. Specify `"false"` for Envoy to mark the endpoint as HTTPS only. All other values are ignored.
+
+The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over `kubernetes.io/ingress.allow-http`. If they are set to `"true"` and `"false"` respectively, Contour *will* create an Envoy HTTP route for the Virtual host, and set the `require_tls` virtual host option.
+
+## Contour specific Ingress annotations
+
+ - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
+ - `projectcontour.io/num-retries`: [The maximum number of retries][1] Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt][2], if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout][3], specified as a [golang duration][4]. By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
+ - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
+ - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
+ - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
+ - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
+ - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
+ - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
+ - `contour.heptio.com/request-timeout`: deprecated form of `projectcontour.io/response-timeout`. _Note_ this is **response-timeout**.
+ - `contour.heptio.com/retry-on`:  deprecated form of `projectcontour.io/retry-on`.
+ - `contour.heptio.com/tls-minimum-protocol-version`: deprecated form of `projectcontour.io/tls-minimum-protocol-version`.
+ - `contour.heptio.com/websocket-routes`: deprecated form of `projectcontour.io/websocket-routes`.
+
+## Contour specific Service annotations
+
+A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have many settings to control specific behaviors. These annotations allow access to some of those settings.
+
+- `projectcontour.io/max-connections`: [The maximum number of connections][11] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-pending-requests`: [The maximum number of pending requests][13] that a single Envoy instance allows to the Kubernetes Service; defaults to 1024.
+- `projectcontour.io/max-requests`: [The maximum parallel requests][13] a single Envoy instance allows to the Kubernetes Service; defaults to 1024
+- `projectcontour.io/max-retries`: [The maximum number of parallel retries][14] a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
+- `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
+  - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
+- `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
+- `contour.heptio.com/max-pending-requests`: deprecated form of `projectcontour.io/max-pending-requests`.
+- `contour.heptio.com/max-requests`: deprecated form of `projectcontour.io/max-requests`.
+- `contour.heptio.com/max-retries`: deprecated form of `projectcontour.io/max-retries`.
+- `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
+
+## Contour specific IngressRoute annotations
+
+[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
+[2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[3]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[4]: https://golang.org/pkg/time/#ParseDuration
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
+[6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on
+[7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters
+[8]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket
+[9]: https://kubernetes.io/docs/concepts/services-networking/service/
+[10]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html
+[11]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections
+[12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
+[13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
+[14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
+[15]: {% link docs/v1.0.1/ingressroute.md %}
+[16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls

--- a/site/docs/v1.0.1/architecture.md
+++ b/site/docs/v1.0.1/architecture.md
@@ -1,0 +1,26 @@
+The Contour Ingress controller is a collaboration between:
+
+* Envoy, which provides the high performance reverse proxy.
+* Contour, which acts as a management server for Envoy and provides it with configuration.
+
+These containers are deployed separately, Contour as a Deployment and Envoy as a Daemonset, although other configurations are possible.
+
+In the Envoy Pods, Contour runs as an initcontainer in `bootstrap` mode and writes a bootstrap configuration to a temporary volume.
+This volume is passed to the Envoy container and directs Envoy to treat Contour as its [management server][1].
+
+After initialisation is complete, the Envoy container starts, retrieves the bootstrap configuration written by Contour's `bootstrap` mode, and starts to poll Contour for configuration.
+
+Envoy will gracefully retry if the management server is unavailable, which removes any container startup ordering issues.
+
+Contour is a client of the Kubernetes API. Contour watches Ingress, Service, and Endpoint objects, and acts as the management server for its Envoy sibling by translating its cache of objects into the relevant JSON stanzas: Service objects for CDS, Ingress for RDS, Endpoint objects for SDS, and so on).
+
+The transfer of information from Kubernetes to Contour is by watching the API with the SharedInformer framework.
+The transfer of information from Contour to Envoy is by polling from the Envoy side.
+
+Kubernetes liveness and readiness probes are configured to check the status of Envoy.
+These are enabled over the metrics port and are served over http via `/healthz`.
+
+For Contour, a liveness probe checks the `/healthz` running on the Pod's metrics port.
+Readiness probe is a TCP check that the gRPC port is open.
+
+[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-docs/xds_protocol

--- a/site/docs/v1.0.1/configuration.md
+++ b/site/docs/v1.0.1/configuration.md
@@ -1,0 +1,33 @@
+A configuration file can be passed to the `contour serve` command which specified additional properties that Contour should use when starting up.
+This file is passed to Contour via a ConfigMap which is mounted as a volume to the Contour pod.
+
+Following is an example ConfigMap with configuration file included: 
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: projectcontour
+data:
+  contour.yaml: |
+    # should contour expect to be running inside a k8s cluster
+    # incluster: true
+    #
+    # path to kubeconfig (if not running inside a k8s cluster)
+    # kubeconfig: /path/to/.kube/config
+    #
+    # disable ingressroute permitInsecure field
+    # disablePermitInsecure: false
+    tls:
+      # minimum TLS version that Contour will negotiate
+      # minimumProtocolVersion: "1.1"
+    # The following config shows the defaults for the leader election.
+    # leaderelection:
+      # configmap-name: contour
+      # configmap-namespace: leader-elect
+```
+
+_Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
+
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/docs/v1.0.1/deploy-options.md
+++ b/site/docs/v1.0.1/deploy-options.md
@@ -1,0 +1,230 @@
+The [Getting Started][8] guide shows you a simple way to get started with Contour on your cluster.
+This topic explains the details and shows you additional options.
+Most of this covers running Contour using a Kubernetes Service of `Type: LoadBalancer`.
+If you don't have a cluster with that capability see the [Running without a Kubernetes LoadBalancer][1] section.
+
+## Installation
+
+### Recommended installation details
+
+The recommended installation of Contour is Contour running in a Deployment and Envoy in a Daemonset with TLS securing the gRPC communication between them.
+The [`contour` example][2] will install this for you.
+A Service of `type: LoadBalancer` is also set up to forward traffic to the Envoy instances.
+
+If you wish to use Host Networking, please see the [appropriate section][3] for the details.
+
+## Testing your installation
+
+### Get your hostname or IP address
+
+To retrieve the IP address or DNS name assigned to your Contour deployment, run:
+
+```bash
+$ kubectl get -n projectcontour service contour -o wide
+```
+
+On AWS, for example, the response looks like:
+
+```
+NAME      CLUSTER-IP     EXTERNAL-IP                                                                    PORT(S)        AGE       SELECTOR
+contour   10.106.53.14   a47761ccbb9ce11e7b27f023b7e83d33-2036788482.ap-southeast-2.elb.amazonaws.com   80:30274/TCP   3h        app=contour
+```
+
+Depending on your cloud provider, the `EXTERNAL-IP` value is an IP address, or, in the case of Amazon AWS, the DNS name of the ELB created for Contour. Keep a record of this value.
+
+Note that if you are running an Elastic Load Balancer (ELB) on AWS, you must add more details to your configuration to get the remote address of your incoming connections.
+See the [instructions for enabling the PROXY protocol.][9].
+
+#### Minikube
+
+On Minikube, to get the IP address of the Contour service run:
+
+```bash
+$ minikube service -n projectcontour contour --url
+```
+
+The response is always an IP address, for example `http://192.168.99.100:30588`. This is used as CONTOUR_IP in the rest of the documentation.
+
+#### kind
+
+When creating the cluster on Kind, pass a custom configuration to allow Kind to expose port 8080 to your local host:
+
+```yaml
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+  extraPortMappings:
+  - containerPort: 8080
+    hostPort: 8080
+    listenAddress: "0.0.0.0"
+```
+
+Then run the create cluster command passing the config file as a parameter.
+This file is in the `examples/kind` directory:
+
+```bash
+$ kind create cluster --config examples/kind/kind-expose-port.yaml
+```
+
+Then, your CONTOUR_IP (as used below) will just be `localhost:8080`.
+
+_Note: If you change Envoy's ports to bind to 80/443 then it's possible to add entries to your local `/etc/hosts` file and make requests like `http://kuard.local` which matches how it might work on a production installation._
+
+### Test with Ingress
+
+The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard][5].
+To test your Contour deployment, deploy `kuard` with the following command:
+
+```bash
+$ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
+```
+
+Then monitor the progress of the deployment with:
+
+```bash
+$ kubectl get po,svc,ing -l app=kuard
+```
+
+You should see something like:
+
+```
+NAME                       READY     STATUS    RESTARTS   AGE
+po/kuard-370091993-ps2gf   1/1       Running   0          4m
+po/kuard-370091993-r63cm   1/1       Running   0          4m
+po/kuard-370091993-t4dqk   1/1       Running   0          4m
+
+NAME        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+svc/kuard   10.110.67.121   <none>        80/TCP    4m
+
+NAME        HOSTS     ADDRESS     PORTS     AGE
+ing/kuard   *         10.0.0.47   80        4m
+```
+
+... showing that there are three Pods, one Service, and one Ingress that is bound to all virtual hosts (`*`).
+
+In your browser, navigate your browser to the IP or DNS address of the Contour Service to interact with the demo application.
+
+### Test with IngressRoute
+
+To test your Contour deployment with [IngressRoutes][6], run the following command:
+
+```sh
+$ kubectl apply -f https://projectcontour.io/examples/kuard-ingressroute.yaml
+```
+
+Then monitor the progress of the deployment with:
+
+```sh
+$ kubectl get po,svc,ingressroute -l app=kuard
+```
+
+You should see something like:
+
+```sh
+NAME                        READY     STATUS    RESTARTS   AGE
+pod/kuard-bcc7bf7df-9hj8d   1/1       Running   0          1h
+pod/kuard-bcc7bf7df-bkbr5   1/1       Running   0          1h
+pod/kuard-bcc7bf7df-vkbtl   1/1       Running   0          1h
+
+NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
+service/kuard   ClusterIP   10.102.239.168   <none>        80/TCP    1h
+
+NAME                                    CREATED AT
+ingressroute.contour.heptio.com/kuard   1h
+```
+
+... showing that there are three Pods, one Service, and one IngressRoute.
+
+In your terminal, use curl with the IP or DNS address of the Contour Service to send a request to the demo application:
+
+```sh
+$ curl -H 'Host: kuard.local' ${CONTOUR_IP}
+```
+### Test with HTTPProxy
+
+To test your Contour deployment with [HTTPProxy][9], run the following command:
+
+```sh
+$ kubectl apply -f https://projectcontour.io/examples/kuard-httpproxy.yaml
+```
+
+Then monitor the progress of the deployment with:
+
+```sh
+$ kubectl get po,svc,httpproxy -l app=kuard
+```
+
+You should see something like:
+
+```sh
+NAME                        READY     STATUS    RESTARTS   AGE
+pod/kuard-bcc7bf7df-9hj8d   1/1       Running   0          1h
+pod/kuard-bcc7bf7df-bkbr5   1/1       Running   0          1h
+pod/kuard-bcc7bf7df-vkbtl   1/1       Running   0          1h
+
+NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
+service/kuard   ClusterIP   10.102.239.168   <none>        80/TCP    1h
+
+NAME                                    FQDN                TLS SECRET                  FIRST ROUTE  STATUS  STATUS DESCRIPT
+httpproxy.projectcontour.io/kuard      kuard.local         <SECRET NAME IF TLS USED>                valid   valid HTTPProxy 
+```
+
+... showing that there are three Pods, one Service, and one HTTPProxy .
+
+In your terminal, use curl with the IP or DNS address of the Contour Service to send a request to the demo application:
+
+```sh
+$ curl -H 'Host: kuard.local' ${CONTOUR_IP}
+```
+
+## Running without a Kubernetes LoadBalancer
+
+If you can't or don't want to use a Service of `type: LoadBalancer` there are other ways to run Contour.
+
+### NodePort Service
+
+If your cluster doesn't have the capability to configure a Kubernetes LoadBalancer,
+or if you want to configure the load balancer outside Kubernetes,
+you can change the Envoy Service in the [`02-service-envoy.yaml`][7] file and set `type` to `NodePort`.
+
+This will have every node in your cluster listen on the resultant port and forward traffic to Contour.
+That port can be discovered by taking the second number listed in the `PORT` column when listing the service, for example `30274` in `80:30274/TCP`.
+
+Now you can point your browser at the specified port on any node in your cluster to communicate with Contour.
+
+### Host Networking
+
+You can run Contour without a Kubernetes Service at all.
+This is done by having the Contour pod run with host networking.
+Do this with `hostNetwork: true` on your pod definition.
+Envoy will listen directly on port 8080 on each host that it is running.
+This is best paired with a DaemonSet (perhaps paired with Node affinity) to ensure that a single instance of Contour runs on each Node.
+See the [AWS NLB tutorial][10] as an example.
+
+## Running Contour in tandem with another ingress controller
+
+If you're running multiple ingress controllers, or running on a cloudprovider that natively handles ingress,
+you can specify the annotation `kubernetes.io/ingress.class: "contour"` on all ingresses that you would like Contour to claim.
+You can customize the class name with the `--ingress-class-name` flag at runtime.
+If the `kubernetes.io/ingress.class` annotation is present with a value other than `"contour"`, Contour will ignore that ingress.
+
+## Uninstall Contour
+
+To remove Contour from your cluster, delete the namespace:
+
+```bash
+$ kubectl delete ns projectcontour
+```
+
+[1]: #running-without-a-kubernetes-loadbalancer
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[3]: #host-networking
+[4]: {% link _guides/proxy-proto.md %}
+[5]: https://github.com/kubernetes-up-and-running/kuard
+[6]: {% link docs/v1.0.1/ingressroute.md %}
+[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[8]: {% link getting-started.md %}
+[9]: {% link docs/v1.0.0/httpproxy.md %}
+[10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/docs/v1.0.1/github.md
+++ b/site/docs/v1.0.1/github.md
@@ -1,0 +1,80 @@
+This document outlines how we use GitHub.
+
+## Milestones
+
+Contour attempts to ship on a monthly-ish, generally every four to six weeks, basis.
+These releases are tracked with a milestone.
+The _current_ release is the milestone with the closest delivery date.
+
+Issues which are not assigned to the current milestone _should not be worked on_.
+
+## Priorities
+
+This project has three levels of priority:
+
+- p0 - Must fix immediately.
+This is reserved for bugs and security issues. A milestone cannot ship with open p0 issues.
+- p1 - Should be done.
+p1 issues assigned to a milestone _should_ be completed during that milestone.
+- p2 - May be done.
+p2 issues assigned to a milestone _may_ be completed during that milestone if time permits. 
+
+Issues without a priority are _unprioritised_. Priority will be assigned by a PM or release manager during issue triage.
+
+## Questions
+
+We encourage support questions via issues.
+Questions will be tagged `question` and are not assigned a milestone or a priority.
+
+## Waiting for information
+
+Any issue which lacks sufficient information for triage will be tagged `waiting-for-info`.
+Issues with this tag may be closed after a reasonable length of time if further information is not forthcoming.
+
+## Issue tagging
+
+Issues without tags have not be triaged.
+
+During issue triage, usually by a project member, release manager, or pm, one or more tags will be assigned.
+
+- `Needs-Product` indicates the issue needs attention by a product owner or PM.
+- `Needs-design-doc` indicates the issue requires a design document to be circulated.
+
+These are blocking states, these labels must be resolved, either by PM or agreeing on a design. 
+
+## Assigning an issue
+
+Issues within a milestone _should_ be assigned to an owner when work commences on them.
+Assigning an issue indicates that you are working on it.
+
+Before you start to work on an issue you should assign yourself.
+From that point onward you are responsible for the issue and you are expected to report timely status on the issue to anyone that asks.
+
+If you cease work on an issue, even if incomplete, you should leave a comment to that effect on the issue and remove yourself as the assignee.
+From that point onward you are no longer responsible for the issue, however you may be approached as a subject matter expert--as the last person to touch the issue--by future assignees.
+
+For infrequent contributors who are not members of the Contour project, assign yourself by leaving a comment to that effect on the issue.
+
+*Do not hoard issues, you won't enjoy it*
+
+## Requesting a review
+
+PRs which are related to issues in the current milestone should be assigned to the current milestone.
+This is an indicator to reviewers that the PR is ready for review and should be reviewed in the current milestone.
+Occasionally PRs may be assigned to the next milestone indicating they are for review at the start of the next development cycle.
+
+All PRs should reference the issue they relate to either by one of the following;
+
+- `Fixes #NNNN` indicating that merging this issue will fix issue #NNNN
+- `Updates #NNNN` indicating that merging this issue will progress issue #NNNN to some degree. 
+
+If there is no `Updates` or `Fixes` line in the PR the review will, with the exception of trivial or self evident fixes, be deferred.
+
+[Further reading]
+
+## Help wanted and good first issues
+
+The `help wanted` and `good first issue` tags _may_ be assigned to issues _in the current milestone_.
+To limit the amount of work in progress, `help wanted` and `good first issue` should not be used for issues outside the current milestone.
+
+[1]: https://dave.cheney.net/2019/02/18/talk-then-code

--- a/site/docs/v1.0.1/grpc-tls-howto.md
+++ b/site/docs/v1.0.1/grpc-tls-howto.md
@@ -1,0 +1,120 @@
+---
+title: Enabling TLS between Envoy and Contour
+layout: page
+---
+This document describes the steps required to secure communication between Envoy and Contour.
+
+## Outcomes
+
+The outcome of this is that we will have three Secrets available in the `projectcontour` namespace:
+
+- **cacert:** contains the CA's public certificate.
+- **contourcert:** contains Contour's keypair, used for serving TLS secured gRPC. This must be a valid certificate for the name `contour` in order for this to work. This is currently hardcoded by Contour.
+- **envoycert:** contains Envoy's keypair, used as a client for connecting to Contour.
+
+### Ways you can get the certificates into your cluster
+
+- Deploy the Job from [certgen.yaml][1].
+This will run `contour certgen --kube` for you.
+- Run `contour certgen --kube` locally.
+- Run the manual procedure below.
+
+## Caveats and warnings
+
+**Be very careful with your production certificates!**
+
+This is intended as an example to help you get started. For any real deployment, you should **carefully** manage all the certificates and control who has access to them. Make sure you don't commit them to any git repos either.
+
+## Manual TLS certificate generation process
+
+### Generating a CA keypair
+
+First, we need to generate a keypair:
+
+```
+$ openssl req -x509 -new -nodes \
+    -keyout certs/cakey.pem -sha256 \
+    -days 1825 -out certs/cacert.pem \
+    -subj "/O=Project Contour/CN=Contour CA"
+```
+
+Then, the new CA key will be stored in `certs/cakey.pem` and the cert in `certs/cacert.pem`.
+
+### Generating Contour's keypair
+
+Then, we need to generate a keypair for Contour. First, we make a new private key:
+
+```
+$ openssl genrsa -out certs/contourkey.pem 2048
+```
+
+Then, we create a CSR and have our CA sign the CSR and issue a cert. This uses the file [_integration/cert-contour.ext][2], which ensures that at least one of the valid names of the certificate is the bareword `contour`. This is required for the handshake to succeed, as `contour bootstrap` configures Envoy to pass this as the SNI for the connection.
+
+```
+$ openssl req -new -key certs/contourkey.pem \
+	-out certs/contour.csr \
+	-subj "/O=Project Contour/CN=contour"
+
+$ openssl x509 -req -in certs/contour.csr \
+    -CA certs/cacert.pem \
+    -CAkey certs/cakey.pem \
+    -CAcreateserial \
+    -out certs/contourcert.pem \
+    -days 1825 -sha256 \
+    -extfile _integration/cert-contour.ext
+```
+
+At this point, the contour cert and key are in the files `certs/contourcert.pem` and `certs/contourkey.pem` respectively.
+
+### Generating Envoy's keypair
+
+Next, we generate a keypair for Envoy:
+
+```
+$ openssl genrsa -out certs/envoykey.pem 2048
+```
+
+Then, we generated a CSR and have the CA sign it:
+
+```
+$ openssl req -new -key certs/envoykey.pem \
+	-out certs/envoy.csr \
+	-subj "/O=Project Contour/CN=envoy"
+
+$ openssl x509 -req -in certs/envoy.csr \
+    -CA certs/cacert.pem \
+    -CAkey certs/cakey.pem \
+    -CAcreateserial \
+    -out certs/envoycert.pem \
+    -days 1825 -sha256 \
+    -extfile _integration/cert-envoy.ext
+```
+
+Like the contour cert, this CSR uses the file [_integration/cert-envoy.ext][3]. However, in this case, there are no special names required.
+
+### Putting the certs in the cluster
+
+Next, we create the required secrets in the target Kubernetes cluster:
+
+```
+$ kubectl create secret -n projectcontour generic cacert \
+        --from-file=./certs/cacert.pem
+
+$ kubectl create secret -n projectcontour tls contourcert \
+        --key=./certs/contourkey.pem --cert=./certs/contourcert.pem
+
+$ kubectl create secret -n projectcontour tls envoycert \
+        --key=./certs/envoykey.pem --cert=./certs/envoycert.pem
+```
+
+Note that we don't put the CA **key** into the cluster, there's no reason for that to be there, and that would create a security problem. That also means that the `cacert` secret can't be a `tls` type secret, as they must be a keypair.
+
+# Conclusion
+
+Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
+[examples/contour][4].
+
+[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour

--- a/site/docs/v1.0.1/httpproxy.md
+++ b/site/docs/v1.0.1/httpproxy.md
@@ -1,0 +1,1115 @@
+<div id="toc" class="navigation"></div>
+
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
+
+The goal of the `HTTPProxy` (previously `IngressRoute`) Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well addressing the limitations of the latter's use in multi tenent environments.
+
+## Key HTTPProxy Benefits
+
+- Safely supports multi-team Kubernetes clusters, with the ability to limit which Namespaces may configure virtual hosts and TLS credentials.
+- Enables including of routing configuration for a path or domain from another HTTPProxy, possibly in another Namespace.
+- Accepts multiple services within a single route and load balances traffic across them.
+- Natively allows defining service weighting and load balancing strategy without annotations.
+- Validation of HTTPProxy objects at creation time and status reporting for post-creation validity.
+
+## Ingress to HTTPProxy
+
+A minimal Ingress object might look like:
+
+```yaml
+# ingress.yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: basic
+spec:
+  rules:
+  - host: foo-basic.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s1
+          servicePort: 80
+```
+
+This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.
+Implementing similar behavior using an HTTPProxy looks like this:
+
+{% highlight yaml linenos %}
+# httpproxy.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: basic
+spec:
+  virtualhost:
+    fqdn: foo-basic.bar.com
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: s1
+          port: 80
+{% endhighlight %}
+
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+
+**Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
+The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
+
+**Lines 9-14**: Each HTTPProxy **must** have one or more routes, each of which **must** have one or more services which will handle the HTTP traffic. In addition, each route **may** have one or more conditions to match against.
+
+**Lines 12-14**: The `services` field is an array of named Service & Port combinations that will be used for this HTTPProxy path.
+HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
+
+## Interacting with HTTPProxies
+
+As with all Kubernetes objects, you can use `kubectl` to create, list, describe, edit, and delete HTTPProxy CRDs.
+
+Creating an HTTPProxy:
+
+```bash
+$ kubectl create -f basic.httpproxy.yaml
+httpproxy "basic" created
+```
+
+Listing HTTPProxies:
+
+```bash
+$ kubectl get httpproxy
+NAME      AGE
+basic     24s
+```
+
+Describing HTTPProxy:
+
+```bash
+$ kubectl describe httpproxy basic
+Name:         basic
+Namespace:    default
+Labels:       <none>
+API Version:  projectcontour.io/v1
+Kind:         HTTPProxy
+Metadata:
+  Cluster Name:
+  Creation Timestamp:  2019-07-05T19:26:54Z
+  Resource Version:    19373717
+  Self Link:           /apis/projectcontour.io/v1/namespaces/default/httpproxy/basic
+  UID:                 6036a9d7-8089-11e8-ab00-f80f4182762e
+Spec:
+  Routes:
+    Conditions:
+      Prefix: /
+    Services:
+      Name:  s1
+      Port:  80
+  Virtualhost:
+    Fqdn:  foo-basic.bar.com
+Events:    <none>
+```
+
+Deleting HTTPProxies:
+
+```bash
+$ kubectl delete httpproxy basic
+httpproxy "basic" deleted
+```
+
+## HTTPProxy API Specification
+
+There are a number of [working examples][3] of HTTPProxy objects in the `examples/example-workload` directory.
+
+We will use these examples as a mechanism to describe HTTPProxy API functionality.
+
+### Virtual Host Configuration
+
+#### Fully Qualified Domain Name
+
+Similar to Ingress, HTTPProxy support name-based virtual hosting.
+Name-based virtual hosts use multiple host names with the same IP address.
+
+```
+foo.bar.com --|                 |-> foo.bar.com s1:80
+              | 178.91.123.132  |
+bar.foo.com --|                 |-> bar.foo.com s2:80
+```
+
+Unlike Ingress, HTTPProxy only support a single root domain per HTTPProxy object.
+As an example, this Ingress object:
+
+```yaml
+# ingress-name.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: name-example
+spec:
+  rules:
+  - host: foo1.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s1
+          servicePort: 80
+  - host: bar1.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s2
+          servicePort: 80
+```
+
+must be represented by two different HTTPProxy objects:
+
+```yaml
+# httpproxy-name.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: name-example-foo
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: foo1.bar.com
+  routes:
+    - services:
+      - name: s1
+        port: 80
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: name-example-bar
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: bar1.bar.com
+  routes:
+    - services:
+        - name: s2
+          port: 80
+```
+
+#### TLS
+
+HTTPProxy follows a similar pattern to Ingress for configuring TLS credentials.
+
+You can secure a HTTPProxy by specifying a Secret that contains TLS private key and certificate information.
+Contour (via Envoy) uses the SNI TLS extension to handle this behavior.
+If multiple HTTPProxy's utilize the same Secret, the certificate must include the necessary Subject Authority Name (SAN) for each fqdn.
+
+Contour also follows a "secure first" approach.
+When TLS is enabled for a virtual host any request to the insecure port is redirected to the secure interface with a 301 redirect.
+Specific routes can be configured to override this behavior and handle insecure requests by enabling the `spec.routes.permitInsecure` parameter on a Route.
+
+The TLS secret must contain keys named tls.crt and tls.key that contain the certificate and private key to use for TLS, e.g.:
+
+```yaml
+# ingress-tls.secret.yaml
+apiVersion: v1
+data:
+  tls.crt: base64 encoded cert
+  tls.key: base64 encoded key
+kind: Secret
+metadata:
+  name: testsecret
+  namespace: default
+type: kubernetes.io/tls
+```
+
+The HTTPProxy can be configured to use this secret using `tls.secretName` property:
+
+```yaml
+# httpproxy-tls.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: tls-example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: testsecret
+  routes:
+    - services:
+        - name: s1
+          port: 80
+```
+
+If the `tls.secretName` property contains a slash, eg. `somenamespace/somesecret` then, subject to TLS Certificate Delegation, the TLS certificate will be read from `somesecret` in `somenamespace`.
+See TLS Certificate Delegation below for more information.
+
+The TLS **Minimum Protocol Version** a vhost should negotiate can be specified by setting the `spec.virtualhost.tls.minimumProtocolVersion`:
+
+- 1.3
+- 1.2
+- 1.1 (Default)
+
+#### Upstream TLS
+
+A HTTPProxy can proxy to an upstream TLS connection by first annotating the upstream Kubernetes service with: `projectcontour.io/upstream-protocol.tls: "443,https"`.
+This annotation tells Contour which port should be used for the TLS connection.
+In this example, the upstream service is named `https` and uses port `443`.
+Additionally, it is possible for Envoy to verify the backend service's certificate.
+The service of an HTTPProxy can optionally specify a `validation` struct which has a mandatory `caSecret` key as well as an mandatory `subjectName`.
+
+Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation.
+
+##### Sample YAML
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: secure-backend
+spec:
+  virtualhost:
+    fqdn: www.example.com  
+  routes:
+    - services:
+        - name: service
+          port: 8443
+          validation:
+            caSecret: my-certificate-authority
+            subjectName: backend.example.com
+```
+
+##### Error conditions
+
+If the `validation` spec is defined on a service, but the secret which it references does not exist, Contour will reject the update and set the status of the HTTPProxy object accordingly.
+This helps prevent the case of proxying to an upstream where validation is requested, but not yet available.
+
+```yaml
+Status:
+  Current Status:  invalid
+  Description:     route "/": service "tls-nginx": upstreamValidation requested but secret not found or misconfigured
+```
+
+#### TLS Certificate Delegation
+
+In order to support wildcard certificates, TLS certificates for a `*.somedomain.com`, which are stored in a namespace controlled by the cluster administrator, Contour supports a facility known as TLS Certificate Delegation.
+This facility allows the owner of a TLS certificate to delegate, for the purposes of referencing the TLS certificate, permission to Contour to read the Secret object from another namespace.
+
+The `TLSCertificateDelegation` resource defines a set of `delegations` in the `spec`.
+Each delegation references a `secretName` from the namespace where the `TLSCertificateDelegation` is created as well as describing a set of `targetNamespaces` in which the certificate can be referenced.
+If all namespaces should be able to reference the secret, then set `"*"` as the value of `targetNamespaces` (see example below).
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: TLSCertificateDelegation
+metadata:
+  name: example-com-wildcard
+  namespace: www-admin
+spec:
+  delegations:
+    - secretName: example-com-wildcard
+      targetNamespaces:
+      - example-com 
+    - secretName: another-com-wildcard
+      targetNamespaces:
+      - "*"
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: www
+  namespace: example-com
+spec:
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: www-admin/example-com-wildcard
+  routes:
+    - services:
+        - name: s1
+          port: 80
+```
+
+In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
+Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
+
+### Conditions
+
+Each Route entry in a HTTPProxy **may** contain one or more conditions.
+These conditions are combined with an AND operator on the route passed to Envoy.
+
+Conditions can be either a `prefix` or a `header` condition.
+
+#### Prefix conditions
+
+For `prefix`, this adds a path prefix.
+
+Up to one prefix condition may be present in any condition block.
+
+Prefix conditions **must** start with a `/` if they are present.
+
+#### Header conditions
+
+For `header` conditions there is one required field, `name`, and five operator fields: `present`, `contains`, `notcontains`, `exact`, and `notexact`.
+
+- `present` is a boolean and checks that the header is present. The value will not be checked.
+
+- `contains` is a string, and checks that the header contains the string. `notcontains` similarly checks that the header does *not* contain the string.
+
+- `exact` is a string, and checks that the header exactly matches the whole string. `notexact` checks that the header does *not* exactly match the whole string.
+
+#### Multiple Routes
+
+HTTPProxy must have at least one route or include defined.
+Paths defined are matched using prefix conditions.
+In this example, any requests to `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*` will be routed to the Service `s2`.
+All other requests to the host `multi-path.bar.com` will be routed to the Service `s1`.
+
+```yaml
+# httpproxy-multiple-paths.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: multiple-paths
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: multi-path.bar.com
+  routes:
+    - conditions:
+      - prefix: / # matches everything else
+      services:
+        - name: s1
+          port: 80
+    - conditions:
+      - prefix: /blog # matches `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*`
+      services:
+        - name: s2
+          port: 80
+```
+
+In the following example, we match on headers and send to different services, with a default route if those do not match.
+
+```yaml
+# httpproxy-multiple-headers.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: multiple-paths
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: multi-path.bar.com
+  routes:
+    - conditions:
+      - header:
+          name: x-os
+          contains: ios
+      services:
+        - name: s1
+          port: 80
+    - conditions:
+      - header:
+          name: x-os
+          contains: android
+      services:
+        - name: s2
+          port: 80
+    - services:
+        - name: s3
+          port: 80
+```
+
+#### Multiple Upstreams
+
+One of the key HTTPProxy features is the ability to support multiple services for a given path:
+
+```yaml
+# httpproxy-multiple-upstreams.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: multiple-upstreams
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: multi.bar.com
+  routes:
+    - services:
+        - name: s1
+          port: 80
+        - name: s2
+          port: 80
+```
+
+In this example, requests for `multi.bar.com/` will be load balanced across two Kubernetes Services, `s1`, and `s2`.
+This is helpful when you need to split traffic for a given URL across two different versions of an application.
+
+#### Upstream Weighting
+
+Building on multiple upstreams is the ability to define relative weights for upstream Services.
+This is commonly used for canary testing of new versions of an application when you want to send a small fraction of traffic to a specific Service.
+
+```yaml
+# httpproxy-weight-shfiting.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: weight-shifting
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: weights.bar.com
+  routes:
+    - services:
+        - name: s1
+          port: 80
+          weight: 10
+        - name: s2
+          port: 80
+          weight: 90
+```
+
+In this example, we are sending 10% of the traffic to Service `s1`, while Service `s2` receives the remaining 90% of traffic.
+
+HTTPProxy weighting follows some specific rules:
+
+- If no weights are specified for a given route, it's assumed even distribution across the Services.
+- Weights are relative and do not need to add up to 100. If all weights for a route are specified, then the "total" weight is the sum of those specified. As an example, if weights are 20, 30, 20 for three upstreams, the total weight would be 70. In this example, a weight of 30 would receive approximately 42.9% of traffic (30/70 = .4285).
+- If some weights are specified but others are not, then it's assumed that upstreams without weights have an implicit weight of zero, and thus will not receive traffic.
+
+#### Traffic mirroring
+
+Per route a service can be nominated as a mirror.
+The mirror service will receive a copy of the read traffic sent to any non mirror service.
+The mirror traffic is considered _read only_, any response by the mirror will be discarded.
+
+This service can be useful for recording traffic for later replay or for smoke testing new deployments.
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: traffic-mirror
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: www.example.com
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: www
+          port: 80
+        - name: www-mirror
+          port: 80
+          mirror: true
+```
+
+#### Response Timeout
+
+Each Route can be configured to have a timeout policy and a retry policy as shown:
+
+```yaml
+# httpproxy-response-timeout.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: response-timeout
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: timeout.bar.com
+  routes:
+  - timeoutPolicy:
+      response: 1s
+      idle: 10s
+    retryPolicy:
+      count: 3
+      perTryTimeout: 150ms
+    services:
+    - name: s1
+      port: 80
+```
+
+In this example, requests to `timeout.bar.com/` will have a response timeout policy of 1s.
+This refers to the time that spans between the point at which complete client request has been processed by the proxy, and when the response from the server has been completely processed.
+
+- `timeoutPolicy.response` This field can be any positive time period or "infinity".
+The time period of **0s** will also be treated as infinity.
+This timeout covers the time from the *end of the client request* to the *end of the upstream response*.
+By default, Envoy has a 15 second value for this timeout.
+More information can be found in [Envoy's documentation][4].
+- `timeoutPolicy.idle` This field can be any positive time period or "infinity".
+The time period of **0s** will also be treated as infinity.
+By default, there is no per-route idle timeout.
+Note that the default connection manager idle timeout of 5 minutes will apply if this is not set.
+
+TimeoutPolicy durations are expressed as per the format specified in the [ParseDuration documentation][5].
+Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+The string 'infinity' is also a valid input and specifies no timeout.
+
+More information can be found in [Envoy's documentation][6]
+- `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request.
+  - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
+  - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional.
+  If left unspecified, `timeoutPolicy.request` will be used.
+
+#### Load Balancing Strategy
+
+Each upstream service can have a load balancing strategy applied to determine which of its Endpoints is selected for the request.
+The following list are the options available to choose from:
+
+- `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
+- `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
+- `Random`: The random strategy selects a random healthy Endpoints.
+
+More information on the load balancing strategy can be found in [Envoy's documentation][7].
+
+The following example defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
+Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
+
+```yaml
+# httpproxy-lb-strategy.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: lb-strategy
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: strategy.bar.com
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: s1-strategy
+          port: 80
+        - name: s2-strategy
+          port: 80
+          strategy: WeightedLeastRequest
+```
+
+#### Session Affinity
+
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
+
+```yaml
+# httpproxy-sticky-sessions.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: httpbin
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: httpbin.davecheney.com
+  routes:
+  - services:
+    - name: httpbin
+      port: 8080
+      strategy: Cookie
+```
+
+##### Limitations
+
+Session affinity is based on the premise that the backend servers are robust, do not change ordering, or grow and shrink according to load.
+None of these properties are guaranteed by a Kubernetes cluster and will be visible to applications that rely heavily on session affinity.
+
+Any perturbation in the set of pods backing a service risks redistributing backends around the hash ring.
+
+#### Per route health checking
+
+Active health checking can be configured on a per route basis.
+Contour supports HTTP health checking and can be configured with various settings to tune the behavior.
+
+During HTTP health checking Envoy will send an HTTP request to the upstream Endpoints.
+It expects a 200 response if the host is healthy.
+The upstream host can return 503 if it wants to immediately notify Envoy to no longer forward traffic to it.
+It is important to note that these are health checks which Envoy implements and are separate from any other system such as those that exist in Kubernetes.
+
+```yaml
+# httpproxy-health-checks.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: health-check
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: health.bar.com
+  routes:
+  - conditions:
+    - prefix: /
+    healthCheckPolicy:
+      path: /healthy
+      intervalSeconds: 5
+      timeoutSeconds: 2
+      unhealthyThresholdCount: 3
+      healthyThresholdCount: 5
+    services:
+      - name: s1-health
+        port: 80
+      - name: s2-health
+        port: 80
+```
+
+Health check configuration parameters:
+
+- `path`: HTTP endpoint used to perform health checks on upstream service (e.g. `/healthz`). It expects a 200 response if the host is healthy. The upstream host can return 503 if it wants to immediately notify downstream hosts to no longer forward traffic to it.
+- `host`: The value of the host header in the HTTP health check request. If left empty (default value), the name "contour-envoy-healthcheck" will be used.
+- `intervalSeconds`: The interval (seconds) between health checks. Defaults to 5 seconds if not set.
+- `timeoutSeconds`: The time to wait (seconds) for a health check response. If the timeout is reached the health check attempt will be considered a failure. Defaults to 2 seconds if not set.
+- `unhealthyThresholdCount`: The number of unhealthy health checks required before a host is marked unhealthy. Note that for http health checking if a host responds with 503 this threshold is ignored and the host is considered unhealthy immediately. Defaults to 3 if not defined.
+- `healthyThresholdCount`: The number of healthy health checks required before a host is marked healthy. Note that during startup, only a single successful health check is required to mark a host healthy.
+
+#### WebSocket Support
+
+WebSocket support can be enabled on specific routes using the `enableWebsockets` field:
+
+```yaml
+# httpproxy-websockets.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: chat
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: chat.example.com
+  routes:
+    - services:
+        - name: chat-app
+          port: 80
+    - conditions:
+      - prefix: /websocket
+      enableWebsockets: true # Setting this to true enables websocket for all paths that match /websocket
+      services:
+        - name: chat-app
+          port: 80
+```
+
+#### Permit Insecure
+
+A HTTPProxy can be configured to permit insecure requests to specific Routes.
+In this example, any request to `foo2.bar.com/blog` will not receive a 301 redirect to HTTPS, but the `/` route will:
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: tls-example-insecure
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: testsecret
+  routes:
+    - services:
+        - name: s1
+          port: 80
+    - conditions:
+      - prefix: /blog
+      permitInsecure: true
+      services:
+        - name: s2
+          port: 80
+```
+
+#### ExternalName
+
+HTTPProxy supports routing traffic to service types `ExternalName`.
+Contour looks at the `spec.externalName` field of the service and configures the route to use that DNS name instead of utilizing EDS.
+
+There's nothing specific in the HTTPProxy object that needs to be configured other than referencing a service of type `ExternalName`.
+
+NOTE: The ports are required to be specified.
+
+```yaml
+# httpproxy-externalname.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: externaldns
+  name: externaldns
+  namespace: default
+spec:
+  externalName: foo-basic.bar.com
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ExternalName
+```
+
+## HTTPProxy inclusion
+
+HTTPProxy permits the splitting of a system's configuration into separate HTTPProxy instances using **inclusion**.
+
+Inclusion, as the name implies, allows for one HTTPProxy object to be included in another, optionally with some conditions inherited from the parent.
+Contour reads the inclusion tree and merges the included routes into one big object internally before rendering Envoy config.
+Importantly, the included HTTPProxy objects do not have to be in the same namespace, so this is functionally the same as the delegation feature of the now-deprecated IngressRoute.
+
+Each tree of HTTPProxy starts with a root, the top level object of the configuration for a particular virtual host.
+Each root HTTPProxy defines a `virtualhost` key, which describes properties such as the fully qualified name of the virtual host, TLS configuration, etc.
+
+HTTPProxies included from the root must not contain a virtualhost key.
+Root objects cannot include other roots either transitively or directly.
+This permits the owner of an HTTPProxy root to allow the inclusion of a portion of the route space inside a virtual host, and to allow that route space to be further subdivided with inclusions.
+Because the path is not necessarily used as the only key, the route space can be multi-dimensional.
+
+### Conditions and Inclusion
+
+Like Routes, Inclusion may specify a set of [conditions][8].
+These conditions are added to any conditions on the routes included.
+This process is recursive.
+
+Conditions are sets of individual condition statements, for example `prefix: /blog` is the condition that the matching request's path must start with `/blog`.
+When conditions are combined through inclusion Contour merges the conditions inherited via inclusion with any conditions specified on the route.
+This may result in duplicates, for example two `prefix:` conditions, or two header match conditions with the same name and value.
+To resolve this Contour applies the following logic.
+
+- `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
+- Proxies with repeated identical `header:` conditions of type "exact match" (the same header keys exactly) are marked as "Invalid" since they create an un-routable configuration.
+
+### Configuring inclusion
+
+Inclusion is a top-level part of the HTTPProxy `spec` element.
+It requires one field, `name`, and has two optional fields:
+
+- `namespace`. This will assume the included HTTPProxy is in the same namespace if it's not specified.
+- a `conditions` block.
+
+#### Within the same namespace
+
+HTTPProxies can include other HTTPProxy objects in the namespace by specifying the name of the object and its namespace in the top-level `includes` block.
+Note that `includes` is a list, and so it must use the YAML list construct.
+
+In this example, the HTTPProxy `include-root` has included the configuration for paths matching `/service2` from the HTTPPRoxy named `service2` in the same namespace as `include-root` (the `default` namespace).
+It's important to note that `service2` HTTPProxy has not defined a `virtualhost` property as it is NOT a root HTTPProxy.
+
+```yaml
+# httpproxy-inclusion-samenamespace.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: include-root
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: root.bar.com
+  includes:
+  # Includes the /service2 path from service2 in the same namespace
+  - name: www
+    namespace: default
+    conditions:
+    - prefix: /service2
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: s1
+          port: 80
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: service2
+  namespace: default
+spec:
+  routes:
+    - conditions:
+      - prefix: / # matches /service2
+      services:
+        - name: s2
+          port: 80
+    - conditions:
+      - prefix: /blog # matches /service2/blog
+      services:
+        - name: blog
+          port: 80
+```
+
+#### Virtualhost aliases
+
+To present the same set of routes under multiple dns entries, for example www.example.com and example.com, including a service with a `prefix` condition of `/` can be used.
+
+```yaml
+# httpproxy-inclusion-multipleroots.yaml
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: multiple-root
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: bar.com
+  includes:
+  - name: main
+    namespace: default
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: multiple-root-www
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: www.bar.com
+  includes:
+  - name: main
+    namespace: default
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: main
+  namespace: default
+spec:
+  routes:
+  - services:
+    - name: s2
+      port: 80
+```
+
+#### Across namespaces
+
+Inclusion can also happen across Namespaces by specifying a `namespace` in the `inclusion`.
+This is a particularly powerful paradigm for enabling multi-team Ingress management.
+
+In this example, the root HTTPProxy has included configuration for paths matching `/blog` to the `blog` HTTPProxy object in the `marketing` namespace.
+
+```yaml
+# httpproxy-inclusion-across-namespaces.yaml
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: namespace-include-root
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: ns-root.bar.com
+  includes:
+  # delegate the subpath, `/blog` to the IngressRoute object in the marketing namespace with the name `blog`
+  - name: blog
+    namespace: marketing
+    conditions:
+    - prefix: /blog
+  routes:
+    - services:
+        - name: s1
+          port: 80
+
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: blog
+  namespace: marketing
+spec:
+  routes:
+    - services:
+        - name: s2
+          port: 80
+```
+
+### Orphaned HTTPProxy children
+
+It is possible for HTTPProxy objects to exist that have not been delegated to by another HTTPProxy.
+These objects are considered "orphaned" and will be ignored by Contour in determining ingress configuration.
+
+### Restricted root namespaces
+
+HTTPProxy inclusion allows for Administrators to limit which users/namespaces may configure routes for a given domain, but it does not restrict where root HTTPProxy may be created.
+Contour has an enforcing mode which accepts a list of namespaces where root HTTPProxy are valid.
+Only users permitted to operate in those namespaces can therefore create HTTPProxy with the `virtualhost` field.
+
+This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
+
+HTTPProxy with a defined `virtualhost` field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+
+Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
+Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
+An example of this is included in the [examples directory][1] and shows how you might create a namespace called `root-httproxies`.
+
+> **NOTE: The restricted root namespace feature is only supported for HTTPProxy CRDs.
+> `--root-namespaces` does not affect the operation of `v1beta1.Ingress` objects**
+
+## TCP Proxying
+
+HTTPProxy supports proxying of TLS encapsulated TCP sessions.
+
+_Note_: The TCP session must be encrypted with TLS.
+This is necessary so that Envoy can use SNI to route the incoming request to the correct service.
+
+### TLS Termination at the edge
+
+If `spec.virtualhost.tls.secretName` is present then that secret will be used to decrypt the TCP traffic at the edge.
+
+```yaml
+# httpproxy-tls-termination.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: tcp.example.com
+    tls:
+      secretName: secret
+  tcpproxy:
+    services:
+    - name: tcpservice
+      port: 8080
+    - name: otherservice
+      port: 9999
+      weight: 20
+```
+
+The `spec.tcpproxy` key indicates that this _root_ HTTPProxy will forward the de-encrypted TCP traffic to the backend service.
+
+### TLS passthrough to the backend service
+
+If you wish to handle the TLS handshake at the backend service set `spec.virtualhost.tls.passthrough: true` indicates that once SNI demuxing is performed, the encrypted connection will be forwarded to the backend service.
+The backend service is expected to have a key which matches the SNI header received at the edge, and be capable of completing the TLS handshake. This is called SSL/TLS Passthrough.
+
+```yaml
+# httpproxy-tls-passthrough.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: tcp.example.com
+    tls:
+      passthrough: true
+  tcpproxy:
+    services:
+    - name: tcpservice
+      port: 8080
+    - name: otherservice
+      port: 9999
+      weight: 20
+```
+
+### TCPProxy delegation
+
+There can be at most one TCPProxy stanza per root HTTPProxy, however that TCPProxy does not need to be defined in the root HTTPProxy object.
+HTTPProxy authors can delegate the configuration of a TCPProxy to the TCPProxy configuration defined in a HTTPProxy child object.
+
+```yaml
+# httpproxy-parent-termination.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: parent
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: tcp.example.com
+    tls:
+      secretName: secret
+  tcpproxy:
+    include:
+      name: child
+      namespace: app
+---
+# httpproxy-child-termination.yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: child
+  namespace: app
+spec:
+  tcpproxy:
+     services:
+    - name: tcpservice
+      port: 8080
+    - name: otherservice
+      port: 9999
+      weight: 20
+```
+In this example `default/parent` delegates the configuration of the TCPProxy services to `app/child`.
+
+## Upstream Validation
+
+When defining upstream services on a route, it's possible to configure the connection from Envoy to the backend endpoint to communicate over TLS.
+Two configuration items are required, a CA certificate and a `SubjectName` which are both used to verify the backend endpoint's identity.
+
+The CA certificate bundle for the backend service should be supplied in a Kubernetes Secret.
+The referenced Secret must be of type "Opaque" and have a data key named `ca.crt`.
+This data value must be a PEM-encoded certificate bundle.
+
+In addition to the CA certificate and the subject name, the Kubernetes service must also be annotated with a Contour specific annotation: `projectcontour.io/upstream-protocol.tls: <port>` ([see annotations section][9])
+
+_Note: This annotation is applied to the Service not the Ingress or HTTPProxy object._
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: blog
+  namespace: marketing
+spec:
+  routes:
+    - services:
+        - name: s2
+          port: 80
+          validation:
+            caSecret: foo-ca-cert
+            subjectName: foo.marketing
+```
+
+## Status Reporting
+
+There are many misconfigurations that could cause an HTTPProxy or delegation to be invalid.
+To aid users in resolving these issues, Contour updates a `status` field in all HTTPProxy objects.
+In the current specification, invalid HTTPProxy are ignored by Contour and will not be used in the ingress routing configuration.
+
+If an HTTPProxy object is valid, it will have a status property that looks like this:
+
+```yaml
+status:
+  currentStatus: valid
+  description: valid HTTPProxy
+```
+
+If the HTTPProxy is invalid, the `currentStatus` field will be `invalid` and the `description` field will provide a description of the issue.
+
+As an example, if an HTTPProxy object has specified a negative value for weighting, the HTTPProxy status will be:
+
+```yaml
+status:
+  currentStatus: invalid
+  description: "route '/foo': service 'home': weight must be greater than or equal to zero"
+```
+
+Some examples of invalid configurations that Contour provides statuses for:
+
+- Negative weight provided in the route definition.
+- Invalid port number provided for service.
+- Prefix in parent does not match route in delegated route.
+- Root HTTPProxy created in a namespace other than the allowed root namespaces.
+- A given Route of an HTTPProxy both delegates to another HTTPProxy and has a list of services.
+- Orphaned route.
+- Delegation chain produces a cycle.
+- Root HTTPProxy does not specify fqdn.
+- Multiple prefixes cannot be specified on the same set of route conditions.
+- Multiple header conditions of type "exact match" with the same header key.
+
+
+ [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+ [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+ [5]: https://godoc.org/time#ParseDuration
+ [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout
+ [7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+ [8]: #conditions
+ [9]: {% link docs/v1.0.1/annotations.md %}

--- a/site/docs/v1.0.1/ingressroute.md
+++ b/site/docs/v1.0.1/ingressroute.md
@@ -1,0 +1,1013 @@
+<div id="toc" class="navigation"></div>
+
+The [Ingress][1] object was added to Kubernetes in version 1.1 to describe properties of a cluster-wide reverse HTTP proxy.
+Since that time, the Ingress object has not progressed beyond the beta stage, and its stagnation inspired an [explosion of annotations][2] to express missing properties of HTTP routing.
+
+The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upon the functionality of the Ingress API to allow for a richer user experience as well as solve shortcomings in the original design.
+
+At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
+
+<p class="alert-deprecation">
+<b>Deprecation Notice</b></br>
+<code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
+Please see the documentation for <a href="/docs/v1.0.1/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
+You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.
+</p>
+
+## Key IngressRoute Benefits
+
+- Safely supports multi-team Kubernetes clusters, with the ability to limit which Namespaces may configure virtual hosts and TLS credentials.
+- Enables delegation of routing configuration for a path or domain to another Namespace.
+- Accepts multiple services within a single route and load balances traffic across them.
+- Natively allows defining service weighting and load balancing strategy without annotations.
+- Validation of IngressRoute objects at creation time and status reporting for post-creation validity.
+
+## Ingress to IngressRoute
+
+A minimal Ingress object might look like:
+
+```yaml
+# ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: basic
+spec:
+  rules:
+  - host: foo-basic.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s1
+          servicePort: 80
+```
+
+This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.
+Implementing similar behavior using an IngressRoute looks like this:
+
+{% highlight yaml linenos %}
+# ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: basic
+spec:
+  virtualhost:
+    fqdn: foo-basic.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+{% endhighlight %}
+
+**Lines 1-5**: As with all other Kubernetes objects, an IngressRoute needs apiVersion, kind, and metadata fields. Note that the IngressRoute API is currently considered beta.
+
+**Line 7-8**: The presence of the `virtualhost` field indicates that this is a root IngressRoute that is the top level entry point for this domain.
+The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.
+
+**Lines 9-13**: IngressRoutes must have one or more `routes`, each of which must have a path to match against (e.g. `/blog`) and then one or more `services` which will handle the HTTP traffic.
+
+**Lines 11-13**: The `services` field is an array of named Service & Port combinations that will be used for this IngressRoute path.
+Ingress HTTP traffic will be sent directly to the Endpoints corresponding to the Service.
+
+## Interacting with IngressRoutes
+
+As with all Kubernetes objects, you can use `kubectl` to create, list, describe, edit, and delete IngressRoute CRDs.
+
+Creating an IngressRoute:
+
+```bash
+$ kubectl create -f basic.ingressroute.yaml
+ingressroute "basic" created
+```
+
+Listing IngressRoutes:
+
+```bash
+$ kubectl get ingressroute
+NAME      AGE
+basic     24s
+```
+
+Describing IngressRoutes:
+
+```bash
+$ kubectl describe ingressroute basic
+Name:         basic
+Namespace:    default
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"contour.heptio.com/v1beta1","kind":"IngressRoute","metadata":{"annotations":{},"name":"basic","namespace":"default"},"spec":{"routes":[{...
+API Version:  contour.heptio.com/v1beta1
+Kind:         IngressRoute
+Metadata:
+  Cluster Name:
+  Creation Timestamp:  2018-07-05T19:26:54Z
+  Resource Version:    19373717
+  Self Link:           /apis/contour.heptio.com/v1beta1/namespaces/default/ingressroutes/basic
+  UID:                 6036a9d7-8089-11e8-ab00-f80f4182762e
+Spec:
+  Routes:
+    Match:  /
+    Services:
+      Name:  s1
+      Port:  80
+  Virtualhost:
+    Fqdn:  foo-basic.bar.com
+Events:    <none>
+```
+
+Deleting IngressRoutes:
+
+```bash
+$ kubectl delete ingressroute basic
+ingressroute "basic" deleted
+```
+
+## IngressRoute API Specification
+
+There are a number of [working examples][3] of IngressRoute objects in the `examples/example-workload` directory.
+We will use these examples as a mechanism to describe IngressRoute API functionality.
+
+### Virtual Host Configuration
+
+#### Fully Qualified Domain Name
+
+Similar to Ingress, IngressRoutes support name-based virtual hosting.
+Name-based virtual hosts use multiple host names with the same IP address.
+
+```
+foo.bar.com --|                 |-> foo.bar.com s1:80
+              | 178.91.123.132  |
+bar.foo.com --|                 |-> bar.foo.com s2:80
+```
+
+Unlike, Ingress, however, IngressRoutes only support a single root domain per IngressRoute object.
+As an example, this Ingress object:
+
+```yaml
+# ingress-name.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: name-example
+spec:
+  rules:
+  - host: foo1.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s1
+          servicePort: 80
+  - host: bar1.bar.com
+    http:
+      paths:
+      - backend:
+          serviceName: s2
+          servicePort: 80
+```
+
+must be represented by two different IngressRoute objects:
+
+```yaml
+# ingressroute-name.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: name-example-foo
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: foo1.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: name-example-bar
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: bar1.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s2
+          port: 80
+```
+
+#### TLS
+
+IngressRoutes follow a similar pattern to Ingress for configuring TLS credentials.
+
+You can secure an IngressRoute by specifying a secret that contains a TLS private key and certificate.
+Currently, IngressRoutes only support a single TLS port, 443, and assume TLS termination.
+If multiple IngressRoute's utilize the same secret, then the certificate must include the necessary Subject Authority Name (SAN) for each fqdn.
+Contour (via Envoy) uses the SNI TLS extension to handle this behavior.
+
+Contour also follows a "secure first" approach. When TLS is enabled for a virtual host, any request to the insecure port is redirected to the secure interface with a 301 redirect.
+Specific routes can be configured to override this behavior and handle insecure requests by enabling the `spec.routes.permitInsecure` parameter on a Route.
+
+The TLS secret must contain keys named tls.crt and tls.key that contain the certificate and private key to use for TLS, e.g.:
+
+```yaml
+# ingress-tls.secret.yaml
+apiVersion: v1
+data:
+  tls.crt: base64 encoded cert
+  tls.key: base64 encoded key
+kind: Secret
+metadata:
+  name: testsecret
+  namespace: default
+type: kubernetes.io/tls
+```
+
+The IngressRoute can be configured to use this secret using `tls.secretName` property:
+
+```yaml
+# tls.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: tls-example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: testsecret
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+```
+
+If the `tls.secretName` property contains a slash, eg. `somenamespace/somesecret` then, subject to TLS Certificate Delegation, the TLS certificate will be read from `somesecret` in `somenamespace`.
+See TLS Certificate Delegation below for more information.
+
+The TLS **Minimum Protocol Version** a vhost should negotiate can be specified by setting the `spec.virtualhost.tls.minimumProtocolVersion`:
+  - 1.3
+  - 1.2
+  - 1.1 (Default)
+
+The IngressRoute can be configured to permit insecure requests to specific Routes. In this example, any request to `foo2.bar.com/blog` will not receive a 301 redirect to HTTPS, but the `/` route will:
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata: 
+  name: tls-example-insecure
+  namespace: default
+spec: 
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: testsecret
+  routes: 
+    - match: /
+      services: 
+        - name: s1
+          port: 80
+    - match: /blog
+      permitInsecure: true
+      services: 
+        - name: s2
+          port: 80
+```
+
+#### Upstream TLS
+
+An IngressRoute route can proxy to an upstream TLS connection by first annotating the upstream Kubernetes service with: `contour.heptio.com/upstream-protocol.tls: "443,https"`.
+This annotation tells Contour which port should be used for the TLS connection.
+In this example, the upstream service is named `https` and uses port `443`.
+Additionally, it is possible for Envoy to verify the backend service's certificate.
+The service of an `IngressRoute` can optionally specify a `validation` struct which has a mandatory `caSecret` key as well as an mandatory `subjectName`.
+
+Note: If spec.routes.services[].validation is present, spec.routes.services[].{name,port} must point to a service with a matching contour.heptio.com/upstream-protocol.tls Service annotation.
+
+##### Sample YAML
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: secure-backend
+spec:
+  virtualhost:
+    fqdn: www.example.com  
+  routes:
+    - match: /
+      services:
+        - name: service
+          port: 8443
+          validation:
+            caSecret: my-certificate-authority
+            subjectName: backend.example.com
+```
+
+##### Error conditions
+
+If the `validation` spec is defined on a service, but the secret which it references does not exist, Contour will rejct the update and set the status of the `IngressRoute` object accordingly.
+This is to help prevent the case of proxying to an upstream where validation is requested, but not yet available.
+
+```yaml
+Status:
+  Current Status:  invalid
+  Description:     route "/": service "tls-nginx": upstreamValidation requested but secret not found or misconfigured
+```
+
+#### TLS Certificate Delegation
+
+In order to support wildcard certificates, TLS certificates for a `*.somedomain.com`, which are stored in a namespace controlled by the cluster administrator, Contour supports a facility known as TLS Certificate Delegation.
+This facility allows the owner of a TLS certificate to delegate, for the purposes of reference the TLS certificate, the when processing an IngressRoute to Contour will reference the Secret object from another namespace.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: TLSCertificateDelegation
+metadata:
+  name: example-com-wildcard
+  namespace: www-admin
+spec:
+  delegations:
+    - secretName: example-com-wildcard
+      targetNamespaces:
+      - example-com
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: www
+  namespace: example-com
+spec:
+  virtualhost:
+    fqdn: foo2.bar.com
+    tls:
+      secretName: www-admin/example-com-wildcard
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+```
+
+In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to IngressRoute objects in the `example-com` namespace.
+
+### Routing
+
+Each route entry in an IngressRoute must start with a prefix match.
+
+#### Multiple Routes
+
+IngressRoutes must have at least one route defined, but may support more.
+Paths defined are matched using prefix rules.
+In this example, any requests to `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*` will be routed to the Service `s2`.
+All other requests to the host `multi-path.bar.com` will be routed to the Service `s1`.
+
+```yaml
+# multiple-paths.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: multiple-paths
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: multi-path.bar.com
+  routes:
+    - match: / # matches everything else
+      services:
+        - name: s1
+          port: 80
+    - match: /blog # matches `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*`
+      services:
+        - name: s2
+          port: 80
+```
+
+#### Multiple Upstreams
+
+One of the key IngressRoute features is the ability to support multiple services for a given path:
+
+```yaml
+# multiple-upstreams.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: multiple-upstreams
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: multi.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+        - name: s2
+          port: 80
+```
+
+In this example, requests for `multi.bar.com/` will be load balanced across two Kubernetes Services, `s1`, and `s2`.
+This is helpful when you need to split traffic for a given URL across two different versions of an application.
+
+#### Upstream Weighting
+
+Building on multiple upstreams is the ability to define relative weights for upstream Services.
+This is commonly used for canary testing of new versions of an application when you want to send a small fraction of traffic to a specific Service.
+
+```yaml
+# weight-shifting.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: weight-shifting
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: weights.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+          weight: 10
+        - name: s2
+          port: 80
+          weight: 90
+```
+
+In this example, we are sending 10% of the traffic to Service `s1`, while Service `s2` receives the other 90% of traffic.
+
+IngressRoute weighting follows some specific rules:
+
+- If no weights are specified for a given route, it's assumed even distribution across the Services.
+- Weights are relative and do not need to add up to 100. If all weights for a route are specified, then the "total" weight is the sum of those specified. As an example, if weights are 20, 30, 20 for three upstreams, the total weight would be 70. In this example, a weight of 30 would receive approximately 42.9% of traffic (30/70 = .4285).
+- If some weights are specified but others are not, then it's assumed that upstreams without weights have an implicit weight of zero, and thus will not receive traffic.
+
+#### Request Timeout
+
+Each Route can be configured to have a timeout policy and a retry policy as shown:
+
+```yaml
+# request-timeout.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: request-timeout
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: timeout.bar.com
+  routes:
+  - match: /
+    timeoutPolicy:
+      request: 1s
+    retryPolicy:
+      count: 3
+      perTryTimeout: 150ms
+    services:
+    - name: s1
+      port: 80
+``` 
+
+In this example, requests to `timeout.bar.com/` will have a request timeout policy of 1s. 
+This refers to the time that spans between the point at which complete client request has been processed by the proxy, and when the response from the server has been completely processed. 
+
+- `timeoutPolicy.request` This field can be any positive time period or "infinity". 
+The time period of **0s** will also be treated as infinity. 
+By default, Envoy has a 15 second timeout for a backend service to respond.
+More information can be found in [Envoy's documentation][4].
+
+- `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request. 
+    - `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
+    - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional. 
+    If left unspecified, `timeoutPolicy.request` will be used. 
+
+
+#### Load Balancing Strategy
+
+Each upstream service can have a load balancing strategy applied to determine which of its Endpoints is selected for the request.
+The following list are the options available to choose from:
+
+- `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
+- `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
+- `Random`: The random strategy selects a random healthy Endpoints.
+
+More information on the load balancing strategy can be found in [Envoy's documentation][5].
+
+The following example IngressRoute defines the strategy for Service `s2-strategy` as `WeightedLeastRequest`.
+Service `s1-strategy` does not have an explicit strategy defined so it will use the strategy of `RoundRobin`.
+
+```yaml
+# lb-strategy.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: lb-strategy
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: strategy.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1-strategy
+          port: 80
+        - name: s2-strategy
+          port: 80
+          strategy: WeightedLeastRequest
+```
+#### Session Affinity
+
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: httpbin
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: httpbin.davecheney.com
+  routes:
+  - match: /
+    services:
+    - name: httpbin
+      port: 8080
+      strategy: Cookie
+```
+##### Limitations
+
+Session affinity is based on the premise that the backend servers are robust, do not change ordering, or grow and shrink according to load.
+None of these properties are guaranteed by a Kubernetes cluster and will be visible to applications that rely heavily on session affinity.
+
+Any pertibation in the set of pods backing a service risks redistributing backends around the hash ring.
+This is an unavoidable consiquence of Envoy's session affinity implementation and the pods-as-cattle approach of Kubernetes.
+
+#### Per-Upstream Active Health Checking
+
+Active health checking can be configured on a per-upstream Service basis.
+Contour supports HTTP health checking and can be configured with various settings to tune the behavior.
+
+During HTTP health checking Envoy will send an HTTP request to the upstream Endpoints.
+It expects a 200 response if the host is healthy.
+The upstream host can return 503 if it wants to immediately notify Envoy to no longer forward traffic to it.
+It is important to note that these are health checks which Envoy implements and are separate from any other system such as those that exist in Kubernetes.
+
+```yaml
+# health-checks.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: health-check
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: health.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1-health
+          port: 80
+          healthCheck:
+            path: /healthy
+            intervalSeconds: 5
+            timeoutSeconds: 2
+            unhealthyThresholdCount: 3
+            healthyThresholdCount: 5
+        - name: s2-health # no health-check defined for this service
+          port: 80
+```
+
+Health check configuration parameters:
+
+- `path`: HTTP endpoint used to perform health checks on upstream service (e.g. `/healthz`). It expects a 200 response if the host is healthy. The upstream host can return 503 if it wants to immediately notify downstream hosts to no longer forward traffic to it.
+- `host`: The value of the host header in the HTTP health check request. If left empty (default value), the name "contour-envoy-healthcheck" will be used.
+- `intervalSeconds`: The interval (seconds) between health checks. Defaults to 5 seconds if not set.
+- `timeoutSeconds`: The time to wait (seconds) for a health check response. If the timeout is reached the health check attempt will be considered a failure. Defaults to 2 seconds if not set.
+- `unhealthyThresholdCount`: The number of unhealthy health checks required before a host is marked unhealthy. Note that for http health checking if a host responds with 503 this threshold is ignored and the host is considered unhealthy immediately. Defaults to 3 if not defined.
+- `healthyThresholdCount`: The number of healthy health checks required before a host is marked healthy. Note that during startup, only a single successful health check is required to mark a host healthy.
+
+#### IngressRoute Default Health Checking (Not supported in beta.1)
+
+In order to reduce the amount of duplicated configuration, the IngressRoute specification supports a default health check that will be applied to all Services.
+You may still override this default on a per-Service basis.
+
+```yaml
+# default-health-checks.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: health-check
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: health.bar.com
+  healthCheck:
+    path: /healthy
+    intervalSeconds: 5
+    timeoutSeconds: 2
+    unhealthyThresholdCount: 3
+    healthyThresholdCount: 5
+  routes:
+    - match: /
+      services:
+        - name: s1-def-health
+          port: 80
+        - name: s2-def-health
+          port: 80
+```
+
+#### WebSocket Support
+
+WebSocket support can be enabled on specific routes using the `EnableWebsockets` field:
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: chat
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: chat.example.com
+  routes:
+    - match: /
+      services:
+        - name: chat-app
+          port: 80
+    - match: /websocket
+      enableWebsockets: true # Setting this to true enables websocket for all paths that match /websocket
+      services:
+        - name: chat-app
+          port: 80
+```
+
+#### Prefix Rewrite Support
+
+Indicates that during forwarding, the matched prefix (or path) should be swapped with this value. This option allows application URLs to be rooted at a different path from those exposed at the reverse proxy layer. The original path before rewrite will be placed into the into the `x-envoy-original-path` header.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: app
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: app.example.com
+  routes:
+    - match: /
+      services:
+        - name: app
+          port: 80
+    - match: /service2
+      prefixRewrite: "/" # Setting this rewrites the request from `/service2` to `/`
+      services:
+        - name: app-service
+          port: 80
+```
+
+#### Permit Insecure
+
+IngressRoutes support allowing HTTP alongside HTTPS. This way, the path responds to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: permit-insecure
+spec:
+  virtualhost:
+    fqdn: foo-basic.bar.com
+  routes:
+    - match: /
+      permitInsecure: true
+      services:
+        - name: s1
+          port: 80
+```
+
+#### ExternalName
+
+IngressRoute supports routing traffic to service types `ExternalName`.
+Contour looks at the `spec.externalName` field of the service and configures the route to use that DNS name instead of utilizing EDS.
+
+There's nothing specific in the `IngressRoute` object that needs configured other than referencing a service of type `ExternalName`.
+
+NOTE: The ports are required to be specified.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: externaldns
+  name: externaldns
+  namespace: default
+spec:
+  externalName: foo-basic.bar.com
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ExternalName
+```
+
+## IngressRoute Delegation
+
+A key feature of the IngressRoute specification is route delegation which follows the working model of DNS:
+
+> As the owner of a DNS domain, for example `whitehouse.gov`, I delegate to another nameserver the responsibility for handing the subdomain `treasury.whitehouse.gov`.
+> Any nameserver can hold a record for `treasury.whitehouse.gov`, but without the linkage from the parent `whitehouse.gov` nameserver, its information is unreachable and non authoritative.
+
+The "root" IngressRoute is the only entry point for an ingress virtual host and is used as the top level configuration of a cluster's ingress resources.
+Each root IngressRoute defines a `virtualhost` key, which describes properties such as the fully qualified name of the virtual host, TLS configuration, etc.
+
+IngressRoutes that have been delegated to do not contain virtual host information, as they will inherit the properties of the parent IngressRoute.
+This permits the owner of an IngressRoute root to both delegate the authority to publish a service on a portion of the route space inside a virtual host, and to further delegate authority to publish and delegate.
+
+In practice, the linkage, or delegation, from root IngressRoute to child IngressRoute is performed with a specific route action.
+You can think of this as routing traffic to another IngressRoute object for further processing, rather than routing traffic directly to a Service.
+
+### Delegation within a namespace
+
+IngressRoutes can delegate to other IngressRoute objects in the namespace by specifying the action of a route path as `delegate` and providing the name of the IngressRoute to delegate the path to.
+
+In this example, the IngressRoute `delegation-root` has delegated the configuration for paths matching `/service2` to the IngressRoute named `service2` in the same namespace as `delegation-root` (the `default` namespace).
+It's important to note that `service2` IngressRoute has not defined a `virtualhost` property as it is NOT a root IngressRoute.
+
+```yaml
+# root.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: delegation-root
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: root.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+    # delegate the path, `/service2` to the IngressRoute object in this namespace with the name `service2`
+    - match: /service2
+      delegate:
+        name: service2
+---
+# service2.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: service2
+  namespace: default
+spec:
+  routes:
+    - match: /service2
+      services:
+        - name: s2
+          port: 80
+    - match: /service2/blog
+      services:
+        - name: blog
+          port: 80
+```
+
+### Virtualhost aliases
+
+To present the same set of routes under multiple dns entries, for example www.example.com and example.com, delegation of the root route, `/` can be used.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: www-example-com
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: www.example.com
+  routes:
+    - match: /
+      delegate:
+        name: example-root
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: example-com
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: example.com
+  routes:
+    - match: /
+      delegate:
+        name: example-root
+---
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: example-root
+  namespace: default
+spec:
+  routes:
+    - match: /
+      services:
+        - name: example-service
+          port: 8080
+    - match: /static
+      services:
+        - name: example-static
+          port: 8080
+```
+
+### Across namespaces
+
+Delegation can also happen across Namespaces by specifying a `namespace` property for the delegate.
+This is a particularly powerful paradigm for enabling multi-team Ingress management.
+
+In this example, the root IngressRoute has delegated configuration of paths matching `/blog` to the `blog` IngressRoute object in the `marketing` namespace.
+
+```yaml
+# root.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: namespace-delegation-root
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: ns-root.bar.com
+  routes:
+    - match: /
+      services:
+        - name: s1
+          port: 80
+# delegate the subpath, `/blog` to the IngressRoute object in the marketing namespace with the name `blog`
+    - match: /blog
+      delegate:
+        name: blog
+        namespace: marketing
+---
+# blog.ingressroute.yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: blog
+  namespace: marketing
+spec:
+  routes:
+    - match: /blog
+      services:
+        - name: s2
+          port: 80
+```
+
+### Orphaned IngressRoutes
+
+It is possible for IngressRoute objects to exist that have not been delegated to by another IngressRoute.
+These objects are considered "orphaned" and will be ignored by Contour in determining ingress configuration.
+
+### Restricted root namespaces
+
+IngressRoute delegation allows for Administrators to limit which users/namespaces may configure routes for a given domain, but it does not restrict where root IngressRoutes may be created.
+Contour has an enforcing mode which accepts a list of namespaces where root IngressRoutes are valid.
+Only users permitted to operate in those namespaces can therefore create IngressRoutes with the `virtualhost` field.
+
+This restricted mode is enabled in Contour by specifying a command line flag, `--ingressroute-root-namespaces`, which will restrict Contour to only searching the defined namespaces for root IngressRoutes. This CLI flag accepts a comma separated list of namespaces where IngressRoutes are valid (e.g. `--ingressroute-root-namespaces=default,kube-system,my-admin-namespace`).
+
+IngressRoutes with a defined `virtualhost` field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+
+Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
+Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
+An example of this is included in the [examples directory][6] and shows how you might create a namespace called `root-ingressroutes`.
+
+> **NOTE: The restricted root namespace feature is only supported for IngressRoute CRDs.
+> `--ingressroute-root-namespaces` does not affect the operation of `v1beta1.Ingress` objects**
+
+## TCP Proxying
+
+Ingressroute supports proxying of TLS encapsulated TCP sessions.
+
+_Note_: The TCP session must be encrypted with TLS.
+This is necessary so that Envoy can use SNI to route the incoming request to the correct service.
+
+### TLS Termination at the edge
+
+If `spec.virtualhost.tls.secretName` is present then that secret will be used to decrypt the TCP traffic at the edge.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: tcp.example.com
+    tls:
+      secretName: secret
+  tcpproxy:
+    services:
+    - name: tcpservice
+      port: 8080
+    - name: otherservice
+      port: 9999
+      weight: 20
+  routes:
+  - match: /
+    services:
+    - name: kuard
+      port: 80
+```
+
+The `spec.tcpproxy` key indicates that this _root_ IngressRoute will forward the de-encrypted TCP traffic to the backend service.
+
+### TLS passthrough to the backend service
+
+If you wish to handle the TLS handshake at the backend service set `spec.virtualhost.tls.passthrough: true` indicates that once SNI demuxing is performed, the encrypted connection will be forwarded to the backend service. The backend service is expected to have a key which matches the SNI header received at the edge, and be capable of completing the TLS handshake. This is called SSL/TLS Passthrough.
+
+```yaml
+apiVersion: contour.heptio.com/v1beta1
+kind: IngressRoute
+metadata:
+  name: example
+  namespace: default
+spec:
+  virtualhost:
+    fqdn: tcp.example.com
+    tls:
+      passthrough: true
+  tcpproxy:
+    services:
+    - name: tcpservice
+      port: 8080
+    - name: otherservice
+      port: 9999
+      weight: 20
+  routes:
+  - match: /
+    services:
+    - name: kuard
+      port: 80
+```
+
+### Limitations
+
+The current limitations are present in Contour 0.8. These will be addressed in later Contour versions.
+
+- TCP Proxying is not available on Kubernetes Ingress objects.
+- A dummy `spec.routes` entry is required for input validation.
+
+## Status Reporting
+
+There are many misconfigurations that could cause an IngressRoute or delegation to be invalid.
+To aid users in resolving these issues, Contour updates a `status` field in all IngressRoute objects.
+In the current specification, invalid IngressRoutes are ignored by Contour and will not be used in the ingress routing configuration.
+
+If an IngressRoute object is valid, it will have a status property that looks like this:
+
+```yaml
+status:
+  currentStatus: valid
+  description: valid IngressRoute
+```
+
+If the IngressRoute is invalid, the `currentStatus` field will be `invalid` and the `description` field will provide a description of the issue.
+
+As an example, if an IngressRoute object has specified a negative value for weighting, the IngressRoute status will be:
+
+```yaml
+status:
+  currentStatus: invalid
+  description: "route '/foo': service 'home': weight must be greater than or equal to zero"
+```
+
+Some examples of invalid configurations that Contour provides statuses for:
+
+- Negative weight provided in the route definition.
+- Invalid port number provided for service.
+- Prefix in parent does not match route in delegated route.
+- Root IngressRoute created in a namespace other than the allowed root namespaces.
+- A given Route of an IngressRoute both delegates to another IngressRoute and has a list of services.
+- Orphaned route.
+- Delegation chain produces a cycle.
+- Root IngressRoute does not specify fqdn.
+
+[1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
+[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac

--- a/site/docs/v1.0.1/start-contributing.md
+++ b/site/docs/v1.0.1/start-contributing.md
@@ -1,0 +1,15 @@
+## Contributing
+
+Thanks for taking the time to join our community and start contributing!
+
+- Please familiarize yourself with the [Code of Conduct][1] before contributing.
+- See [CONTRIBUTING.md][2] for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
+- Check out the [open issues][3].
+- Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
+- Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
+  - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
+  - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
+
+[1]: {{site.github.repository_url}}/blob/master/CODE_OF_CONDUCT.md
+[2]: {{site.github.repository_url}}/blob/master/CONTRIBUTING.md
+[3]: {{site.github.repository_url}}/issues

--- a/site/docs/v1.0.1/tagging.md
+++ b/site/docs/v1.0.1/tagging.md
@@ -1,0 +1,22 @@
+This document describes Contour's image tagging policy.
+
+## Released versions
+
+`docker.io/projectcontour/contour:<SemVer>`
+
+Contour follows the [Semantic Versioning][1] standard for releases.
+Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:v1.0.1`
+
+### Latest
+
+`docker.io/projectcontour/contour:latest`
+
+The `latest` tag follows the most recent stable version of Contour.
+
+## Development
+
+`docker.io/projectcontour/contour:master`
+
+The `master` tag follows the latest commit to land on the `master` branch.
+
+[1]: http://semver.org/

--- a/site/docs/v1.0.1/troubleshooting.md
+++ b/site/docs/v1.0.1/troubleshooting.md
@@ -1,0 +1,91 @@
+This document contains suggestions for debugging issues with your Contour installation.
+
+## Envoy container not listening on port 8080 or 8443
+
+Contour does not configure Envoy to listen on a port unless there is traffic to be served.
+For example, if you have not configured any TLS ingress objects then Contour does not command Envoy to open port 8443 (443 in the service object).
+Because the HTTP and HTTPS listeners both use the same code, if you have no ingress objects deployed in your cluster, or if no ingress objects are permitted to talk on HTTP, then Envoy does not listen on port 8080 (80 in the service object).
+
+To test whether Contour is correctly deployed you can deploy the kuard example service:
+
+```sh
+$ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
+```
+
+## Access the Envoy admin interface remotely
+
+Getting access to the Envoy admin interface can be useful for diagnosing issues with routing or cluster health.
+
+The Envoy admin interface is bound by default to `http://127.0.0.1:9001`.
+To access it from your workstation use `kubectl port-forward` like so,
+
+```sh
+# Get one of the pods that matches the Envoy daemonset
+ENVOY_POD=$(kubectl -n projectcontour get pod -l app=envoy -o name | head -1)
+# Do the port forward to that pod
+kubectl -n projectcontour port-forward $ENVOY_POD 9001
+```
+
+Then navigate to `http://127.0.0.1:9001/` to access the admin interface for the Envoy container running on that pod.
+
+## Accessing Contour's /debug/pprof service
+
+Contour exposes the [net/http/pprof][1]handlers for `go tool pprof` and `go tool trace` by default on `127.0.0.1:6060`.
+This service is useful for profiling Contour.
+To access it from your workstation use `kubectl port-forward` like so,
+
+```sh
+# Get one of the pods that matches the Contour deployment
+CONTOUR_POD=$(kubectl -n projectcontour get pod -l app=contour -o name | head -1)
+# Do the port forward to that pod
+kubectl -n projectcontour port-forward $CONTOUR_POD 6060
+```
+
+## Visualizing Contour's internal directed acyclic graph (DAG)
+
+Contour models its configuration using a DAG, which can be visualized through a debug endpoint that outputs the DAG in [DOT][2] format.
+To visualize the graph, you must have [`graphviz`][3] installed on your system.
+
+To download the graph and save it as a PNG:
+
+```sh
+# Port forward into the contour pod
+CONTOUR_POD=$(kubectl -n projectcontour get pod -l app=contour -o name | head -1)
+# Do the port forward to that pod
+kubectl -n projectcontour port-forward $CONTOUR_POD 6060
+# Download and store the DAG in png format
+curl localhost:6060/debug/dag | dot -T png > contour-dag.png
+```
+
+The following is an example of a DAG that maps `http://kuard.local:80/` to the
+`kuard` service in the `default` namespace:
+
+![Sample DAG][4]
+
+## Interrogate Contour's gRPC API
+
+Sometimes it's helpful to be able to interrogate Contour to find out exactly the data it is sending to Envoy.
+Contour ships with a `contour cli` subcommand which can be used for this purpose.
+
+Because Contour secures its communications with Envoy using Secrets in the cluster, the easiest way is to run `contour cli` commands _inside_ the pod.
+Do this is via `kubectl exec`:
+
+```sh
+# Get one of the pods that matches the examples/daemonset
+CONTOUR_POD=$(kubectl -n projectcontour get pod -l app=contour -o jsonpath='{.items[0].metadata.name}')
+# Do the port forward to that pod
+kubectl -n projectcontour exec $CONTOUR_POD -c contour -- contour cli lds --cafile=/ca/cacert.pem --cert-file=/certs/tls.crt --key-file=/certs/tls.key
+```
+
+Which will stream changes to the LDS api endpoint to your terminal.
+Replace `contour cli lds` with `contour cli rds` for RDS, `contour cli cds` for CDS, and `contour cli eds` for EDS.
+
+## I've deployed on Minikube or kind and nothing seems to work
+
+See [the deployment documentation][5] for some tips on using these two deployment options successfully.
+
+[1]: https://golang.org/pkg/net/http/pprof
+[2]: https://en.wikipedia.org/wiki/DOT
+[3]: https://graphviz.gitlab.io/
+[4]: {% link img/kuard-dag.png %}
+[5]: {% link docs/v1.0.1/deploy-options.md %}


### PR DESCRIPTION
Fixes #2011

- set latest to v1.0.1
- add v1.0.1 documentation
- hand edit all v1.0.1 documentation to remove hard links to v1.0.0 docs

Signed-off-by: Dave Cheney <dave@cheney.net>