### PR TITLE
docs: suggested to delete CRDs as well when upgrading with the easy way

### DIFF
--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -36,7 +36,7 @@ Please see the [Envoy Release Notes][15] for information about issues fixed in E
 If the following are true for you:
 
  * Your installation is in the `projectcontour` namespace.
- * You are using one of the [example][11] deployments.
+ * You are using one of the [example][1] deployments.
  * Your cluster can take few minutes of downtime.
 
 Then the simplest way to upgrade to 1.1.0 is to delete the `projectcontour` namespace and reapply one of the example configurations.
@@ -112,7 +112,7 @@ Ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.11.2`.
 If the following are true for you:
 
  * Your previous installation is in the `projectcontour` namespace.
- * You are using one of the [example][1] deployments.
+ * You are using one of the [example][2] deployments.
  * Your cluster can take few minutes of downtime.
 
 Then the simplest way to upgrade is to delete the `projectcontour` namespace and reapply the `examples/contour` sample manifest.
@@ -416,6 +416,7 @@ $ kubectl get configmap -n heptio-contour -o yaml contour
 ```
 
 [1]: {{site.github.repository_url}}/blob/{{site.latest}}/examples
+[2]: {{site.github.repository_url}}/blob/v1.0.0/examples
 [3]: /docs/{{site.latest}}/httpproxy
 [4]: /docs/{{site.latest}}/annotations
 [5]: {{site.github.repository_url}}/issues/899

--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -54,6 +54,14 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than `projectcontour` with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `projectcontour` and replace it with your preferred name space and apply the updated manifest.
 
+**Note:** If you are deploying to a cluster where you have previously installed alpha versions of the Contour API, applying the Contour CRDs in `examples/contour` may fail with a message similar to `Invalid value: "v1alpha1": must appear in spec.versions`. In this case, you need to delete the old CRDs and apply the new ones.
+
+```
+$ kubectl delete namespace projectcontour
+$ kubectl get crd  | awk '/projectcontour.io|contour.heptio.com/{print $1}' | xargs kubectl delete crd
+$ kubectl apply -f examples/<your-desired-deployment>
+```
+
 ## The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.0.1 to 1.1.0 changes manually.


### PR DESCRIPTION
otherwise, users might see errors because of the old CRDs.