### PR TITLE
api: consistently use the +optional annotation

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -150,13 +150,13 @@ type Route struct {
 	// The policy for rewriting the path of the request URL
 	// after the request has been routed to a Service.
 	//
-	// +kubebuilder:validation:Optional
+	// +optional
 	PathRewritePolicy *PathRewritePolicy `json:"pathRewritePolicy,omitempty"`
 	// The policy for managing request headers during proxying
-	// +kubebuilder:validation:Optional
+	// +optional
 	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
 	// The policy for managing response headers during proxying
-	// +kubebuilder:validation:Optional
+	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
 
@@ -209,10 +209,10 @@ type Service struct {
 	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
 	Mirror bool `json:"mirror,omitempty"`
 	// The policy for managing request headers during proxying
-	// +kubebuilder:validation:Optional
+	// +optional
 	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
 	// The policy for managing response headers during proxying
-	// +kubebuilder:validation:Optional
+	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
 
@@ -280,7 +280,7 @@ type ReplacePrefix struct {
 	// If Prefix is not specified, all routing prefixes rendered
 	// by the include chain will be replaced.
 	//
-	// +kubebuilder:validation:Optional
+	// +optional
 	// +kubebuilder:validation:MinLength=1
 	Prefix string `json:"prefix,omitempty"`
 
@@ -300,7 +300,7 @@ type ReplacePrefix struct {
 // Exactly one field in this struct may be specified.
 type PathRewritePolicy struct {
 	// ReplacePrefix describes how the path prefix should be replaced.
-	// +kubebuilder:validation:Optional
+	// +optional
 	ReplacePrefix []ReplacePrefix `json:"replacePrefix,omitempty"`
 }
 
@@ -312,10 +312,10 @@ type LoadBalancerPolicy struct {
 // HeadersPolicy defines how headers are managed during forwarding
 type HeadersPolicy struct {
 	// Set specifies a list of HTTP header values that will be set in the HTTP header
-	// +kubebuilder:validation:Optional
+	// +optional
 	Set []HeaderValue `json:"set,omitempty"`
 	// Remove specifies a list of HTTP header names to remove
-	// +kubebuilder:validation:Optional
+	// +optional
 	Remove []string `json:"remove,omitempty"`
 }
 

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -647,6 +647,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Set specifies a list of HTTP header values that will be set in the HTTP header</p>
 </td>
 </tr>
@@ -658,6 +659,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Remove specifies a list of HTTP header names to remove</p>
 </td>
 </tr>
@@ -780,6 +782,7 @@ No HTTP headers or body content is rewritten.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ReplacePrefix describes how the path prefix should be replaced.</p>
 </td>
 </tr>
@@ -810,6 +813,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Prefix specifies the URL path prefix to be replaced.</p>
 <p>If Prefix is specified, it must exactly match the Condition
 prefix that is rendered by the chain of including HTTPProxies
@@ -1014,6 +1018,7 @@ PathRewritePolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The policy for rewriting the path of the request URL
 after the request has been routed to a Service.</p>
 </td>
@@ -1028,6 +1033,7 @@ HeadersPolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The policy for managing request headers during proxying</p>
 </td>
 </tr>
@@ -1041,6 +1047,7 @@ HeadersPolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The policy for managing response headers during proxying</p>
 </td>
 </tr>
@@ -1147,6 +1154,7 @@ HeadersPolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The policy for managing request headers during proxying</p>
 </td>
 </tr>
@@ -1160,6 +1168,7 @@ HeadersPolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>The policy for managing response headers during proxying</p>
 </td>
 </tr>


### PR DESCRIPTION
Always use "+optional" rather than "+kubebuilder:validation:Optional".
Although they do the same thing, the API reference documentation
generator only recognizes the former.

This fixes #2074.

Signed-off-by: James Peach <jpeach@vmware.com>