### PR TITLE
Remove the restriction on websockets with weighted clusters.

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -671,11 +671,6 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 	}
 
 	for _, route := range proxy.Spec.Routes {
-		if len(route.Services) > 1 && route.EnableWebsockets {
-			sw.SetInvalid("route: cannot specify multiple services and enable websockets")
-			continue
-		}
-
 		if !pathConditionsValid(sw, route.Conditions, "route") {
 			return nil
 		}
@@ -905,12 +900,6 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 		// route cannot both delegate and point to services
 		if len(route.Services) > 0 && route.Delegate != nil {
 			sw.SetInvalid(fmt.Sprintf("route %q: cannot specify services and delegate in the same route", route.Match))
-			return
-		}
-
-		// Cannot support multiple services with websockets (See: https://github.com/projectcontour/contour/issues/732)
-		if len(route.Services) > 1 && route.EnableWebsockets {
-			sw.SetInvalid(fmt.Sprintf("route %q: cannot specify multiple services and enable websockets", route.Match))
 			return
 		}
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1293,9 +1293,6 @@ func TestDAGInsert(t *testing.T) {
 				Services: []ingressroutev1.Service{{
 					Name: "kuard",
 					Port: 8080,
-				}, {
-					Name: "kuard",
-					Port: 8080,
 				}},
 			}},
 		},
@@ -2244,9 +2241,6 @@ func TestDAGInsert(t *testing.T) {
 				}},
 				EnableWebsockets: true,
 				Services: []projcontour.Service{{
-					Name: "kuard",
-					Port: 8080,
-				}, {
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -3508,7 +3502,7 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-		"insert ingressroute with multiple upstreams prefix rewrite route, websocket routes are dropped": {
+		"insert ingressroute with multiple upstreams prefix rewrite route with websockets on a single upstream": {
 			objs: []interface{}{
 				ir10b, s1,
 			},
@@ -3518,6 +3512,7 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
 							prefixroute("/", service(s1)),
+							routeWebsocket("/websocket", service(s1)),
 						),
 					),
 				},
@@ -4865,7 +4860,7 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-		"insert httpproxy with multiple upstreams prefix rewrite route, websocket routes are dropped": {
+		"insert httpproxy with multiple upstreams prefix rewrite route and websockets along one path": {
 			objs: []interface{}{
 				proxy10b, s1,
 			},
@@ -4875,6 +4870,7 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
 							prefixroute("/", service(s1)),
+							routeWebsocket("/websocket", service(s1)),
 						),
 					),
 				},


### PR DESCRIPTION
Envoy has fixed the issue related to using websockets with weighted clusters, so this drops the exclusion which kept those clusters out of the DAG.

Fixes: https://github.com/projectcontour/contour/issues/2054

cc @stevesloka 