### PR TITLE
docs: Fixes sign-off email reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ PR will probably save you some time.
 Updates #NNNN
 Fixes #MMMM
 
-Signed-off-by: Your Name you@youremail.com
+Signed-off-by: Your Name <you@youremail.com>
 
 <longer change description/justification>
 
@@ -117,7 +117,7 @@ internal\contour: Add quux functions
 
 Fixes #xxyyz
 
-Signed-off-by: Your Name you@youremail.com
+Signed-off-by: Your Name <you@youremail.com>
 
 To implement the quux functions from #xxyyz, we need to
 florble the greep dots, then ensure that the florble is


### PR DESCRIPTION
Previously, the DCO CI job would fail when creating a PR following `CONTRIBUTING.md`. This is due to the DCO email address being improperly formatted. This PR updates `CONTRIBUTING.md` to incase the DCO sign-off email in `<>`.