### PR TITLE
Fix community meeting times

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Thanks for taking the time to join our community and start contributing!
 - See [CONTRIBUTING.md](/CONTRIBUTING.md) for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues](https://github.com/projectcontour/contour/issues).
 - Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
-- Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
-  - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
-  - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
+- Join the **Contour Community Meetings** - [schedule, notes, and recordings can be found here](https://projectcontour.io/community)
 
 ## Changelog
 

--- a/site/community.md
+++ b/site/community.md
@@ -16,9 +16,9 @@ If you’re a newcomer, check out the “[Good first issue][1]” and “[Help w
 
 * Join the [Contour Community Meetings][5] on Zoom
   * For Australia time zones:
-    * Every second Tuesday at 6:30 PM Eastern Time / 3:30 PM Pacific Time / Wednesday at 8:30 AM Australian Eastern Time.
+    * Every first and third Tuesday at 6:30 PM Eastern Time / 3:30 PM Pacific Time / Wednesday at 9:30 AM Australian Eastern Time.
   * For Americas time zones:
-    * Every second Tuesday at 1 PM Eastern Time / 10 AM Pacific Time
+    * Every second and fourth Tuesday at 1 PM Eastern Time / 10 AM Pacific Time
   * Meeting notes can be found [here][6].
   * Meetings are recorded and can be found [here][7].
   * Join the [mailing list](https://groups.google.com/forum/#!forum/projectcontour-announce) to get an automated invitation to the meeting.


### PR DESCRIPTION
This PR will fix the description of the community meeting times.
Reminder for myself to change the Australian time on April 5th for daylight savings.

Signed-off-by: jonasrosland <jrosland@vmware.com>