### PR TITLE
cli: improve help text consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ Check_Targets := \
 	check-ineffassign \
 	check-yamllint \
 	check-stale \
+	check-flags
 
 .PHONY: check
 check: install $(Check_Targets) ## Run tests and CI checks
@@ -142,6 +143,23 @@ check-gofmt:
 .PHONY: check-vet
 check-vet: | check-test
 	go vet $(MODULE)/...
+
+
+# Check that CLI flags are formatted consistently. We are checking
+# for calls to Kingping Flags() and Command() APIs where the 2nd
+# argument (the help text) either doesn't start with a capital letter
+# or doesn't end with a period. "xDS" and "gRPC" are exceptions to
+# the first rule.
+.PHONY: check-flags
+check-flags:
+	@if git grep --extended-regexp '[.]Flag\("[^"]+", "([^A-Zxg][^"]+|[^"]+[^.])"' cmd/contour; then \
+		echo "ERROR: CLI flag help strings must start with a capital and end with a period."; \
+		exit 2; \
+	fi
+	@if git grep --extended-regexp '[.]Command\("[^"]+", "([^A-Z][^"]+|[^"]+[^.])"' cmd/contour; then \
+		echo "ERROR: CLI flag help strings must start with a capital and end with a period."; \
+		exit 2; \
+	fi
 
 # TODO(youngnick): Move these local bootstrap config files out of the repo root dir.
 $(LOCAL_BOOTSTRAP_CONFIG): install

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -28,15 +28,15 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *bootstrap
 	var ctx bootstrapContext
 
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
-	bootstrap.Arg("path", "Configuration file ('-' for standard output)").Required().StringVar(&ctx.path)
-	bootstrap.Flag("admin-address", "Envoy admin interface address").StringVar(&ctx.config.AdminAddress)
-	bootstrap.Flag("admin-port", "Envoy admin interface port").IntVar(&ctx.config.AdminPort)
-	bootstrap.Flag("xds-address", "xDS gRPC API address").StringVar(&ctx.config.XDSAddress)
-	bootstrap.Flag("xds-port", "xDS gRPC API port").IntVar(&ctx.config.XDSGRPCPort)
-	bootstrap.Flag("envoy-cafile", "gRPC CA Filename for Envoy to load").Envar("ENVOY_CAFILE").StringVar(&ctx.config.GrpcCABundle)
-	bootstrap.Flag("envoy-cert-file", "gRPC Client cert filename for Envoy to load").Envar("ENVOY_CERT_FILE").StringVar(&ctx.config.GrpcClientCert)
-	bootstrap.Flag("envoy-key-file", "gRPC Client key filename for Envoy to load").Envar("ENVOY_KEY_FILE").StringVar(&ctx.config.GrpcClientKey)
-	bootstrap.Flag("namespace", "The namespace the Envoy container will run in").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&ctx.config.Namespace)
+	bootstrap.Arg("path", "Configuration file ('-' for standard output).").Required().StringVar(&ctx.path)
+	bootstrap.Flag("admin-address", "Envoy admin interface address.").StringVar(&ctx.config.AdminAddress)
+	bootstrap.Flag("admin-port", "Envoy admin interface port.").IntVar(&ctx.config.AdminPort)
+	bootstrap.Flag("xds-address", "xDS gRPC API address.").StringVar(&ctx.config.XDSAddress)
+	bootstrap.Flag("xds-port", "xDS gRPC API port.").IntVar(&ctx.config.XDSGRPCPort)
+	bootstrap.Flag("envoy-cafile", "gRPC CA Filename for Envoy to load.").Envar("ENVOY_CAFILE").StringVar(&ctx.config.GrpcCABundle)
+	bootstrap.Flag("envoy-cert-file", "gRPC Client cert filename for Envoy to load.").Envar("ENVOY_CERT_FILE").StringVar(&ctx.config.GrpcClientCert)
+	bootstrap.Flag("envoy-key-file", "gRPC Client key filename for Envoy to load.").Envar("ENVOY_KEY_FILE").StringVar(&ctx.config.GrpcClientKey)
+	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&ctx.config.Namespace)
 	return bootstrap, &ctx
 }
 

