### PR TITLE
site: fix API docs rendering

### DIFF
--- a/site/_data/refdocs/members.tpl
+++ b/site/_data/refdocs/members.tpl
@@ -4,7 +4,8 @@
 {{ if not (hiddenMember .)}}
 <tr>
     <td style="white-space:nowrap">
-        <code>{{ fieldName . }}</code></br>
+        <code>{{ fieldName . }}</code>
+        <br>
         <em>
             {{ if linkForType .Type }}
                 <a href="{{ linkForType .Type}}">
@@ -34,8 +35,8 @@
     {{ end }}
 
     {{ if or (eq (fieldName .) "spec") }}
-        <br/>
-        <br/>
+        <br>
+        <br>
         <table style="border:none">
             {{ template "members" .Type }}
         </table>

--- a/site/_data/refdocs/type.tpl
+++ b/site/_data/refdocs/type.tpl
@@ -34,7 +34,8 @@
         {{ if isExportedType . }}
         <tr>
             <td>
-                <code>apiVersion</code></br>
+                <code>apiVersion</code>
+                <br>
                 string</td>
             <td>
                 <code>
@@ -44,7 +45,8 @@
         </tr>
         <tr>
             <td>
-                <code>kind</code></br>
+                <code>kind</code>
+                <br>
                 string
             </td>
             <td><code>{{.Name.Name}}</code></td>

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -29,7 +29,8 @@ Resource Types:
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code>
+<br>
 string</td>
 <td>
 <code>
@@ -39,14 +40,16 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code>
+<br>
 string
 </td>
 <td><code>HTTPProxy</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code>
+<br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -60,7 +63,8 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HTTPProxySpec">
 HTTPProxySpec
@@ -68,12 +72,13 @@ HTTPProxySpec
 </em>
 </td>
 <td>
-<br/>
-<br/>
+<br>
+<br>
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -88,7 +93,8 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -102,7 +108,8 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -116,7 +123,8 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -133,7 +141,8 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>status</code></br>
+<code>status</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Status">
 Status
@@ -162,7 +171,8 @@ See design/tls-certificate-delegation.md for details.</p>
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code>
+<br>
 string</td>
 <td>
 <code>
@@ -172,14 +182,16 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code>
+<br>
 string
 </td>
 <td><code>TLSCertificateDelegation</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code>
+<br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -193,7 +205,8 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TLSCertificateDelegationSpec">
 TLSCertificateDelegationSpec
@@ -201,12 +214,13 @@ TLSCertificateDelegationSpec
 </em>
 </td>
 <td>
-<br/>
-<br/>
+<br>
+<br>
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -241,7 +255,8 @@ in the current namespace to a set of namespaces.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code>
+<br>
 <em>
 string
 </em>
@@ -252,7 +267,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>targetNamespaces</code></br>
+<code>targetNamespaces</code>
+<br>
 <em>
 []string
 </em>
@@ -288,7 +304,8 @@ One of Prefix or Header must be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code>
+<br>
 <em>
 string
 </em>
@@ -300,7 +317,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>header</code></br>
+<code>header</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeaderCondition">
 HeaderCondition
@@ -333,7 +351,8 @@ HeaderCondition
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>path</code></br>
+<code>path</code>
+<br>
 <em>
 string
 </em>
@@ -344,7 +363,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>host</code></br>
+<code>host</code>
+<br>
 <em>
 string
 </em>
@@ -357,7 +377,8 @@ will be used.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code>
+<br>
 <em>
 int64
 </em>
@@ -369,7 +390,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code>
+<br>
 <em>
 int64
 </em>
@@ -381,7 +403,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code>
+<br>
 <em>
 int64
 </em>
@@ -393,7 +416,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code>
+<br>
 <em>
 int64
 </em>
@@ -424,7 +448,8 @@ int64
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -439,7 +464,8 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -453,7 +479,8 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -467,7 +494,8 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -502,7 +530,8 @@ be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code>
+<br>
 <em>
 string
 </em>
@@ -514,7 +543,8 @@ Header names are case insensitive.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>present</code></br>
+<code>present</code>
+<br>
 <em>
 bool
 </em>
@@ -526,7 +556,8 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>contains</code></br>
+<code>contains</code>
+<br>
 <em>
 string
 </em>
@@ -539,7 +570,8 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notcontains</code></br>
+<code>notcontains</code>
+<br>
 <em>
 string
 </em>
@@ -552,7 +584,8 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>exact</code></br>
+<code>exact</code>
+<br>
 <em>
 string
 </em>
@@ -565,7 +598,8 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notexact</code></br>
+<code>notexact</code>
+<br>
 <em>
 string
 </em>
@@ -597,7 +631,8 @@ in the request.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code>
+<br>
 <em>
 string
 </em>
@@ -608,7 +643,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>value</code></br>
+<code>value</code>
+<br>
 <em>
 string
 </em>
@@ -639,7 +675,8 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>set</code></br>
+<code>set</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeaderValue">
 []HeaderValue
@@ -653,7 +690,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>remove</code></br>
+<code>remove</code>
+<br>
 <em>
 []string
 </em>
