### PR TITLE
cmd/contour: remove --use-extensions-v1beta1-ingress

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -121,8 +121,6 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("accesslog-format", "Format for Envoy access logs.").StringVar(&ctx.AccessLogFormat)
 	serve.Flag("disable-leader-election", "Disable leader election mechanism.").BoolVar(&ctx.DisableLeaderElection)
 
-	serve.Flag("use-extensions-v1beta1-ingress", "Subscribe to the deprecated extensions/v1beta1.Ingress type.").BoolVar(&ctx.UseExtensionsV1beta1Ingress)
-
 	serve.Flag("debug", "Enable debug logging.").Short('d').BoolVar(&ctx.Debug)
 	serve.Flag("experimental-service-apis", "Subscribe to the new service-apis types.").BoolVar(&ctx.UseExperimentalServiceAPITypes)
 	return serve, ctx
@@ -233,6 +231,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	informerSyncList.Add(dynamicInformers.ForResource(projectcontour.TLSCertificateDelegationGVR).Informer()).AddEventHandler(dynamicHandler)
 
 	informerSyncList.Add(coreInformers.Core().V1().Services().Informer()).AddEventHandler(eventRecorder)
+	informerSyncList.Add(coreInformers.Networking().V1beta1().Ingresses().Informer()).AddEventHandler(eventRecorder)
 
 	if ctx.UseExperimentalServiceAPITypes {
 		log.Info("Enabling Experimental Service APIs types")
@@ -240,16 +239,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		informerSyncList.Add(dynamicInformers.ForResource(serviceapis.GroupVersion.WithResource("gateways")).Informer()).AddEventHandler(dynamicHandler)
 		informerSyncList.Add(dynamicInformers.ForResource(serviceapis.GroupVersion.WithResource("httproutes")).Informer()).AddEventHandler(dynamicHandler)
 		informerSyncList.Add(dynamicInformers.ForResource(serviceapis.GroupVersion.WithResource("tcproutes")).Informer()).AddEventHandler(dynamicHandler)
-	}
-
-	// After K8s 1.13 the API server will automatically translate extensions/v1beta1.Ingress objects
-	// to networking/v1beta1.Ingress objects so we should only listen for one type or the other.
-	// The default behavior is to listen for networking/v1beta1.Ingress objects and let the API server
-	// transparently upgrade the extensions version for us.
-	if ctx.UseExtensionsV1beta1Ingress {
-		informerSyncList.Add(coreInformers.Extensions().V1beta1().Ingresses().Informer()).AddEventHandler(eventRecorder)
-	} else {
-		informerSyncList.Add(coreInformers.Networking().V1beta1().Ingresses().Informer()).AddEventHandler(eventRecorder)
 	}
 
 	// Add informers for each root-ingressroute namespaces

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -103,15 +103,6 @@ type serveContext struct {
 	// RequestTimeout sets the client request timeout globally for Contour.
 	RequestTimeout time.Duration `yaml:"request-timeout,omitempty"`
 
-	// Should Contour fall back to registering an informer for the deprecated
-	// extensions/v1beta1.Ingress type.
-	// By default this value is false, meaning Contour will register an informer for
-	// networking/v1beta1.Ingress and expect the API server to rewrite extensions/v1beta1.Ingress
-	// objects transparently.
-	// If the value is true, Contour will register for extensions/v1beta1.Ingress type and do
-	// the rewrite itself.
-	UseExtensionsV1beta1Ingress bool `yaml:"-"`
-
 	// Should Contour register to watch the new service-apis types?
 	// By default this value is false, meaning Contour will not do anything with any of the new
 	// types.
@@ -173,7 +164,6 @@ func newServeContext() *serveContext {
 			Namespace:     "projectcontour",
 			Name:          "leader-elect",
 		},
-		UseExtensionsV1beta1Ingress:    false,
 		UseExperimentalServiceAPITypes: false,
 	}
 }

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -38,7 +38,6 @@ spec:
       - args:
         - serve
         - --incluster
-        - --use-extensions-v1beta1-ingress
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1561,7 +1561,6 @@ spec:
       - args:
         - serve
         - --incluster
-        - --use-extensions-v1beta1-ingress
         - --xds-address=0.0.0.0
         - --xds-port=8001
         - --envoy-service-http-port=80

