### PR TITLE
Break integration tests into discrete stages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,51 @@
-matrix:
+os: linux
+dist: bionic
+language: go
+go: 1.13.x
+services:
+- docker
+cache:
+  directories:
+  - /home/travis/.cache/go-build
+  - /home/travis/gopath/pkg/mod
+env:
+  global:
+  - GOPROXY=https://proxy.golang.org/
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+jobs:
   include:
-    - language: go
-      name: test make process
-      go:
-        - 1.13.x
-      sudo: false
-      services:
-        - docker
-      cache:
-        directories:
-          - /home/travis/.cache/go-build
-          - /home/travis/gopath/pkg/mod
-      env:
-        - GOPROXY=https://proxy.golang.org/
-      script:
-        - go mod vendor
-        - make check
-        - make check-coverage
+  - name: test
+    install:
+    - go mod vendor
+    script:
+    - make install
+    - make check-coverage
+    after_success:
+    - CODECOV_NAME=coverage.out bash <(curl -s https://codecov.io/bash)
 
-      after_success:
-        - CODECOV_NAME=coverage.out bash <(curl -s https://codecov.io/bash)
+  - name: lint
+    install:
+    - go mod vendor
+    script:
+    - make lint
 
-    - language: ruby
-      rvm: 2.6
-      name: Site Proofing
-      sudo: false # route your build to the container-based infrastructure for a faster build
-      cache: bundler
-      env:
-        - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-        - SEARCH_DIRECTORIES="site"
-      addons:
-        apt:
-          packages:
-            - libcurl4-openssl-dev
-      install:
-        - ./hack/travis/travis-check-files-changed.sh $SEARCH_DIRECTORIES ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
-      script:
-        - ./hack/site-proofing/cibuild
+  - name: codegen
+    install:
+    - go mod vendor
+    script:
+    - make generate
+    - ./hack/travis/check-uncommitted-codegen.sh
+
+  - name: site proof
+    language: ruby
+    rvm: 2.6
+    cache: bundler
+    addons:
+      apt:
+        packages:
+        - libcurl4-openssl-dev
+    install:
+    - ./hack/travis/travis-check-files-changed.sh ./site ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
+    script:
+    - ./hack/site-proofing/cibuild

--- a/hack/travis/check-uncommitted-codegen.sh
+++ b/hack/travis/check-uncommitted-codegen.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly HERE=$(cd $(dirname $0) && pwd)
+readonly REPO=$(cd ${HERE}/.. && pwd)
+
+declare -r -a DIRS=(
+	${REPO}/apis
+	${REPO}/site/_metrics
+	${REPO}/examples/render
+	${REPO}/examples/contour
+)
+
+if git status -s ${DIRS[@]} 2>&1 | grep -E -q '^\s+[MADRCU]'
+then
+	echo Uncommitted changes in generated sources:
+	git status -s ${DIRS[@]}
+	exit 1
+fi

--- a/hack/travis/travis-check-files-changed.sh
+++ b/hack/travis/travis-check-files-changed.sh
@@ -12,7 +12,9 @@
 #      install:
 #        - ./hack/travis/travis-check-files-changed.sh $SEARCH_DIRECTORIES ; RETURN_CODE=$? ; if [ $RETURN_CODE -eq 137 ]; then travis_terminate 0; elif [ $RETURN_CODE -ne 0 ]; then travis_terminate $RETURN_CODE; fi
 
-set -e # halt script on error
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # 1. Make sure the paths to search are not empty
 if [ $# -eq 0 ]; then
@@ -21,10 +23,10 @@ if [ $# -eq 0 ]; then
 fi
 
 # 2. Get the latest commit
-LATEST_COMMIT=$(git rev-parse HEAD)
+readonly LATEST_COMMIT=$(git rev-parse HEAD)
 
 # 3. Get the latest commit in the searched paths
-LATEST_COMMIT_IN_PATH=$(git log -1 --format=format:%H --full-diff "$@")
+readonly LATEST_COMMIT_IN_PATH=$(git log -1 --format=format:%H --full-diff "$@")
 
 if [ $LATEST_COMMIT != $LATEST_COMMIT_IN_PATH ]; then
     echo "Exiting this job because code in the following paths have not changed:"


### PR DESCRIPTION
Break the Travis CI integration checks into separate jobs that run in
parallel. This makes is easier to see an overview of what categories
of checks we are running, and makes it easier to see any failures in
the logs.

This fixes #2181

Signed-off-by: James Peach <jpeach@vmware.com>