### PR TITLE
site\_guides\cert-manager.md

### DIFF
--- a/site/_guides/cert-manager.md
+++ b/site/_guides/cert-manager.md
@@ -574,7 +574,7 @@ spec:
   tls:
   - hosts:
     - httpbinproxy.davecheney.com
-    secretName: httpbinproxy
+    secretName: httpbin
 ```
 
 Once cert-manager has done its thing, you will have a `httpbinproxy` secret, that will contain the keypair.


### PR DESCRIPTION
Fixes #228

site: fix secret name in cert-manager documentation

Signed-off-by: vukg <vuk.gojnic@gmail.com>