### PR TITLE
cmd/contour: unify client creation

### DIFF
--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/projectcontour/contour/internal/certgen"
+	"github.com/projectcontour/contour/internal/k8s"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/client-go/kubernetes"
 )
@@ -134,10 +135,10 @@ func doCertgen(config *certgenConfig) {
 	generatedCerts, err := GenerateCerts(config)
 	check(err)
 
-	clients, err := newKubernetesClients(config.KubeConfig, config.InCluster)
+	clients, err := k8s.NewClients(config.KubeConfig, config.InCluster)
 	if err != nil {
 		check(fmt.Errorf("failed to create Kubernetes client: %w", err))
 	}
 
-	OutputCerts(config, clients.core, generatedCerts)
+	OutputCerts(config, clients.ClientSet(), generatedCerts)
 }

--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -134,12 +134,7 @@ func doCertgen(config *certgenConfig) {
 	generatedCerts, err := GenerateCerts(config)
 	check(err)
 
-	restconfig, err := restConfig(config.KubeConfig, config.InCluster)
-	if err != nil {
-		check(fmt.Errorf("failed to get Kubernetes restconfig: %w", err))
-	}
-
-	clients, err := newKubernetesClients(restconfig)
+	clients, err := newKubernetesClients(config.KubeConfig, config.InCluster)
 	if err != nil {
 		check(fmt.Errorf("failed to create Kubernetes client: %w", err))
 	}

--- a/cmd/contour/clients.go
+++ b/cmd/contour/clients.go
@@ -1,0 +1,91 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+)
+
+// kubernetesClients holds the various API clients required by Contour.
+type kubernetesClients struct {
+	core         *kubernetes.Clientset
+	coordination *coordinationv1.CoordinationV1Client
+	dynamic      dynamic.Interface
+}
+
+// newKubernetesClients returns a new set of the various API clients
+// required by Contour using the supplied kubeconfig path, or the cluster
+// environment variables if inCluster is true..
+func newKubernetesClients(kubeconfig string, inCluster bool) (*kubernetesClients, error) {
+	config, err := newRestConfig(kubeconfig, inCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	var clients kubernetesClients
+	clients.core, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	clients.coordination, err = coordinationv1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	clients.dynamic, err = dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clients, nil
+}
+
+func newRestConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
+	if kubeconfig != "" && !inCluster {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}
+
+// note: 0 means resync timers are disabled
+const resyncInterval time.Duration = 0
+
+// newInformerFactory returns a new SharedInformerFactory for the core
+// Kubernetes API types.
+func (kc *kubernetesClients) newInformerFactory() informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(kc.core, resyncInterval)
+}
+
+// newInformerFactoryForNamespace returns a new SharedInformerFactory
+// for the core Kubernetes API types for the namespace supplied.
+func (kc *kubernetesClients) newInformerFactoryForNamespace(namespace string) informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactoryWithOptions(
+		kc.core, resyncInterval, informers.WithNamespace(namespace))
+}
+
+// newDynamicInformerFactory returns a new DynamicSharedInformerFactory for
+// use with any registered Kubernetes API type.
+func (kc *kubernetesClients) newDynamicInformerFactory() dynamicinformer.DynamicSharedInformerFactory {
+	return dynamicinformer.NewDynamicSharedInformerFactory(kc.dynamic, resyncInterval)
+}

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -20,10 +20,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
-	"k8s.io/client-go/kubernetes"
-	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )
 
@@ -103,35 +99,6 @@ func main() {
 		app.Usage(args)
 		os.Exit(2)
 	}
