### PR TITLE
internal/envoy: switch to match_subject_alt_names for CA validation

### DIFF
--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -16,6 +16,7 @@ package envoy
 import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 )
 
 var (
@@ -87,7 +88,11 @@ func validationContext(ca []byte, subjectName string) *envoy_api_v2_auth.CommonT
 					InlineBytes: ca,
 				},
 			},
-			VerifySubjectAltName: []string{subjectName},
+			MatchSubjectAltNames: []*matcher.StringMatcher{{
+				MatchPattern: &matcher.StringMatcher_Exact{
+					Exact: subjectName,
+				}},
+			},
 		},
 	}
 }

--- a/internal/envoy/auth_test.go
+++ b/internal/envoy/auth_test.go
@@ -18,6 +18,7 @@ import (
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -66,7 +67,11 @@ func TestUpstreamTLSContext(t *testing.T) {
 									InlineBytes: []byte("ca"),
 								},
 							},
-							VerifySubjectAltName: []string{"www.example.com"},
+							MatchSubjectAltNames: []*matcher.StringMatcher{{
+								MatchPattern: &matcher.StringMatcher_Exact{
+									Exact: "www.example.com",
+								}},
+							},
 						},
 					},
 				},

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	clusterv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
@@ -128,7 +129,11 @@ func upstreamFileTLSContext(cafile, certfile, keyfile string) *envoy_api_v2_auth
 						},
 					},
 					// TODO(youngnick): Does there need to be a flag wired down to here?
-					VerifySubjectAltName: []string{"contour"},
+					MatchSubjectAltNames: []*matcher.StringMatcher{{
+						MatchPattern: &matcher.StringMatcher_Exact{
+							Exact: "contour",
+						}},
+					},
 				},
 			},
 		},

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -713,8 +713,10 @@ func TestBootstrap(t *testing.T) {
                 "trusted_ca": {
                   "filename": "CA.cert"
                 },
-                "verify_subject_alt_name": [
-                  "contour"
+		"match_subject_alt_names": [
+		  {
+		    "exact": "contour"
+		  }
                 ]
               }
             }


### PR DESCRIPTION
Updates #2132

Envoy 1.13.2 deprecated the auth.CertificateValidationContext.verify_subject_alt_name
field, replacing it with match_subject_alt_names which takes an array of
string matchers.

Signed-off-by: Dave Cheney <dave@cheney.net>