### PR TITLE
site: Change ordering of releases so the docs menu is in proper order

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -81,8 +81,8 @@ versioning: true
 latest: v1.0.1
 versions:
   - master
-  - v1.0.0
   - v1.0.1
+  - v1.0.0
 
 # Build settings
 permalink: :title/

--- a/site/_data/toc-mapping.yml
+++ b/site/_data/toc-mapping.yml
@@ -3,5 +3,6 @@
 # that the navigation for older versions still work.
 
 master: master-toc
-v1.0.0: v1-0-0-toc
 v1.0.1: v1-0-1-toc
+v1.0.0: v1-0-0-toc
+


### PR DESCRIPTION
This fixes #2033  by changing the order of the release so the drop-down menu follows the most recent release to oldest. 

Signed-off-by: Steve Sloka <slokas@vmware.com>