### PR TITLE
docs: document the allowed LoadBalancer strategies

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -340,6 +340,12 @@ type PathRewritePolicy struct {
 
 // LoadBalancerPolicy defines the load balancing policy.
 type LoadBalancerPolicy struct {
+	// Strategy specifies the policy used to balance requests
+	// across the pool of backend pods. Valid policy names are
+	// `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+	// and `Cookie`. If an unknown strategy name is specified
+	// or no policy is supplied, the default `RoundRobin` policy
+	// is used.
 	Strategy string `json:"strategy,omitempty"`
 }
 

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -639,6 +639,12 @@ spec:
                     description: The load balancing policy for this route.
                     properties:
                       strategy:
+                        description: Strategy specifies the policy used to balance
+                          requests across the pool of backend pods. Valid policy names
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+                          and `Cookie`. If an unknown strategy name is specified or
+                          no policy is supplied, the default `RoundRobin` policy is
+                          used.
                         type: string
                     type: object
                   pathRewritePolicy:
@@ -955,6 +961,11 @@ spec:
                   description: The load balancing policy for the backend services.
                   properties:
                     strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
                       type: string
                   type: object
                 services:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -713,6 +713,12 @@ spec:
                     description: The load balancing policy for this route.
                     properties:
                       strategy:
+                        description: Strategy specifies the policy used to balance
+                          requests across the pool of backend pods. Valid policy names
+                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random`
+                          and `Cookie`. If an unknown strategy name is specified or
+                          no policy is supplied, the default `RoundRobin` policy is
+                          used.
                         type: string
                     type: object
                   pathRewritePolicy:
@@ -1029,6 +1035,11 @@ spec:
                   description: The load balancing policy for the backend services.
                   properties:
                     strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
                       type: string
                   type: object
                 services:

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -493,6 +493,7 @@ func TestLBPolicy(t *testing.T) {
 	tests := map[string]v2.Cluster_LbPolicy{
 		"WeightedLeastRequest": v2.Cluster_LEAST_REQUEST,
 		"Random":               v2.Cluster_RANDOM,
+		"RoundRobin":           v2.Cluster_ROUND_ROBIN,
 		"":                     v2.Cluster_ROUND_ROBIN,
 		"unknown":              v2.Cluster_ROUND_ROBIN,
 		"Cookie":               v2.Cluster_RING_HASH,

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -791,6 +791,12 @@ string
 </em>
 </td>
 <td>
+<p>Strategy specifies the policy used to balance requests
+across the pool of backend pods. Valid policy names are
+<code>Random</code>, <code>RoundRobin</code>, <code>WeightedLeastRequest</code>, <code>Random</code>
+and <code>Cookie</code>. If an unknown strategy name is specified
+or no policy is supplied, the default <code>RoundRobin</code> policy
+is used.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Document the LoadBalancerPolicy strategy names in the API reference.

Signed-off-by: James Peach <jpeach@vmware.com>