### PR TITLE
Add announce mailing list

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -12,9 +12,12 @@ If you’re a newcomer, check out the “[Good first issue][1]” and “[Help w
 
 * Join our Kubernetes Slack channel and talk to over 300 other community members: [#contour​][4]
 
+* Join the [Project Contour Announce][8] mailing list for release notifications and other important news.
+
 * Join the [Contour Community Meetings][5], every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
   * Meeting notes can be found [here][6].
   * Meetings are recorded and can be found [here][7].
+  * Join the [mailing list][8] above to get an automated invitation to the meeting.
 
 [1]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22
 [2]: {{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+
@@ -23,3 +26,4 @@ If you’re a newcomer, check out the “[Good first issue][1]” and “[Help w
 [5]: https://vmware.zoom.us/j/347232187
 [6]: https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw
 [7]: https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj
+[8]: https://groups.google.com/forum/#!forum/projectcontour-announce


### PR DESCRIPTION
Add Project Contour Announce mailing list to the community page.

This closes #1796.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>