@@ -684,7 +722,8 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code>
+<br>
 <em>
 string
 </em>
@@ -695,7 +734,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code>
+<br>
 <em>
 string
 </em>
@@ -707,7 +747,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -741,7 +782,8 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>strategy</code></br>
+<code>strategy</code>
+<br>
 <em>
 string
 </em>
@@ -774,7 +816,8 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>replacePrefix</code></br>
+<code>replacePrefix</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.ReplacePrefix">
 []ReplacePrefix
@@ -807,7 +850,8 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code>
+<br>
 <em>
 string
 </em>
@@ -827,7 +871,8 @@ by the include chain will be replaced.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>replacement</code></br>
+<code>replacement</code>
+<br>
 <em>
 string
 </em>
@@ -858,7 +903,8 @@ will be replaced with. This must not be empty.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>count</code></br>
+<code>count</code>
+<br>
 <em>
 int64
 </em>
@@ -871,7 +917,8 @@ If not supplied, the number of retries is one.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>perTryTimeout</code></br>
+<code>perTryTimeout</code>
+<br>
 <em>
 string
 </em>
@@ -902,7 +949,8 @@ Ignored if NumRetries is not supplied.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -916,7 +964,8 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -929,7 +978,8 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>enableWebsockets</code></br>
+<code>enableWebsockets</code>
+<br>
 <em>
 bool
 </em>
@@ -941,7 +991,8 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>permitInsecure</code></br>
+<code>permitInsecure</code>
+<br>
 <em>
 bool
 </em>
@@ -954,7 +1005,8 @@ not permitted when a <code>virtualhost.tls</code> block is present.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutPolicy</code></br>
+<code>timeoutPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TimeoutPolicy">
 TimeoutPolicy
@@ -968,7 +1020,8 @@ TimeoutPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>retryPolicy</code></br>
+<code>retryPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.RetryPolicy">
 RetryPolicy
@@ -982,7 +1035,8 @@ RetryPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HTTPHealthCheckPolicy">
 HTTPHealthCheckPolicy
@@ -996,7 +1050,8 @@ HTTPHealthCheckPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1010,7 +1065,8 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>pathRewritePolicy</code></br>
+<code>pathRewritePolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.PathRewritePolicy">
 PathRewritePolicy
@@ -1025,7 +1081,8 @@ after the request has been routed to a Service.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1039,7 +1096,8 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1073,7 +1131,8 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code>
+<br>
 <em>
 string
 </em>
@@ -1085,7 +1144,8 @@ Names defined here will be used to look up corresponding endpoints which contain
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>port</code></br>
+<code>port</code>
+<br>
 <em>
 int
 </em>
@@ -1096,7 +1156,8 @@ int
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>protocol</code></br>
+<code>protocol</code>
+<br>
 <em>
 string
 </em>
@@ -1109,7 +1170,8 @@ Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>weight</code></br>
+<code>weight</code>
+<br>
 <em>
 int64
 </em>
@@ -1121,7 +1183,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>validation</code></br>
+<code>validation</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.UpstreamValidation">
 UpstreamValidation
@@ -1135,7 +1198,8 @@ UpstreamValidation
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>mirror</code></br>
+<code>mirror</code>
+<br>
 <em>
 bool
 </em>
@@ -1146,7 +1210,8 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1160,7 +1225,8 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1193,7 +1259,8 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>currentStatus</code></br>
+<code>currentStatus</code>
+<br>
 <em>
 string
 </em>
@@ -1204,7 +1271,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>description</code></br>
+<code>description</code>
+<br>
 <em>
 string
 </em>
@@ -1234,7 +1302,8 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code>
+<br>
 <em>
 int64
 </em>
@@ -1246,7 +1315,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code>
+<br>
 <em>
 int64
 </em>
@@ -1258,7 +1328,8 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code>
+<br>
 <em>
 uint32
 </em>
@@ -1270,7 +1341,8 @@ uint32
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code>
+<br>
 <em>
 uint32
 </em>
@@ -1301,7 +1373,8 @@ uint32
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1315,7 +1388,8 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -1328,7 +1402,8 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>include</code></br>
+<code>include</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1342,7 +1417,8 @@ TCPProxyInclude
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1358,7 +1434,8 @@ when it should have been singular. This field should stay to not break backwards
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TCPHealthCheckPolicy">
 TCPHealthCheckPolicy
@@ -1391,7 +1468,8 @@ TCPHealthCheckPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code>
+<br>
 <em>
 string
 </em>
@@ -1402,7 +1480,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code>
+<br>
 <em>
 string
 </em>
@@ -1435,7 +1514,8 @@ matching certificate unless tls.passthrough is set to true.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code>
+<br>
 <em>
 string
 </em>
@@ -1446,7 +1526,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>minimumProtocolVersion</code></br>
+<code>minimumProtocolVersion</code>
+<br>
 <em>
 string
 </em>
@@ -1458,7 +1539,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>passthrough</code></br>
+<code>passthrough</code>
+<br>
 <em>
 bool
 </em>
@@ -1491,7 +1573,8 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -1522,7 +1605,8 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>response</code></br>
+<code>response</code>
+<br>
 <em>
 string
 </em>
