### PR TITLE
internal: extract Envoy sort polices

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -17,22 +17,24 @@ import (
 	"sort"
 	"sync"
 
-	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/sorter"
 )
 
 // ClusterCache manages the contents of the gRPC CDS cache.
 type ClusterCache struct {
 	mu     sync.Mutex
-	values map[string]*envoy_api_v2.Cluster
+	values map[string]*v2.Cluster
 	Cond
 }
 
 // Update replaces the contents of the cache with the supplied map.
-func (c *ClusterCache) Update(v map[string]*envoy_api_v2.Cluster) {
+func (c *ClusterCache) Update(v map[string]*v2.Cluster) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -44,18 +46,18 @@ func (c *ClusterCache) Update(v map[string]*envoy_api_v2.Cluster) {
 func (c *ClusterCache) Contents() []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var values []proto.Message
+	var values []*v2.Cluster
 	for _, v := range c.values {
 		values = append(values, v)
 	}
-	sort.Stable(clusterByName(values))
-	return values
+	sort.Stable(sorter.For(values))
+	return protobuf.AsMessages(values)
 }
 
 func (c *ClusterCache) Query(names []string) []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var values []proto.Message
+	var values []*v2.Cluster
 	for _, n := range names {
 		// if the cluster is not registered we cannot return
 		// a blank cluster because each cluster has a required
@@ -66,28 +68,20 @@ func (c *ClusterCache) Query(names []string) []proto.Message {
 			values = append(values, v)
 		}
 	}
-	sort.Stable(clusterByName(values))
-	return values
-}
-
-type clusterByName []proto.Message
-
-func (c clusterByName) Len() int      { return len(c) }
-func (c clusterByName) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c clusterByName) Less(i, j int) bool {
-	return c[i].(*envoy_api_v2.Cluster).Name < c[j].(*envoy_api_v2.Cluster).Name
+	sort.Stable(sorter.For(values))
+	return protobuf.AsMessages(values)
 }
 
 func (*ClusterCache) TypeURL() string { return cache.ClusterType }
 
 type clusterVisitor struct {
-	clusters map[string]*envoy_api_v2.Cluster
+	clusters map[string]*v2.Cluster
 }
 
-// visitCluster produces a map of *envoy_api_v2.Clusters.
-func visitClusters(root dag.Vertex) map[string]*envoy_api_v2.Cluster {
+// visitCluster produces a map of *v2.Clusters.
+func visitClusters(root dag.Vertex) map[string]*v2.Cluster {
 	cv := clusterVisitor{
-		clusters: make(map[string]*envoy_api_v2.Cluster),
+		clusters: make(map[string]*v2.Cluster),
 	}
 	cv.visit(root)
 	return cv.clusters

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -30,7 +30,7 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 	}{
 		"empty": {
 			contents: nil,
-			want:     []proto.Message{},
+			want:     nil,
 		},
 		"simple": {
 			contents: clusterloadassignments(
@@ -256,7 +256,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
-			want: []proto.Message{},
+			want: nil,
 		},
 		"remove different": {
 			setup: func(et *EndpointsTranslator) {
@@ -285,7 +285,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
-			want: []proto.Message{},
+			want: nil,
 		},
 		"remove long name": {
 			setup: func(et *EndpointsTranslator) {
@@ -319,7 +319,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					),
 				},
 			),
-			want: []proto.Message{},
+			want: nil,
 		},
 	}
 
@@ -392,7 +392,7 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 					port("", 8080),
 				),
 			}),
-			want: []proto.Message{},
+			want: nil,
 		},
 	}
 
@@ -430,7 +430,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 	et.OnUpdate(e1, e2)
 
 	// Assert endpoints are removed
-	want = []proto.Message{}
+	want = nil
 	got = et.Contents()
 
 	assert.Equal(t, want, got)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -17,9 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/assert"
-	"github.com/projectcontour/contour/internal/dag"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -27,6 +24,8 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/sorter"
 )
 
 // TLSInspector returns a new TLS inspector listener filter.
@@ -157,7 +158,7 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accesslogger []*accesslog.
 				Weight: weight,
 			})
 		}
