### PR TITLE
Fix documented defaults for leaderelection config

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -25,8 +25,8 @@ data:
     #   minimum-protocol-version: "1.1"
     # The following config shows the defaults for the leader election.
     # leaderelection:
-    #   configmap-name: contour
-    #   configmap-namespace: leader-elect
+    #   configmap-name: leader-elect
+    #   configmap-namespace: projectcontour
     ### Logging options
     # Default setting
     accesslog-format: envoy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -39,8 +39,8 @@ data:
     #   minimum-protocol-version: "1.1"
     # The following config shows the defaults for the leader election.
     # leaderelection:
-    #   configmap-name: contour
-    #   configmap-namespace: leader-elect
+    #   configmap-name: leader-elect
+    #   configmap-namespace: projectcontour
     ### Logging options
     # Default setting
     accesslog-format: envoy

--- a/site/docs/master/configuration.md
+++ b/site/docs/master/configuration.md
@@ -26,8 +26,8 @@ data:
       # minimumProtocolVersion: "1.1"
     # The following config shows the defaults for the leader election.
     # leaderelection:
-      # configmap-name: contour
-      # configmap-namespace: leader-elect
+      # configmap-name: leader-elect
+      # configmap-namespace: projectcontour
 ```
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.

--- a/site/docs/v1.1.0/configuration.md
+++ b/site/docs/v1.1.0/configuration.md
@@ -26,8 +26,8 @@ data:
       # minimumProtocolVersion: "1.1"
     # The following config shows the defaults for the leader election.
     # leaderelection:
-      # configmap-name: contour
-      # configmap-namespace: leader-elect
+      # configmap-name: leader-elect
+      # configmap-namespace: projectcontour
 ```
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.


### PR DESCRIPTION
- configmap name defaults to `leader-elect`
- namespace defaults to `projectcontour`

Documentation for already-released versions was not updated, even if inaccurate. 