@@ -1535,7 +1619,8 @@ If not supplied the timeout duration is undefined.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>idle</code></br>
+<code>idle</code>
+<br>
 <em>
 string
 </em>
@@ -1567,7 +1652,8 @@ Envoy and the backend will be closed. If not specified, there is no per-route id
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>caSecret</code></br>
+<code>caSecret</code>
+<br>
 <em>
 string
 </em>
@@ -1578,7 +1664,8 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>subjectName</code></br>
+<code>subjectName</code>
+<br>
 <em>
 string
 </em>
@@ -1609,7 +1696,8 @@ to be a &ldquo;root&rdquo;.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>fqdn</code></br>
+<code>fqdn</code>
+<br>
 <em>
 string
 </em>
@@ -1621,7 +1709,8 @@ all leaves of the DAG rooted at this object relate to the fqdn</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tls</code></br>
+<code>tls</code>
+<br>
 <em>
 <a href="#projectcontour.io/v1.TLS">
 TLS

--- a/site/docs/master/ingressroute.md
+++ b/site/docs/master/ingressroute.md
@@ -10,7 +10,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.

--- a/site/docs/v1.0.0/ingressroute.md
+++ b/site/docs/v1.0.0/ingressroute.md
@@ -8,7 +8,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.

--- a/site/docs/v1.0.1/annotations.md
+++ b/site/docs/v1.0.1/annotations.md
@@ -8,7 +8,7 @@ annotations.
 However, Contour still supports a number of annotations on the Ingress resources.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 The <code>contour.heptio.com</code> annotations are deprecated, please use the <code>projectcontour.io</code> form going forward.
 </p>
 

--- a/site/docs/v1.0.1/ingressroute.md
+++ b/site/docs/v1.0.1/ingressroute.md
@@ -8,7 +8,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.1/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.

--- a/site/docs/v1.1.0/annotations.md
+++ b/site/docs/v1.1.0/annotations.md
@@ -10,7 +10,7 @@ annotations.
 However, Contour still supports a number of annotations on the Ingress resources.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 The <code>contour.heptio.com</code> annotations are deprecated, please use the <code>projectcontour.io</code> form going forward.
 </p>
 

--- a/site/docs/v1.1.0/api-reference.html
+++ b/site/docs/v1.1.0/api-reference.html
@@ -29,7 +29,7 @@ Resource Types:
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -39,14 +39,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>HTTPProxy</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -60,7 +60,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPProxySpec">
 HTTPProxySpec
@@ -73,7 +73,7 @@ HTTPProxySpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -88,7 +88,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -102,7 +102,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -116,7 +116,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -133,7 +133,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#projectcontour.io/v1.Status">
 Status
@@ -162,7 +162,7 @@ See design/tls-certificate-delegation.md for details.</p>
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -172,14 +172,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>TLSCertificateDelegation</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -193,7 +193,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLSCertificateDelegationSpec">
 TLSCertificateDelegationSpec
@@ -206,7 +206,7 @@ TLSCertificateDelegationSpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -241,7 +241,7 @@ in the current namespace to a set of namespaces.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -252,7 +252,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>targetNamespaces</code></br>
+<code>targetNamespaces</code><br>
 <em>
 []string
 </em>
@@ -288,7 +288,7 @@ One of Prefix or Header must be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -300,7 +300,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>header</code></br>
+<code>header</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderCondition">
 HeaderCondition
@@ -333,7 +333,7 @@ HeaderCondition
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>path</code></br>
+<code>path</code><br>
 <em>
 string
 </em>
@@ -344,7 +344,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>host</code></br>
+<code>host</code><br>
 <em>
 string
 </em>
@@ -357,7 +357,7 @@ will be used.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code><br>
 <em>
 int64
 </em>
@@ -369,7 +369,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br>
 <em>
 int64
 </em>
@@ -381,7 +381,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -393,7 +393,7 @@ uint32
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -424,7 +424,7 @@ uint32
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -439,7 +439,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -453,7 +453,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -467,7 +467,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -502,7 +502,7 @@ be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -514,7 +514,7 @@ Header names are case insensitive.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>present</code></br>
+<code>present</code><br>
 <em>
 bool
 </em>
@@ -526,7 +526,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>contains</code></br>
+<code>contains</code><br>
 <em>
 string
 </em>
@@ -539,7 +539,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notcontains</code></br>
+<code>notcontains</code><br>
 <em>
 string
 </em>
@@ -552,7 +552,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>exact</code></br>
+<code>exact</code><br>
 <em>
 string
 </em>
@@ -565,7 +565,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notexact</code></br>
+<code>notexact</code><br>
 <em>
 string
 </em>
@@ -597,7 +597,7 @@ in the request.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -608,7 +608,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>value</code></br>
+<code>value</code><br>
 <em>
 string
 </em>
@@ -639,7 +639,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>set</code></br>
+<code>set</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderValue">
 []HeaderValue
@@ -653,7 +653,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>remove</code></br>
+<code>remove</code><br>
 <em>
 []string
 </em>
