### PR TITLE
Move CRD informer list generation to k8s

### DIFF
--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -1,0 +1,62 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+
+	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+)
+
+type gvrmap map[schema.GroupVersionResource]cache.SharedIndexInformer
+
+// InformerSet stores a table of Kubernetes GVR objects to their associated informers.
+type InformerSet struct {
+	Informers gvrmap
+}
+
+// DefaultInformerSet creates a new InformerSet lookup table and populates with the default
+// GVRs that Contour will try to watch.
+func DefaultInformerSet(inffactory dynamicinformer.DynamicSharedInformerFactory, serviceAPIs bool) InformerSet {
+
+	defaultGVRs := []schema.GroupVersionResource{
+		ingressroutev1.IngressRouteGVR,
+		ingressroutev1.TLSCertificateDelegationGVR,
+		projectcontour.HTTPProxyGVR,
+		projectcontour.TLSCertificateDelegationGVR,
+	}
+
+	// TODO(youngnick): Remove this boolean once we have autodetection of available types (Further work on #2219).
+	if serviceAPIs {
+		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("gatewayclasses"))
+		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("gateways"))
+		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("httproutes"))
+		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("tcproutes"))
+	}
+
+	gvri := InformerSet{
+		Informers: make(gvrmap),
+	}
+
+	for _, gvr := range defaultGVRs {
+		gvri.Informers[gvr] = inffactory.ForResource(gvr).Informer()
+	}
+	return gvri
+}

--- a/internal/k8s/syncer.go
+++ b/internal/k8s/syncer.go
@@ -23,11 +23,11 @@ type InformerSyncList struct {
 	syncers []cache.InformerSynced
 }
 
-// Add adds the sync function from an informer to InformerSyncList and returns the informer
-// so that .AddEventHandler() can be called on it.
-func (sl *InformerSyncList) Add(inf cache.SharedIndexInformer) cache.SharedIndexInformer {
+// RegisterInformer adds the sync function from an informer to InformerSyncList and calls the informers
+// AddEventHandler method.
+func (sl *InformerSyncList) RegisterInformer(inf cache.SharedIndexInformer, handler cache.ResourceEventHandler) {
 	sl.syncers = append(sl.syncers, inf.HasSynced)
-	return inf
+	inf.AddEventHandler(handler)
 }
 
 // WaitForSync ensures that all the informers in the InformerSyncList are synced before returning.


### PR DESCRIPTION
This is in preparation for adding in filtering by discovered CRD types.

Updates #2219 

Signed-off-by: Nick Young <ynick@vmware.com>