### PR TITLE
golangci.yml: remove exclude for deleted path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,13 +24,6 @@ linters-settings:
     check-exported: false
 
 issues:
-  exclude-rules:
-  - path: apis/generated/
-    linters:
-    - deadcode
-    - unparam
-    - unused
-    - varcheck
   exclude:
   # TODO(jpeach): exclude unparam warnings about functions that always recieve
   # the same arguments. We should clean those up some time.


### PR DESCRIPTION
apis/generated was deleted in 1.2, we don't need to exclude it any
more.

Signed-off-by: Dave Cheney <dave@cheney.net>