### PR TITLE
cmd/contour: add IngressStatusWriter

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -1,0 +1,94 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sync"
+
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ingressStatusWriter manages the lifetime of StatusLoadBalancerUpdaters.
+//
+// The theory of operation of the ingressStatusWriter is as follows:
+// 1. On startup the ingressStatusWriter waits to be elected leader.
+// 2. Once elected leader, the ingressStatusWriter waits to receive a
+//    v1.LoadBalancerStatus value.
+// 3. Once a v1.LoadBalancerStatus value has been received, any existing informer
+//    is stopped and a new informer started in its place.
+// 4. Each informer is connected to a k8s.StatusLoadBalancerUpdater which reacts to
+//    OnAdd events for networking.k8s.io/ingress.v1beta1 objects. For each OnAdd
+//    the object is patched with the v1.LoadBalancerStatus value obtained on creation.
+//    OnUpdate and OnDelete events are ignored.If a new v1.LoadBalancerStatus value
+//    is been received, operation restarts at step 3.
+// 5. If the worker is stopped, any existing informer is stopped before the worker stops.
+type ingressStatusWriter struct {
+	log      logrus.FieldLogger
+	clients  *k8s.Clients
+	isLeader chan struct{}
+	lbStatus chan v1.LoadBalancerStatus
+}
+
+func (isw *ingressStatusWriter) Start(stop <-chan struct{}) error {
+
+	// await leadership election
+	isw.log.Info("awaiting leadership election")
+	select {
+	case <-stop:
+		// asked to stop before elected leader
+		return nil
+	case <-isw.isLeader:
+		isw.log.Info("elected leader")
+	}
+
+	for {
+		var shutdown chan struct{}
+		var stopping sync.WaitGroup
+		select {
+		case <-stop:
+			// stop existing informer and shut down
+			if shutdown != nil {
+				close(shutdown)
+			}
+			stopping.Wait()
+			return nil
+		case lbs := <-isw.lbStatus:
+			// stop existing informer
+			if shutdown != nil {
+				close(shutdown)
+			}
+			stopping.Wait()
+
+			// create informer for the new LoadBalancerStatus
+			factory := isw.clients.NewInformerFactory()
+			inf := factory.Networking().V1beta1().Ingresses().Informer()
+			inf.AddEventHandler(&k8s.StatusLoadBalancerUpdater{
+				Client: isw.clients.ClientSet(),
+				Logger: isw.log.WithField("context", "statusLoadBalancerUpdater"),
+				Status: lbs,
+			})
+
+			shutdown = make(chan struct{})
+			stopping.Add(1)
+			go func() {
+				isw.log.Info("starting informer")
+				defer stopping.Done()
+				defer isw.log.Info("stopping informer")
+				factory.Start(shutdown)
+			}()
+		}
+	}
+}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers"
 )
 
@@ -277,6 +278,15 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// step 10. register leadership election
 	eventHandler.IsLeader = setupLeadershipElection(&g, log, ctx, clients, eventHandler.UpdateNow)
+
+	// step 11. set up ingress status writer
+	isw := ingressStatusWriter{
+		log:      log.WithField("context", "ingressStatusWriter"),
+		clients:  clients,
+		isLeader: eventHandler.IsLeader,
+		lbStatus: make(chan v1.LoadBalancerStatus, 1),
+	}
+	g.Add(isw.Start)
 
 	// step 12. create grpc handler and register with workgroup.
 	g.Add(func(stop <-chan struct{}) error {

--- a/internal/k8s/ingressstatus.go
+++ b/internal/k8s/ingressstatus.go
@@ -1,0 +1,61 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// StatusLoadbalancerUpdater observes informer OnAdd events and
+// updates the ingress.status.loadBalancer field on all Ingress
+// objects that match the ingress class (if used).
+type StatusLoadBalancerUpdater struct {
+	Client clientset.Interface
+	Logger logrus.FieldLogger
+	Status v1.LoadBalancerStatus
+}
+
+func (s *StatusLoadBalancerUpdater) OnAdd(obj interface{}) {
+	ing := obj.(*v1beta1.Ingress).DeepCopy()
+
+	// TODO(dfc) check ingress class
+
+	ing.Status.LoadBalancer = s.Status
+	_, err := s.Client.NetworkingV1beta1().Ingresses(ing.GetNamespace()).UpdateStatus(ing)
+	if err != nil {
+		s.Logger.
+			WithField("name", ing.GetName()).
+			WithField("namespace", ing.GetNamespace()).
+			WithError(err).Error("unable to update status")
+	}
+}
+
+func (s *StatusLoadBalancerUpdater) OnUpdate(oldObj, newObj interface{}) {
+	// Ignoring OnUpdate allows us to avoid the message generated
+	// from the status update.
+
+	// TODO(dfc) handle these cases:
+	// - OnUpdate transitions from an ingress class which is out of scope
+	// to one in scope.
+	// - OnUpdate transitions from an ingress class in scope to one out
+	// of scope.
+}
+
+func (s *StatusLoadBalancerUpdater) OnDelete(obj interface{}) {
+	// we don't need to update the status on resources that
+	// have been deleted.
+}


### PR DESCRIPTION
Updates #403

This PR adds a worker to doServe's group which writes back load balancer
status to ingress.v1beta1 objects.

In this PR, the population of the isw.lbStatus channel is not present
but has been manually verified with the following code:

        g.Add(func(stop <-chan struct{}) error {
                tick := time.Tick(2 * time.Second)
                for {
                        select {
                        case <-tick:
                                isw.lbStatus <- v1.LoadBalancerStatus{
                                        Ingress: []v1.LoadBalancerIngress{{
                                                Hostname: "gke.davecheney.com",
                                        }},
                                }
                        case <-stop:
                                return nil
                        }
                }
        })

Future PRs will add workers to populate the channel.

Signed-off-by: Dave Cheney <dave@cheney.net>