### PR TITLE
site: Remove heptio annotations from documentation

### DIFF
--- a/site/docs/master/annotations.md
+++ b/site/docs/master/annotations.md
@@ -4,19 +4,14 @@
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 
-Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API][15], which provides a more robust configuration interface over
+Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [HTTPProxy API][15], which provides a more robust configuration interface over
 annotations.
 
 However, Contour still supports a number of annotations on the Ingress resources.
 
-<p class="alert-deprecation">
-<b>Deprecation Notice</b><br>
-The <code>contour.heptio.com</code> annotations are deprecated, please use the <code>projectcontour.io</code> form going forward.
-</p>
-
 ## Standard Kubernetes Ingress annotations
 
-The following Kubernetes annotions are supported on [`Ingress`] objects:
+The following Kubernetes annotations are supported on [`Ingress`] objects:
 
  - `kubernetes.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `kubernetes.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
  - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls][16].
@@ -33,13 +28,6 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
  - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
  - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
  - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
- - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
- - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
- - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
- - `contour.heptio.com/request-timeout`: deprecated form of `projectcontour.io/response-timeout`. _Note_ this is **response-timeout**.
- - `contour.heptio.com/retry-on`:  deprecated form of `projectcontour.io/retry-on`.
- - `contour.heptio.com/tls-minimum-protocol-version`: deprecated form of `projectcontour.io/tls-minimum-protocol-version`.
- - `contour.heptio.com/websocket-routes`: deprecated form of `projectcontour.io/websocket-routes`.
 
 ## Contour specific Service annotations
 
