### PR TITLE
internal: Initial support for external client cert validation

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -24,6 +24,7 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -1067,8 +1068,18 @@ func TestListenerVisit(t *testing.T) {
 }
 
 func transportSocket(tlsMinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, alpnprotos ...string) *envoy_api_v2_core.TransportSocket {
+	secret := &dag.Secret{
+		Object: &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "default",
+			},
+			Type: v1.SecretTypeTLS,
+			Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		},
+	}
 	return envoy.DownstreamTLSTransportSocket(
-		envoy.DownstreamTLSContext("default/secret/68621186db", tlsMinProtoVersion, alpnprotos...),
+		envoy.DownstreamTLSContext(secret, tlsMinProtoVersion, nil, alpnprotos...),
 	)
 }
 

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -789,7 +789,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				return nil
 			}
 
-			var uv *UpstreamValidation
+			var uv *PeerValidationContext
 			if protocol == "tls" {
 				// we can only validate TLS connections to services that talk TLS
 				uv, err = b.lookupUpstreamValidation(service.UpstreamValidation, proxy.Namespace)
@@ -999,7 +999,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 					return
 				}
 
-				var uv *UpstreamValidation
+				var uv *PeerValidationContext
 				var err error
 				if s.Protocol == "tls" {
 					// we can only validate TLS connections to services that talk TLS
@@ -1070,7 +1070,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 	sw.SetValid()
 }
 
