### PR TITLE
internal/contour: refactor metrics test for accurate line numbers

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -26,6 +26,43 @@ import (
 )
 
 func TestIngressRouteMetrics(t *testing.T) {
+	type testcase struct {
+		objs           []interface{}
+		wantIR         *metrics.RouteMetric
+		wantProxy      *metrics.RouteMetric
+		rootNamespaces []string
+	}
+
+	run := func(t *testing.T, name string, tc testcase) {
+		t.Helper()
+
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			builder := dag.Builder{
+				Source: dag.KubernetesCache{
+					RootNamespaces: tc.rootNamespaces,
+					FieldLogger:    testLogger(t),
+				},
+			}
+
+			for _, o := range tc.objs {
+				builder.Source.Insert(o)
+			}
+
+			dag := builder.Build()
+
+			gotIR, gotProxy := calculateRouteMetric(dag.Statuses())
+			if tc.wantIR != nil {
+				assert.Equal(t, *tc.wantIR, gotIR)
+			}
+
+			if tc.wantProxy != nil {
+				assert.Equal(t, *tc.wantProxy, gotProxy)
+			}
+		})
+	}
+
 	// ir1 is a valid ingressroute
 	ir1 := &ingressroutev1.IngressRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -578,428 +615,419 @@ func TestIngressRouteMetrics(t *testing.T) {
 		},
 	}
 
-	tests := map[string]struct {
-		objs           []interface{}
-		wantIR         *metrics.RouteMetric
-		wantProxy      *metrics.RouteMetric
-		rootNamespaces []string
-	}{
-		"valid ingressroute": {
-			objs: []interface{}{ir1, s3},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
+	run(t, "valid ingressroute", testcase{
+		objs: []interface{}{ir1, s3},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
 			},
-			wantProxy: nil,
-		},
-		"invalid port in service": {
-			objs: []interface{}{ir2},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
 			},
-			wantProxy: nil,
-		},
-		"root ingressroute outside of roots namespace": {
-			objs: []interface{}{ir3},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-			},
-			wantProxy:      nil,
-			rootNamespaces: []string{"foo"},
-		},
-		"delegated route's match prefix does not match parent's prefix": {
-			objs: []interface{}{ir1, ir4, s3},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-			},
-			wantProxy: nil,
-		},
-		"root ingressroute does not specify FQDN": {
-			objs: []interface{}{ir13},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-			wantProxy: nil,
-		},
-		"self-edge produces a cycle": {
-			objs: []interface{}{ir6},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-			wantProxy: nil,
-		},
-		"child delegates to parent, producing a cycle": {
-			objs: []interface{}{ir7, ir8},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-			},
-			wantProxy: nil,
-		},
-		"route has a list of services and also delegates": {
-			objs: []interface{}{ir9},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-			wantProxy: nil,
-		},
-		"ingressroute is an orphaned route": {
-			objs: []interface{}{ir8},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{},
-				Valid:   map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Root: map[metrics.Meta]int{},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-			wantProxy: nil,
-		},
-		"ingressroute delegates to multiple ingressroutes, one is invalid": {
-			objs: []interface{}{ir10, ir11, ir12, s1, s2},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots"}:                       1,
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 3,
-				},
-			},
-			wantProxy: nil,
-		},
-		"invalid parent orphans children": {
-			objs: []interface{}{ir14, ir11},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-			},
-			wantProxy: nil,
-		},
-		"multi-parent children is not orphaned when one of the parents is invalid": {
-			objs: []interface{}{ir14, ir11, ir10, s2},
-			wantIR: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-					{Namespace: "roots"}:                       1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 3,
-				},
-			},
-			wantProxy: nil,
-		},
-		"valid proxy": {
-			objs:   []interface{}{proxy1, s3},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
 			},
 		},
-		"invalid port in service - proxy": {
-			objs:   []interface{}{proxy2},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-		},
-		"root proxy outside of roots namespace": {
-			objs:   []interface{}{proxy3},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "finance"}: 1,
-				},
-			},
-			rootNamespaces: []string{"foo"},
-		},
-		"root proxy does not specify FQDN": {
-			objs:   []interface{}{proxy13},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-		},
-		"self-edge produces a cycle - proxy": {
-			objs:   []interface{}{proxy6},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid:    map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-		},
-		"child delegates to parent, producing a cycle - proxy": {
-			objs:   []interface{}{proxy7, proxy8},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-			},
-		},
-		"proxy is an orphaned route": {
-			objs:   []interface{}{proxy8},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{},
-				Valid:   map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Root: map[metrics.Meta]int{},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-			},
-		},
-		"proxy delegates to multiple proxies, one is invalid": {
-			objs:   []interface{}{proxy10, proxy11, proxy12, s1, s2},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots"}:                       1,
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 3,
-				},
-			},
-		},
-		"invalid parent orphans children - proxy": {
-			objs:   []interface{}{proxy14, proxy11},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Valid: map[metrics.Meta]int{},
-				Orphaned: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-			},
-		},
-		"multi-parent children is not orphaned when one of the parents is invalid - proxy": {
-			objs:   []interface{}{proxy14, proxy11, proxy10, s2},
-			wantIR: nil,
-			wantProxy: &metrics.RouteMetric{
-				Invalid: map[metrics.Meta]int{
-					{Namespace: "roots"}:                       1,
-					{Namespace: "roots", VHost: "example.com"}: 1,
-				},
-				Valid: map[metrics.Meta]int{
-					{Namespace: "roots"}: 1,
-				},
-				Orphaned: map[metrics.Meta]int{},
-				Root: map[metrics.Meta]int{
-					{Namespace: "roots"}: 2,
-				},
-				Total: map[metrics.Meta]int{
-					{Namespace: "roots"}: 3,
-				},
-			},
-		},
-	}
+		wantProxy: nil,
+	})
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			builder := dag.Builder{
-				Source: dag.KubernetesCache{
-					RootNamespaces: tc.rootNamespaces,
-					FieldLogger:    testLogger(t),
-				},
-			}
-			for _, o := range tc.objs {
-				builder.Source.Insert(o)
-			}
-			dag := builder.Build()
+	run(t, "invalid port in service", testcase{
+		objs: []interface{}{ir2},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+		wantProxy: nil,
+	})
 