@@ -51,14 +39,10 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 - `projectcontour.io/max-retries`: [The maximum number of parallel retries][14] a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
 - `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
   - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
-- `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
-- `contour.heptio.com/max-pending-requests`: deprecated form of `projectcontour.io/max-pending-requests`.
-- `contour.heptio.com/max-requests`: deprecated form of `projectcontour.io/max-requests`.
-- `contour.heptio.com/max-retries`: deprecated form of `projectcontour.io/max-retries`.
-- `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
 
-## Contour specific IngressRoute annotations
-- `contour.heptio.com/ingress.class`: The Ingress class that should interpret and serve the IngressRoute. If not set, then all all Contour instances serve the IngressRoute. If specified as `contour.heptio.com/ingress.class: contour`, then Contour serves the IngressRoute. If any other value, Contour ignores the IngressRoute definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
+## Contour specific HTTPProxy annotations
+- `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the HTTPProxy. If not set, then all all Contour instances serve the HTTPProxy. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the HTTPProxy and any others that have no annotation defined. If any other value, Contour ignores the HTTPProxy definition.
+You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
 
 [1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
 [2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
@@ -74,5 +58,5 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
 [13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
-[15]: {% link docs/master/ingressroute.md %}
+[15]: ingressroute.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls

--- a/site/docs/v1.2.0/annotations.md
+++ b/site/docs/v1.2.0/annotations.md
@@ -4,19 +4,14 @@
 
 Annotations are used in Ingress Controllers to configure features that are not covered by the Kubernetes Ingress API.
 
-Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [IngressRoute API][15], which provides a more robust configuration interface over
+Some of the features that have been historically configured via annotations are supported as first-class features in Contour's [HTTPProxy API][15], which provides a more robust configuration interface over
 annotations.
 
 However, Contour still supports a number of annotations on the Ingress resources.
 
-<p class="alert-deprecation">
-<b>Deprecation Notice</b><br>
-The <code>contour.heptio.com</code> annotations are deprecated, please use the <code>projectcontour.io</code> form going forward.
-</p>
-
 ## Standard Kubernetes Ingress annotations
 
-The following Kubernetes annotions are supported on [`Ingress`] objects:
+The following Kubernetes annotations are supported on [`Ingress`] objects:
 
  - `kubernetes.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. If not set, then all Ingress controllers serve the Ingress. If specified as `kubernetes.io/ingress.class: contour`, then Contour serves the Ingress. If any other value, Contour ignores the Ingress definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime. This can be useful while you are migrating from another controller, or if you need multiple instances of Contour.
  - `ingress.kubernetes.io/force-ssl-redirect`: Requires TLS/SSL for the Ingress to Envoy by setting the [Envoy virtual host option require_tls][16].
@@ -33,13 +28,6 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
  - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
  - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
  - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
- - `contour.heptio.com/ingress.class`: deprecated form of `projectcontour.io/ingress.class`.
- - `contour.heptio.com/num-retries`: deprecated form of `projectcontour.io/num-retries`.
- - `contour.heptio.com/per-try-timeout`: deprecated form of `projectcontour.io/per-try-timeout`.
- - `contour.heptio.com/request-timeout`: deprecated form of `projectcontour.io/response-timeout`. _Note_ this is **response-timeout**.
- - `contour.heptio.com/retry-on`:  deprecated form of `projectcontour.io/retry-on`.
- - `contour.heptio.com/tls-minimum-protocol-version`: deprecated form of `projectcontour.io/tls-minimum-protocol-version`.
- - `contour.heptio.com/websocket-routes`: deprecated form of `projectcontour.io/websocket-routes`.
 
 ## Contour specific Service annotations
 
@@ -51,14 +39,10 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 - `projectcontour.io/max-retries`: [The maximum number of parallel retries][14] a single Envoy instance allows to the Kubernetes Service; defaults to 1024. This is independent of the per-Kubernetes Ingress number of retries (`projectcontour.io/num-retries`) and retry-on (`projectcontour.io/retry-on`), which control whether retries are attempted and how many times a single request can retry.
 - `projectcontour.io/upstream-protocol.{protocol}` : The protocol used in the upstream. The annotation value contains a list of port names and/or numbers separated by a comma that must match with the ones defined in the `Service` definition. For now, just `h2`, `h2c`, and `tls` are supported: `contour.heptio.com/upstream-protocol.h2: "443,https"`. Defaults to Envoy's default behavior which is `http1` in the upstream.
   - The `tls` protocol allows for requests which terminate at Envoy to proxy via tls to the upstream. _Note: This does not validate the upstream certificate._
-- `contour.heptio.com/max-connections`:  deprecated form of `projectcontour.io/max-connections`
-- `contour.heptio.com/max-pending-requests`: deprecated form of `projectcontour.io/max-pending-requests`.
-- `contour.heptio.com/max-requests`: deprecated form of `projectcontour.io/max-requests`.
-- `contour.heptio.com/max-retries`: deprecated form of `projectcontour.io/max-retries`.
-- `contour.heptio.com/upstream-protocol.{protocol}` : deprecated form of `projectcontour.io/upstream-protocol.{protocol}`.
 
-## Contour specific IngressRoute annotations
-- `contour.heptio.com/ingress.class`: The Ingress class that should interpret and serve the IngressRoute. If not set, then all all Contour instances serve the IngressRoute. If specified as `contour.heptio.com/ingress.class: contour`, then Contour serves the IngressRoute. If any other value, Contour ignores the IngressRoute definition. You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
+## Contour specific HTTPProxy annotations
+- `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the HTTPProxy. If not set, then all all Contour instances serve the HTTPProxy. If specified as `projectcontour.io/ingress.class: contour`, then Contour serves the HTTPProxy and any others that have no annotation defined. If any other value, Contour ignores the HTTPProxy definition.
+You can override the default class `contour` with the `--ingress-class-name` flag at runtime.
 
 [1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
 [2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
@@ -74,5 +58,5 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
 [13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
-[15]: {% link docs/v1.2.0/ingressroute.md %}
+[15]: ingressroute.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls


### PR DESCRIPTION
Fixes #1835 by removing references to heptio annotations. Also, it moves references to `IngressRoute` to use `HTTPProxy` instead.

Signed-off-by: Steve Sloka <slokas@vmware.com>