### PR TITLE
makefile: Add a 'make checkall' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ export GO111MODULE=on
 .PHONY: check
 check: install check-test check-test-race ## Install and run tests
 
+.PHONY: checkall
+checkall: check lint check-generate
+
 install: ## Build and install the contour binary
 	go install -mod=readonly -v $(GO_TAGS) $(MODULE)/cmd/contour
 
@@ -86,10 +89,10 @@ check-coverage: ## Run tests to generate code coverage
 
 .PHONY: lint
 lint: ## Run lint checks
-lint: check-golint check-yamllint check-flags check-misspell
+lint: lint-golint lint-yamllint lint-flags lint-misspell
 
 .PHONY: check-misspell
-check-misspell:
+lint-misspell:
 	@echo Running spell checker ...
 	@go run github.com/client9/misspell/cmd/misspell \
 		-locale US \
@@ -97,12 +100,12 @@ check-misspell:
 		design/* site/*.md site/_{guides,posts,resources} site/docs/**/* *.md
 
 .PHONY: check-golint
-check-golint:
+lint-golint:
 	@echo Running Go linter ...
 	@./hack/golangci-lint run
 
 .PHONY: check-yamllint
-check-yamllint:
+lint-yamllint:
 	@echo Running YAML linter ...
 	@docker run --rm -ti -v $(CURDIR):/workdir giantswarm/yamllint examples/ site/examples/
 
@@ -112,7 +115,7 @@ check-yamllint:
 # or doesn't end with a period. "xDS" and "gRPC" are exceptions to
 # the first rule.
 .PHONY: check-flags
-check-flags:
+lint-flags:
 	@if git --no-pager grep --extended-regexp '[.]Flag\("[^"]+", "([^A-Zxg][^"]+|[^"]+[^.])"' cmd/contour; then \
 		echo "ERROR: CLI flag help strings must start with a capital and end with a period."; \
 		exit 2; \
@@ -150,6 +153,10 @@ generate-api-docs:
 generate-metrics-docs:
 	@echo Generating metrics documentation ...
 	@cd site/_metrics && rm -f *.md && go run ../../hack/generate-metrics-doc.go
+
+.PHONY: check-generate
+check-generate: generate
+	@./hack/travis/check-uncommitted-codegen.sh
 
 # TODO(youngnick): Move these local bootstrap config files out of the repo root dir.
 $(LOCAL_BOOTSTRAP_CONFIG): install


### PR DESCRIPTION
Fixes #2291 

This PR adds a `make checkall` task which runs the tests, install, linting and generate tasks. It's using the aliases such that as these commands grow, the meaning behind the commands doesn't have to be translated. 

Additionally, it renames the `check-` tasks under the `lint` task to be prefixed with `lint-*` to keep consistency. 

Signed-off-by: Steve Sloka <slokas@vmware.com>