-			gotIR, gotProxy := calculateRouteMetric(dag.Statuses())
-			if tc.wantIR != nil {
-				assert.Equal(t, *tc.wantIR, gotIR)
-			}
-			if tc.wantProxy != nil {
-				assert.Equal(t, *tc.wantProxy, gotProxy)
-			}
-		})
-	}
+	run(t, "root ingressroute outside of roots namespace", testcase{
+		objs: []interface{}{ir3},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+		},
+		wantProxy:      nil,
+		rootNamespaces: []string{"foo"},
+	})
+
+	run(t, "delegated route's match prefix does not match parent's prefix", testcase{
+		objs: []interface{}{ir1, ir4, s3},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "root ingressroute does not specify FQDN", testcase{
+		objs: []interface{}{ir13},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "self-edge produces a cycle", testcase{
+		objs: []interface{}{ir6},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "child delegates to parent, producing a cycle", testcase{
+		objs: []interface{}{ir7, ir8},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "route has a list of services and also delegates", testcase{
+		objs: []interface{}{ir9},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "ingressroute is an orphaned route", testcase{
+		objs: []interface{}{ir8},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{},
+			Valid:   map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Root: map[metrics.Meta]int{},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "ingressroute delegates to multiple ingressroutes, one is invalid", testcase{
+		objs: []interface{}{ir10, ir11, ir12, s1, s2},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots"}:                       1,
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 3,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "invalid parent orphans children", testcase{
+		objs: []interface{}{ir14, ir11},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "multi-parent children is not orphaned when one of the parents is invalid", testcase{
+		objs: []interface{}{ir14, ir11, ir10, s2},
+		wantIR: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+				{Namespace: "roots"}:                       1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 3,
+			},
+		},
+		wantProxy: nil,
+	})
+
+	run(t, "valid proxy", testcase{
+		objs:   []interface{}{proxy1, s3},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+	})
+
+	run(t, "invalid port in service - proxy", testcase{
+		objs:   []interface{}{proxy2},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+	})
+
+	run(t, "root proxy outside of roots namespace", testcase{
+		objs:   []interface{}{proxy3},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "finance"}: 1,
+			},
+		},
+		rootNamespaces: []string{"foo"},
+	})
+
+	run(t, "root proxy does not specify FQDN", testcase{
+		objs:   []interface{}{proxy13},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+	})
+
+	run(t, "self-edge produces a cycle - proxy", testcase{
+		objs:   []interface{}{proxy6},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid:    map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+	})
+
+	run(t, "child delegates to parent, producing a cycle - proxy", testcase{
+		objs:   []interface{}{proxy7, proxy8},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+		},
+	})
+
+	run(t, "proxy is an orphaned route", testcase{
+		objs:   []interface{}{proxy8},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{},
+			Valid:   map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Root: map[metrics.Meta]int{},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+		},
+	})
+
+	run(t, "proxy delegates to multiple proxies, one is invalid", testcase{
+		objs:   []interface{}{proxy10, proxy11, proxy12, s1, s2},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots"}:                       1,
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 3,
+			},
+		},
+	})
+
+	run(t, "invalid parent orphans children - proxy", testcase{
+		objs:   []interface{}{proxy14, proxy11},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Valid: map[metrics.Meta]int{},
+			Orphaned: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+		},
+	})
+
+	run(t, "multi-parent children is not orphaned when one of the parents is invalid - proxy", testcase{
+		objs:   []interface{}{proxy14, proxy11, proxy10, s2},
+		wantIR: nil,
+		wantProxy: &metrics.RouteMetric{
+			Invalid: map[metrics.Meta]int{
+				{Namespace: "roots"}:                       1,
+				{Namespace: "roots", VHost: "example.com"}: 1,
+			},
+			Valid: map[metrics.Meta]int{
+				{Namespace: "roots"}: 1,
+			},
+			Orphaned: map[metrics.Meta]int{},
+			Root: map[metrics.Meta]int{
+				{Namespace: "roots"}: 2,
+			},
+			Total: map[metrics.Meta]int{
+				{Namespace: "roots"}: 3,
+			},
+		},
+	})
 }


### PR DESCRIPTION
When a test fails, the reported line number is in the subtest, and
you have to search for the tesst case name to find the test case
that had a problem. Refactor the test code into a local function
so we can preserve the attributed of table-driven tests but aldo
get accurate reporting of line numbers for failures.

Signed-off-by: James Peach <jpeach@vmware.com>