### PR TITLE
internal/k8s: simplify DynamicConverter

### DIFF
--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -40,52 +40,39 @@ type DynamicClientHandler struct {
 }
 
 func (d *DynamicClientHandler) OnAdd(obj interface{}) {
-	if d.Converter.CanConvert(obj) {
-		var err error
-		obj, err = d.Converter.Convert(obj)
-		if err != nil {
-			d.Logger.Error(err)
-			return
-		}
+	obj, err := d.Converter.Convert(obj)
+	if err != nil {
+		d.Logger.Error(err)
+		return
 	}
 	d.Next.OnAdd(obj)
 }
 
 func (d *DynamicClientHandler) OnUpdate(oldObj, newObj interface{}) {
-	if d.Converter.CanConvert(oldObj) {
-		var err error
-		oldObj, err = d.Converter.Convert(oldObj)
-		if err != nil {
-			d.Logger.Error(err)
-			return
-		}
+	oldObj, err := d.Converter.Convert(oldObj)
+	if err != nil {
+		d.Logger.Error(err)
+		return
 	}
-	if d.Converter.CanConvert(newObj) {
-		var err error
-		newObj, err = d.Converter.Convert(newObj)
-		if err != nil {
-			d.Logger.Error(err)
-			return
-		}
+	newObj, err = d.Converter.Convert(newObj)
+	if err != nil {
+		d.Logger.Error(err)
+		return
 	}
 	d.Next.OnUpdate(oldObj, newObj)
 }
 
 func (d *DynamicClientHandler) OnDelete(obj interface{}) {
-	if d.Converter.CanConvert(obj) {
-		var err error
-		obj, err = d.Converter.Convert(obj)
-		if err != nil {
-			d.Logger.Error(err)
-			return
-		}
+	obj, err := d.Converter.Convert(obj)
+	if err != nil {
+		d.Logger.Error(err)
+		return
 	}
 	d.Next.OnDelete(obj)
 }
 
 type Converter interface {
 	Convert(obj interface{}) (interface{}, error)
-	CanConvert(obj interface{}) bool
 }
 
 // UnstructuredConverter handles conversions between unstructured.Unstructured and Contour types
@@ -112,16 +99,12 @@ func NewUnstructuredConverter() (*UnstructuredConverter, error) {
 	return uc, nil
 }
 
-func (c *UnstructuredConverter) CanConvert(obj interface{}) bool {
-	_, ok := obj.(*unstructured.Unstructured)
-	return ok
-}
-
-// Convert converts an unstructured.Unstructured to typed struct
+// Convert converts an unstructured.Unstructured to typed struct. If obj
+// is not an unstructured.Unstructured it is returned without further processing.
 func (c *UnstructuredConverter) Convert(obj interface{}) (interface{}, error) {
 	unstructured, ok := obj.(*unstructured.Unstructured)
 	if !ok {
-		return nil, fmt.Errorf("unsupported object type: %T", obj)
+		return obj, nil
 	}
 	switch unstructured.GetKind() {
 	case "HTTPProxy":

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -368,8 +368,8 @@ func TestConvertUnstructured(t *testing.T) {
 
 	run(t, "notunstructured", testcase{
 		obj:       proxy1,
-		want:      nil,
-		wantError: errors.New("unable to convert unstructured object to projectcontour.io/v1, Kind=HTTPProxy: cannot convert int to string"),
+		want:      proxy1,
+		wantError: nil,
 	})
 
 	run(t, "gatewayclass", testcase{


### PR DESCRIPTION
Updates #403

Currently in cmd/contour.doServe we have three ResourceEventHandler
types defined;

- eventHandler, which is the internal/contour.EventHandler connected to
the dag
- eventRecorder, which wraps eventHandler to add metrics
- dynamicHandler, which wraps eventRecorder to handle dynamic objects.

These three objects are all in scope and used to register with various
informers in a fragile pattern; eventHandler needs to be in scope to
be registed with the group later in the function, eventRecorder is
registered with the k8s core types, and dynamicHandler with the CRD
types. This is all rather fragile.

This PR prepares to make the DynamicHandler the only entry point for all
k8s types by refactoring the DynamicHandler to make accepting non
dynamic types less unexpected.

Signed-off-by: Dave Cheney <dave@cheney.net>