### PR TITLE
internal/dag: move extension ingress translation to a helper

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -247,7 +247,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// The default behavior is to listen for networking/v1beta1.Ingress objects and let the API server
 	// transparently upgrade the extensions version for us.
 	if ctx.UseExtensionsV1beta1Ingress {
-		informerSyncList.Add(coreInformers.Extensions().V1beta1().Ingresses().Informer()).AddEventHandler(eventRecorder)
+		translator := &k8s.ExtensionsIngressTranslator{
+			Next:   eventRecorder,
+			Logger: log.WithField("context", "extensionsIngressTranslator"),
+		}
+		informerSyncList.Add(coreInformers.Extensions().V1beta1().Ingresses().Informer()).AddEventHandler(translator)
 	} else {
 		informerSyncList.Add(coreInformers.Networking().V1beta1().Ingresses().Informer()).AddEventHandler(eventRecorder)
 	}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,13 +14,9 @@
 package dag
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"github.com/projectcontour/contour/internal/k8s"
 
 	v1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
@@ -164,18 +160,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			kc.ingresses[m] = obj
 			return true
 		}
-	case *extensionsv1beta1.Ingress:
-		if kc.matchesIngressClass(obj) {
-			ingress := new(v1beta1.Ingress)
-			if err := transposeIngress(obj, ingress); err != nil {
-				om := obj.GetObjectMeta()
-				kc.WithField("name", om.GetName()).
-					WithField("namespace", om.GetNamespace()).
-					Error(err)
-				return false
-			}
-			return kc.Insert(ingress)
-		}
 	case *ingressroutev1.IngressRoute:
 		if kc.matchesIngressClass(obj) {
 			m := toMeta(obj)
@@ -282,11 +266,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		delete(kc.services, m)
 		return ok
 	case *v1beta1.Ingress:
-		m := toMeta(obj)
-		_, ok := kc.ingresses[m]
-		delete(kc.ingresses, m)
-		return ok
-	case *extensionsv1beta1.Ingress:
 		m := toMeta(obj)
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
@@ -531,16 +510,4 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 	}
 
 	return false
-}
-
-// transposeIngress transposes extensionis/v1beta1.Ingress objects into
-// networking/v1beta1.Ingress objects.
-func transposeIngress(src *extensionsv1beta1.Ingress, dst *v1beta1.Ingress) error {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	if err := enc.Encode(src); err != nil {
-		return nil
-	}
-	dec := json.NewDecoder(&buf)
-	return dec.Decode(dst)
 }

--- a/internal/k8s/translator.go
+++ b/internal/k8s/translator.go
@@ -1,0 +1,87 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/sirupsen/logrus"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ExtensionsIngressTranslator translates extensions/v1beta1.Ingress objects into
+// networking/v1beta1.Ingress objects.
+type ExtensionsIngressTranslator struct {
+
+	// Next is the next handler in the chain.
+	Next cache.ResourceEventHandler
+
+	Logger logrus.FieldLogger
+}
+
+func (e *ExtensionsIngressTranslator) OnAdd(obj interface{}) {
+	obj, err := translateExtensionsIngressToNetworkingIngress(obj)
+	if err != nil {
+		e.Logger.Error(err)
+		return
+	}
+	e.Next.OnAdd(obj)
+}
+
+func (e *ExtensionsIngressTranslator) OnUpdate(oldObj, newObj interface{}) {
+	oldObj, err := translateExtensionsIngressToNetworkingIngress(oldObj)
+	if err != nil {
+		e.Logger.Error(err)
+		return
+	}
+	newObj, err = translateExtensionsIngressToNetworkingIngress(newObj)
+	if err != nil {
+		e.Logger.Error(err)
+		return
+	}
+	e.Next.OnUpdate(oldObj, newObj)
+}
+
+func (e *ExtensionsIngressTranslator) OnDelete(obj interface{}) {
+	obj, err := translateExtensionsIngressToNetworkingIngress(obj)
+	if err != nil {
+		e.Logger.Error(err)
+		return
+	}
+	e.Next.OnDelete(obj)
+}
+
+// translateExtensionsIngressToNetworkingIngress translates extensions/v1beta1.Ingress
+// objects into networking/v1beta1.Ingress objects. If obj is not an extensions/v1beta1.Ingress
+// it is returned untouched.
+func translateExtensionsIngressToNetworkingIngress(src interface{}) (interface{}, error) {
+	if _, ok := src.(*extensionsv1beta1.Ingress); !ok {
+		// not an *extensionsv1beta1.Ingress, leave it alone.
+		return src, nil
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(src); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(&buf)
+	dst := new(v1beta1.Ingress)
+	if err := dec.Decode(dst); err != nil {
+		return nil, err
+	}
+	return dst, nil
+}

--- a/internal/k8s/translator_test.go
+++ b/internal/k8s/translator_test.go
@@ -1,0 +1,73 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/projectcontour/contour/internal/assert"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestConvertConvertExtensionsIngressToNetworkingIngress(t *testing.T) {
+	type testcase struct {
+		obj       interface{}
+		want      interface{}
+		wantError error
+	}
+
+	run := func(t *testing.T, name string, tc testcase) {
+		t.Helper()
+
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			got, err := translateExtensionsIngressToNetworkingIngress(tc.obj)
+			assert.Equal(t, tc.wantError, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	run(t, "extensionsv1beta1.Ingress -> v1beta1.Ingress", testcase{
+		obj: &extensionsv1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Spec: extensionsv1beta1.IngressSpec{
+				Backend: &extensionsv1beta1.IngressBackend{
+					ServiceName: "kuard",
+					ServicePort: intstr.FromInt(80),
+				},
+			},
+		},
+		want: &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Spec: v1beta1.IngressSpec{
+				Backend: &v1beta1.IngressBackend{
+					ServiceName: "kuard",
+					ServicePort: intstr.FromInt(80),
+				},
+			},
+		},
+		wantError: nil,
+	})
+
+}


### PR DESCRIPTION
Updates #403

Prior to this PR the automagic translation of the deprecated
extensions/ingress.v1beta1 types to networking/ingress.v1beta1 types was
handled during dag.KubernetesCache insertion.

This PR moves this code to internal/k8s as a helper, a la the
DynamicConverter. This removes the requirement to care about those
deprecated API types from things that process them, including the cache
and ingress status writer.

Signed-off-by: Dave Cheney <dave@cheney.net>