### PR TITLE
Update kind cluster example to expose port 80 and 443 instead of 8080

### DIFF
--- a/examples/kind/kind-expose-port.yaml
+++ b/examples/kind/kind-expose-port.yaml
@@ -4,6 +4,9 @@ nodes:
 - role: control-plane
 - role: worker
   extraPortMappings:
-  - containerPort: 8080
-    hostPort: 8080
+  - containerPort: 80
+    hostPort: 80
+    listenAddress: "0.0.0.0"
+  - containerPort: 443
+    hostPort: 443
     listenAddress: "0.0.0.0"


### PR DESCRIPTION
Currently examples/kind/kind-expose-port.yaml is exposing port 8080 to the host. However, by default envoy is listening on hostPort 80 and 443. So, the kind-expose-port.yaml has to be changed to expose port 80 and 443 instead of 8080 