### PR TITLE
Add release tooling scripts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/tools v0.0.0-20190929041059-e7abfedfabcf // indirect
 	google.golang.org/grpc v1.25.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v2 v2.2.5
+	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
@@ -31,5 +31,6 @@ require (
 	k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e // indirect
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-tools v0.2.4
+	sigs.k8s.io/kustomize/kyaml v0.1.1
 	sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,10 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/ahmetb/gen-crd-api-reference-docs v0.1.5 h1:OU+AFpBEhyclrQGx4I6zpCx5WvXiKqvFeeOASOmhKCY=
 github.com/ahmetb/gen-crd-api-reference-docs v0.1.5/go.mod h1:P/XzJ+c2+khJKNKABcm2biRwk2QAuwbLf8DlXuaL7WM=
@@ -79,6 +81,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
+github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -95,9 +99,12 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
+github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
+github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
+github.com/go-openapi/jsonreference v0.19.2 h1:o20suLFB4Ri0tuzpWtyHlh7E7HnkqTNLq6aR6WVNS1w=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -109,6 +116,8 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
+github.com/go-openapi/spec v0.19.5 h1:Xm0Ao53uqnk9QE/LlYV5DEU09UAgpliA85QoT9LzqPw=
+github.com/go-openapi/spec v0.19.5/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -116,6 +125,8 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
+github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -204,6 +215,8 @@ github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
+github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
@@ -269,6 +282,7 @@ github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNue
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -298,6 +312,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -343,6 +358,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -449,8 +465,12 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 h1:XZx7nhd5GMaZpmDaEHFVafUZC7ya0fuo7cSJ3UCKYmM=
+gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -499,6 +519,8 @@ sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/controller-tools v0.2.4 h1:la1h46EzElvWefWLqfsXrnsO3lZjpkI0asTpX6h8PLA=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
+sigs.k8s.io/kustomize/kyaml v0.1.1 h1:nGUNYINljZNmlAS8uoobUv/wx/s3Pg8dNxYo+W7uYh0=
+sigs.k8s.io/kustomize/kyaml v0.1.1/go.mod h1:/NdPPfrperSCGjm55cwEro1loBVtbtVIXSb7FguK6uk=
 sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266 h1:bK/QqvXgJnYDz27pv4WIkgCcSseyub9aWETKzpyTtlw=
 sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266/go.mod h1:s6Cwc0sg5w4xxZ/HEr88qPkQ4CITr80lnMpYZUzL9VY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/hack/make-release-tag.sh
+++ b/hack/make-release-tag.sh
@@ -1,0 +1,60 @@
+#! /usr/bin/env bash
+
+# make-release-tag.sh: This script assumes that you are on a branch and have
+# otherwise prepared the release. It rewrites the Docker image version in
+# the deployment YAML, then created a tag with a message containing the
+# shortlog from the previous versio.
+
+readonly PROGNAME=$(basename "$0")
+readonly OLDVERS="$1"
+readonly NEWVERS="$2"
+
+if [ -z "$OLDVERS" ] || [ -z "$NEWVERS" ]; then
+    printf "Usage: %s OLDVERS NEWVERS\n" PROGNAME
+    exit 1
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly IMG="docker.io/projectcontour/contour:$NEWVERS"
+
+
+if [ -n "$(git tag --list "$NEWVERS")" ]; then
+    printf "%s: tag '%s' already exists\n" "$PROGNAME" "$NEWVERS"
+    exit 1
+fi
+
+# NOTE(jpeach): this will go away or change once we move to kustomize
+# since at that point the versioned image name will appear exactly once.
+for f in examples/contour/03-envoy.yaml examples/contour/03-contour.yaml ; do
+    case $(uname -s) in
+    Darwin)
+        sed -i '' "-es|docker.io/projectcontour/contour:master|$IMG|" "$f"
+        ;;
+    Linux)
+        sed -i "-es|docker.io/projectcontour/contour:master|$IMG|" "$f"
+        ;;
+    *)
+        printf "Unsupported system '%s'" "$(uname -s)"
+        exit 2
+        ;;
+    esac
+done
+
+make generate
+
+git commit -s -m "Update Contour Docker image to $NEWVERS." \
+    examples/contour/03-contour.yaml \
+    examples/contour/03-envoy.yaml \
+    examples/render/contour.yaml
+
+git tag -F - "$NEWVERS" <<EOF
+Tag $NEWVERS release.
+
+$(git shortlog "$OLDVERS..HEAD")
+EOF
+
+printf "Created tag '%s'\n" "$NEWVERS"
+printf "Run '%s' to push the tag if you are happy\n" "git push --tags"

