### PR TITLE
internal/envoy: switch from route.RouteMirrorPolicy to RouteMirrorPolicies

### DIFF
--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -2316,8 +2316,8 @@ func routeConfigurations(rcs ...*v2.RouteConfiguration) map[string]*v2.RouteConf
 }
 
 func withMirrorPolicy(route *envoy_api_v2_route.Route_Route, mirror string) *envoy_api_v2_route.Route_Route {
-	route.Route.RequestMirrorPolicy = &envoy_api_v2_route.RouteAction_RequestMirrorPolicy{
+	route.Route.RequestMirrorPolicies = []*envoy_api_v2_route.RouteAction_RequestMirrorPolicy{{
 		Cluster: mirror,
-	}
+	}}
 	return route
 }

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -57,12 +57,12 @@ func RouteMatch(route *dag.Route) *envoy_api_v2_route.RouteMatch {
 // weighted cluster.
 func RouteRoute(r *dag.Route) *envoy_api_v2_route.Route_Route {
 	ra := envoy_api_v2_route.RouteAction{
-		RetryPolicy:         retryPolicy(r),
-		Timeout:             responseTimeout(r),
-		IdleTimeout:         idleTimeout(r),
-		PrefixRewrite:       r.PrefixRewrite,
-		HashPolicy:          hashPolicy(r),
-		RequestMirrorPolicy: mirrorPolicy(r),
+		RetryPolicy:           retryPolicy(r),
+		Timeout:               responseTimeout(r),
+		IdleTimeout:           idleTimeout(r),
+		PrefixRewrite:         r.PrefixRewrite,
+		HashPolicy:            hashPolicy(r),
+		RequestMirrorPolicies: mirrorPolicy(r),
 	}
 
 	// Check for host header policy and set if found
@@ -113,14 +113,14 @@ func hashPolicy(r *dag.Route) []*envoy_api_v2_route.RouteAction_HashPolicy {
 	return nil
 }
 
-func mirrorPolicy(r *dag.Route) *envoy_api_v2_route.RouteAction_RequestMirrorPolicy {
+func mirrorPolicy(r *dag.Route) []*envoy_api_v2_route.RouteAction_RequestMirrorPolicy {
 	if r.MirrorPolicy == nil {
 		return nil
 	}
 
-	return &envoy_api_v2_route.RouteAction_RequestMirrorPolicy{
+	return []*envoy_api_v2_route.RouteAction_RequestMirrorPolicy{{
 		Cluster: Clustername(r.MirrorPolicy.Cluster),
-	}
+	}}
 }
 
 func hostReplaceHeader(hp *dag.HeadersPolicy) string {

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -433,6 +433,37 @@ func TestRouteRoute(t *testing.T) {
 				},
 			},
 		},
+		"mirror": {
+			route: &dag.Route{
+				Clusters: []*dag.Cluster{{
+					Upstream: &dag.Service{
+						Name:        s1.Name,
+						Namespace:   s1.Namespace,
+						ServicePort: &s1.Spec.Ports[0],
+					},
+					Weight: 90,
+				}},
+				MirrorPolicy: &dag.MirrorPolicy{
+					Cluster: &dag.Cluster{
+						Upstream: &dag.Service{
+							Name:        s1.Name,
+							Namespace:   s1.Namespace,
+							ServicePort: &s1.Spec.Ports[0],
+						},
+					},
+				},
+			},
+			want: &envoy_api_v2_route.Route_Route{
+				Route: &envoy_api_v2_route.RouteAction{
+					ClusterSpecifier: &envoy_api_v2_route.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RequestMirrorPolicies: []*envoy_api_v2_route.RouteAction_RequestMirrorPolicy{{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					}},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -130,9 +130,9 @@ func withIdleTimeout(route *envoy_api_v2_route.Route_Route, timeout time.Duratio
 }
 
 func withMirrorPolicy(route *envoy_api_v2_route.Route_Route, mirror string) *envoy_api_v2_route.Route_Route {
-	route.Route.RequestMirrorPolicy = &envoy_api_v2_route.RouteAction_RequestMirrorPolicy{
+	route.Route.RequestMirrorPolicies = []*envoy_api_v2_route.RouteAction_RequestMirrorPolicy{{
 		Cluster: mirror,
-	}
+	}}
 	return route
 }
 


### PR DESCRIPTION
Updates #2132

Envoy 1.13 deprecated RouteMirrorPolicy singular and replaced it with
RouteMirrorPolicies plural. Make this change throughout and address the
missing test of request mirroring for enovy.RouteRoute.

Signed-off-by: Dave Cheney <dave@cheney.net>