### PR TITLE
interna/dag: accept format strings for status messages

### DIFF
--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -14,7 +14,6 @@
 package dag
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -56,12 +55,12 @@ func pathConditionsValid(sw *ObjectStatusWriter, conds []projcontour.Condition, 
 		if cond.Prefix != "" {
 			prefixCount++
 			if cond.Prefix[0] != '/' {
-				sw.SetInvalid(fmt.Sprintf("%s: Prefix conditions must start with /, %s was supplied", conditionsContext, cond.Prefix))
+				sw.SetInvalid("%s: Prefix conditions must start with /, %s was supplied", conditionsContext, cond.Prefix)
 				return false
 			}
 		}
 		if prefixCount > 1 {
-			sw.SetInvalid(fmt.Sprintf("%s: More than one prefix is not allowed in a condition block", conditionsContext))
+			sw.SetInvalid("%s: More than one prefix is not allowed in a condition block", conditionsContext)
 			return false
 		}
 	}

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -14,6 +14,8 @@
 package dag
 
 import (
+	"fmt"
+
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -85,8 +87,8 @@ func (osw *ObjectStatusWriter) WithValue(key, val string) *ObjectStatusWriter {
 	return osw
 }
 
-func (osw *ObjectStatusWriter) SetInvalid(desc string) {
-	osw.WithValue("description", desc).WithValue("status", k8s.StatusInvalid)
+func (osw *ObjectStatusWriter) SetInvalid(format string, args ...interface{}) {
+	osw.WithValue("description", fmt.Sprintf(format, args...)).WithValue("status", k8s.StatusInvalid)
 }
 
 func (osw *ObjectStatusWriter) SetValid() {


### PR DESCRIPTION
There are a fair number of locations that use fmt.Sprintf to
format errors for the object status writer. Simplify the call
sites by accepting a format string and formatting internally.

Signed-off-by: James Peach <jpeach@vmware.com>