### PR TITLE
ci: enable codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       script:
         - go mod vendor
         - make check
+        - make check-coverage
+
+      after_success:
+        - CODECOV_NAME=coverage.out bash <(curl -s https://codecov.io/bash)
 
     - language: ruby
       rvm: 2.6


### PR DESCRIPTION
Add a `check-coverage` make target that emits aggregated coverage across
all the project packages. Enable coverage data upload to codecov.io.

This fixes #2176.

Signed-off-by: James Peach <jpeach@vmware.com>