### PR TITLE
internal/featuretests: test ingress class updates

### DIFF
--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -27,7 +27,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/contour"
@@ -174,6 +173,10 @@ type resourceEventHandler struct {
 }
 
 func (r *resourceEventHandler) OnAdd(obj interface{}) {
+	if r.statusCache.IsCacheable(obj) {
+		r.statusCache.Delete(obj)
+	}
+
 	switch obj.(type) {
 	case *v1.Endpoints:
 		r.EndpointsTranslator.OnAdd(obj)
@@ -184,6 +187,11 @@ func (r *resourceEventHandler) OnAdd(obj interface{}) {
 }
 
 func (r *resourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	// Ensure that tests don't sample stale status.
+	if r.statusCache.IsCacheable(oldObj) {
+		r.statusCache.Delete(oldObj)
+	}
+
 	switch newObj.(type) {
 	case *v1.Endpoints:
 		r.EndpointsTranslator.OnUpdate(oldObj, newObj)
@@ -196,10 +204,7 @@ func (r *resourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
 func (r *resourceEventHandler) OnDelete(obj interface{}) {
 	// Delete this object from the status cache before we make
 	// the deletion visible.
-	switch obj.(type) {
-	case *ingressroutev1.IngressRoute:
-		r.statusCache.Delete(obj)
-	case *projcontour.HTTPProxy:
+	if r.statusCache.IsCacheable(obj) {
 		r.statusCache.Delete(obj)
 	}
 
@@ -307,6 +312,15 @@ func (c *Contour) Status(obj interface{}) *statusResult {
 		Err:     err,
 		Have:    s,
 	}
+}
+
+// NoStatus asserts that the given object did not get any status set.
+func (c *Contour) NoStatus(obj interface{}) *Contour {
+	if _, err := c.statusCache.GetStatus(obj); err == nil {
+		c.T.Errorf("found cached object status, wanted no status")
+	}
+
+	return c
 }
 
 func (c *Contour) Request(typeurl string, names ...string) *Response {

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -60,6 +60,17 @@ func objectKey(obj interface{}) string {
 	}
 }
 
+// IsCacheable returns whether this type of object can be stored in
+// the status cache.
+func (c *StatusCacher) IsCacheable(obj interface{}) bool {
+	switch obj.(type) {
+	case *ingressroutev1.IngressRoute, *projcontour.HTTPProxy:
+		return true
+	default:
+		return false
+	}
+}
+
 // Delete removes an object from the status cache.
 func (c *StatusCacher) Delete(obj interface{}) {
 	if c.objectStatus != nil {


### PR DESCRIPTION
Add a test to ensure that Contour will ignore objects when they change
their ingress class to an ingress class it is not configured to use.

This updates #2199.

Signed-off-by: James Peach <jpeach@vmware.com>