### PR TITLE
Migrate Service and Ingress to client-go dynamic client

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -208,10 +208,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		informerSyncList.RegisterInformer(inf, dynamicHandler)
 	}
 
-	// We need to register this separately for now, as the core stuff uses a non-dynamic InformerFactory.
-	informerSyncList.RegisterInformer(informerFactory.Core().V1().Services().Informer(), dynamicHandler)
-	informerSyncList.RegisterInformer(informerFactory.Networking().V1beta1().Ingresses().Informer(), dynamicHandler)
-
+	// TODO(youngnick): Move this logic out to internal/k8s/informers.go somehow.
 	// Add informers for each root-ingressroute namespaces
 	for _, factory := range namespacedInformerFactories {
 		informerSyncList.RegisterInformer(factory.Core().V1().Secrets().Informer(), dynamicHandler)

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -17,9 +17,11 @@ import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 
 	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
@@ -41,6 +43,8 @@ func DefaultInformerSet(inffactory dynamicinformer.DynamicSharedInformerFactory,
 		ingressroutev1.TLSCertificateDelegationGVR,
 		projectcontour.HTTPProxyGVR,
 		projectcontour.TLSCertificateDelegationGVR,
+		corev1.SchemeGroupVersion.WithResource("services"),
+		v1beta1.SchemeGroupVersion.WithResource("ingresses"),
 	}
 
 	// TODO(youngnick): Remove this boolean once we have autodetection of available types (Further work on #2219).


### PR DESCRIPTION
This is further refactoring for #2219.

Moves Service and Ingress to the client-go dynamic client, leaving only Secrets and Endpoints not handled by the new InformerSet. Secrets need namespace handling, and Endpoints need a separate handler.

Signed-off-by: Nick Young <ynick@vmware.com>