### PR TITLE
Add kubebuilder enum validation to limit the values for service.protocol

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -197,7 +197,8 @@ type Service struct {
 	// Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
 	Port int `json:"port"`
 	// Protocol may be used to specify (or override) the protocol used to reach this Service.
-	// Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.
+	// Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+	// +kubebuilder:validation:Enum=h2;h2c;tls
 	// +optional
 	Protocol *string `json:"protocol,omitempty"`
 	// Weight defines percentage of traffic to balance traffic

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -755,8 +755,12 @@ spec:
                         protocol:
                           description: Protocol may be used to specify (or override)
                             the protocol used to reach this Service. Values may be
-                            tls, h2, h2c.  It omitted protocol-selection falls back
+                            tls, h2, h2c. If omitted, protocol-selection falls back
                             on Service annotations.
+                          enum:
+                          - h2
+                          - h2c
+                          - tls
                           type: string
                         requestHeadersPolicy:
                           description: The policy for managing request headers during
@@ -909,8 +913,12 @@ spec:
                       protocol:
                         description: Protocol may be used to specify (or override)
                           the protocol used to reach this Service. Values may be tls,
-                          h2, h2c.  It omitted protocol-selection falls back on Service
+                          h2, h2c. If omitted, protocol-selection falls back on Service
                           annotations.
+                        enum:
+                        - h2
+                        - h2c
+                        - tls
                         type: string
                       requestHeadersPolicy:
                         description: The policy for managing request headers during

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -829,8 +829,12 @@ spec:
                         protocol:
                           description: Protocol may be used to specify (or override)
                             the protocol used to reach this Service. Values may be
-                            tls, h2, h2c.  It omitted protocol-selection falls back
+                            tls, h2, h2c. If omitted, protocol-selection falls back
                             on Service annotations.
+                          enum:
+                          - h2
+                          - h2c
+                          - tls
                           type: string
                         requestHeadersPolicy:
                           description: The policy for managing request headers during
@@ -983,8 +987,12 @@ spec:
                       protocol:
                         description: Protocol may be used to specify (or override)
                           the protocol used to reach this Service. Values may be tls,
-                          h2, h2c.  It omitted protocol-selection falls back on Service
+                          h2, h2c. If omitted, protocol-selection falls back on Service
                           annotations.
+                        enum:
+                        - h2
+                        - h2c
+                        - tls
                         type: string
                       requestHeadersPolicy:
                         description: The policy for managing request headers during

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1104,7 +1104,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.</p>
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>

--- a/site/docs/v1.1.0/api-reference.html
+++ b/site/docs/v1.1.0/api-reference.html
@@ -1104,7 +1104,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c.  It omitted protocol-selection falls back on Service annotations.</p>
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Fixes #2152 by adding an enum validation to limit the values for the service.protocol field. 

```
Release Note: Users will need to reapply the crd spec to get the validation
```

Signed-off-by: Steve Sloka <steve@stevesloka.com>