### PR TITLE
Pre-size the array when dumping EndpointTranslator Contents()

### DIFF
--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -79,7 +79,7 @@ func (e *EndpointsTranslator) Contents() []proto.Message {
 func (e *EndpointsTranslator) Query(names []string) []proto.Message {
 	e.clusterLoadAssignmentCache.mu.Lock()
 	defer e.clusterLoadAssignmentCache.mu.Unlock()
-	var values []proto.Message
+	values := make([]proto.Message, 0, len(names))
 	for _, n := range names {
 		v, ok := e.entries[n]
 		if !ok {
@@ -220,7 +220,7 @@ func (c *clusterLoadAssignmentCache) Remove(name string) {
 func (c *clusterLoadAssignmentCache) Contents() []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var values []proto.Message
+	values := make([]proto.Message, 0, len(c.entries))
 	for _, v := range c.entries {
 		values = append(values, v)
 	}

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -30,7 +30,7 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 	}{
 		"empty": {
 			contents: nil,
-			want:     nil,
+			want:     []proto.Message{},
 		},
 		"simple": {
 			contents: clusterloadassignments(
@@ -256,6 +256,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
+			want: []proto.Message{},
 		},
 		"remove different": {
 			setup: func(et *EndpointsTranslator) {
@@ -284,6 +285,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
+			want: []proto.Message{},
 		},
 		"remove long name": {
 			setup: func(et *EndpointsTranslator) {
@@ -317,6 +319,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					),
 				},
 			),
+			want: []proto.Message{},
 		},
 	}
 
@@ -389,8 +392,10 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 					port("", 8080),
 				),
 			}),
+			want: []proto.Message{},
 		},
 	}
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var et EndpointsTranslator
@@ -425,7 +430,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 	et.OnUpdate(e1, e2)
 
 	// Assert endpoints are removed
-	want = nil
+	want = []proto.Message{}
 	got = et.Contents()
 
 	assert.Equal(t, want, got)


### PR DESCRIPTION
Just something I noticed poking around.

Signed-off-by: Matt Moore <mattmoor@vmware.com>