### PR TITLE
Authenticate Envoy DaemonSet

### DIFF
--- a/examples/contour/00-common.yaml
+++ b/examples/contour/00-common.yaml
@@ -2,10 +2,16 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: projectcontour 
+  name: projectcontour
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
   namespace: projectcontour

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -122,7 +122,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      automountServiceAccountToken: false
+      serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
         - name: envoy-config

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -17,12 +17,18 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: projectcontour 
+  name: projectcontour
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: contour
+  namespace: projectcontour
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy
   namespace: projectcontour
 ---
 apiVersion: v1
@@ -1784,7 +1790,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      automountServiceAccountToken: false
+      serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
         - name: envoy-config


### PR DESCRIPTION
I'm not sure if editing this file is the right thing, but I can't find the `examples/render.sh` file mentioned in the header

If applied, this commit will authenticate the pods in the Envoy DaemonSet so that a PodSecurityPolicy can be targeted specifically for the Envoy containers. The Envoy image runs as root user and a default restricted policy for the namespace would not do.

As I understand the current manifest, the pods don't need a Role to run. However, a PodSecurityPolicy for this DaemonSet is much more difficult to apply, since we'd be looking at unauthenticated pods in the namespace and that could be anything running outside RBAC.