### PR TITLE
site: Fix tcpproxy include to be singular

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -180,7 +180,13 @@ type TCPProxy struct {
 	Services []Service `json:"services"`
 	// Include specifies that this tcpproxy should be delegated to another HTTPProxy.
 	// +optional
-	Include *TCPProxyInclude `json:"includes,omitempty"`
+	Include *TCPProxyInclude `json:"include,omitempty"`
+	// IncludesDeprecated allow for specific routing configuration to be appended to another HTTPProxy in another namespace.
+	//
+	// Exists due to a mistake when developing HTTPProxy and the field was marked plural
+	// when it should have been singular. This field should stay to not break backwards compatibility to v1 users.
+	// +optional
+	IncludesDeprecated *TCPProxyInclude `json:"includes,omitempty"`
 	// The health check policy for this tcp proxy
 	// +optional
 	HealthCheckPolicy *TCPHealthCheckPolicy `json:"healthCheckPolicy,omitempty"`

--- a/apis/projectcontour/v1/zz_generated.deepcopy.go
+++ b/apis/projectcontour/v1/zz_generated.deepcopy.go
@@ -486,6 +486,11 @@ func (in *TCPProxy) DeepCopyInto(out *TCPProxy) {
 		*out = new(TCPProxyInclude)
 		**out = **in
 	}
+	if in.IncludesDeprecated != nil {
+		in, out := &in.IncludesDeprecated, &out.IncludesDeprecated
+		*out = new(TCPProxyInclude)
+		**out = **in
+	}
 	if in.HealthCheckPolicy != nil {
 		in, out := &in.HealthCheckPolicy, &out.HealthCheckPolicy
 		*out = new(TCPHealthCheckPolicy)

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -914,9 +914,26 @@ spec:
                       format: int32
                       type: integer
                   type: object
-                includes:
+                include:
                   description: Include specifies that this tcpproxy should be delegated
                     to another HTTPProxy.
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                includes:
+                  description: "IncludesDeprecated allow for specific routing configuration
+                    to be appended to another HTTPProxy in another namespace. \n Exists
+                    due to a mistake when developing HTTPProxy and the field was marked
+                    plural when it should have been singular. This field should stay
+                    to not break backwards compatibility to v1 users."
                   properties:
                     name:
                       description: Name of the child HTTPProxy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -988,9 +988,26 @@ spec:
                       format: int32
                       type: integer
                   type: object
-                includes:
+                include:
                   description: Include specifies that this tcpproxy should be delegated
                     to another HTTPProxy.
+                  properties:
+                    name:
+                      description: Name of the child HTTPProxy
+                      type: string
+                    namespace:
+                      description: Namespace of the HTTPProxy to include. Defaults
+                        to the current namespace if not supplied.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                includes:
+                  description: "IncludesDeprecated allow for specific routing configuration
+                    to be appended to another HTTPProxy in another namespace. \n Exists
+                    due to a mistake when developing HTTPProxy and the field was marked
+                    plural when it should have been singular. This field should stay
+                    to not break backwards compatibility to v1 users."
                   properties:
                     name:
                       description: Name of the child HTTPProxy

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2395,6 +2395,64 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	// proxy39broot is a valid TCPProxy which includes to another TCPProxy
+	proxy39broot := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "www.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			TCPProxy: &projcontour.TCPProxy{
+				Include: &projcontour.TCPProxyInclude{
+					Name:      "foo",
+					Namespace: s1.Namespace,
+				},
+			},
+		},
+	}
+
+	proxy39brootplural := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "www.example.com",
+				TLS: &projcontour.TLS{
+					Passthrough: true,
+				},
+			},
+			TCPProxy: &projcontour.TCPProxy{
+				IncludesDeprecated: &projcontour.TCPProxyInclude{
+					Name:      "foo",
+					Namespace: s1.Namespace,
+				},
+			},
+		},
+	}
+
+	proxy39bchild := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			TCPProxy: &projcontour.TCPProxy{
+				Services: []projcontour.Service{{
+					Name: s1.Name,
+					Port: 8080,
+				}},
+			},
+		},
+	}
+
 	proxy40 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -5232,6 +5290,47 @@ func TestDAGInsert(t *testing.T) {
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
 								Name: "www.example.com", // this is proxy39, not proxy38
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(
+									service(s1),
+								),
+							},
+						},
+					),
+				},
+			),
+		},
+		"insert httpproxy w/tcpproxy w/include": {
+			objs: []interface{}{proxy39broot, proxy39bchild, s1},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					VirtualHosts: virtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name: "www.example.com",
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(
+									service(s1),
+								),
+							},
+						},
+					),
+				},
+			),
+		},
+		// Issue #2218
+		"insert httpproxy w/tcpproxy w/include plural": {
+			objs: []interface{}{proxy39brootplural, proxy39bchild, s1},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					VirtualHosts: virtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name: "www.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1328,7 +1328,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>include</code></br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1338,6 +1338,22 @@ TCPProxyInclude
 <td>
 <em>(Optional)</em>
 <p>Include specifies that this tcpproxy should be delegated to another HTTPProxy.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>includes</code></br>
+<em>
+<a href="#projectcontour.io/v1.TCPProxyInclude">
+TCPProxyInclude
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IncludesDeprecated allow for specific routing configuration to be appended to another HTTPProxy in another namespace.</p>
+<p>Exists due to a mistake when developing HTTPProxy and the field was marked plural
+when it should have been singular. This field should stay to not break backwards compatibility to v1 users.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Fixes #2218 

The TCPProxy `include` example was wrong. According to our spec, it should be plural (But I think this is an oversight from conversion from IngressRoute). 

Signed-off-by: Steve Sloka <slokas@vmware.com>