--- a/internal/dag/annotations_test.go
+++ b/internal/dag/annotations_test.go
@@ -23,7 +23,6 @@ import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	v1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -440,7 +439,6 @@ func TestAnnotationKindValidation(t *testing.T) {
 	for _, kind := range []string{
 		k8s.KindOf(&v1.Service{}),
 		k8s.KindOf(&v1beta1.Ingress{}),
-		k8s.KindOf(&extensionsv1beta1.Ingress{}),
 		k8s.KindOf(&ingressroutev1.IngressRoute{}),
 		k8s.KindOf(&projectcontour.HTTPProxy{}),
 	} {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,13 +14,9 @@
 package dag
 
 import (
-	"bytes"
-	"encoding/json"
-
 	"github.com/projectcontour/contour/internal/k8s"
 
 	v1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
@@ -164,18 +160,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			kc.ingresses[m] = obj
 			return true
 		}
-	case *extensionsv1beta1.Ingress:
-		if kc.matchesIngressClass(obj) {
-			ingress := new(v1beta1.Ingress)
-			if err := transposeIngress(obj, ingress); err != nil {
-				om := obj.GetObjectMeta()
-				kc.WithField("name", om.GetName()).
-					WithField("namespace", om.GetNamespace()).
-					Error(err)
-				return false
-			}
-			return kc.Insert(ingress)
-		}
 	case *ingressroutev1.IngressRoute:
 		if kc.matchesIngressClass(obj) {
 			m := toMeta(obj)
@@ -282,11 +266,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		delete(kc.services, m)
 		return ok
 	case *v1beta1.Ingress:
-		m := toMeta(obj)
-		_, ok := kc.ingresses[m]
-		delete(kc.ingresses, m)
-		return ok
-	case *extensionsv1beta1.Ingress:
 		m := toMeta(obj)
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
@@ -531,16 +510,4 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 	}
 
 	return false
-}
-
-// transposeIngress transposes extensionis/v1beta1.Ingress objects into
-// networking/v1beta1.Ingress objects.
-func transposeIngress(src *extensionsv1beta1.Ingress, dst *v1beta1.Ingress) error {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	if err := enc.Encode(src); err != nil {
-		return nil
-	}
-	dec := json.NewDecoder(&buf)
-	return dec.Decode(dst)
 }

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -38,7 +38,7 @@ import (
 
 // heptio/contour#172. Updating an object from
 //
-// apiVersion: extensions/v1beta1
+// apiVersion: networking/v1beta1
 // kind: Ingress
 // metadata:
 //   name: kuard
@@ -49,7 +49,7 @@ import (
 //
 // to
 //
-// apiVersion: extensions/v1beta1
+// apiVersion: networking/v1beta1
 // kind: Ingress
 // metadata:
 //   name: kuard
@@ -153,7 +153,7 @@ func TestEditIngress(t *testing.T) {
 // heptio/contour#101
 // The path /hello should point to default/hello/80 on "*"
 //
-// apiVersion: extensions/v1beta1
+// apiVersion: networking/v1beta1
 // kind: Ingress
 // metadata:
 //   name: hello
@@ -697,7 +697,7 @@ func TestIssue257(t *testing.T) {
 	rh, cc, done := setup(t)
 	defer done()
 
-	// apiVersion: extensions/v1beta1
+	// apiVersion: networking/v1beta1
 	// kind: Ingress
 	// metadata:
 	//   name: kuard-ing
@@ -751,7 +751,7 @@ func TestIssue257(t *testing.T) {
 		),
 	), nil)
 
-	// apiVersion: extensions/v1beta1
+	// apiVersion: networking/v1beta1
 	// kind: Ingress
 	// metadata:
 	//   name: kuard-ing
@@ -1311,7 +1311,7 @@ func TestRDSAssertNoDataRaceDuringInsertAndStream(t *testing.T) {
 }
 
 // issue 606: spec.rules.host without a http key causes panic.
-// apiVersion: extensions/v1beta1
+// apiVersion: networking/v1beta1
 // kind: Ingress
 // metadata:
 //   name: test-ingress3

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -17,7 +17,6 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	v1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/api/networking/v1beta1"
 )
 
@@ -33,8 +32,6 @@ func KindOf(obj interface{}) string {
 	case *v1.Service:
 		return "Service"
 	case *v1beta1.Ingress:
-		return "Ingress"
-	case *extensionsv1beta1.Ingress:
 		return "Ingress"
 	case *ingressroutev1.IngressRoute:
 		return "IngressRoute"


### PR DESCRIPTION
Fixes #2302

Contour no longer supports a version of k8s that provides the
extensions/ingress.v1beta1 type. Remove support in cmd/contour for
automagically translating extensions/ingress to networking/ingress. From
k8s 1.13 onwards this is handled via the API server and as of Contour
1.2.0 there is no support for extensions/ingress in any form.

Signed-off-by: Dave Cheney <dave@cheney.net>