### PR TITLE
apis: replace unsigned integers in CRD fields with signed integers, add validation

### DIFF
--- a/apis/contour/v1beta1/ingressroute.go
+++ b/apis/contour/v1beta1/ingressroute.go
@@ -86,7 +86,8 @@ type Service struct {
 	Port int `json:"port"`
 	// Weight defines percentage of traffic to balance traffic
 	// +optional
-	Weight uint32 `json:"weight,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	Weight int64 `json:"weight,omitempty"`
 	// HealthCheck defines optional healthchecks on the upstream service
 	// +optional
 	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
@@ -115,10 +116,12 @@ type HealthCheck struct {
 	TimeoutSeconds int64 `json:"timeoutSeconds"`
 	// The number of unhealthy health checks required before a host is marked unhealthy
 	// +optional
-	UnhealthyThresholdCount uint32 `json:"unhealthyThresholdCount"`
+	// +kubebuilder:validation:Minimum=0
+	UnhealthyThresholdCount int64 `json:"unhealthyThresholdCount"`
 	// The number of healthy health checks required before a host is marked healthy
 	// +optional
-	HealthyThresholdCount uint32 `json:"healthyThresholdCount"`
+	// +kubebuilder:validation:Minimum=0
+	HealthyThresholdCount int64 `json:"healthyThresholdCount"`
 }
 
 // Delegate allows for delegating VHosts to other IngressRoutes

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -205,7 +205,8 @@ type Service struct {
 	Protocol *string `json:"protocol,omitempty"`
 	// Weight defines percentage of traffic to balance traffic
 	// +optional
-	Weight uint32 `json:"weight,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	Weight int64 `json:"weight,omitempty"`
 	// UpstreamValidation defines how to verify the backend service's certificate
 	// +optional
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
@@ -235,10 +236,12 @@ type HTTPHealthCheckPolicy struct {
 	TimeoutSeconds int64 `json:"timeoutSeconds"`
 	// The number of unhealthy health checks required before a host is marked unhealthy
 	// +optional
-	UnhealthyThresholdCount uint32 `json:"unhealthyThresholdCount"`
+	// +kubebuilder:validation:Minimum=0
+	UnhealthyThresholdCount int64 `json:"unhealthyThresholdCount"`
 	// The number of healthy health checks required before a host is marked healthy
 	// +optional
-	HealthyThresholdCount uint32 `json:"healthyThresholdCount"`
+	// +kubebuilder:validation:Minimum=0
+	HealthyThresholdCount int64 `json:"healthyThresholdCount"`
 }
 
 // TCPHealthCheckPolicy defines health checks on the upstream service.
@@ -279,7 +282,8 @@ type RetryPolicy struct {
 	// NumRetries is maximum allowed number of retries.
 	// If not supplied, the number of retries is one.
 	// +optional
-	NumRetries uint32 `json:"count"`
+	// +kubebuilder:validation:Minimum=0
+	NumRetries int64 `json:"count"`
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if NumRetries is not supplied.
 	PerTryTimeout string `json:"perTryTimeout,omitempty"`

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -94,7 +94,8 @@ spec:
                       count:
                         description: NumRetries is maximum allowed number of retries.
                           If not supplied, the number of retries is one.
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       perTryTimeout:
                         description: PerTryTimeout specifies the timeout per retry
@@ -113,7 +114,8 @@ spec:
                             healthyThresholdCount:
                               description: The number of healthy health checks required
                                 before a host is marked healthy
-                              format: int32
+                              format: int64
+                              minimum: 0
                               type: integer
                             host:
                               description: The value of the host header in the HTTP
@@ -136,7 +138,8 @@ spec:
                             unhealthyThresholdCount:
                               description: The number of unhealthy health checks required
                                 before a host is marked unhealthy
-                              format: int32
+                              format: int64
+                              minimum: 0
                               type: integer
                           required:
                           - path
@@ -172,7 +175,8 @@ spec:
                         weight:
                           description: Weight defines percentage of traffic to balance
                             traffic
-                          format: int32
+                          format: int64
+                          minimum: 0
                           type: integer
                       required:
                       - name
@@ -221,7 +225,8 @@ spec:
                           healthyThresholdCount:
                             description: The number of healthy health checks required
                               before a host is marked healthy
-                            format: int32
+                            format: int64
+                            minimum: 0
                             type: integer
                           host:
                             description: The value of the host header in the HTTP
@@ -244,7 +249,8 @@ spec:
                           unhealthyThresholdCount:
                             description: The number of unhealthy health checks required
                               before a host is marked unhealthy
-                            format: int32
+                            format: int64
+                            minimum: 0
                             type: integer
                         required:
                         - path
@@ -280,7 +286,8 @@ spec:
                       weight:
                         description: Weight defines percentage of traffic to balance
                           traffic
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - name
@@ -586,7 +593,8 @@ spec:
                       healthyThresholdCount:
                         description: The number of healthy health checks required
                           before a host is marked healthy
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       host:
                         description: The value of the host header in the HTTP health
@@ -609,7 +617,8 @@ spec:
                       unhealthyThresholdCount:
                         description: The number of unhealthy health checks required
                           before a host is marked unhealthy
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - path
@@ -726,7 +735,8 @@ spec:
                       count:
                         description: NumRetries is maximum allowed number of retries.
                           If not supplied, the number of retries is one.
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       perTryTimeout:
                         description: PerTryTimeout specifies the timeout per retry
@@ -845,7 +855,8 @@ spec:
                         weight:
                           description: Weight defines percentage of traffic to balance
                             traffic
-                          format: int32
+                          format: int64
+                          minimum: 0
                           type: integer
                       required:
                       - name
@@ -1025,7 +1036,8 @@ spec:
                       weight:
                         description: Weight defines percentage of traffic to balance
                           traffic
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - name

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -168,7 +168,8 @@ spec:
                       count:
                         description: NumRetries is maximum allowed number of retries.
                           If not supplied, the number of retries is one.
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       perTryTimeout:
                         description: PerTryTimeout specifies the timeout per retry
@@ -187,7 +188,8 @@ spec:
                             healthyThresholdCount:
                               description: The number of healthy health checks required
                                 before a host is marked healthy
-                              format: int32
+                              format: int64
+                              minimum: 0
                               type: integer
                             host:
                               description: The value of the host header in the HTTP
@@ -210,7 +212,8 @@ spec:
                             unhealthyThresholdCount:
                               description: The number of unhealthy health checks required
                                 before a host is marked unhealthy
-                              format: int32
+                              format: int64
+                              minimum: 0
                               type: integer
                           required:
                           - path
@@ -246,7 +249,8 @@ spec:
                         weight:
                           description: Weight defines percentage of traffic to balance
                             traffic
-                          format: int32
+                          format: int64
+                          minimum: 0
                           type: integer
                       required:
                       - name
@@ -295,7 +299,8 @@ spec:
                           healthyThresholdCount:
                             description: The number of healthy health checks required
                               before a host is marked healthy
-                            format: int32
+                            format: int64
+                            minimum: 0
                             type: integer
                           host:
                             description: The value of the host header in the HTTP
@@ -318,7 +323,8 @@ spec:
                           unhealthyThresholdCount:
                             description: The number of unhealthy health checks required
                               before a host is marked unhealthy
-                            format: int32
+                            format: int64
+                            minimum: 0
                             type: integer
                         required:
                         - path
@@ -354,7 +360,8 @@ spec:
                       weight:
                         description: Weight defines percentage of traffic to balance
                           traffic
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - name
@@ -660,7 +667,8 @@ spec:
                       healthyThresholdCount:
                         description: The number of healthy health checks required
                           before a host is marked healthy
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       host:
                         description: The value of the host header in the HTTP health
@@ -683,7 +691,8 @@ spec:
                       unhealthyThresholdCount:
                         description: The number of unhealthy health checks required
                           before a host is marked unhealthy
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - path
@@ -800,7 +809,8 @@ spec:
                       count:
                         description: NumRetries is maximum allowed number of retries.
                           If not supplied, the number of retries is one.
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                       perTryTimeout:
                         description: PerTryTimeout specifies the timeout per retry
@@ -919,7 +929,8 @@ spec:
                         weight:
                           description: Weight defines percentage of traffic to balance
                             traffic
-                          format: int32
+                          format: int64
+                          minimum: 0
                           type: integer
                       required:
                       - name
@@ -1099,7 +1110,8 @@ spec:
                       weight:
                         description: Weight defines percentage of traffic to balance
                           traffic
-                        format: int32
+                        format: int64
+                        minimum: 0
                         type: integer
                     required:
                     - name

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -808,7 +808,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			c := &Cluster{
 				Upstream:              s,
 				LoadBalancerPolicy:    loadBalancerPolicy(route.LoadBalancerPolicy),
-				Weight:                service.Weight,
+				Weight:                uint32(service.Weight),
 				HTTPHealthCheckPolicy: httpHealthCheckPolicy(route.HealthCheckPolicy),
 				UpstreamValidation:    uv,
 				RequestHeadersPolicy:  reqHP,
@@ -1006,7 +1006,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 				r.Clusters = append(r.Clusters, &Cluster{
 					Upstream:              s,
 					LoadBalancerPolicy:    service.Strategy,
-					Weight:                service.Weight,
+					Weight:                uint32(service.Weight),
 					HTTPHealthCheckPolicy: ingressrouteHealthCheckPolicy(service.HealthCheck),
 					UpstreamValidation:    uv,
 					Protocol:              s.Protocol,

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -32,7 +32,7 @@ func retryPolicy(rp *projcontour.RetryPolicy) *RetryPolicy {
 	perTryTimeout, _ := time.ParseDuration(rp.PerTryTimeout)
 	return &RetryPolicy{
 		RetryOn:       "5xx",
-		NumRetries:    max(1, rp.NumRetries),
+		NumRetries:    max(1, uint32(rp.NumRetries)),
 		PerTryTimeout: perTryTimeout,
 	}
 }
@@ -156,8 +156,8 @@ func ingressrouteHealthCheckPolicy(hc *ingressroutev1.HealthCheck) *HTTPHealthCh
 		Host:               hc.Host,
 		Interval:           time.Duration(hc.IntervalSeconds) * time.Second,
 		Timeout:            time.Duration(hc.TimeoutSeconds) * time.Second,
-		UnhealthyThreshold: hc.UnhealthyThresholdCount,
-		HealthyThreshold:   hc.HealthyThresholdCount,
+		UnhealthyThreshold: uint32(hc.UnhealthyThresholdCount),
+		HealthyThreshold:   uint32(hc.HealthyThresholdCount),
 	}
 }
 
@@ -170,8 +170,8 @@ func httpHealthCheckPolicy(hc *projcontour.HTTPHealthCheckPolicy) *HTTPHealthChe
 		Host:               hc.Host,
 		Interval:           time.Duration(hc.IntervalSeconds) * time.Second,
 		Timeout:            time.Duration(hc.TimeoutSeconds) * time.Second,
-		UnhealthyThreshold: hc.UnhealthyThresholdCount,
-		HealthyThreshold:   hc.HealthyThresholdCount,
+		UnhealthyThreshold: uint32(hc.UnhealthyThresholdCount),
+		HealthyThreshold:   uint32(hc.HealthyThresholdCount),
 	}
 }
 

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -383,7 +383,7 @@ int64
 <td style="white-space:nowrap">
 <code>unhealthyThresholdCount</code></br>
 <em>
-uint32
+int64
 </em>
 </td>
 <td>
@@ -395,7 +395,7 @@ uint32
 <td style="white-space:nowrap">
 <code>healthyThresholdCount</code></br>
 <em>
-uint32
+int64
 </em>
 </td>
 <td>
@@ -860,7 +860,7 @@ will be replaced with. This must not be empty.</p>
 <td style="white-space:nowrap">
 <code>count</code></br>
 <em>
-uint32
+int64
 </em>
 </td>
 <td>
@@ -1111,7 +1111,7 @@ Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service
 <td style="white-space:nowrap">
 <code>weight</code></br>
 <em>
-uint32
+int64
 </em>
 </td>
 <td>


### PR DESCRIPTION
This commit replaces the unsigned integers in the HTTPProxy and IngressRoute CRDs
with signed integers. Unsigned integers are discouraged due to API compatibility
issues. Validation rules have been added to the fields to ensure that the value
provided is always positive.

Fixes #2123

Signed-off-by: Alex Price <aprice@atlassian.com>