### PR TITLE
site: fix html table rendering error

### DIFF
--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -9,8 +9,6 @@ This page describes the compatibility matrix of Contour and Envoy versions.
 
 ## Supported Envoy versions
 
-<center>
-
 | Envoy version | Contour v1.0.0<sup>5</sup> | Contour v1.0.1<sup>6</sup> | Contour v1.1.0 | Contour v1.2.0 |
 | ------------ | :-----------: | :-----------: | :----------: | :----------: |
 | 1.11.0 | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> |
@@ -20,8 +18,6 @@ This page describes the compatibility matrix of Contour and Envoy versions.
 | 1.12.1 | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> |
 | 1.12.2 | Not supported | *Supported*<sup>6</sup> | *Supported* | Not supported |
 | 1.13.0 | Not supported | Not supported | Not supported | *Supported* |
-
-</center>
 
 #### Notes
 

--- a/site/_resources/kubernetes.md
+++ b/site/_resources/kubernetes.md
@@ -17,7 +17,6 @@ The `client-go` package includes a [compatibility matrix][2] as to what Kubernet
 | 1.16.x | Supported | Supported | Supported |
 | 1.17.x | Supported | Supported | Supported | 
 | 1.18.x | Not Supported<sup>1</sup>  | Not Supported<sup>1</sup> | Not Supported <sup>1</sup> |
-<br>
 
 ### Notes
 


### PR DESCRIPTION
Fixes #2233

html elements cannot surround markdown tables or jekyll will treat the
table as text.