-func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, namespace string) (*UpstreamValidation, error) {
+func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, namespace string) (*PeerValidationContext, error) {
 	if uv == nil {
 		// no upstream validation requested, nothing to do
 		return nil, nil
@@ -1087,7 +1087,7 @@ func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, n
 		return nil, errors.New("missing subject alternative name")
 	}
 
-	return &UpstreamValidation{
+	return &PeerValidationContext{
 		CACertificate: cacert,
 		SubjectName:   uv.SubjectName,
 	}, nil

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4309,7 +4309,7 @@ func TestDAGInsert(t *testing.T) {
 										Protocol:    "tls",
 									},
 									Protocol: "tls",
-									UpstreamValidation: &UpstreamValidation{
+									UpstreamValidation: &PeerValidationContext{
 										CACertificate: secret(cert1),
 										SubjectName:   "example.com",
 									},
@@ -5259,7 +5259,7 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-		"insert httpproxy expecting verification": {
+		"insert httpproxy expecting upstream verification": {
 			objs: []interface{}{
 				cert1, proxy17, s1a,
 			},
@@ -5277,7 +5277,7 @@ func TestDAGInsert(t *testing.T) {
 										Protocol:    "tls",
 									},
 									Protocol: "tls",
-									UpstreamValidation: &UpstreamValidation{
+									UpstreamValidation: &PeerValidationContext{
 										CACertificate: secret(cert1),
 										SubjectName:   "example.com",
 									},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -15,6 +15,9 @@ package dag
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/assert"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestVirtualHostValid(t *testing.T) {
@@ -71,6 +74,28 @@ func TestSecureVirtualHostValid(t *testing.T) {
 		TCPProxy: new(TCPProxy),
 	}
 	assert.True(vh.Valid())
+}
+
+func TestPeerValidationContext(t *testing.T) {
+	pvc1 := PeerValidationContext{
+		CACertificate: &Secret{
+			Object: &v1.Secret{
+				Data: map[string][]byte{
+					CACertificateKey: []byte("cacert"),
+				},
+			},
+		},
+		SubjectName: "subject",
+	}
+	pvc2 := PeerValidationContext{}
+	var pvc3 *PeerValidationContext
+
+	assert.Equal(t, pvc1.GetSubjectName(), "subject")
+	assert.Equal(t, pvc1.GetCACertificate(), []byte("cacert"))
+	assert.Equal(t, pvc2.GetSubjectName(), "")
+	assert.Equal(t, pvc2.GetCACertificate(), []byte(nil))
+	assert.Equal(t, pvc3.GetSubjectName(), "")
+	assert.Equal(t, pvc3.GetCACertificate(), []byte(nil))
 }
 
 type Assert struct {

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -439,12 +439,14 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			envoy.FilterChainTLS(
 				"kuard.example.com",
-				&dag.Secret{Object: secret1},
+				envoy.DownstreamTLSContext(
+					&dag.Secret{Object: secret1},
+					envoy_api_v2_auth.TlsParameters_TLSv1_3,
+					nil,
+					"h2", "http/1.1"),
 				envoy.Filters(
 					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				envoy_api_v2_auth.TlsParameters_TLSv1_3,
-				"h2", "http/1.1",
 			),
 		},
 	}
@@ -1102,12 +1104,14 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			envoy.FilterChainTLS(
 				"kuard.example.com",
-				&dag.Secret{Object: secret1},
+				envoy.DownstreamTLSContext(
+					&dag.Secret{Object: secret1},
+					envoy_api_v2_auth.TlsParameters_TLSv1_2,
+					nil,
+					"h2", "http/1.1"),
 				envoy.Filters(
 					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				envoy_api_v2_auth.TlsParameters_TLSv1_2,
-				"h2", "http/1.1",
 			),
 		},
 	}
@@ -1164,12 +1168,14 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			envoy.FilterChainTLS(
 				"kuard.example.com",
-				&dag.Secret{Object: secret1},
+				envoy.DownstreamTLSContext(
+					&dag.Secret{Object: secret1},
+					envoy_api_v2_auth.TlsParameters_TLSv1_3,
+					nil,
+					"h2", "http/1.1"),
 				envoy.Filters(
 					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				envoy_api_v2_auth.TlsParameters_TLSv1_3,
-				"h2", "http/1.1",
 			),
 		},
 	}
@@ -1293,10 +1299,12 @@ func filterchaintls(domain string, secret *v1.Secret, filter *envoy_api_v2_liste
 	return []*envoy_api_v2_listener.FilterChain{
 		envoy.FilterChainTLS(
 			domain,
-			&dag.Secret{Object: secret},
+			envoy.DownstreamTLSContext(
+				&dag.Secret{Object: secret},
+				envoy_api_v2_auth.TlsParameters_TLSv1_1,
+				nil,
+				alpn...),
 			envoy.Filters(filter),
-			envoy_api_v2_auth.TlsParameters_TLSv1_1,
-			alpn...,
 		),
 	}
 }

--- a/internal/envoy/auth.go
+++ b/internal/envoy/auth.go
@@ -17,6 +17,8 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 var (
@@ -48,7 +50,7 @@ var (
 // UpstreamTLSContext creates an envoy_api_v2_auth.UpstreamTlsContext. By default
 // UpstreamTLSContext returns a HTTP/1.1 TLS enabled context. A list of
 // additional ALPN protocols can be provided.
-func UpstreamTLSContext(ca []byte, subjectName string, sni string, alpnProtocols ...string) *envoy_api_v2_auth.UpstreamTlsContext {
+func UpstreamTLSContext(peerValidationContext *dag.PeerValidationContext, sni string, alpnProtocols ...string) *envoy_api_v2_auth.UpstreamTlsContext {
 	context := &envoy_api_v2_auth.UpstreamTlsContext{
 		CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
 			AlpnProtocols: alpnProtocols,
@@ -56,31 +58,23 @@ func UpstreamTLSContext(ca []byte, subjectName string, sni string, alpnProtocols
 		Sni: sni,
 	}
 
-	// we have to do explicitly assign the value from validationContext
-	// to context.CommonTlsContext.ValidationContextType because the latter
-	// is an interface, returning nil from validationContext directly into
-	// this field boxes the nil into the unexported type of this grpc OneOf field
-	// which causes proto marshaling to explode later on. Not happy Jan.
-	vc := validationContext(ca, subjectName)
-	if vc != nil {
-		context.CommonTlsContext.ValidationContextType = vc
+	if peerValidationContext.GetCACertificate() != nil && len(peerValidationContext.GetSubjectName()) > 0 {
+		// We have to do explicitly assign the value from validationContext
+		// to context.CommonTlsContext.ValidationContextType because the latter
+		// is an interface, returning nil from validationContext directly into
+		// this field boxes the nil into the unexported type of this grpc OneOf field
+		// which causes proto marshaling to explode later on. Not happy Jan.
+		vc := validationContext(peerValidationContext.GetCACertificate(), peerValidationContext.GetSubjectName())
+		if vc != nil {
+			context.CommonTlsContext.ValidationContextType = vc
+		}
 	}
 
 	return context
 }
 
 func validationContext(ca []byte, subjectName string) *envoy_api_v2_auth.CommonTlsContext_ValidationContext {
-	if len(ca) < 1 {
-		// no ca provided, nothing to do
-		return nil
-	}
-
-	if len(subjectName) < 1 {
-		// no subject name provided, nothing to do
-		return nil
-	}
-
-	return &envoy_api_v2_auth.CommonTlsContext_ValidationContext{
+	vc := &envoy_api_v2_auth.CommonTlsContext_ValidationContext{
 		ValidationContext: &envoy_api_v2_auth.CertificateValidationContext{
 			TrustedCa: &envoy_api_v2_core.DataSource{
 				// TODO(dfc) update this for SDS
@@ -88,18 +82,23 @@ func validationContext(ca []byte, subjectName string) *envoy_api_v2_auth.CommonT
 					InlineBytes: ca,
 				},
 			},
-			MatchSubjectAltNames: []*matcher.StringMatcher{{
-				MatchPattern: &matcher.StringMatcher_Exact{
-					Exact: subjectName,
-				}},
-			},
 		},
 	}
+
+	if len(subjectName) > 0 {
+		vc.ValidationContext.MatchSubjectAltNames = []*matcher.StringMatcher{{
+			MatchPattern: &matcher.StringMatcher_Exact{
+				Exact: subjectName,
+			}},
+		}
+	}
+
+	return vc
 }
 
 // DownstreamTLSContext creates a new DownstreamTlsContext.
-func DownstreamTLSContext(secretName string, tlsMinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, alpnProtos ...string) *envoy_api_v2_auth.DownstreamTlsContext {
-	return &envoy_api_v2_auth.DownstreamTlsContext{
+func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, peerValidationContext *dag.PeerValidationContext, alpnProtos ...string) *envoy_api_v2_auth.DownstreamTlsContext {
+	context := &envoy_api_v2_auth.DownstreamTlsContext{
 		CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
 			TlsParams: &envoy_api_v2_auth.TlsParameters{
 				TlsMinimumProtocolVersion: tlsMinProtoVersion,
@@ -107,10 +106,20 @@ func DownstreamTLSContext(secretName string, tlsMinProtoVersion envoy_api_v2_aut
 				CipherSuites:              ciphers,
 			},
 			TlsCertificateSdsSecretConfigs: []*envoy_api_v2_auth.SdsSecretConfig{{
-				Name:      secretName,
+				Name:      Secretname(serverSecret),
 				SdsConfig: ConfigSource("contour"),
 			}},
 			AlpnProtocols: alpnProtos,
 		},
 	}
+
+	if peerValidationContext.GetCACertificate() != nil {
+		vc := validationContext(peerValidationContext.GetCACertificate(), "")
+		if vc != nil {
+			context.CommonTlsContext.ValidationContextType = vc
+			context.RequireClientCertificate = protobuf.Bool(true)
+		}
+	}
+
+	return context
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -79,16 +79,14 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 	case "tls":
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
-				upstreamValidationCACert(c),
-				upstreamValidationSubjectAltName(c),
+				c.UpstreamValidation,
 				service.ExternalName,
 			),
 		)
 	case "h2":
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
-				upstreamValidationCACert(c),
-				upstreamValidationSubjectAltName(c),
+				c.UpstreamValidation,
 				service.ExternalName,
 				"h2",
 			),
@@ -99,22 +97,6 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 	}
 
 	return cluster
-}
-
-func upstreamValidationCACert(c *dag.Cluster) []byte {
-	if c.UpstreamValidation == nil {
-		// No validation required
-		return nil
-	}
-	return c.UpstreamValidation.CACertificate.Object.Data[dag.CACertificateKey]
-}
-
-func upstreamValidationSubjectAltName(c *dag.Cluster) string {
-	if c.UpstreamValidation == nil {
-		// No validation required
-		return ""
-	}
-	return c.UpstreamValidation.SubjectName
 }
 
 // StaticClusterLoadAssignment creates a *v2.ClusterLoadAssignment pointing to the external DNS address of the service

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -242,18 +242,17 @@ func FilterChains(filters ...*envoy_api_v2_listener.Filter) []*envoy_api_v2_list
 }
 
 // FilterChainTLS returns a TLS enabled envoy_api_v2_listener.FilterChain,
-func FilterChainTLS(domain string, secret *dag.Secret, filters []*envoy_api_v2_listener.Filter, tlsMinProtoVersion envoy_api_v2_auth.TlsParameters_TlsProtocol, alpnProtos ...string) *envoy_api_v2_listener.FilterChain {
+func FilterChainTLS(domain string, downstream *envoy_api_v2_auth.DownstreamTlsContext, filters []*envoy_api_v2_listener.Filter) *envoy_api_v2_listener.FilterChain {
 	fc := &envoy_api_v2_listener.FilterChain{
 		Filters: filters,
 		FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 			ServerNames: []string{domain},
 		},
 	}
-	// attach certificate data to this listener if provided.
-	if secret != nil {
-		fc.TransportSocket = DownstreamTLSTransportSocket(
-			DownstreamTLSContext(Secretname(secret), tlsMinProtoVersion, alpnProtos...),
-		)
+	// Attach TLS data to this listener if provided.
+	if downstream != nil {
+		fc.TransportSocket = DownstreamTLSTransportSocket(downstream)
+
 	}
 	return fc
 }

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DefaultCluster returns a copy of c, updated with default values.
@@ -109,7 +110,20 @@ func cluster(name, servicename, statName string) *v2.Cluster {
 
 func tlsCluster(c *v2.Cluster, ca []byte, subjectName string, sni string, alpnProtocols ...string) *v2.Cluster {
 	c.TransportSocket = envoy.UpstreamTLSTransportSocket(
-		envoy.UpstreamTLSContext(ca, subjectName, sni, alpnProtocols...),
+		envoy.UpstreamTLSContext(
+			&dag.PeerValidationContext{
+				CACertificate: &dag.Secret{Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Type: "kubernetes.io/tls",
+					Data: map[string][]byte{dag.CACertificateKey: ca},
+				}},
+				SubjectName: subjectName},
+			sni,
+			alpnProtocols...,
+		),
 	)
 	return c
 }
@@ -209,10 +223,12 @@ func filterchaintls(domain string, secret *v1.Secret, filter *envoy_api_v2_liste
 	return []*envoy_api_v2_listener.FilterChain{
 		envoy.FilterChainTLS(
 			domain,
-			&dag.Secret{Object: secret},
+			envoy.DownstreamTLSContext(
+				&dag.Secret{Object: secret},
+				envoy_api_v2_auth.TlsParameters_TLSv1_1,
+				nil,
+				alpn...),
 			envoy.Filters(filter),
-			envoy_api_v2_auth.TlsParameters_TLSv1_1,
-			alpn...,
 		),
 	}
 }

--- a/internal/featuretests/tlsprotocolversion_test.go
+++ b/internal/featuretests/tlsprotocolversion_test.go
@@ -131,12 +131,14 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			envoy.FilterChainTLS(
 				"kuard.example.com",
-				&dag.Secret{Object: sec1},
+				envoy.DownstreamTLSContext(
+					&dag.Secret{Object: sec1},
+					envoy_api_v2_auth.TlsParameters_TLSv1_3,
+					nil,
+					"h2", "http/1.1"),
 				envoy.Filters(
 					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				envoy_api_v2_auth.TlsParameters_TLSv1_3,
-				"h2", "http/1.1",
 			),
 		},
 	}


### PR DESCRIPTION
internal: Initial support for external client cert validation

Adds initial support for authentication of external clients (downstream) by
validating their client certificates against trusted CA certificate.

The feature is not yet exposed in the API.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>