### PR TITLE
ci: enable Github stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,26 @@
+# Stale issue and PR management
+# See  https://github.com/marketplace/actions/close-stale-issues
+
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Leave the issue message empty so that issues are not marked stale.
+        stale-issue-message:
+        stale-pr-message: >
+          Marking this PR stale since there has been no activity for 14
+          days. It will be closed if there is no activity for another
+          90 days.
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 14
+        days-before-close: 90


### PR DESCRIPTION
Emable the Github stale action to label (and eventually close)
PRs that are inactive. This makes it easier to see which PRs
need to be followed up on.

This fixes #2174.

Signed-off-by: James Peach <jpeach@vmware.com>