### PR TITLE
cmd/contour: improve Kubernetes client error message

### DIFF
--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -128,6 +128,11 @@ func OutputCerts(config *certgenConfig,
 func doCertgen(config *certgenConfig) {
 	generatedCerts, err := GenerateCerts(config)
 	check(err)
-	kubeclient, _, _ := newClient(config.KubeConfig, config.InCluster)
-	OutputCerts(config, kubeclient, generatedCerts)
+
+	clients, err := newKubernetesClients(config.KubeConfig, config.InCluster)
+	if err != nil {
+		check(fmt.Errorf("failed to create Kubernetes client: %w", err))
+	}
+
+	OutputCerts(config, clients.core, generatedCerts)
 }


### PR DESCRIPTION
If Contour failes to create a Kubernetes API clien on startup,
add context to the message to make it clear what kind of problem
happened.

For example, if you are running a local Contour and don't have a
current Kubernetes context, Contour would previously exit with the
message "invalid configuration: no configuration has been provided".
This doesn't make it clear the problem is the Kubernetes config,
not the Contour config.

Signed-off-by: James Peach <jpeach@vmware.com>