@@ -684,7 +684,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -695,7 +695,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -707,7 +707,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -741,7 +741,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>strategy</code></br>
+<code>strategy</code><br>
 <em>
 string
 </em>
@@ -774,7 +774,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>replacePrefix</code></br>
+<code>replacePrefix</code><br>
 <em>
 <a href="#projectcontour.io/v1.ReplacePrefix">
 []ReplacePrefix
@@ -807,7 +807,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -827,7 +827,7 @@ by the include chain will be replaced.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>replacement</code></br>
+<code>replacement</code><br>
 <em>
 string
 </em>
@@ -858,7 +858,7 @@ will be replaced with. This must not be empty.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>count</code></br>
+<code>count</code><br>
 <em>
 uint32
 </em>
@@ -871,7 +871,7 @@ If not supplied, the number of retries is one.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>perTryTimeout</code></br>
+<code>perTryTimeout</code><br>
 <em>
 string
 </em>
@@ -902,7 +902,7 @@ Ignored if NumRetries is not supplied.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -916,7 +916,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -929,7 +929,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>enableWebsockets</code></br>
+<code>enableWebsockets</code><br>
 <em>
 bool
 </em>
@@ -941,7 +941,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>permitInsecure</code></br>
+<code>permitInsecure</code><br>
 <em>
 bool
 </em>
@@ -954,7 +954,7 @@ not permitted when a <code>virtualhost.tls</code> block is present.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutPolicy</code></br>
+<code>timeoutPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TimeoutPolicy">
 TimeoutPolicy
@@ -968,7 +968,7 @@ TimeoutPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>retryPolicy</code></br>
+<code>retryPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.RetryPolicy">
 RetryPolicy
@@ -982,7 +982,7 @@ RetryPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPHealthCheckPolicy">
 HTTPHealthCheckPolicy
@@ -996,7 +996,7 @@ HTTPHealthCheckPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1010,7 +1010,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>pathRewritePolicy</code></br>
+<code>pathRewritePolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.PathRewritePolicy">
 PathRewritePolicy
@@ -1025,7 +1025,7 @@ after the request has been routed to a Service.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1039,7 +1039,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1073,7 +1073,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1085,7 +1085,7 @@ Names defined here will be used to look up corresponding endpoints which contain
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>port</code></br>
+<code>port</code><br>
 <em>
 int
 </em>
@@ -1096,7 +1096,7 @@ int
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>protocol</code></br>
+<code>protocol</code><br>
 <em>
 string
 </em>
@@ -1109,7 +1109,7 @@ Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>weight</code></br>
+<code>weight</code><br>
 <em>
 uint32
 </em>
@@ -1121,7 +1121,7 @@ uint32
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>validation</code></br>
+<code>validation</code><br>
 <em>
 <a href="#projectcontour.io/v1.UpstreamValidation">
 UpstreamValidation
@@ -1135,7 +1135,7 @@ UpstreamValidation
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>mirror</code></br>
+<code>mirror</code><br>
 <em>
 bool
 </em>
@@ -1146,7 +1146,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1160,7 +1160,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1193,7 +1193,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>currentStatus</code></br>
+<code>currentStatus</code><br>
 <em>
 string
 </em>
@@ -1204,7 +1204,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>description</code></br>
+<code>description</code><br>
 <em>
 string
 </em>
@@ -1234,7 +1234,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1248,7 +1248,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -1261,7 +1261,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1294,7 +1294,7 @@ TCPProxyInclude
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1305,7 +1305,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -1338,7 +1338,7 @@ matching certificate unless tls.passthrough is set to true.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -1349,7 +1349,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>minimumProtocolVersion</code></br>
+<code>minimumProtocolVersion</code><br>
 <em>
 string
 </em>
@@ -1361,7 +1361,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>passthrough</code></br>
+<code>passthrough</code><br>
 <em>
 bool
 </em>
@@ -1394,7 +1394,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -1425,7 +1425,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>response</code></br>
+<code>response</code><br>
 <em>
 string
 </em>
@@ -1438,7 +1438,7 @@ If not supplied the timeout duration is undefined.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 string
 </em>
@@ -1470,7 +1470,7 @@ Envoy and the backend will be closed. If not specified, there is no per-route id
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>caSecret</code></br>
+<code>caSecret</code><br>
 <em>
 string
 </em>
@@ -1481,7 +1481,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>subjectName</code></br>
+<code>subjectName</code><br>
 <em>
 string
 </em>
@@ -1512,7 +1512,7 @@ to be a &ldquo;root&rdquo;.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>fqdn</code></br>
+<code>fqdn</code><br>
 <em>
 string
 </em>
@@ -1524,7 +1524,7 @@ all leaves of the DAG rooted at this object relate to the fqdn</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tls</code></br>
+<code>tls</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLS">
 TLS

--- a/site/docs/v1.1.0/ingressroute.md
+++ b/site/docs/v1.1.0/ingressroute.md
@@ -10,7 +10,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.

--- a/site/docs/v1.2.0/api-reference.html
+++ b/site/docs/v1.2.0/api-reference.html
@@ -29,7 +29,7 @@ Resource Types:
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -39,14 +39,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>HTTPProxy</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -60,7 +60,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPProxySpec">
 HTTPProxySpec
