### PR TITLE
Improve server logging.

### DIFF
--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -106,8 +106,8 @@ func (e *EventHandler) Start() func(<-chan struct{}) error {
 
 // run is the main event handling loop.
 func (e *EventHandler) run(stop <-chan struct{}) error {
-	e.Info("started")
-	defer e.Info("stopped")
+	e.Info("started event handler")
+	defer e.Info("stopped event handler")
 
 	var (
 		// outstanding counts the number of events received but not

--- a/internal/httpsvc/http.go
+++ b/internal/httpsvc/http.go
@@ -38,9 +38,9 @@ type Service struct {
 func (svc *Service) Start(stop <-chan struct{}) (err error) {
 	defer func() {
 		if err != nil {
-			svc.WithError(err).Error("terminated with error")
+			svc.WithError(err).Error("terminated HTTP server with error")
 		} else {
-			svc.Info("stopped")
+			svc.Info("stopped HTTP server")
 		}
 	}()
 
@@ -63,6 +63,6 @@ func (svc *Service) Start(stop <-chan struct{}) (err error) {
 		_ = s.Shutdown(ctx) // ignored, will always be a cancelation error
 	}()
 
-	svc.WithField("address", s.Addr).Info("started")
+	svc.WithField("address", s.Addr).Info("started HTTP server")
 	return s.ListenAndServe()
 }


### PR DESCRIPTION
When we starts and stop a subsystem, mention the subsystem that we are
starting or stopping to log better context around what Contour is doing.

Signed-off-by: James Peach <jpeach@vmware.com>