### PR TITLE
internal/envoy: bump the max Envoy regex program size

### DIFF
--- a/internal/envoy/regex.go
+++ b/internal/envoy/regex.go
@@ -18,13 +18,23 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
+// maxRegexProgramSize is the default value for the Envoy regex max
+// program size tunable. There's no way to really know what a good
+// value for this is, except that the RE2 maintainer thinks that 100
+// is low. As a rule of thumb, each '.*' expression costs about 15
+// units of program size. AFAIK, there's no obvious correlation
+// between regex size and execution time.
+//
+// https://github.com/envoyproxy/envoy/pull/9171#discussion_r351974033
+const maxRegexProgramSize = 1000
+
 // SafeRegexMatch retruns a matcher.RegexMatcher for the supplied regex.
 // SafeRegexMatch does not escape regex meta characters.
 func SafeRegexMatch(regex string) *matcher.RegexMatcher {
 	return &matcher.RegexMatcher{
 		EngineType: &matcher.RegexMatcher_GoogleRe2{
 			GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-				MaxProgramSize: protobuf.UInt32(uint32(len(regex))),
+				MaxProgramSize: protobuf.UInt32(maxRegexProgramSize),
 			},
 		},
 		Regex: regex,

--- a/internal/envoy/regex_test.go
+++ b/internal/envoy/regex_test.go
@@ -31,7 +31,7 @@ func TestSafeRegexMatch(t *testing.T) {
 			want: &matcher.RegexMatcher{
 				EngineType: &matcher.RegexMatcher_GoogleRe2{
 					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-						MaxProgramSize: protobuf.UInt32(0),
+						MaxProgramSize: protobuf.UInt32(maxRegexProgramSize),
 					},
 				},
 			},
@@ -41,7 +41,7 @@ func TestSafeRegexMatch(t *testing.T) {
 			want: &matcher.RegexMatcher{
 				EngineType: &matcher.RegexMatcher_GoogleRe2{
 					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-						MaxProgramSize: protobuf.UInt32(6),
+						MaxProgramSize: protobuf.UInt32(maxRegexProgramSize),
 					},
 				},
 				Regex: "chrome",
@@ -52,7 +52,7 @@ func TestSafeRegexMatch(t *testing.T) {
 			want: &matcher.RegexMatcher{
 				EngineType: &matcher.RegexMatcher_GoogleRe2{
 					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-						MaxProgramSize: protobuf.UInt32(7),
+						MaxProgramSize: protobuf.UInt32(maxRegexProgramSize),
 					},
 				},
 				Regex: "[a-z]+$", // meta characters are not escaped.


### PR DESCRIPTION
There's no obvious way to know what a reasonable regex program
size is (and that's not really what the RE2 program size number
means).  However, Envoy makes us send something here and if it's
too low, it will NACK the update and Contour will not handle that
gracefully. So, we send a large number that should be enough for
all reasonable regex cases.

This fixes #2043.

Signed-off-by: James Peach <jpeach@vmware.com>