-		sort.Stable(clustersByNameAndWeight(clusters))
+		sort.Stable(sorter.For(clusters))
 		return &envoy_api_v2_listener.Filter{
 			Name: wellknown.TCPProxy,
 			ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
@@ -174,17 +175,6 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accesslogger []*accesslog.
 			},
 		}
 	}
-}
-
-type clustersByNameAndWeight []*tcp.TcpProxy_WeightedCluster_ClusterWeight
-
-func (c clustersByNameAndWeight) Len() int      { return len(c) }
-func (c clustersByNameAndWeight) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c clustersByNameAndWeight) Less(i, j int) bool {
-	if c[i].Name == c[j].Name {
-		return c[i].Weight < c[j].Weight
-	}
-	return c[i].Name < c[j].Name
 }
 
 // SocketAddress creates a new TCP envoy_api_v2_core.Address.

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -15,8 +15,10 @@
 package protobuf
 
 import (
+	"reflect"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
 )
@@ -41,4 +43,22 @@ func Bool(val bool) *wrappers.BoolValue {
 	return &wrappers.BoolValue{
 		Value: val,
 	}
+}
+
+// AsMessages casts the given slice of values (that implement the proto.Message
+// interface) to a slice of proto.Message. If the length of the slice is 0, it
+// returns nil.
+func AsMessages(messages interface{}) []proto.Message {
+	v := reflect.ValueOf(messages)
+	if v.Len() == 0 {
+		return nil
+	}
+
+	protos := make([]proto.Message, v.Len())
+
+	for i := range protos {
+		protos[i] = v.Index(i).Interface().(proto.Message)
+	}
+
+	return protos
 }

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -1,0 +1,222 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sorter
+
+import (
+	"sort"
+	"strings"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	tcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
+	"github.com/golang/protobuf/proto"
+)
+
+// Sorts the given route configuration values by name.
+type routeConfigurationSorter []*v2.RouteConfiguration
+
+func (s routeConfigurationSorter) Len() int           { return len(s) }
+func (s routeConfigurationSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s routeConfigurationSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
+
+// Sorts the given host values by name.
+type virtualHostSorter []*envoy_api_v2_route.VirtualHost
+
+func (s virtualHostSorter) Len() int           { return len(s) }
+func (s virtualHostSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s virtualHostSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
+
+// Sorts HeaderMatcher objects, first by the header name,
+// then by their matcher conditions (textually).
+type headerMatcherSorter []*envoy_api_v2_route.HeaderMatcher
+
+func (s headerMatcherSorter) Len() int      { return len(s) }
+func (s headerMatcherSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s headerMatcherSorter) Less(i, j int) bool {
+	val := strings.Compare(s[i].Name, s[j].Name)
+	switch val {
+	case -1:
+		return true
+	case 1:
+		return false
+	case 0:
+		return proto.CompactTextString(s[i]) < proto.CompactTextString(s[j])
+	}
+
+	panic("bad comparison")
+}
+
+// longestRouteByHeaders compares the HeaderMatcher slices for lhs and rhs and
+// returns true if lhs is longer.
+func longestRouteByHeaders(lhs, rhs *envoy_api_v2_route.Route) bool {
+	if len(lhs.Match.Headers) == len(rhs.Match.Headers) {
+		pair := make([]*envoy_api_v2_route.HeaderMatcher, 2)
+
+		for i := 0; i < len(lhs.Match.Headers); i++ {
+			pair[0] = lhs.Match.Headers[i]
+			pair[1] = rhs.Match.Headers[i]
+
+			if headerMatcherSorter(pair).Less(0, 1) {
+				return true
+			}
+		}
+	}
+
+	return len(lhs.Match.Headers) > len(rhs.Match.Headers)
+}
+
+// Sorts the given Route slice in place. Routes are ordered first by
+// longest prefix (or regex), then by the length of the HeaderMatch
+// slice (if any). The HeaderMatch slice is also ordered by the matching
+// header name.
+type routeSorter []*envoy_api_v2_route.Route
+
+func (s routeSorter) Len() int      { return len(s) }
+func (s routeSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s routeSorter) Less(i, j int) bool {
+	switch a := s[i].Match.PathSpecifier.(type) {
+	case *envoy_api_v2_route.RouteMatch_Prefix:
+		switch b := s[j].Match.PathSpecifier.(type) {
+		case *envoy_api_v2_route.RouteMatch_Prefix:
+			cmp := strings.Compare(a.Prefix, b.Prefix)
+			switch cmp {
+			case 1:
+				// Sort longest prefix first.
+				return true
+			case -1:
+				return false
+			default:
+				return longestRouteByHeaders(s[i], s[j])
+			}
+		}
+	case *envoy_api_v2_route.RouteMatch_SafeRegex:
+		switch b := s[j].Match.PathSpecifier.(type) {
+		case *envoy_api_v2_route.RouteMatch_SafeRegex:
+			cmp := strings.Compare(a.SafeRegex.Regex, b.SafeRegex.Regex)
+			switch cmp {
+			case 1:
+				// Sort longest regex first.
+				return true
+			case -1:
+				return false
+			default:
+				return longestRouteByHeaders(s[i], s[j])
+			}
+		case *envoy_api_v2_route.RouteMatch_Prefix:
+			return true
+		}
+	}
+
+	return false
+}
+
+// Sorts clusters by name.
+type clusterSorter []*v2.Cluster
+
+func (s clusterSorter) Len() int           { return len(s) }
+func (s clusterSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s clusterSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
+
+// Sorts cluster load assignments by name.
+type clusterLoadAssignmentSorter []*v2.ClusterLoadAssignment
+
+func (s clusterLoadAssignmentSorter) Len() int           { return len(s) }
+func (s clusterLoadAssignmentSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s clusterLoadAssignmentSorter) Less(i, j int) bool { return s[i].ClusterName < s[j].ClusterName }
+
+// Sorts the weighted clusters by name, then by weight.
+type httpWeightedClusterSorter []*envoy_api_v2_route.WeightedCluster_ClusterWeight
+
+func (s httpWeightedClusterSorter) Len() int      { return len(s) }
+func (s httpWeightedClusterSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s httpWeightedClusterSorter) Less(i, j int) bool {
+	if s[i].Name == s[j].Name {
+		return s[i].Weight.Value < s[j].Weight.Value
+	}
+
+	return s[i].Name < s[j].Name
+}
+
+// Sorts the weighted clusters by name, then by weight.
+type tcpWeightedClusterSorter []*tcp.TcpProxy_WeightedCluster_ClusterWeight
+
+func (s tcpWeightedClusterSorter) Len() int      { return len(s) }
+func (s tcpWeightedClusterSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s tcpWeightedClusterSorter) Less(i, j int) bool {
+	if s[i].Name == s[j].Name {
+		return s[i].Weight < s[j].Weight
+	}
+
+	return s[i].Name < s[j].Name
+}
+
+// Listeners sorts the listeners by name.
+type listenerSorter []*v2.Listener
+
+func (s listenerSorter) Len() int           { return len(s) }
+func (s listenerSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s listenerSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
+
+// FilterChains sorts the filter chains by the first server name in the chain match.
+type filterChainSorter []*envoy_api_v2_listener.FilterChain
+
+func (s filterChainSorter) Len() int      { return len(s) }
+func (s filterChainSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s filterChainSorter) Less(i, j int) bool {
+	// The ServerNames field will only ever have a single entry
+	// in our FilterChain config, so it's okay to only sort
+	// on the first slice entry.
+	return s[i].FilterChainMatch.ServerNames[0] < s[j].FilterChainMatch.ServerNames[0]
+}
+
+// Sorts the secret values by name.
+type secretSorter []*envoy_api_v2_auth.Secret
+
+func (s secretSorter) Len() int           { return len(s) }
+func (s secretSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s secretSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
+
+// For returns a sort.Interface object that can be used to sort the
+// given value. It returns nil if there is no sorter for the type of
+// value.
+func For(v interface{}) sort.Interface {
+	switch v := v.(type) {
+	case []*envoy_api_v2_auth.Secret:
+		return secretSorter(v)
+	case []*v2.RouteConfiguration:
+		return routeConfigurationSorter(v)
+	case []*envoy_api_v2_route.VirtualHost:
+		return virtualHostSorter(v)
+	case []*envoy_api_v2_route.Route:
+		return routeSorter(v)
+	case []*envoy_api_v2_route.HeaderMatcher:
+		return headerMatcherSorter(v)
+	case []*v2.Cluster:
+		return clusterSorter(v)
+	case []*v2.ClusterLoadAssignment:
+		return clusterLoadAssignmentSorter(v)
+	case []*envoy_api_v2_route.WeightedCluster_ClusterWeight:
+		return httpWeightedClusterSorter(v)
+	case []*tcp.TcpProxy_WeightedCluster_ClusterWeight:
+		return tcpWeightedClusterSorter(v)
+	case []*v2.Listener:
+		return listenerSorter(v)
+	case []*envoy_api_v2_listener.FilterChain:
+		return filterChainSorter(v)
+	default:
+		return nil
+	}
+}

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -1,0 +1,346 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sorter
+
+import (
+	"sort"
+	"testing"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	tcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+func TestInvalidSorter(t *testing.T) {
+	assert.Equal(t, nil, For([]string{"invalid"}))
+}
+
+func TestSortRouteConfiguration(t *testing.T) {
+	want := []*v2.RouteConfiguration{
+		&v2.RouteConfiguration{Name: "bar"},
+		&v2.RouteConfiguration{Name: "baz"},
+		&v2.RouteConfiguration{Name: "foo"},
+		&v2.RouteConfiguration{Name: "same", InternalOnlyHeaders: []string{"z", "y"}},
+		&v2.RouteConfiguration{Name: "same", InternalOnlyHeaders: []string{"a", "b"}},
+	}
+
+	have := []*v2.RouteConfiguration{
+		want[3], // Ensure the "same" element stays stable.
+		want[4],
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortVirtualHosts(t *testing.T) {
+	want := []*envoy_api_v2_route.VirtualHost{
+		&envoy_api_v2_route.VirtualHost{Name: "bar"},
+		&envoy_api_v2_route.VirtualHost{Name: "baz"},
+		&envoy_api_v2_route.VirtualHost{Name: "foo"},
+		&envoy_api_v2_route.VirtualHost{Name: "same", Domains: []string{"z", "y"}},
+		&envoy_api_v2_route.VirtualHost{Name: "same", Domains: []string{"a", "b"}},
+	}
+
+	have := []*envoy_api_v2_route.VirtualHost{
+		want[3], // Ensure the "same" element stays stable.
+		want[4],
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func matchPrefix(str string) *envoy_api_v2_route.RouteMatch_Prefix {
+	return &envoy_api_v2_route.RouteMatch_Prefix{
+		Prefix: str,
+	}
+}
+
+func matchRegex(str string) *envoy_api_v2_route.RouteMatch_SafeRegex {
+	return &envoy_api_v2_route.RouteMatch_SafeRegex{
+		SafeRegex: &matcher.RegexMatcher{
+			Regex: str,
+		},
+	}
+}
+
+func exactHeader(name string, value string) *envoy_api_v2_route.HeaderMatcher {
+	return &envoy_api_v2_route.HeaderMatcher{
+		Name: name,
+		HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_ExactMatch{
+			ExactMatch: value,
+		},
+	}
+}
+
+func presentHeader(name string) *envoy_api_v2_route.HeaderMatcher {
+	return &envoy_api_v2_route.HeaderMatcher{
+		Name: name,
+		HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_PresentMatch{
+			PresentMatch: true,
+		},
+	}
+}
+
+func TestSortRoutesLongestPath(t *testing.T) {
+	want := []*envoy_api_v2_route.Route{
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchRegex("/this/is/the/longest"),
+			}},
+
+		// Note that regex matches sort before prefix matches.
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchRegex("."),
+			}},
+
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchPrefix("/path/prefix2"),
+			}},
+
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchPrefix("/path/prefix"),
+			}},
+	}
+
+	have := []*envoy_api_v2_route.Route{
+		want[1],
+		want[3],
+		want[0],
+		want[2],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortRoutesLongestHeaders(t *testing.T) {
+	want := []*envoy_api_v2_route.Route{
+		// Although the header names are the same, this value
+		// should sort before the next one because it is
+		// textually longer.
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchPrefix("/path"),
+				Headers: []*envoy_api_v2_route.HeaderMatcher{
+					exactHeader("header-name", "header-value"),
+				},
+			}},
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchPrefix("/path"),
+				Headers: []*envoy_api_v2_route.HeaderMatcher{
+					presentHeader("header-name"),
+				},
+			}},
+		&envoy_api_v2_route.Route{
+			Match: &envoy_api_v2_route.RouteMatch{
+				PathSpecifier: matchPrefix("/path"),
+				Headers: []*envoy_api_v2_route.HeaderMatcher{
+					exactHeader("long-header-name", "long-header-value"),
+				},
+			}},
+	}
+
+	have := []*envoy_api_v2_route.Route{
+		want[1],
+		want[0],
+		want[2],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortSecrets(t *testing.T) {
+	want := []*envoy_api_v2_auth.Secret{
+		&envoy_api_v2_auth.Secret{Name: "first"},
+		&envoy_api_v2_auth.Secret{Name: "second"},
+	}
+
+	have := []*envoy_api_v2_auth.Secret{
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortHeaderMatchers(t *testing.T) {
+	want := []*envoy_api_v2_route.HeaderMatcher{
+		// Note that if the header names are the same, we
+		// order by the protobuf string, in which case "exact"
+		// is less than "present".
+		exactHeader("header-name", "anything"),
+		presentHeader("header-name"),
+		exactHeader("long-header-name", "long-header-value"),
+	}
+
+	have := []*envoy_api_v2_route.HeaderMatcher{
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortClusters(t *testing.T) {
+	want := []*v2.Cluster{
+		&v2.Cluster{Name: "first"},
+		&v2.Cluster{Name: "second"},
+	}
+
+	have := []*v2.Cluster{
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortClusterLoadAssignments(t *testing.T) {
+	want := []*v2.ClusterLoadAssignment{
+		&v2.ClusterLoadAssignment{ClusterName: "first"},
+		&v2.ClusterLoadAssignment{ClusterName: "second"},
+	}
+
+	have := []*v2.ClusterLoadAssignment{
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortHTTPWeightedClusters(t *testing.T) {
+	want := []*envoy_api_v2_route.WeightedCluster_ClusterWeight{
+		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+			Name:   "first",
+			Weight: protobuf.UInt32(10),
+		},
+		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+			Name:   "second",
+			Weight: protobuf.UInt32(10),
+		},
+		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+			Name:   "second",
+			Weight: protobuf.UInt32(20),
+		},
+	}
+
+	have := []*envoy_api_v2_route.WeightedCluster_ClusterWeight{
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortTCPWeightedClusters(t *testing.T) {
+	want := []*tcp.TcpProxy_WeightedCluster_ClusterWeight{
+		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   "first",
+			Weight: 10,
+		},
+		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   "second",
+			Weight: 10,
+		},
+		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   "second",
+			Weight: 20,
+		},
+	}
+
+	have := []*tcp.TcpProxy_WeightedCluster_ClusterWeight{
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortListeners(t *testing.T) {
+	want := []*v2.Listener{
+		&v2.Listener{Name: "first"},
+		&v2.Listener{Name: "second"},
+	}
+
+	have := []*v2.Listener{
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}
+
+func TestSortFilterChains(t *testing.T) {
+	names := func(n ...string) *envoy_api_v2_listener.FilterChainMatch {
+		return &envoy_api_v2_listener.FilterChainMatch{
+			ServerNames: n,
+		}
+	}
+
+	want := []*envoy_api_v2_listener.FilterChain{
+		&envoy_api_v2_listener.FilterChain{
+			FilterChainMatch: names("first"),
+		},
+
+		// The following two entries should match the order
+		// in "have" because we are doing a stable sort, and
+		// they are equal since we only compare the first
+		// server name.
+		&envoy_api_v2_listener.FilterChain{
+			FilterChainMatch: names("second", "zzzzz"),
+		},
+
+		&envoy_api_v2_listener.FilterChain{
+			FilterChainMatch: names("second", "aaaaa"),
+		},
+	}
+
+	have := []*envoy_api_v2_listener.FilterChain{
+		want[1], // zzzzz
+		want[2], // aaaaa
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, have, want)
+}


### PR DESCRIPTION
Extract the various sorting policies for Envoy types into a single
package that can be tested and conveniently consumed without causing
dependency cycles.

This fixes #2376.

Signed-off-by: James Peach <jpeach@vmware.com>