### PR TITLE
internal/k8s: move dynamic client translation to k8s package

### DIFF
--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -62,8 +62,6 @@ type EventHandler struct {
 	// seq is the sequence counter of the number of times
 	// an event has been received.
 	seq int
-
-	k8s.Converter
 }
 
 type opAdd struct {
@@ -79,46 +77,14 @@ type opDelete struct {
 }
 
 func (e *EventHandler) OnAdd(obj interface{}) {
-	if e.Converter.CanConvert(obj) {
-		var err error
-		obj, err = e.Converter.Convert(obj)
-		if err != nil {
-			e.Error(err)
-			return
-		}
-	}
 	e.update <- opAdd{obj: obj}
 }
 
 func (e *EventHandler) OnUpdate(oldObj, newObj interface{}) {
-	if e.Converter.CanConvert(oldObj) {
-		var err error
-		oldObj, err = e.Converter.Convert(oldObj)
-		if err != nil {
-			e.Error(err)
-			return
-		}
-	}
-	if e.Converter.CanConvert(newObj) {
-		var err error
-		newObj, err = e.Converter.Convert(newObj)
-		if err != nil {
-			e.Error(err)
-			return
-		}
-	}
 	e.update <- opUpdate{oldObj: oldObj, newObj: newObj}
 }
 
 func (e *EventHandler) OnDelete(obj interface{}) {
-	if e.Converter.CanConvert(obj) {
-		var err error
-		obj, err = e.Converter.Convert(obj)
-		if err != nil {
-			e.Error(err)
-			return
-		}
-	}
 	e.update <- opDelete{obj: obj}
 }
 

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -98,7 +98,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 		Sequence:        make(chan int, 1),
 		HoldoffDelay:    time.Duration(rand.Intn(100)) * time.Millisecond,
 		HoldoffMaxDelay: time.Duration(rand.Intn(500)) * time.Millisecond,
-		Converter:       k8s.NewUnstructuredConverter(),
 	}
 
 	for _, opt := range opts {

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -92,7 +92,6 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 				FieldLogger: log,
 			},
 		},
-		Converter: k8s.NewUnstructuredConverter(),
 	}
 
 	for _, opt := range opts {

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/k8s"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
@@ -199,7 +197,6 @@ func TestGRPC(t *testing.T) {
 			eh = &contour.EventHandler{
 				CacheHandler: &ch,
 				FieldLogger:  log,
-				Converter:    k8s.NewUnstructuredConverter(),
 			}
 			r := prometheus.NewRegistry()
 			srv := NewAPI(log, map[string]Resource{

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -295,3 +296,5 @@ func TestConvertUnstructured(t *testing.T) {
 		wantError: errors.New("unable to convert unstructured object to projectcontour.io/v1, Kind=HTTPProxy: cannot convert int to string"),
 	})
 }
+
+var _ cache.ResourceEventHandler = &DynamicClientHandler{}


### PR DESCRIPTION
Updates #2235

Contour 1.2.x is moving to the k8s dynamic client for deserialising
Contour's CRD objects. To make #2244 easier to backport to Contour's 1.1
branch, which does not support the dynamic client, break this logic out
into its own ResourceEventHandler wrapper which returns the current
contour.EventHandler logic to Contour 1.1 spec.

As a side effect, we only need to use the DynamicClientHandler wrapper
in cases where we know the resources are coming from the DynamicClient.
Specifically we don't need to use this path for Core.v1 and Extension
objects. Also, we don't need to use the DynamicClientHandler wrapper in
e2e/feature tests as there is no k8s API server connected to those tests
-- we construct the final k8s object as a fixture and call
contour.EventHandler.OnAdd/Update/Delete directly.

Signed-off-by: Dave Cheney <dave@cheney.net>