### PR TITLE
internal/dag: reject HTTPProxy's that lack at least one service per route

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -716,6 +716,11 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			return nil
 		}
 
+		if len(route.Services) < 1 {
+			sw.SetInvalid("route.services must have at least one entry")
+			return nil
+		}
+
 		r := &Route{
 			PathCondition:         mergePathConditions(conds),
 			HeaderConditions:      mergeHeaderConditions(conds),

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2468,6 +2468,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
+	// issue 2309, each route must have at least one service
+	proxy41 := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-service",
+			Namespace: s1.Namespace,
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "missing-service.example.com",
+			},
+			Routes: []projcontour.Route{{
+				Conditions: []projcontour.Condition{{
+					Prefix: "/",
+				}},
+				Services: nil, // missing
+			}},
+		},
+	}
+
 	proxy100 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
@@ -5361,6 +5380,10 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 			),
+		},
+		"insert httproxy w/ route w/ no services": {
+			objs: []interface{}{proxy41, s1},
+			want: listeners(), // expect empty, route is invalid so vhost is invalid
 		},
 		"insert httpproxy with pathPrefix include": {
 			objs: []interface{}{


### PR DESCRIPTION
Fixes #2309

Reject any HTTPProxy that does not have at least one service entry per
route. This logic is enforced in the 1.3.0 CRD validations.

This PR does not include support for IngressRoute.

Signed-off-by: Dave Cheney <dave@cheney.net>