@@ -73,7 +73,7 @@ HTTPProxySpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -88,7 +88,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -102,7 +102,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -116,7 +116,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -133,7 +133,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#projectcontour.io/v1.Status">
 Status
@@ -162,7 +162,7 @@ See design/tls-certificate-delegation.md for details.</p>
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -172,14 +172,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>TLSCertificateDelegation</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -193,7 +193,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLSCertificateDelegationSpec">
 TLSCertificateDelegationSpec
@@ -206,7 +206,7 @@ TLSCertificateDelegationSpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -241,7 +241,7 @@ in the current namespace to a set of namespaces.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -252,7 +252,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>targetNamespaces</code></br>
+<code>targetNamespaces</code><br>
 <em>
 []string
 </em>
@@ -288,7 +288,7 @@ One of Prefix or Header must be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -300,7 +300,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>header</code></br>
+<code>header</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderCondition">
 HeaderCondition
@@ -333,7 +333,7 @@ HeaderCondition
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>path</code></br>
+<code>path</code><br>
 <em>
 string
 </em>
@@ -344,7 +344,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>host</code></br>
+<code>host</code><br>
 <em>
 string
 </em>
@@ -357,7 +357,7 @@ will be used.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code><br>
 <em>
 int64
 </em>
@@ -369,7 +369,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br>
 <em>
 int64
 </em>
@@ -381,7 +381,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code><br>
 <em>
 int64
 </em>
@@ -393,7 +393,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code><br>
 <em>
 int64
 </em>
@@ -424,7 +424,7 @@ int64
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -439,7 +439,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -453,7 +453,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -467,7 +467,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -502,7 +502,7 @@ be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -514,7 +514,7 @@ Header names are case insensitive.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>present</code></br>
+<code>present</code><br>
 <em>
 bool
 </em>
@@ -526,7 +526,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>contains</code></br>
+<code>contains</code><br>
 <em>
 string
 </em>
@@ -539,7 +539,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notcontains</code></br>
+<code>notcontains</code><br>
 <em>
 string
 </em>
@@ -552,7 +552,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>exact</code></br>
+<code>exact</code><br>
 <em>
 string
 </em>
@@ -565,7 +565,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notexact</code></br>
+<code>notexact</code><br>
 <em>
 string
 </em>
@@ -597,7 +597,7 @@ in the request.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -608,7 +608,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>value</code></br>
+<code>value</code><br>
 <em>
 string
 </em>
@@ -639,7 +639,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>set</code></br>
+<code>set</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderValue">
 []HeaderValue
@@ -653,7 +653,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>remove</code></br>
+<code>remove</code><br>
 <em>
 []string
 </em>
@@ -684,7 +684,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -695,7 +695,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -707,7 +707,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -741,7 +741,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>strategy</code></br>
+<code>strategy</code><br>
 <em>
 string
 </em>
@@ -774,7 +774,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>replacePrefix</code></br>
+<code>replacePrefix</code><br>
 <em>
 <a href="#projectcontour.io/v1.ReplacePrefix">
 []ReplacePrefix
@@ -807,7 +807,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -827,7 +827,7 @@ by the include chain will be replaced.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>replacement</code></br>
+<code>replacement</code><br>
 <em>
 string
 </em>
@@ -858,7 +858,7 @@ will be replaced with. This must not be empty.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>count</code></br>
+<code>count</code><br>
 <em>
 int64
 </em>
@@ -871,7 +871,7 @@ If not supplied, the number of retries is one.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>perTryTimeout</code></br>
+<code>perTryTimeout</code><br>
 <em>
 string
 </em>
@@ -902,7 +902,7 @@ Ignored if NumRetries is not supplied.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -916,7 +916,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -929,7 +929,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>enableWebsockets</code></br>
+<code>enableWebsockets</code><br>
 <em>
 bool
 </em>
@@ -941,7 +941,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>permitInsecure</code></br>
+<code>permitInsecure</code><br>
 <em>
 bool
 </em>
@@ -954,7 +954,7 @@ not permitted when a <code>virtualhost.tls</code> block is present.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutPolicy</code></br>
+<code>timeoutPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TimeoutPolicy">
 TimeoutPolicy
@@ -968,7 +968,7 @@ TimeoutPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>retryPolicy</code></br>
+<code>retryPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.RetryPolicy">
 RetryPolicy
@@ -982,7 +982,7 @@ RetryPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPHealthCheckPolicy">
 HTTPHealthCheckPolicy
@@ -996,7 +996,7 @@ HTTPHealthCheckPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1010,7 +1010,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>pathRewritePolicy</code></br>
+<code>pathRewritePolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.PathRewritePolicy">
 PathRewritePolicy
@@ -1025,7 +1025,7 @@ after the request has been routed to a Service.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1039,7 +1039,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1073,7 +1073,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1085,7 +1085,7 @@ Names defined here will be used to look up corresponding endpoints which contain
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>port</code></br>
+<code>port</code><br>
 <em>
 int
 </em>
