### PR TITLE
Makefile: Update spell check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ check-misspell:
 		-i clas \
 		-locale US \
 		-error \
-		cmd/* internal/* docs/* design/* site/*.md site/_{guides,posts,resources} *.md
+		cmd/* internal/* design/* site/*.md site/_{guides,posts,resources} site/docs/**/* *.md
 
 .PHONY: check-unconvert
 check-unconvert:

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -197,7 +197,7 @@ type Service struct {
 	// Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
 	Port int `json:"port"`
 	// Protocol may be used to specify (or override) the protocol used to reach this Service.
-	// Values may be tls, h2, h2c.  It ommitted protocol-selection falls back on Service annotations.
+	// Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.
 	// +optional
 	Protocol *string `json:"protocol,omitempty"`
 	// Weight defines percentage of traffic to balance traffic

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -755,7 +755,7 @@ spec:
                         protocol:
                           description: Protocol may be used to specify (or override)
                             the protocol used to reach this Service. Values may be
-                            tls, h2, h2c.  It ommitted protocol-selection falls back
+                            tls, h2, h2c.  It omitted protocol-selection falls back
                             on Service annotations.
                           type: string
                         requestHeadersPolicy:
@@ -909,7 +909,7 @@ spec:
                       protocol:
                         description: Protocol may be used to specify (or override)
                           the protocol used to reach this Service. Values may be tls,
-                          h2, h2c.  It ommitted protocol-selection falls back on Service
+                          h2, h2c.  It omitted protocol-selection falls back on Service
                           annotations.
                         type: string
                       requestHeadersPolicy:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -829,7 +829,7 @@ spec:
                         protocol:
                           description: Protocol may be used to specify (or override)
                             the protocol used to reach this Service. Values may be
-                            tls, h2, h2c.  It ommitted protocol-selection falls back
+                            tls, h2, h2c.  It omitted protocol-selection falls back
                             on Service annotations.
                           type: string
                         requestHeadersPolicy:
@@ -983,7 +983,7 @@ spec:
                       protocol:
                         description: Protocol may be used to specify (or override)
                           the protocol used to reach this Service. Values may be tls,
-                          h2, h2c.  It ommitted protocol-selection falls back on Service
+                          h2, h2c.  It omitted protocol-selection falls back on Service
                           annotations.
                         type: string
                       requestHeadersPolicy:

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1104,7 +1104,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c.  It ommitted protocol-selection falls back on Service annotations.</p>
+Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>

--- a/site/docs/v1.1.0/api-reference.html
+++ b/site/docs/v1.1.0/api-reference.html
@@ -1104,7 +1104,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c.  It ommitted protocol-selection falls back on Service annotations.</p>
+Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Updates #2130 by adding the `site/docs` repo to the check for spelling errors. Additionally, it fixes some of the errors that resulted from this change.

One issue in testing this PR is that the spell-check tool doesn't always find errors. There are still errors that exist that the tool isn't finding, but this makes the check a little better.   