### PR TITLE
Add .gitattributes to hide generated code from code reviews.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+# Collapse generated code in code reviews.
+**/zz_generated.*.go linguist-generated=true
+/apis/generated/** linguist-generated=true


### PR DESCRIPTION
We use this file to collapse generated files by default in code reviews in [Knative](https://github.com/knative/serving/blob/270c395bf985566649f3993b9d3f1c446518211d/.gitattributes#L5-L7), and it is generally useful to improve signal-to-noise ratios in changes that touch API surfaces.

Not sure if y'all want this, but I figured I'd see if there was interest :)