@@ -1096,7 +1096,7 @@ int
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>protocol</code></br>
+<code>protocol</code><br>
 <em>
 string
 </em>
@@ -1109,7 +1109,7 @@ Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>weight</code></br>
+<code>weight</code><br>
 <em>
 int64
 </em>
@@ -1121,7 +1121,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>validation</code></br>
+<code>validation</code><br>
 <em>
 <a href="#projectcontour.io/v1.UpstreamValidation">
 UpstreamValidation
@@ -1135,7 +1135,7 @@ UpstreamValidation
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>mirror</code></br>
+<code>mirror</code><br>
 <em>
 bool
 </em>
@@ -1146,7 +1146,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1160,7 +1160,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1193,7 +1193,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>currentStatus</code></br>
+<code>currentStatus</code><br>
 <em>
 string
 </em>
@@ -1204,7 +1204,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>description</code></br>
+<code>description</code><br>
 <em>
 string
 </em>
@@ -1234,7 +1234,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code><br>
 <em>
 int64
 </em>
@@ -1246,7 +1246,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br>
 <em>
 int64
 </em>
@@ -1258,7 +1258,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -1270,7 +1270,7 @@ uint32
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -1301,7 +1301,7 @@ uint32
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1315,7 +1315,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -1328,7 +1328,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1342,7 +1342,7 @@ TCPProxyInclude
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPHealthCheckPolicy">
 TCPHealthCheckPolicy
@@ -1375,7 +1375,7 @@ TCPHealthCheckPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1386,7 +1386,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -1419,7 +1419,7 @@ matching certificate unless tls.passthrough is set to true.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -1430,7 +1430,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>minimumProtocolVersion</code></br>
+<code>minimumProtocolVersion</code><br>
 <em>
 string
 </em>
@@ -1442,7 +1442,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>passthrough</code></br>
+<code>passthrough</code><br>
 <em>
 bool
 </em>
@@ -1475,7 +1475,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -1506,7 +1506,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>response</code></br>
+<code>response</code><br>
 <em>
 string
 </em>
@@ -1519,7 +1519,7 @@ If not supplied the timeout duration is undefined.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 string
 </em>
@@ -1551,7 +1551,7 @@ Envoy and the backend will be closed. If not specified, there is no per-route id
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>caSecret</code></br>
+<code>caSecret</code><br>
 <em>
 string
 </em>
@@ -1562,7 +1562,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>subjectName</code></br>
+<code>subjectName</code><br>
 <em>
 string
 </em>
@@ -1593,7 +1593,7 @@ to be a &ldquo;root&rdquo;.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>fqdn</code></br>
+<code>fqdn</code><br>
 <em>
 string
 </em>
@@ -1605,7 +1605,7 @@ all leaves of the DAG rooted at this object relate to the fqdn</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tls</code></br>
+<code>tls</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLS">
 TLS

--- a/site/docs/v1.2.0/ingressroute.md
+++ b/site/docs/v1.2.0/ingressroute.md
@@ -10,7 +10,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.

--- a/site/docs/v1.2.1/api-reference.html
+++ b/site/docs/v1.2.1/api-reference.html
@@ -29,7 +29,7 @@ Resource Types:
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -39,14 +39,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>HTTPProxy</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -60,7 +60,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPProxySpec">
 HTTPProxySpec
@@ -73,7 +73,7 @@ HTTPProxySpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -88,7 +88,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -102,7 +102,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -116,7 +116,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -133,7 +133,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>status</code></br>
+<code>status</code><br>
 <em>
 <a href="#projectcontour.io/v1.Status">
 Status
@@ -162,7 +162,7 @@ See design/tls-certificate-delegation.md for details.</p>
 <tbody class="border-top">
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br>
 string</td>
 <td>
 <code>
@@ -172,14 +172,14 @@ projectcontour.io/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br>
 string
 </td>
 <td><code>TLSCertificateDelegation</code></td>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>metadata</code></br>
+<code>metadata</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -193,7 +193,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>spec</code></br>
+<code>spec</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLSCertificateDelegationSpec">
 TLSCertificateDelegationSpec
@@ -206,7 +206,7 @@ TLSCertificateDelegationSpec
 <table style="border:none">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -241,7 +241,7 @@ in the current namespace to a set of namespaces.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -252,7 +252,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>targetNamespaces</code></br>
+<code>targetNamespaces</code><br>
 <em>
 []string
 </em>
@@ -288,7 +288,7 @@ One of Prefix or Header must be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -300,7 +300,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>header</code></br>
+<code>header</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderCondition">
 HeaderCondition
@@ -333,7 +333,7 @@ HeaderCondition
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>path</code></br>
+<code>path</code><br>
 <em>
 string
 </em>
@@ -344,7 +344,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>host</code></br>
+<code>host</code><br>
 <em>
 string
 </em>
@@ -357,7 +357,7 @@ will be used.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code><br>
 <em>
 int64
 </em>
@@ -369,7 +369,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br>
 <em>
 int64
 </em>
@@ -381,7 +381,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code><br>
 <em>
 int64
 </em>
@@ -393,7 +393,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code><br>
 <em>
 int64
 </em>