--- a/hack/prepare-release.go
+++ b/hack/prepare-release.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func must(err error) {
+	if err != nil {
+		log.Fatalf("%s", err.Error())
+	}
+}
+
+func run(cmd []string) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	if err := c.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func capture(cmd []string) string {
+	out := bytes.Buffer{}
+	c := exec.Command(cmd[0], cmd[1:]...)
+
+	c.Stdin = nil
+	c.Stdout = &out
+	c.Stderr = &out
+
+	if err := c.Run(); err != nil {
+		log.Fatal(err)
+	}
+
+	return out.String()
+}
+
+func updateMappingForTOC(filePath string, vers string, toc string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	rn := yaml.MustParse(string(data))
+
+	if _, err := rn.Pipe(
+		yaml.FieldSetter{Name: vers, StringValue: toc}); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filePath, []byte(rn.MustString()), 0644)
+}
+
+// List yaml.ElementAppender except it inserts after the named node.
+type InsertAfter struct {
+	After string
+	Node  *yaml.Node
+}
+
+func (a InsertAfter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	if err := yaml.ErrorIfInvalid(rn, yaml.SequenceNode); err != nil {
+		return nil, err
+	}
+
+	content := make([]*yaml.Node, 0)
+
+	for _, node := range rn.YNode().Content {
+		content = append(content, node)
+		if node.Value == a.After {
+			content = append(content, a.Node)
+		}
+	}
+
+	rn.YNode().Content = content
+	return rn, nil
+}
+
+func updateConfigForSite(filePath string, vers string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	scopeNode := yaml.MustParse(
+		fmt.Sprintf(`
+scope:
+  path: docs/%s
+values:
+  version: %s
+  layout: "docs"
+`, vers, vers))
+
+	rn := yaml.MustParse(string(data))
+
+	// Append the new scope to the "defaults" array.
+	if _, err := rn.Pipe(
+		yaml.Lookup("defaults"),
+		yaml.Append(scopeNode.YNode()),
+	); err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	// Set this version to the "latest" value.
+	if _, err := rn.Pipe(
+		yaml.FieldSetter{Name: "latest", StringValue: vers}); err != nil {
+		return err
+	}
+
+	versNode := yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: vers,
+	}
+
+	// Insert the new scope to the "defaults" array. We insert
+	// after the "master" element so that it stays in order.
+	if _, err := rn.Pipe(
+		yaml.Lookup("versions"),
+		InsertAfter{After: "master", Node: &versNode},
+	); err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	return ioutil.WriteFile(filePath, []byte(rn.MustString()), 0644)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: %s NEWVERS\n",
+			path.Base(os.Args[0]))
+		os.Exit(1)
+	}
+
+	newVers := os.Args[1]
+
+	log.Printf("Verifying repository state ...")
+
+	status := capture([]string{"git", "status", "--short"})
+	for _, line := range strings.Split(status, "\n") {
+		// See https://git-scm.com/docs/git-status#_short_format.
+		if strings.IndexAny(line, "MADRCU") != -1 {
+			log.Fatal("uncommitted changes in respository")
+		}
+	}
+
+	log.Printf("Cloning versioned documentation ...")
+
+	// Jekyll hates it when the TOC file name contains a dot.
+	tocName := strings.ReplaceAll(fmt.Sprintf("%s-toc", newVers), ".", "-")
+
+	// Make a versioned copy of the amster docs.
+	run([]string{"cp", "-r", "site/docs/master", fmt.Sprintf("site/docs/%s", newVers)})
+	run([]string{"git", "add", fmt.Sprintf("site/docs/%s", newVers)})
+
+	// Make a versioned TOC for the docs.
+	run([]string{"cp", "-r", "site/_data/master-toc.yml", fmt.Sprintf("site/_data/%s.yml", tocName)})
+	run([]string{"git", "add", fmt.Sprintf("site/_data/%s.yml", tocName)})
+
+	// Insert the versioned TOC.
+	must(updateMappingForTOC("site/_data/toc-mapping.yml", newVers, tocName))
+	run([]string{"git", "add", "site/_data/toc-mapping.yml"})
+
+	// Insert the versioned docs into the main site layout.
+	must(updateConfigForSite("site/_config.yml", newVers))
+	run([]string{"git", "add", "site/_config.yml"})
+
+	// Now commit everything
+	run([]string{"git", "commit", "-s", "-m", fmt.Sprintf("Prepare documentation site for %s release.", newVers)})
+}

--- a/site/_resources/release-process.md
+++ b/site/_resources/release-process.md
@@ -36,10 +36,17 @@ The documentation site (projectcontour.io) has versioned documentation. The foll
   - Add yml file to site/_data/toc-mapping.yml
 - Copy `master` directory to the new version (e.g. v1.1.0)
 - In: `site/_config.yml`
-  - Update `defaults and add new version
+  - Update `defaults` and add new version
   - Update `collections` to add new version
   - Update `versions` to add new version
   - Update `latest` to change previous version to new version
+
+These changes can be automatically performed by the `hack/prepare-release.go` tool.
+For example:
+
+```sh
+$ go run ./hack/prepare-release.go v9.9.9
+```
 
 ## Branch for release
 
@@ -69,6 +76,13 @@ Tag the head of your release branch with the release tag, and push
 ```sh
 $ git tag -a v1.2.0 -m 'contour 1.2.0'
 $ git push --tags
+```
+
+These two steps can be automatically performed by the `hack/make-release-tag.sh` tool.
+For example:
+
+```sh
+$ ./hack/make-release-tag.sh v1.2.1 v1.3.1
 ```
 
 ## Patch release

--- a/tools.go
+++ b/tools.go
@@ -12,4 +12,5 @@ import (
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+	_ "sigs.k8s.io/kustomize/kyaml"
 )


### PR DESCRIPTION
Add some basic release tooling scripts to make releasing more consistent
and reliable.

`prepare-release.go` cuts a new copy of the versioned documentation and
updates the Jekyll metadata YAML in various places.

`make-release-tag.sh` updates the Docker image version and creates the
release tag, pupulating the tag message with the shortlog of changes
since the previous release.

This fixes #2351.

Signed-off-by: James Peach <jpeach@vmware.com>