### PR TITLE
examples: update Envoy to 1.13.0

### DIFF
--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -32,7 +32,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.12.2
+        image: docker.io/envoyproxy/envoy:v1.13.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1586,7 +1586,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.12.2
+        image: docker.io/envoyproxy/envoy:v1.13.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -11,14 +11,15 @@ This page describes the compatibility matrix of Contour and Envoy versions.
 
 <center>
 
-| Envoy version | Contour v1.0.0<sup>5</sup> | Contour v1.0.1<sup>6</sup> | Contour v1.1.0 |
-| ------------ | :-----------: | :-----------: | :----------: |
-| 1.11.0 | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> |
-| 1.11.1 | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> |
-| 1.11.2 | Supported<sup>5</sup> | Not Supported | Not Supported |
-| 1.12.0 | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> |
-| 1.12.1 | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> |
-| 1.12.2 | Not supported | Supported | Supported |
+| Envoy version | Contour v1.0.0<sup>5</sup> | Contour v1.0.1<sup>6</sup> | Contour v1.1.0 | Contour v1.2.0 |
+| ------------ | :-----------: | :-----------: | :----------: | :----------: |
+| 1.11.0 | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> |
+| 1.11.1 | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> |
+| 1.11.2 | *Supported*<sup>5</sup> | Not supported | Not supported | Not supported |
+| 1.12.0 | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> |
+| 1.12.1 | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> |
+| 1.12.2 | Not supported | *Supported*<sup>6</sup> | *Supported* | Not supported |
+| 1.13.0 | Not supported | Not supported | Not supported | *Supported* |
 
 </center>
 


### PR DESCRIPTION
Fixes #2132

Also update the Envoy compatability matrix to include Contour 1.2.0 an
Envoy 1.13.0

Signed-off-by: Dave Cheney <dave@cheney.net>