### PR TITLE
hack: pin golangci-lint version to v1.23.8

### DIFF
--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -12,7 +12,7 @@ if command -v docker >/dev/null; then
 		--rm \
 		--volume $(pwd):/app \
 		--workdir /app \
-		golangci/golangci-lint:latest ${PROGNAME} "$@"
+		golangci/golangci-lint:v1.23.8 ${PROGNAME} "$@"
 fi
 
 cat <<EOF


### PR DESCRIPTION
Updates #2340 

The recently release 1.24.0 seems to OOM in CI.

Signed-off-by: Dave Cheney <dave@cheney.net>