### PR TITLE
internal/dag: have caller set status for invalid path conditions

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -676,7 +676,8 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			return nil
 		}
 
-		if !pathConditionsValid(sw, include.Conditions, "include") {
+		if err := pathConditionsValid(include.Conditions); err != nil {
+			sw.SetInvalid("include: %s", err)
 			return nil
 		}
 
@@ -689,7 +690,8 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 	}
 
 	for _, route := range proxy.Spec.Routes {
-		if !pathConditionsValid(sw, route.Conditions, "route") {
+		if err := pathConditionsValid(route.Conditions); err != nil {
+			sw.SetInvalid("route: %s", err)
 			return nil
 		}
 

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -14,6 +14,8 @@
 package dag
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -49,22 +51,22 @@ func mergePathConditions(conds []projcontour.Condition) Condition {
 
 // pathConditionsValid validates a slice of Conditions can be correctly merged.
 // It encodes the business rules about what is allowed for prefix Conditions.
-func pathConditionsValid(sw *ObjectStatusWriter, conds []projcontour.Condition, conditionsContext string) bool {
+func pathConditionsValid(conds []projcontour.Condition) error {
 	prefixCount := 0
+
 	for _, cond := range conds {
 		if cond.Prefix != "" {
 			prefixCount++
 			if cond.Prefix[0] != '/' {
-				sw.SetInvalid("%s: Prefix conditions must start with /, %s was supplied", conditionsContext, cond.Prefix)
-				return false
+				return fmt.Errorf("prefix conditions must start with /, %s was supplied", cond.Prefix)
 			}
 		}
 		if prefixCount > 1 {
-			sw.SetInvalid("%s: More than one prefix is not allowed in a condition block", conditionsContext)
-			return false
+			return errors.New("more than one prefix is not allowed in a condition block")
 		}
 	}
-	return true
+
+	return nil
 }
 
 func mergeHeaderConditions(conds []projcontour.Condition) []HeaderCondition {

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -18,7 +18,6 @@ import (
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPathCondition(t *testing.T) {
@@ -309,18 +308,8 @@ func TestPrefixConditionsValid(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// TODO(youngnick) This feels dirty but is required for now.
-			// #1652 covers changing ObjectStatusWriter to an interface
-			// instead.
-			swblank := &ObjectStatusWriter{}
-			sw, _ := swblank.WithObject(&projcontour.HTTPProxy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-			})
-			got := pathConditionsValid(sw, tc.conditions, "test")
-			assert.Equal(t, tc.want, got)
+			err := pathConditionsValid(tc.conditions)
+			assert.Equal(t, tc.want, err == nil)
 		})
 	}
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2273,7 +2273,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{name: proxy32.Name, namespace: proxy32.Namespace}: {
 					Object:      proxy32,
 					Status:      "invalid",
-					Description: "route: More than one prefix is not allowed in a condition block",
+					Description: "route: more than one prefix is not allowed in a condition block",
 					Vhost:       "example.com",
 				},
 			},
@@ -2284,7 +2284,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{name: proxy33.Name, namespace: proxy33.Namespace}: {
 					Object:      proxy33,
 					Status:      "invalid",
-					Description: "include: More than one prefix is not allowed in a condition block",
+					Description: "include: more than one prefix is not allowed in a condition block",
 					Vhost:       "example.com",
 				}, {name: proxy34.Name, namespace: proxy34.Namespace}: {
 					Object:      proxy34,
@@ -2299,7 +2299,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{name: proxy35.Name, namespace: proxy35.Namespace}: {
 					Object:      proxy35,
 					Status:      "invalid",
-					Description: "route: Prefix conditions must start with /, api was supplied",
+					Description: "route: prefix conditions must start with /, api was supplied",
 					Vhost:       "example.com",
 				},
 			},
@@ -2310,7 +2310,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{name: proxy36.Name, namespace: proxy36.Namespace}: {
 					Object:      proxy36,
 					Status:      "invalid",
-					Description: "include: Prefix conditions must start with /, api was supplied",
+					Description: "include: prefix conditions must start with /, api was supplied",
 					Vhost:       "example.com",
 				}, {name: proxy34.Name, namespace: proxy34.Namespace}: {
 					Object:      proxy34,


### PR DESCRIPTION
Have the caller set the HTTPPtoxy status based on the error propagted
from pathConditionsValid(). This makes it clearer where status is getting
set during procy processing.

Signed-off-by: James Peach <jpeach@vmware.com>