### PR TITLE
internal/dag: mark ingress.class annotation valid for HTTPProxies

### DIFF
--- a/internal/dag/annotations.go
+++ b/internal/dag/annotations.go
@@ -68,9 +68,11 @@ var annotationsByKind = map[string]map[string]struct{}{
 		"projectcontour.io/upstream-protocol.tls": {},
 	},
 	"HTTPProxy": {
+		"kubernetes.io/ingress.class":     {},
 		"projectcontour.io/ingress.class": {},
 	},
 	"IngressRoute": {
+		"kubernetes.io/ingress.class":     {},
 		"projectcontour.io/ingress.class": {},
 	},
 }


### PR DESCRIPTION
The "kubernetes.io/ingress.class" annotation is valid for all
ingress-like document kinds.

This fixes #2119.

Signed-off-by: James Peach <jpeach@vmware.com>