### PR TITLE
internal/envoy: use correct transport socket name

### DIFF
--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -695,7 +695,7 @@ func TestBootstrap(t *testing.T) {
           }
         },
         "transport_socket": {
-          "name":"tls",
+          "name": "envoy.transport_sockets.tls",
           "typed_config": {
             "@type":"type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
             "common_tls_context": {

--- a/internal/envoy/socket.go
+++ b/internal/envoy/socket.go
@@ -21,7 +21,7 @@ import (
 // UpstreamTLSTransportSocket returns a custom transport socket using the UpstreamTlsContext provided.
 func UpstreamTLSTransportSocket(tls *envoy_api_v2_auth.UpstreamTlsContext) *envoy_api_v2_core.TransportSocket {
 	return &envoy_api_v2_core.TransportSocket{
-		Name: "tls",
+		Name: "envoy.transport_sockets.tls",
 		ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 			TypedConfig: toAny(tls),
 		},
@@ -31,7 +31,7 @@ func UpstreamTLSTransportSocket(tls *envoy_api_v2_auth.UpstreamTlsContext) *envo
 // DownstreamTLSTransportSocket returns a custom transport socket using the DownstreamTlsContext provided.
 func DownstreamTLSTransportSocket(tls *envoy_api_v2_auth.DownstreamTlsContext) *envoy_api_v2_core.TransportSocket {
 	return &envoy_api_v2_core.TransportSocket{
-		Name: "tls",
+		Name: "envoy.transport_sockets.tls",
 		ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 			TypedConfig: toAny(tls),
 		},

--- a/internal/envoy/socket_test.go
+++ b/internal/envoy/socket_test.go
@@ -29,7 +29,7 @@ func TestUpstreamTLSTransportSocket(t *testing.T) {
 		"h2": {
 			ctxt: UpstreamTLSContext(nil, "", "h2"),
 			want: &envoy_api_v2_core.TransportSocket{
-				Name: "tls",
+				Name: "envoy.transport_sockets.tls",
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 					TypedConfig: toAny(UpstreamTLSContext(nil, "", "h2")),
 				},
@@ -53,7 +53,7 @@ func TestDownstreamTLSTransportSocket(t *testing.T) {
 		"default/tls": {
 			ctxt: DownstreamTLSContext("default/tls", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 			want: &envoy_api_v2_core.TransportSocket{
-				Name: "tls",
+				Name: "envoy.transport_sockets.tls",
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 					TypedConfig: toAny(DownstreamTLSContext("default/tls", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1")),
 				},


### PR DESCRIPTION
The envoy documentation is inconsistent about the correct name of a tls
enabled transport socket.  envoyproxy/envoy#9319

This PR uses the name in more common usage inside envoy.

Signed-off-by: Dave Cheney <dave@cheney.net>