### PR TITLE
examples: Add 'ttlSecondsFinished' to the certgen job and set the image to latest

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -44,6 +44,7 @@ metadata:
   name: contour-certgen
   namespace: projectcontour
 spec:
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       labels:
@@ -51,7 +52,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:latest
         imagePullPolicy: Always
         command:
         - contour

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1050,6 +1050,7 @@ metadata:
   name: contour-certgen
   namespace: projectcontour
 spec:
+  ttlSecondsAfterFinished: 0
   template:
     metadata:
       labels:
@@ -1057,7 +1058,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:latest
         imagePullPolicy: IfNotPresent
         command:
         - contour


### PR DESCRIPTION
Fixes #2030 by implementing the following:

- Update the certgen job to use docker tag `latest`
- Add `ttlSecondsAfterFinished: 0` which if running a cluster v1.12+ and enabled feature gate will delete the cert-gen job after the job is complete

Signed-off-by: Steve Sloka <slokas@vmware.com>