@@ -424,7 +424,7 @@ int64
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>virtualhost</code></br>
+<code>virtualhost</code><br>
 <em>
 <a href="#projectcontour.io/v1.VirtualHost">
 VirtualHost
@@ -439,7 +439,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>routes</code></br>
+<code>routes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Route">
 []Route
@@ -453,7 +453,7 @@ to be a &ldquo;root&rdquo;.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tcpproxy</code></br>
+<code>tcpproxy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxy">
 TCPProxy
@@ -467,7 +467,7 @@ TCPProxy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.Include">
 []Include
@@ -502,7 +502,7 @@ be provided.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -514,7 +514,7 @@ Header names are case insensitive.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>present</code></br>
+<code>present</code><br>
 <em>
 bool
 </em>
@@ -526,7 +526,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>contains</code></br>
+<code>contains</code><br>
 <em>
 string
 </em>
@@ -539,7 +539,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notcontains</code></br>
+<code>notcontains</code><br>
 <em>
 string
 </em>
@@ -552,7 +552,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>exact</code></br>
+<code>exact</code><br>
 <em>
 string
 </em>
@@ -565,7 +565,7 @@ in the request.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>notexact</code></br>
+<code>notexact</code><br>
 <em>
 string
 </em>
@@ -597,7 +597,7 @@ in the request.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -608,7 +608,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>value</code></br>
+<code>value</code><br>
 <em>
 string
 </em>
@@ -639,7 +639,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>set</code></br>
+<code>set</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeaderValue">
 []HeaderValue
@@ -653,7 +653,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>remove</code></br>
+<code>remove</code><br>
 <em>
 []string
 </em>
@@ -684,7 +684,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -695,7 +695,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -707,7 +707,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -741,7 +741,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>strategy</code></br>
+<code>strategy</code><br>
 <em>
 string
 </em>
@@ -774,7 +774,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>replacePrefix</code></br>
+<code>replacePrefix</code><br>
 <em>
 <a href="#projectcontour.io/v1.ReplacePrefix">
 []ReplacePrefix
@@ -807,7 +807,7 @@ No HTTP headers or body content is rewritten.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>prefix</code></br>
+<code>prefix</code><br>
 <em>
 string
 </em>
@@ -827,7 +827,7 @@ by the include chain will be replaced.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>replacement</code></br>
+<code>replacement</code><br>
 <em>
 string
 </em>
@@ -858,7 +858,7 @@ will be replaced with. This must not be empty.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>count</code></br>
+<code>count</code><br>
 <em>
 int64
 </em>
@@ -871,7 +871,7 @@ If not supplied, the number of retries is one.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>perTryTimeout</code></br>
+<code>perTryTimeout</code><br>
 <em>
 string
 </em>
@@ -902,7 +902,7 @@ Ignored if NumRetries is not supplied.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>conditions</code></br>
+<code>conditions</code><br>
 <em>
 <a href="#projectcontour.io/v1.Condition">
 []Condition
@@ -916,7 +916,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -929,7 +929,7 @@ Ignored if NumRetries is not supplied.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>enableWebsockets</code></br>
+<code>enableWebsockets</code><br>
 <em>
 bool
 </em>
@@ -941,7 +941,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>permitInsecure</code></br>
+<code>permitInsecure</code><br>
 <em>
 bool
 </em>
@@ -954,7 +954,7 @@ not permitted when a <code>virtualhost.tls</code> block is present.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutPolicy</code></br>
+<code>timeoutPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TimeoutPolicy">
 TimeoutPolicy
@@ -968,7 +968,7 @@ TimeoutPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>retryPolicy</code></br>
+<code>retryPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.RetryPolicy">
 RetryPolicy
@@ -982,7 +982,7 @@ RetryPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HTTPHealthCheckPolicy">
 HTTPHealthCheckPolicy
@@ -996,7 +996,7 @@ HTTPHealthCheckPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1010,7 +1010,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>pathRewritePolicy</code></br>
+<code>pathRewritePolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.PathRewritePolicy">
 PathRewritePolicy
@@ -1025,7 +1025,7 @@ after the request has been routed to a Service.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1039,7 +1039,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1073,7 +1073,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1085,7 +1085,7 @@ Names defined here will be used to look up corresponding endpoints which contain
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>port</code></br>
+<code>port</code><br>
 <em>
 int
 </em>
@@ -1096,7 +1096,7 @@ int
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>protocol</code></br>
+<code>protocol</code><br>
 <em>
 string
 </em>
@@ -1109,7 +1109,7 @@ Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>weight</code></br>
+<code>weight</code><br>
 <em>
 int64
 </em>
@@ -1121,7 +1121,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>validation</code></br>
+<code>validation</code><br>
 <em>
 <a href="#projectcontour.io/v1.UpstreamValidation">
 UpstreamValidation
@@ -1135,7 +1135,7 @@ UpstreamValidation
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>mirror</code></br>
+<code>mirror</code><br>
 <em>
 bool
 </em>
@@ -1146,7 +1146,7 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>requestHeadersPolicy</code></br>
+<code>requestHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1160,7 +1160,7 @@ HeadersPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>responseHeadersPolicy</code></br>
+<code>responseHeadersPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.HeadersPolicy">
 HeadersPolicy
