### PR TITLE
Enable livereload for site-devel task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ PHONY = gencerts
 # https://docs.netlify.com/configure-builds/common-configurations/#jekyll
 JEKYLL_IMAGE ?= jekyll/jekyll:3.8.5
 JEKYLL_PORT := 4000
+JEKYLL_LIVERELOAD_PORT := 35729
 
 TAG_LATEST ?= false
 # Used to supply a local Envoy docker container an IP to connect to that is running
@@ -264,8 +265,8 @@ certs/envoycert.pem: certs/CAkey.pem certs/envoykey.pem
 
 .PHONY: site-devel
 site-devel: ## Launch the website in a Docker container
-	docker run --rm --publish $(JEKYLL_PORT):$(JEKYLL_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
-		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload"
+	docker run --rm -p $(JEKYLL_PORT):$(JEKYLL_PORT) -p $(JEKYLL_LIVERELOAD_PORT):$(JEKYLL_LIVERELOAD_PORT) -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
+		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll serve --host 0.0.0.0 --port $(JEKYLL_PORT) --livereload_port $(JEKYLL_LIVERELOAD_PORT) --livereload"
 
 .PHONY: site-check
 site-check: ## Test the site's links


### PR DESCRIPTION
Fixes #2125 by exposing the livereload port from the site-devel task. 

Signed-off-by: Steve Sloka <slokas@vmware.com>