### PR TITLE
Update manifests for v1.2.0 release

### DIFF
--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -48,7 +48,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: Always
         name: contour
         ports:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -29,7 +29,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -105,7 +105,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1531,7 +1531,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -1617,7 +1617,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1693,7 +1693,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:master
+        image: docker.io/projectcontour/contour:v1.2.0
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:


### PR DESCRIPTION
Fixes #2268 by updating the manifests tags to reference the v1.2.0 release tag.

Signed-off-by: Steve Sloka <slokas@vmware.com>