### PR TITLE
internal/dag,envoy: use constant for ca.crt

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -1345,7 +1345,7 @@ func validSecret(s *v1.Secret) bool {
 }
 
 func validCA(s *v1.Secret) bool {
-	return len(s.Data["ca.crt"]) > 0
+	return len(s.Data[CACertificateKey]) > 0
 }
 
 // routeEnforceTLS determines if the route should redirect the user to a secure TLS listener

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -60,7 +60,7 @@ func TestDAGInsert(t *testing.T) {
 		},
 		Type: v1.SecretTypeTLS,
 		Data: map[string][]byte{
-			"ca.crt":            []byte(""),
+			CACertificateKey:    []byte(""),
 			v1.TLSCertKey:       []byte(CERTIFICATE),
 			v1.TLSPrivateKeyKey: []byte(RSA_PRIVATE_KEY),
 		},
@@ -72,7 +72,7 @@ func TestDAGInsert(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			"ca.crt": []byte(CERTIFICATE),
+			CACertificateKey: []byte(CERTIFICATE),
 		},
 	}
 

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -403,7 +403,7 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 // or IngressRoute object in this cache. If the secret is not in the same namespace
 // it must be mentioned by a TLSCertificateDelegation.
 func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
-	if _, isCA := secret.Data["ca.crt"]; isCA {
+	if _, isCA := secret.Data[CACertificateKey]; isCA {
 		// locating a secret validation usage involves traversing each
 		// ingressroute object, determining if there is a valid delegation,
 		// and if the reference the secret as a certificate. The DAG already

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -50,7 +50,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: v1.SecretTypeTLS,
 				Data: map[string][]byte{
-					"ca.crt":            []byte(""),
+					CACertificateKey:    []byte(""),
 					v1.TLSCertKey:       []byte(CERTIFICATE),
 					v1.TLSPrivateKeyKey: []byte(RSA_PRIVATE_KEY),
 				},
@@ -65,7 +65,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: v1.SecretTypeOpaque,
 				Data: map[string][]byte{
-					"ca.crt": []byte(CERTIFICATE_WITH_TEXT),
+					CACertificateKey: []byte(CERTIFICATE_WITH_TEXT),
 				},
 			},
 			want: true,
@@ -461,7 +461,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: v1.SecretTypeOpaque,
 				Data: map[string][]byte{
-					"ca.crt": []byte(CERTIFICATE),
+					CACertificateKey: []byte(CERTIFICATE),
 				},
 			},
 			// TODO(dfc) this should be false because the CA secret is
@@ -502,7 +502,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: v1.SecretTypeOpaque,
 				Data: map[string][]byte{
-					"ca.crt": []byte(CERTIFICATE),
+					CACertificateKey: []byte(CERTIFICATE),
 				},
 			},
 			want: true,
@@ -541,7 +541,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: v1.SecretTypeOpaque,
 				Data: map[string][]byte{
-					"ca.crt": []byte(CERTIFICATE),
+					CACertificateKey: []byte(CERTIFICATE),
 				},
 			},
 			want: true,

--- a/internal/dag/secret.go
+++ b/internal/dag/secret.go
@@ -24,6 +24,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// CaCertificateKey is the key name for accessing TLS CA certificate bundles in Kubernetes Secrets.
+const CACertificateKey = "ca.crt"
+
 // isValidSecret returns true if the secret is interesting and well
 // formed. TLS certificate/key pairs must be secrets of type
 // "kubernetes.io/tls". Certificate bundles may be "kubernetes.io/tls"
@@ -60,7 +63,7 @@ func isValidSecret(secret *v1.Secret) (bool, error) {
 			return false, nil
 		}
 
-		if data := secret.Data["ca.crt"]; len(data) == 0 {
+		if data := secret.Data[CACertificateKey]; len(data) == 0 {
 			return false, nil
 		}
 
@@ -73,7 +76,7 @@ func isValidSecret(secret *v1.Secret) (bool, error) {
 	// validate that it is PEM certificate(s). Note that the
 	// CA bundle on TLS secrets is allowed to be an empty string
 	// (see https://github.com/projectcontour/contour/issues/1644).
-	if data := secret.Data["ca.crt"]; len(data) > 0 {
+	if data := secret.Data[CACertificateKey]; len(data) > 0 {
 		if err := validateCertificate(data); err != nil {
 			return false, fmt.Errorf("invalid CA certificate bundle: %v", err)
 		}

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -230,6 +230,6 @@ func caBundleData(cert ...string) map[string][]byte {
 	data += "end of CA bundle\n"
 
 	return map[string][]byte{
-		"ca.crt": []byte(data),
+		CACertificateKey: []byte(data),
 	}
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -30,9 +30,6 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
-// CACertificateKey stores the key for the TLS validation secret cert
-const CACertificateKey = "ca.crt"
-
 func clusterDefaults() *v2.Cluster {
 	return &v2.Cluster{
 		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
@@ -109,7 +106,7 @@ func upstreamValidationCACert(c *dag.Cluster) []byte {
 		// No validation required
 		return nil
 	}
-	return c.UpstreamValidation.CACertificate.Object.Data[CACertificateKey]
+	return c.UpstreamValidation.CACertificate.Object.Data[dag.CACertificateKey]
 }
 
 func upstreamValidationSubjectAltName(c *dag.Cluster) string {

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -188,7 +188,7 @@ func TestCluster(t *testing.T) {
 								Namespace: "default",
 							},
 							Data: map[string][]byte{
-								"ca.crt": []byte("cacert"),
+								dag.CACertificateKey: []byte("cacert"),
 							},
 						},
 					},
@@ -470,7 +470,7 @@ func TestClustername(t *testing.T) {
 								Namespace: "default",
 							},
 							Data: map[string][]byte{
-								"ca.crt": []byte("somethingsecret"),
+								dag.CACertificateKey: []byte("somethingsecret"),
 							},
 						},
 					},

--- a/internal/featuretests/backendcavalidation_test.go
+++ b/internal/featuretests/backendcavalidation_test.go
@@ -19,6 +19,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			envoy.CACertificateKey: []byte(CERTIFICATE),
+			dag.CACertificateKey: []byte(CERTIFICATE),
 		},
 	}
 


### PR DESCRIPTION
Cleaning up locally defined strings when referencing to secrets with
CA certificates and replaced them with a single constant.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>