### PR TITLE
internal/contour: record EventHandler operation metrics

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -204,7 +204,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// wrap eventHandler in an EventRecorder which tracks API server events.
 	eventRecorder := &contour.EventRecorder{
 		Next:    eventHandler,
-		Counter: eventHandler.Metrics.EventHandlerOperationGauge,
+		Counter: eventHandler.Metrics.EventHandlerOperations,
 	}
 
 	// wrap eventRecorder in a converter for objects from the dynamic client.

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -39,7 +39,7 @@ func (e *EventRecorder) OnAdd(obj interface{}) {
 }
 
 func (e *EventRecorder) OnUpdate(oldObj, newObj interface{}) {
-	e.recordOperation("update", newObj) // the api server guarentees that an object's kind cannot be updated
+	e.recordOperation("update", newObj) // the api server guarantees that an object's kind cannot be updated
 	e.Next.OnUpdate(oldObj, newObj)
 }
 

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -30,7 +30,7 @@ import (
 // to another ResourceEventHandler.
 type EventRecorder struct {
 	Next    cache.ResourceEventHandler
-	Counter *prometheus.GaugeVec
+	Counter *prometheus.CounterVec
 }
 
 func (e *EventRecorder) OnAdd(obj interface{}) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -176,7 +176,7 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 		EventHandlerOperations: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: eventHandlerOperations,
-				Help: "Total number of ResourceEventHandler operations by operation and object kind",
+				Help: "Total number of Kubernetes object changes Contour has received by operation and object kind.",
 			},
 			[]string{"op", "kind"},
 		),
@@ -225,13 +225,7 @@ func (m *Metrics) Zero() {
 	m.SetIngressRouteMetric(zeroes)
 	m.SetHTTPProxyMetric(zeroes)
 
-	ops := []string{"add", "update", "delete"}
-	kinds := []string{"Secret", "Service", "Ingress", "IngressRoute", "HTTPProxy", "TLSCertificateDelegation"}
-	for _, op := range ops {
-		for _, kind := range kinds {
-			m.EventHandlerOperations.WithLabelValues(op, kind).Add(0)
-		}
-	}
+	m.EventHandlerOperations.WithLabelValues("add", "Secret").Inc()
 
 	prometheus.NewTimer(m.CacheHandlerOnUpdateSummary).ObserveDuration()
 }

--- a/site/_metrics/contour_eventhandler_operation_total.md
+++ b/site/_metrics/contour_eventhandler_operation_total.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_eventhandler_operation_total'
+type: '[COUNTER](https://prometheus.io/docs/concepts/metric_types/#counter)'
+labels: 'kind, op'
+---
+
+Total number of Kubernetes object changes Contour has received by operation and object kind.


### PR DESCRIPTION
Fixes #2235 

Introduce a new handler in the EventHandler chain which emits prometheus
metrics for the various API operations and kinds observed from informers
which sink to the EventHandler chain.

Inserting the EventRecorded between the DynamicClientHandler and the
EventHandler will make this PR easier to backport to Contour versions
which don't use the dynamic client.

Signed-off-by: Dave Cheney <dave@cheney.net>