### PR TITLE
internal/contour: remove unused EventHandler.Metrics field

### DIFF
--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -25,7 +25,6 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/k8s"
-	"github.com/projectcontour/contour/internal/metrics"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -41,8 +40,6 @@ type EventHandler struct {
 	HoldoffDelay, HoldoffMaxDelay time.Duration
 
 	StatusClient k8s.StatusClient
-
-	*metrics.Metrics
 
 	logrus.FieldLogger
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -94,7 +94,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 		},
 		CacheHandler:    ch,
 		StatusClient:    &k8s.StatusCacher{},
-		Metrics:         ch.Metrics,
 		FieldLogger:     log,
 		Sequence:        make(chan int, 1),
 		HoldoffDelay:    time.Duration(rand.Intn(100)) * time.Millisecond,

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -83,7 +83,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 		IsLeader:        make(chan struct{}),
 		CacheHandler:    ch,
 		StatusClient:    statusCache,
-		Metrics:         ch.Metrics,
 		FieldLogger:     log,
 		Sequence:        make(chan int, 1),
 		HoldoffDelay:    time.Duration(rand.Intn(100)) * time.Millisecond,

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -198,7 +198,6 @@ func TestGRPC(t *testing.T) {
 			}
 			eh = &contour.EventHandler{
 				CacheHandler: &ch,
-				Metrics:      ch.Metrics,
 				FieldLogger:  log,
 				Converter:    k8s.NewUnstructuredConverter(),
 			}


### PR DESCRIPTION
Updates #2235

The *metrics.Metrics is already promoted via the embedded *CacheHandler field.

Signed-off-by: Dave Cheney <dave@cheney.net>