-}
-
-type kubernetesClients struct {
-	core         *kubernetes.Clientset
-	coordination *coordinationv1.CoordinationV1Client
-}
-
-func restConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
-	if kubeconfig != "" && !inCluster {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
-	}
-	return rest.InClusterConfig()
-}
-
-func newKubernetesClients(config *rest.Config) (kubernetesClients, error) {
-	var err error
-	var clients kubernetesClients
-
-	clients.core, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return clients, err
-	}
-
-	clients.coordination, err = coordinationv1.NewForConfig(config)
-	if err != nil {
-		return clients, err
-	}
-
-	return clients, nil
 }
 
 func check(err error) {

--- a/internal/k8s/clients.go
+++ b/internal/k8s/clients.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package k8s
 
 import (
 	"time"
@@ -26,23 +26,23 @@ import (
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 )
 
-// kubernetesClients holds the various API clients required by Contour.
-type kubernetesClients struct {
+// Clients holds the various API clients required by Contour.
+type Clients struct {
 	core         *kubernetes.Clientset
 	coordination *coordinationv1.CoordinationV1Client
 	dynamic      dynamic.Interface
 }
 
-// newKubernetesClients returns a new set of the various API clients
-// required by Contour using the supplied kubeconfig path, or the cluster
-// environment variables if inCluster is true..
-func newKubernetesClients(kubeconfig string, inCluster bool) (*kubernetesClients, error) {
+// NewClients returns a new set of the various API clients required
+// by Contour using the supplied kubeconfig path, or the cluster
+// environment variables if inCluster is true.
+func NewClients(kubeconfig string, inCluster bool) (*Clients, error) {
 	config, err := newRestConfig(kubeconfig, inCluster)
 	if err != nil {
 		return nil, err
 	}
 
-	var clients kubernetesClients
+	var clients Clients
 	clients.core, err = kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
@@ -71,21 +71,35 @@ func newRestConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
 // note: 0 means resync timers are disabled
 const resyncInterval time.Duration = 0
 
-// newInformerFactory returns a new SharedInformerFactory for the core
+// NewInformerFactory returns a new SharedInformerFactory for the core
 // Kubernetes API types.
-func (kc *kubernetesClients) newInformerFactory() informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactory(kc.core, resyncInterval)
+func (c *Clients) NewInformerFactory() informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(c.core, resyncInterval)
 }
 
-// newInformerFactoryForNamespace returns a new SharedInformerFactory
+// NewInformerFactoryForNamespace returns a new SharedInformerFactory
 // for the core Kubernetes API types for the namespace supplied.
-func (kc *kubernetesClients) newInformerFactoryForNamespace(namespace string) informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactoryWithOptions(
-		kc.core, resyncInterval, informers.WithNamespace(namespace))
+func (c *Clients) NewInformerFactoryForNamespace(namespace string) informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactoryWithOptions(c.core, resyncInterval, informers.WithNamespace(namespace))
 }
 
-// newDynamicInformerFactory returns a new DynamicSharedInformerFactory for
+// NewDynamicInformerFactory returns a new DynamicSharedInformerFactory for
 // use with any registered Kubernetes API type.
-func (kc *kubernetesClients) newDynamicInformerFactory() dynamicinformer.DynamicSharedInformerFactory {
-	return dynamicinformer.NewDynamicSharedInformerFactory(kc.dynamic, resyncInterval)
+func (c *Clients) NewDynamicInformerFactory() dynamicinformer.DynamicSharedInformerFactory {
+	return dynamicinformer.NewDynamicSharedInformerFactory(c.dynamic, resyncInterval)
+}
+
+// ClientSet returns the Kubernetes Core v1 ClientSet.
+func (c *Clients) ClientSet() *kubernetes.Clientset {
+	return c.core
+}
+
+// CoordinationClient returns the Kubernets Core v1 coordination client.
+func (c *Clients) CoordinationClient() *coordinationv1.CoordinationV1Client {
+	return c.coordination
+}
+
+// DynamicClient returns the Dyanmic client.
+func (c *Clients) DynamicClient() dynamic.Interface {
+	return c.dynamic
 }


### PR DESCRIPTION
Updates #403

Before I can add ingress status support to cmd/contour I need to clean
up the serve method. This change unifies the creation of the various
clients to a single method and improves the naming of the various return
values -- they are infomer _factories_ not informers.

Signed-off-by: Dave Cheney <dave@cheney.net>