### PR TITLE
internal/dag: Allow requestHeadersPolicy to set host header at the

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -709,7 +709,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			return nil
 		}
 
-		respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* allow Host */)
+		respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* disallow Host */)
 		if err != nil {
 			sw.SetInvalid(err.Error())
 			return nil
@@ -793,13 +793,13 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				}
 			}
 
-			reqHP, err := headersPolicy(service.RequestHeadersPolicy, false /* allow Host */)
+			reqHP, err := headersPolicy(service.RequestHeadersPolicy, true /* allow Host */)
 			if err != nil {
 				sw.SetInvalid(err.Error())
 				return nil
 			}
 
-			respHP, err := headersPolicy(service.ResponseHeadersPolicy, false /* allow Host */)
+			respHP, err := headersPolicy(service.ResponseHeadersPolicy, false /* disallow Host */)
 			if err != nil {
 				sw.SetInvalid(err.Error())
 				return nil


### PR DESCRIPTION
Fixes #2153 by allowing requestHeaderPolicy to set host header at the HTTProxy.Routes.Service level. Also, add tests to confirm that it's not possible to set the Host header for responseHeadersPolicy.

Signed-off-by: Steve Sloka <steve@stevesloka.com>