### PR TITLE
doc: link the GRPC TLS deployment page

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,4 +28,4 @@ If you have your own Grafana and Prometheus deployment already, the supplied [Co
 
 ## `kind`, `root-rbac`
 
-Both of these examples are fragments used in other documentation ([deploy-options](../docs/deploy-options.md) and [ingressroute](../docs/ingressroute.md) respectively.)
+Both of these examples are fragments used in other documentation ([deploy-options](https://projectcontour.io/docs/master/deploy-options) and [ingressroute](https://projectcontour.io/docs/master/ingressroute) respectively.)

--- a/examples/contour/README.md
+++ b/examples/contour/README.md
@@ -17,7 +17,7 @@ This configuration has several advantages:
   - `contourcert`: be a Secret of type `kubernetes.io/tls` and must contain `tls.crt` and `tls.key` keys that contain a certificate and key for Contour. The certificate must be valid for the name `contour` either via CN or SAN.
   - `envoycert`: be a Secret of type `kubernetes.io/tls` and must contain `tls.crt` and `tls.key` keys that contain a certificate and key for Envoy.
 
-For detailed instructions on how to configure the required certs manually, see the [step-by-step TLS HOWTO](https://projectcontour.io/guides/grpc-tls-howto).
+For detailed instructions on how to configure the required certs manually, see the [step-by-step TLS HOWTO](https://projectcontour.io/docs/master/grpc-tls-howto).
 
 ## Deploy Contour
 
@@ -44,7 +44,7 @@ This will:
 
 ## Test
 
-1. Install a workload (see the kuard example in the [main deployment guide](https://projectcontour.io/guides/deploy-options/#test-with-httpproxy)).
+1. Install a workload (see the kuard example in the [main deployment guide](https://projectcontour.io/docs/master/deploy-options/#test-with-httpproxy)).
 
 ## Deploying with Host Networking enabled for Envoy
 

--- a/site/_data/master-toc.yml
+++ b/site/_data/master-toc.yml
@@ -19,6 +19,8 @@ toc:
         url: /deploy-options
       - page: Upgrading Contour
         link: /resources/upgrading
+      - page: Enabling TLS between Envoy and Contour
+        url: /grpc-tls-howto
   - title: Guides
     subfolderitems:
       - page: Cert-Manager

--- a/site/_data/v1-0-0-toc.yml
+++ b/site/_data/v1-0-0-toc.yml
@@ -21,6 +21,8 @@ toc:
         url: /deploy-options
       - page: Upgrade
         link: /resources/upgrading
+      - page: Enabling TLS between Envoy and Contour
+        url: /grpc-tls-howto
   - title: Guides
     subfolderitems:
       - page: Cert-Manager

--- a/site/_data/v1-0-1-toc.yml
+++ b/site/_data/v1-0-1-toc.yml
@@ -21,6 +21,8 @@ toc:
         url: /deploy-options
       - page: Upgrade
         link: /resources/upgrading
+      - page: Enabling TLS between Envoy and Contour
+        url: /grpc-tls-howto
   - title: Guides
     subfolderitems:
       - page: Cert-Manager

--- a/site/docs/master/grpc-tls-howto.md
+++ b/site/docs/master/grpc-tls-howto.md
@@ -1,18 +1,13 @@
----
-title: Enabling TLS between Envoy and Contour
-layout: page
----
+# Enabling TLS between Envoy and Contour
+
 This document describes the steps required to secure communication between Envoy and Contour.
-
-## Outcomes
-
 The outcome of this is that we will have three Secrets available in the `projectcontour` namespace:
 
 - **cacert:** contains the CA's public certificate.
 - **contourcert:** contains Contour's keypair, used for serving TLS secured gRPC. This must be a valid certificate for the name `contour` in order for this to work. This is currently hardcoded by Contour.
 - **envoycert:** contains Envoy's keypair, used as a client for connecting to Contour.
 
-### Ways you can get the certificates into your cluster
+## Ways you can get the certificates into your cluster
 
 - Deploy the Job from [certgen.yaml][1].
 This will run `contour certgen --kube` for you.

--- a/site/docs/v1.0.0/grpc-tls-howto.md
+++ b/site/docs/v1.0.0/grpc-tls-howto.md
@@ -1,11 +1,6 @@
----
-title: Enabling TLS between Envoy and Contour
-layout: page
----
+# Enabling TLS between Envoy and Contour
+
 This document describes the steps required to secure communication between Envoy and Contour.
-
-## Outcomes
-
 The outcome of this is that we will have three Secrets available in the `projectcontour` namespace:
 
 - **cacert:** contains the CA's public certificate.

--- a/site/docs/v1.0.1/grpc-tls-howto.md
+++ b/site/docs/v1.0.1/grpc-tls-howto.md
@@ -1,18 +1,13 @@
----
-title: Enabling TLS between Envoy and Contour
-layout: page
----
+# Enabling TLS between Envoy and Contour
+
 This document describes the steps required to secure communication between Envoy and Contour.
-
-## Outcomes
-
 The outcome of this is that we will have three Secrets available in the `projectcontour` namespace:
 
 - **cacert:** contains the CA's public certificate.
 - **contourcert:** contains Contour's keypair, used for serving TLS secured gRPC. This must be a valid certificate for the name `contour` in order for this to work. This is currently hardcoded by Contour.
 - **envoycert:** contains Envoy's keypair, used as a client for connecting to Contour.
 
-### Ways you can get the certificates into your cluster
+## Ways you can get the certificates into your cluster
 
 - Deploy the Job from [certgen.yaml][1].
 This will run `contour certgen --kube` for you.


### PR DESCRIPTION
When the per-version documentation was changes, the documentation
for setting up TLS between Contour and Envoy wasn't linked. Add
links for all documentation versions and for the source tree
references.

This fixes #2055.

Signed-off-by: James Peach <jpeach@vmware.com>