--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -28,16 +28,16 @@ import (
 // with the Application provided.
 func registerCertGen(app *kingpin.Application) (*kingpin.CmdClause, *certgenConfig) {
 	var certgenConfig certgenConfig
-	certgenApp := app.Command("certgen", "Generate new TLS certs for bootstrapping gRPC over TLS")
-	certgenApp.Flag("kube", "Apply the generated certs directly to the current Kubernetes cluster").BoolVar(&certgenConfig.OutputKube)
-	certgenApp.Flag("yaml", "Render the generated certs as Kubernetes Secrets in YAML form to the current directory").BoolVar(&certgenConfig.OutputYAML)
-	certgenApp.Flag("pem", "Render the generated certs as individual PEM files to the current directory").BoolVar(&certgenConfig.OutputPEM)
-	certgenApp.Flag("incluster", "use in cluster configuration.").BoolVar(&certgenConfig.InCluster)
-	certgenApp.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&certgenConfig.KubeConfig)
-	certgenApp.Flag("namespace", "Kubernetes namespace, used for Kube objects").Default("projectcontour").Envar("CONTOUR_NAMESPACE").StringVar(&certgenConfig.Namespace)
-	certgenApp.Arg("outputdir", "Directory to output any files to").Default("certs").StringVar(&certgenConfig.OutputDir)
+	certgenApp := app.Command("certgen", "Generate new TLS certs for bootstrapping gRPC over TLS.")
+	certgenApp.Flag("kube", "Apply the generated certs directly to the current Kubernetes cluster.").BoolVar(&certgenConfig.OutputKube)
+	certgenApp.Flag("yaml", "Render the generated certs as Kubernetes Secrets in YAML form to the current directory.").BoolVar(&certgenConfig.OutputYAML)
+	certgenApp.Flag("pem", "Render the generated certs as individual PEM files to the current directory.").BoolVar(&certgenConfig.OutputPEM)
+	certgenApp.Flag("incluster", "Use in cluster configuration.").BoolVar(&certgenConfig.InCluster)
+	certgenApp.Flag("kubeconfig", "Path to kubeconfig (if not in running inside a cluster).").Default(filepath.Join(os.Getenv("HOME"), ".kube", "config")).StringVar(&certgenConfig.KubeConfig)
+	certgenApp.Flag("namespace", "Kubernetes namespace, used for Kube objects.").Default("projectcontour").Envar("CONTOUR_NAMESPACE").StringVar(&certgenConfig.Namespace)
+	certgenApp.Arg("outputdir", "Directory to write output files into.").Default("certs").StringVar(&certgenConfig.OutputDir)
 	// NOTE: --certificate-lifetime can be used to accept Duration string once certificate rotation is supported.
-	certgenApp.Flag("certificate-lifetime", "Generated certificate lifetime (in days)").Default("365").UintVar(&certgenConfig.Lifetime)
+	certgenApp.Flag("certificate-lifetime", "Generated certificate lifetime (in days).").Default("365").UintVar(&certgenConfig.Lifetime)
 
 	return certgenApp, &certgenConfig
 }

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -46,21 +46,21 @@ func main() {
 
 	cli := app.Command("cli", "A CLI client for the Contour Kubernetes ingress controller.")
 	var client Client
-	cli.Flag("contour", "contour host:port.").Default("127.0.0.1:8001").StringVar(&client.ContourAddr)
-	cli.Flag("cafile", "CA bundle file for connecting to a TLS-secured Contour").Envar("CLI_CAFILE").StringVar(&client.CAFile)
-	cli.Flag("cert-file", "Client certificate file for connecting to a TLS-secured Contour").Envar("CLI_CERT_FILE").StringVar(&client.ClientCert)
-	cli.Flag("key-file", "Client key file for connecting to a TLS-secured Contour").Envar("CLI_KEY_FILE").StringVar(&client.ClientKey)
+	cli.Flag("contour", "Contour host:port.").Default("127.0.0.1:8001").StringVar(&client.ContourAddr)
+	cli.Flag("cafile", "CA bundle file for connecting to a TLS-secured Contour.").Envar("CLI_CAFILE").StringVar(&client.CAFile)
+	cli.Flag("cert-file", "Client certificate file for connecting to a TLS-secured Contour.").Envar("CLI_CERT_FILE").StringVar(&client.ClientCert)
+	cli.Flag("key-file", "Client key file for connecting to a TLS-secured Contour.").Envar("CLI_KEY_FILE").StringVar(&client.ClientKey)
 
 	var resources []string
-	cds := cli.Command("cds", "watch services.")
+	cds := cli.Command("cds", "Watch services.")
 	cds.Arg("resources", "CDS resource filter").StringsVar(&resources)
-	eds := cli.Command("eds", "watch endpoints.")
+	eds := cli.Command("eds", "Watch endpoints.")
 	eds.Arg("resources", "EDS resource filter").StringsVar(&resources)
-	lds := cli.Command("lds", "watch listeners.")
+	lds := cli.Command("lds", "Watch listeners.")
 	lds.Arg("resources", "LDS resource filter").StringsVar(&resources)
-	rds := cli.Command("rds", "watch routes.")
+	rds := cli.Command("rds", "Watch routes.")
 	rds.Arg("resources", "RDS resource filter").StringsVar(&resources)
-	sds := cli.Command("sds", "watch secrets.")
+	sds := cli.Command("sds", "Watch secrets.")
 	sds.Arg("resources", "SDS resource filter").StringsVar(&resources)
 
 	serve, serveCtx := registerServe(app)

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -46,7 +46,7 @@ import (
 // registerServe registers the serve subcommand and flags
 // with the Application provided.
 func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext) {
-	serve := app.Command("serve", "Serve xDS API traffic")
+	serve := app.Command("serve", "Serve xDS API traffic.")
 
 	// The precedence of configuration for contour serve is as follows:
 	// config file, overridden by env vars, overridden by cli flags.
@@ -77,45 +77,45 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 		return dec.Decode(&ctx)
 	}
 
-	serve.Flag("config-path", "path to base configuration").Short('c').Action(parseConfig).ExistingFileVar(&configFile)
+	serve.Flag("config-path", "Path to base configuration.").Short('c').Action(parseConfig).ExistingFileVar(&configFile)
 
-	serve.Flag("incluster", "use in cluster configuration.").BoolVar(&ctx.InCluster)
-	serve.Flag("kubeconfig", "path to kubeconfig (if not in running inside a cluster)").StringVar(&ctx.Kubeconfig)
+	serve.Flag("incluster", "Use in cluster configuration.").BoolVar(&ctx.InCluster)
+	serve.Flag("kubeconfig", "Path to kubeconfig (if not in running inside a cluster).").StringVar(&ctx.Kubeconfig)
 
-	serve.Flag("xds-address", "xDS gRPC API address").StringVar(&ctx.xdsAddr)
-	serve.Flag("xds-port", "xDS gRPC API port").IntVar(&ctx.xdsPort)
+	serve.Flag("xds-address", "xDS gRPC API address.").StringVar(&ctx.xdsAddr)
+	serve.Flag("xds-port", "xDS gRPC API port.").IntVar(&ctx.xdsPort)
 
-	serve.Flag("stats-address", "Envoy /stats interface address").StringVar(&ctx.statsAddr)
-	serve.Flag("stats-port", "Envoy /stats interface port").IntVar(&ctx.statsPort)
+	serve.Flag("stats-address", "Envoy /stats interface address.").StringVar(&ctx.statsAddr)
+	serve.Flag("stats-port", "Envoy /stats interface port.").IntVar(&ctx.statsPort)
 
-	serve.Flag("debug-http-address", "address the debug http endpoint will bind to").StringVar(&ctx.debugAddr)
-	serve.Flag("debug-http-port", "port the debug http endpoint will bind to").IntVar(&ctx.debugPort)
+	serve.Flag("debug-http-address", "Address the debug http endpoint will bind to.").StringVar(&ctx.debugAddr)
+	serve.Flag("debug-http-port", "Port the debug http endpoint will bind to.").IntVar(&ctx.debugPort)
 
-	serve.Flag("http-address", "address the metrics http endpoint will bind to").StringVar(&ctx.metricsAddr)
-	serve.Flag("http-port", "port the metrics http endpoint will bind to").IntVar(&ctx.metricsPort)
+	serve.Flag("http-address", "Address the metrics http endpoint will bind to.").StringVar(&ctx.metricsAddr)
+	serve.Flag("http-port", "Port the metrics http endpoint will bind to.").IntVar(&ctx.metricsPort)
 
-	serve.Flag("contour-cafile", "CA bundle file name for serving gRPC with TLS").Envar("CONTOUR_CAFILE").StringVar(&ctx.caFile)
-	serve.Flag("contour-cert-file", "Contour certificate file name for serving gRPC over TLS").Envar("CONTOUR_CERT_FILE").StringVar(&ctx.contourCert)
-	serve.Flag("contour-key-file", "Contour key file name for serving gRPC over TLS").Envar("CONTOUR_KEY_FILE").StringVar(&ctx.contourKey)
-	serve.Flag("insecure", "Allow serving without TLS secured gRPC").BoolVar(&ctx.PermitInsecureGRPC)
+	serve.Flag("contour-cafile", "CA bundle file name for serving gRPC with TLS.").Envar("CONTOUR_CAFILE").StringVar(&ctx.caFile)
+	serve.Flag("contour-cert-file", "Contour certificate file name for serving gRPC over TLS.").Envar("CONTOUR_CERT_FILE").StringVar(&ctx.contourCert)
+	serve.Flag("contour-key-file", "Contour key file name for serving gRPC over TLS.").Envar("CONTOUR_KEY_FILE").StringVar(&ctx.contourKey)
+	serve.Flag("insecure", "Allow serving without TLS secured gRPC.").BoolVar(&ctx.PermitInsecureGRPC)
 	// TODO(sas) Deprecate `ingressroute-root-namespaces` in v1.0
-	serve.Flag("ingressroute-root-namespaces", "DEPRECATED (Use 'root-namespaces'): Restrict contour to searching these namespaces for root ingress routes").StringVar(&ctx.rootNamespaces)
-	serve.Flag("root-namespaces", "Restrict contour to searching these namespaces for root ingress routes").StringVar(&ctx.rootNamespaces)
+	serve.Flag("ingressroute-root-namespaces", "DEPRECATED (Use 'root-namespaces'): Restrict contour to searching these namespaces for root ingress routes.").StringVar(&ctx.rootNamespaces)
+	serve.Flag("root-namespaces", "Restrict contour to searching these namespaces for root ingress routes.").StringVar(&ctx.rootNamespaces)
 
-	serve.Flag("ingress-class-name", "Contour IngressClass name").StringVar(&ctx.ingressClass)
+	serve.Flag("ingress-class-name", "Contour IngressClass name.").StringVar(&ctx.ingressClass)
 
-	serve.Flag("envoy-http-access-log", "Envoy HTTP access log").StringVar(&ctx.httpAccessLog)
-	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log").StringVar(&ctx.httpsAccessLog)
-	serve.Flag("envoy-service-http-address", "Kubernetes Service address for HTTP requests").StringVar(&ctx.httpAddr)
-	serve.Flag("envoy-service-https-address", "Kubernetes Service address for HTTPS requests").StringVar(&ctx.httpsAddr)
-	serve.Flag("envoy-service-http-port", "Kubernetes Service port for HTTP requests").IntVar(&ctx.httpPort)
-	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests").IntVar(&ctx.httpsPort)
-	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners").BoolVar(&ctx.useProxyProto)
+	serve.Flag("envoy-http-access-log", "Envoy HTTP access log.").StringVar(&ctx.httpAccessLog)
+	serve.Flag("envoy-https-access-log", "Envoy HTTPS access log.").StringVar(&ctx.httpsAccessLog)
+	serve.Flag("envoy-service-http-address", "Kubernetes Service address for HTTP requests.").StringVar(&ctx.httpAddr)
+	serve.Flag("envoy-service-https-address", "Kubernetes Service address for HTTPS requests.").StringVar(&ctx.httpsAddr)
+	serve.Flag("envoy-service-http-port", "Kubernetes Service port for HTTP requests.").IntVar(&ctx.httpPort)
+	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests.").IntVar(&ctx.httpsPort)
+	serve.Flag("use-proxy-protocol", "Use PROXY protocol for all listeners.").BoolVar(&ctx.useProxyProto)
 
-	serve.Flag("accesslog-format", "Format for Envoy access logs").StringVar(&ctx.AccessLogFormat)
-	serve.Flag("disable-leader-election", "Disable leader election mechanism").BoolVar(&ctx.DisableLeaderElection)
+	serve.Flag("accesslog-format", "Format for Envoy access logs.").StringVar(&ctx.AccessLogFormat)
+	serve.Flag("disable-leader-election", "Disable leader election mechanism.").BoolVar(&ctx.DisableLeaderElection)
 
-	serve.Flag("use-extensions-v1beta1-ingress", "Subscribe to the deprecated extensions/v1beta1.Ingress type").BoolVar(&ctx.UseExtensionsV1beta1Ingress)
+	serve.Flag("use-extensions-v1beta1-ingress", "Subscribe to the deprecated extensions/v1beta1.Ingress type.").BoolVar(&ctx.UseExtensionsV1beta1Ingress)
 	return serve, ctx
 }
 


### PR DESCRIPTION
Improve CLI help text by making all the help text for flags and
subcommands begin with a capital letter and end with a period.

Signed-off-by: James Peach <jpeach@vmware.com>