### PR TITLE
internal/contour: Add missing HTTPProxy compare check in EventHandler updates

### DIFF
--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -188,6 +188,7 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 	case opUpdate:
 		if cmp.Equal(op.oldObj, op.newObj,
 			cmpopts.IgnoreFields(ingressroutev1.IngressRoute{}, "Status"),
+			cmpopts.IgnoreFields(projcontour.HTTPProxy{}, "Status"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")) {
 			e.WithField("op", "update").Debugf("%T skipping update, only status has changed", op.newObj)
 			return false


### PR DESCRIPTION
Found the EventHandler update compare logic was missing skipping `HTTPProxy` objects.

Signed-off-by: Steve Sloka <slokas@vmware.com>