@@ -1193,7 +1193,7 @@ HeadersPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>currentStatus</code></br>
+<code>currentStatus</code><br>
 <em>
 string
 </em>
@@ -1204,7 +1204,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>description</code></br>
+<code>description</code><br>
 <em>
 string
 </em>
@@ -1234,7 +1234,7 @@ string
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>intervalSeconds</code></br>
+<code>intervalSeconds</code><br>
 <em>
 int64
 </em>
@@ -1246,7 +1246,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br>
 <em>
 int64
 </em>
@@ -1258,7 +1258,7 @@ int64
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>unhealthyThresholdCount</code></br>
+<code>unhealthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -1270,7 +1270,7 @@ uint32
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthyThresholdCount</code></br>
+<code>healthyThresholdCount</code><br>
 <em>
 uint32
 </em>
@@ -1301,7 +1301,7 @@ uint32
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>loadBalancerPolicy</code></br>
+<code>loadBalancerPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.LoadBalancerPolicy">
 LoadBalancerPolicy
@@ -1315,7 +1315,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>services</code></br>
+<code>services</code><br>
 <em>
 <a href="#projectcontour.io/v1.Service">
 []Service
@@ -1328,7 +1328,7 @@ LoadBalancerPolicy
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>include</code></br>
+<code>include</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1342,7 +1342,7 @@ TCPProxyInclude
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>includes</code></br>
+<code>includes</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPProxyInclude">
 TCPProxyInclude
@@ -1358,7 +1358,7 @@ when it should have been singular. This field should stay to not break backwards
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>healthCheckPolicy</code></br>
+<code>healthCheckPolicy</code><br>
 <em>
 <a href="#projectcontour.io/v1.TCPHealthCheckPolicy">
 TCPHealthCheckPolicy
@@ -1391,7 +1391,7 @@ TCPHealthCheckPolicy
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>name</code></br>
+<code>name</code><br>
 <em>
 string
 </em>
@@ -1402,7 +1402,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>namespace</code></br>
+<code>namespace</code><br>
 <em>
 string
 </em>
@@ -1435,7 +1435,7 @@ matching certificate unless tls.passthrough is set to true.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>secretName</code></br>
+<code>secretName</code><br>
 <em>
 string
 </em>
@@ -1446,7 +1446,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>minimumProtocolVersion</code></br>
+<code>minimumProtocolVersion</code><br>
 <em>
 string
 </em>
@@ -1458,7 +1458,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>passthrough</code></br>
+<code>passthrough</code><br>
 <em>
 bool
 </em>
@@ -1491,7 +1491,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>delegations</code></br>
+<code>delegations</code><br>
 <em>
 <a href="#projectcontour.io/v1.CertificateDelegation">
 []CertificateDelegation
@@ -1522,7 +1522,7 @@ backing cluster.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>response</code></br>
+<code>response</code><br>
 <em>
 string
 </em>
@@ -1535,7 +1535,7 @@ If not supplied the timeout duration is undefined.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>idle</code></br>
+<code>idle</code><br>
 <em>
 string
 </em>
@@ -1567,7 +1567,7 @@ Envoy and the backend will be closed. If not specified, there is no per-route id
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>caSecret</code></br>
+<code>caSecret</code><br>
 <em>
 string
 </em>
@@ -1578,7 +1578,7 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>subjectName</code></br>
+<code>subjectName</code><br>
 <em>
 string
 </em>
@@ -1609,7 +1609,7 @@ to be a &ldquo;root&rdquo;.</p>
 <tbody class="border-top">
 <tr>
 <td style="white-space:nowrap">
-<code>fqdn</code></br>
+<code>fqdn</code><br>
 <em>
 string
 </em>
@@ -1621,7 +1621,7 @@ all leaves of the DAG rooted at this object relate to the fqdn</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>tls</code></br>
+<code>tls</code><br>
 <em>
 <a href="#projectcontour.io/v1.TLS">
 TLS

--- a/site/docs/v1.2.1/ingressroute.md
+++ b/site/docs/v1.2.1/ingressroute.md
@@ -10,7 +10,7 @@ The goal of the `IngressRoute` Custom Resource Definition (CRD) is to expand upo
 At this time, Contour is the only Kubernetes Ingress Controller to support the IngressRoute CRD, though there is nothing that inherently prevents other controllers from supporting the design.
 
 <p class="alert-deprecation">
-<b>Deprecation Notice</b></br>
+<b>Deprecation Notice</b><br>
 <code>IngressRoute</code> has been deprecated and will be removed after Contour 1.0.
 Please see the documentation for <a href="/docs/v1.0.0/httpproxy"><code>HTTPProxy</code></a> the successor to <code>IngressRoute</code>.
 You can also read the <a href="/guides/ingressroute-to-httpproxy">IngressRoute to HTTPProxy upgrade guide</a>.


### PR DESCRIPTION
Remove extraneous slashes from `<br>` tags so that Jekyll
doesn't end up quoting them.

Signed-off-by: James Peach <jpeach@vmware.com>