### PR TITLE
Implement support for specifying a service's protocol in HTTPProxy.

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -196,6 +196,10 @@ type Service struct {
 	Name string `json:"name"`
 	// Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
 	Port int `json:"port"`
+	// Protocol may be used to specify (or override) the protocol used to reach this Service.
+	// Values may be tls, h2, h2c.  It ommitted protocol-selection falls back on Service annotations.
+	// +optional
+	Protocol *string `json:"protocol,omitempty"`
 	// Weight defines percentage of traffic to balance traffic
 	// +optional
 	Weight uint32 `json:"weight,omitempty"`

--- a/design/httpproxy-protocol-selection.md
+++ b/design/httpproxy-protocol-selection.md
@@ -48,6 +48,8 @@ Require downstream consumers to annotate K8s Services with Contour annotations (
 
 Adopt a port-naming convention like the one defined by [Istio](https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/).
 
+Waiting for [KEP 1422](https://github.com/kubernetes/enhancements/pull/1422), which proposes building similar hints into the Kubernetes service itself.  Realistically this is over a year away from being a viable alternative.
+
 ## Security Considerations
 
 None at this time.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -752,6 +752,12 @@ spec:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
                           type: integer
+                        protocol:
+                          description: Protocol may be used to specify (or override)
+                            the protocol used to reach this Service. Values may be
+                            tls, h2, h2c.  It ommitted protocol-selection falls back
+                            on Service annotations.
+                          type: string
                         requestHeadersPolicy:
                           description: The policy for managing request headers during
                             proxying
@@ -900,6 +906,12 @@ spec:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
                         type: integer
+                      protocol:
+                        description: Protocol may be used to specify (or override)
+                          the protocol used to reach this Service. Values may be tls,
+                          h2, h2c.  It ommitted protocol-selection falls back on Service
+                          annotations.
+                        type: string
                       requestHeadersPolicy:
                         description: The policy for managing request headers during
                           proxying

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -826,6 +826,12 @@ spec:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
                           type: integer
+                        protocol:
+                          description: Protocol may be used to specify (or override)
+                            the protocol used to reach this Service. Values may be
+                            tls, h2, h2c.  It ommitted protocol-selection falls back
+                            on Service annotations.
+                          type: string
                         requestHeadersPolicy:
                           description: The policy for managing request headers during
                             proxying
@@ -974,6 +980,12 @@ spec:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
                         type: integer
+                      protocol:
+                        description: Protocol may be used to specify (or override)
+                          the protocol used to reach this Service. Values may be tls,
+                          h2, h2c.  It ommitted protocol-selection falls back on Service
+                          annotations.
+                        type: string
                       requestHeadersPolicy:
                         description: The policy for managing request headers during
                           proxying

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -619,6 +619,23 @@ func expandPrefixMatches(routes []*Route) []*Route {
 	return expandedRoutes
 }
 
+func (b *Builder) getProtocol(sw *ObjectStatusWriter, service projcontour.Service, s *Service) (string, error) {
+	// Determine the protocol to use to speak to this Cluster.
+	var protocol string
+	if service.Protocol != nil {
+		protocol = *service.Protocol
+		switch protocol {
+		case "h2c", "h2", "tls":
+		default:
+			return "", fmt.Errorf("unsupported protocol: %v", protocol)
+		}
+	} else {
+		protocol = s.Protocol
+	}
+
+	return protocol, nil
+}
+
 func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPProxy, conditions []projcontour.Condition, visited []*projcontour.HTTPProxy, enforceTLS bool) []*Route {
 	for _, v := range visited {
 		// ensure we are not following an edge that produces a cycle
@@ -757,9 +774,15 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				return nil
 			}
 
+			// Determine the protocol to use to speak to this Cluster.
+			protocol, err := b.getProtocol(sw, service, s)
+			if err != nil {
+				sw.SetInvalid(err.Error())
+				return nil
+			}
+
 			var uv *UpstreamValidation
-			var err error
-			if s.Protocol == "tls" {
+			if protocol == "tls" {
 				// we can only validate TLS connections to services that talk TLS
 				uv, err = b.lookupUpstreamValidation("??", service.Name, service.UpstreamValidation, proxy.Namespace)
 				if err != nil {
@@ -788,6 +811,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				UpstreamValidation:    uv,
 				RequestHeadersPolicy:  reqHP,
 				ResponseHeadersPolicy: respHP,
+				Protocol:              protocol,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				sw.SetInvalid("only one service per route may be nominated as mirror")
@@ -959,8 +983,8 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 					return
 				}
 				m := Meta{name: service.Name, namespace: ir.Namespace}
-				s := b.lookupService(m, intstr.FromInt(service.Port))
 
+				s := b.lookupService(m, intstr.FromInt(service.Port))
 				if s == nil {
 					sw.SetInvalid("Service [%s:%d] is invalid or missing", service.Name, service.Port)
 					return
@@ -976,12 +1000,14 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 						return
 					}
 				}
+
 				r.Clusters = append(r.Clusters, &Cluster{
 					Upstream:           s,
 					LoadBalancerPolicy: service.Strategy,
 					Weight:             service.Weight,
 					HealthCheckPolicy:  ingressrouteHealthCheckPolicy(service.HealthCheck),
 					UpstreamValidation: uv,
+					Protocol:           s.Protocol,
 				})
 			}
 
@@ -1079,6 +1105,7 @@ func (b *Builder) processIngressRouteTCPProxy(sw *ObjectStatusWriter, ir *ingres
 			proxy.Clusters = append(proxy.Clusters, &Cluster{
 				Upstream:           s,
 				LoadBalancerPolicy: service.Strategy,
+				Protocol:           s.Protocol,
 			})
 		}
 		b.lookupSecureVirtualHost(host).TCPProxy = &proxy
@@ -1153,6 +1180,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 			proxy.Clusters = append(proxy.Clusters, &Cluster{
 				Upstream:           s,
 				LoadBalancerPolicy: loadBalancerPolicy(tcpproxy.LoadBalancerPolicy),
+				Protocol:           s.Protocol,
 			})
 		}
 		b.lookupSecureVirtualHost(host).TCPProxy = &proxy
@@ -1226,6 +1254,7 @@ func route(ingress *v1beta1.Ingress, path string, service *Service) *Route {
 		RetryPolicy:   ingressRetryPolicy(ingress),
 		Clusters: []*Cluster{{
 			Upstream: service,
+			Protocol: service.Protocol,
 		}},
 	}
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -366,6 +366,9 @@ type Cluster struct {
 	// The relative weight of this Cluster compared to its siblings.
 	Weight uint32
 
+	// The protocol to use to speak to this cluster.
+	Protocol string
+
 	// UpstreamValidation defines how to verify the backend service's certificate
 	UpstreamValidation *UpstreamValidation
 

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -78,7 +78,7 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 		}
 	}
 
-	switch c.Upstream.Protocol {
+	switch c.Protocol {
 	case "tls":
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -100,6 +100,7 @@ func TestCluster(t *testing.T) {
 		"h2c upstream": {
 			cluster: &dag.Cluster{
 				Upstream: service(s1, "h2c"),
+				Protocol: "h2c",
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -115,6 +116,7 @@ func TestCluster(t *testing.T) {
 		"h2 upstream": {
 			cluster: &dag.Cluster{
 				Upstream: service(s1, "h2"),
+				Protocol: "h2",
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -144,6 +146,7 @@ func TestCluster(t *testing.T) {
 		"tls upstream": {
 			cluster: &dag.Cluster{
 				Upstream: service(s1, "tls"),
+				Protocol: "tls",
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -161,6 +164,7 @@ func TestCluster(t *testing.T) {
 		"tls upstream - external name": {
 			cluster: &dag.Cluster{
 				Upstream: service(svcExternal, "tls"),
+				Protocol: "tls",
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -175,6 +179,7 @@ func TestCluster(t *testing.T) {
 		"verify tls upstream with san": {
 			cluster: &dag.Cluster{
 				Upstream: service(s1, "tls"),
+				Protocol: "tls",
 				UpstreamValidation: &dag.UpstreamValidation{
 					CACertificate: &dag.Secret{
 						Object: &v1.Secret{


### PR DESCRIPTION
Fixes: #1962
Fixes: #2056

This is based on the design in: https://github.com/projectcontour/contour/pull/2072, which is also included as the base commit here.

Signed-off-by: Matt Moore <mattmoor@vmware.com>