### PR TITLE
internal/envoy: raise SafeRegex limit to 1048576

### DIFF
--- a/internal/envoy/regex.go
+++ b/internal/envoy/regex.go
@@ -25,8 +25,9 @@ import (
 // units of program size. AFAIK, there's no obvious correlation
 // between regex size and execution time.
 //
-// https://github.com/envoyproxy/envoy/pull/9171#discussion_r351974033
-const maxRegexProgramSize = 1000
+// See also https://github.com/envoyproxy/envoy/pull/9171#discussion_r351974033
+// and https://github.com/projectcontour/contour/issues/2240
+const maxRegexProgramSize = 1 << 20
 
 // SafeRegexMatch retruns a matcher.RegexMatcher for the supplied regex.
 // SafeRegexMatch does not escape regex meta characters.


### PR DESCRIPTION
Updates #2240

Raise the SafeRegex size limit from 1,000 to 1048576. There is no evidence
that this number is sufficient for all possible regex patterns, thus the
limit represents the "no limit" limit because it is currently not
possible for envoy to reject a regex entry in a way that Contour can
trace back to the original input.

Signed-off-by: Dave Cheney <dave@cheney.net>