### PR TITLE
internal/contour: enforce SNI name bindings

### DIFF
--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -14,6 +14,7 @@
 package contour
 
 import (
+	"path"
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -124,6 +125,14 @@ func TestListenerCacheQuery(t *testing.T) {
 }
 
 func TestListenerVisit(t *testing.T) {
+	httpsFilterFor := func(vhost string) *envoy_api_v2_listener.Filter {
+		return envoy.HTTPConnectionManagerBuilder().
+			MetricsPrefix(ENVOY_HTTPS_LISTENER).
+			RouteConfigName(path.Join("https", vhost)).
+			AccessLoggers(envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+			Get()
+	}
+
 	tests := map[string]struct {
 		ListenerVisitorConfig
 		objs []interface{}
@@ -266,7 +275,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 			}),
 		},
@@ -353,13 +362,13 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"sortedfirst.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("sortedfirst.example.com")),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedsecond.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("sortedsecond.example.com")),
 				}},
 			}),
 		},
@@ -475,7 +484,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -556,7 +565,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -630,7 +639,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 			}),
 		},
@@ -702,7 +711,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 			}),
 		},
@@ -771,7 +780,11 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy("/tmp/https_access.log"), 0)),
+					Filters: envoy.Filters(envoy.HTTPConnectionManagerBuilder().
+						MetricsPrefix(ENVOY_HTTPS_LISTENER).
+						RouteConfigName(path.Join("https", "whatever.example.com")).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/tmp/https_access.log")).
+						Get()),
 				}},
 			}),
 		},
@@ -836,7 +849,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"),
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -907,7 +920,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -978,7 +991,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -1049,7 +1062,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket(envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoy.Filters(envoy.HTTPConnectionManager(ENVOY_HTTPS_LISTENER, envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					Filters:         envoy.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -142,7 +142,6 @@ func TestRouteVisit(t *testing.T) {
 			objs: nil,
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"one http only ingress with service": {
@@ -179,7 +178,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"one http only ingress with regex match": {
@@ -228,7 +226,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"one http only ingressroute": {
@@ -274,7 +271,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"default backend ingress with secret": {
@@ -323,7 +319,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"vhost ingress with secret": {
@@ -385,7 +380,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https",
+				envoy.RouteConfiguration("https/www.example.com",
 					envoy.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
@@ -456,7 +451,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https",
+				envoy.RouteConfiguration("https/www.example.com",
 					envoy.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
@@ -521,7 +516,7 @@ func TestRouteVisit(t *testing.T) {
 			},
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https",
+				envoy.RouteConfiguration("https/www.example.com",
 					envoy.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
@@ -599,7 +594,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https",
+				envoy.RouteConfiguration("https/www.example.com",
 					envoy.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
@@ -670,7 +665,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress invalid timeout": {
@@ -710,7 +704,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress infinite timeout": {
@@ -750,7 +743,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress 90 second timeout": {
@@ -790,7 +782,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"vhost name exceeds 60 chars": { // heptio/contour#25
@@ -841,7 +832,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress retry-on": {
@@ -881,7 +871,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress retry-on, num-retries": {
@@ -922,7 +911,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 
@@ -964,7 +952,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress retry-on, per-try-timeout": {
@@ -1005,7 +992,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingress retry-on, legacy per-try-timeout": {
@@ -1046,7 +1032,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 
@@ -1121,7 +1106,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingressroute one weight defined": {
@@ -1196,7 +1180,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingressroute all weights defined": {
@@ -1272,7 +1255,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"ingressroute w/ missing fqdn": {
@@ -1309,7 +1291,6 @@ func TestRouteVisit(t *testing.T) {
 			},
 			want: routeConfigurations(
 				envoy.RouteConfiguration("ingress_http"), // should be blank, no fqdn defined.
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with pathPrefix": {
@@ -1385,7 +1366,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with mirror policy": {
@@ -1450,7 +1430,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with pathPrefix with tls": {
@@ -1531,7 +1510,7 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https",
+				envoy.RouteConfiguration("https/www.example.com",
 					envoy.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
@@ -1666,7 +1645,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with header contains conditions": {
@@ -1722,7 +1700,6 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with header notcontains conditions": {
@@ -1782,7 +1759,6 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with header exact match conditions": {
@@ -1842,7 +1818,6 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with header exact not match conditions": {
@@ -1902,7 +1877,6 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with header header present conditions": {
@@ -1960,7 +1934,6 @@ func TestRouteVisit(t *testing.T) {
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 						},
 					)),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 		"httpproxy with route-level header manipulation": {
@@ -2052,7 +2025,6 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 		},
 	}

--- a/internal/e2e/lds_test.go
+++ b/internal/e2e/lds_test.go
@@ -228,7 +228,13 @@ func TestTLSListener(t *testing.T) {
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
-				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1,
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
+					"h2", "http/1.1"),
 			},
 			staticListener(),
 		),
@@ -274,7 +280,13 @@ func TestTLSListener(t *testing.T) {
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
-				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1,
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
+					"h2", "http/1.1"),
 			},
 			staticListener(),
 		),
@@ -389,7 +401,13 @@ func TestIngressRouteTLSListener(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("kuard.example.com", secret1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", secret1,
+			envoy.HTTPConnectionManagerBuilder().
+				RouteConfigName("https/kuard.example.com").
+				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+				Get(),
+			"h2", "http/1.1"),
 	}
 
 	// add service
@@ -445,7 +463,11 @@ func TestIngressRouteTLSListener(t *testing.T) {
 					nil,
 					"h2", "http/1.1"),
 				envoy.Filters(
-					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
 				),
 			),
 		},
@@ -537,7 +559,13 @@ func TestLDSFilter(t *testing.T) {
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
-				FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+				FilterChains: filterchaintls("kuard.example.com", s1,
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
+					"h2", "http/1.1"),
 			},
 		),
 		TypeUrl: listenerType,
@@ -720,7 +748,13 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 			envoy.ProxyProtocol(),
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1,
+			envoy.HTTPConnectionManagerBuilder().
+				RouteConfigName("https/kuard.example.com").
+				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+				Get(),
+			"h2", "http/1.1"),
 	}
 	assert.Equal(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -828,7 +862,15 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1,
+
+			envoy.HTTPConnectionManagerBuilder().
+				RouteConfigName("https/kuard.example.com").
+				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+				Get(),
+
+			"h2", "http/1.1"),
 	}
 	assert.Equal(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -925,7 +967,14 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("kuard.example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/tmp/https_access.log"), 0), "h2", "http/1.1"),
+		FilterChains: filterchaintls("kuard.example.com", s1,
+			envoy.HTTPConnectionManagerBuilder().
+				RouteConfigName("https/kuard.example.com").
+				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+				AccessLoggers(envoy.FileAccessLogEnvoy("/tmp/https_access.log")).
+				Get(),
+
+			"h2", "http/1.1"),
 	}
 	assert.Equal(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -1023,7 +1072,13 @@ func TestIngressRouteHTTPS(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("example.com", s1, envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0), "h2", "http/1.1"),
+		FilterChains: filterchaintls("example.com", s1,
+			envoy.HTTPConnectionManagerBuilder().
+				RouteConfigName("https/example.com").
+				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+				Get(),
+			"h2", "http/1.1"),
 	}
 	assert.Equal(t, &v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -1110,7 +1165,11 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 					nil,
 					"h2", "http/1.1"),
 				envoy.Filters(
-					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
 				),
 			),
 		},
@@ -1174,7 +1233,11 @@ func TestIngressRouteMinimumTLSVersion(t *testing.T) {
 					nil,
 					"h2", "http/1.1"),
 				envoy.Filters(
-					envoy.HTTPConnectionManager("ingress_https", envoy.FileAccessLogEnvoy("/dev/stdout"), 0),
+					envoy.HTTPConnectionManagerBuilder().
+						RouteConfigName("https/kuard.example.com").
+						MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
+						AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
+						Get(),
 				),
 			),
 		},

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -65,62 +65,127 @@ func Listener(name, address string, port int, lf []*envoy_api_v2_listener.Listen
 	return l
 }
 
-// HTTPConnectionManager creates a new HTTP Connection Manager filter
-// for the supplied route, access log, and client request timeout.
-func HTTPConnectionManager(routename string, accesslogger []*accesslog.AccessLog, requestTimeout time.Duration) *envoy_api_v2_listener.Filter {
+type httpConnectionManagerBuilder struct {
+	routeConfigName string
+	metricsPrefix   string
+	accessLoggers   []*accesslog.AccessLog
+	requestTimeout  time.Duration
+}
+
+// RouteConfigName sets the name of the RDS element that contains
+// the routing table for this manager.
+func (b *httpConnectionManagerBuilder) RouteConfigName(name string) *httpConnectionManagerBuilder {
+	b.routeConfigName = name
+	return b
+}
+
+// MetricsPrefix sets the prefix used for emitting metrics from the
+// connection manager. Note that this prefix is externally visible in
+// monitoring tools, so it is subject to compatibility concerns.
+//
+// See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/stats#config-http-conn-man-stats
+func (b *httpConnectionManagerBuilder) MetricsPrefix(prefix string) *httpConnectionManagerBuilder {
+	b.metricsPrefix = prefix
+	return b
+}
+
+// AccessLoggers sets the access logging configuration.
+func (b *httpConnectionManagerBuilder) AccessLoggers(loggers []*accesslog.AccessLog) *httpConnectionManagerBuilder {
+	b.accessLoggers = loggers
+	return b
+}
+
+// RequestTimeout sets the active request timeout on the connection
+// manager. If not specified or set to 0, this timeout is disabled.
+func (b *httpConnectionManagerBuilder) RequestTimeout(timeout time.Duration) *httpConnectionManagerBuilder {
+	b.requestTimeout = timeout
+	return b
+}
+
+// Get returns a new http.HttpConnectionManager filter, constructed
+// from the builder settings.
+//
+// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto.html
+func (b *httpConnectionManagerBuilder) Get() *envoy_api_v2_listener.Filter {
+	cm := &http.HttpConnectionManager{
+		RouteSpecifier: &http.HttpConnectionManager_Rds{
+			Rds: &http.Rds{
+				RouteConfigName: b.routeConfigName,
+				ConfigSource: &envoy_api_v2_core.ConfigSource{
+					ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
+						ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
+							ApiType: envoy_api_v2_core.ApiConfigSource_GRPC,
+							GrpcServices: []*envoy_api_v2_core.GrpcService{{
+								TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{
+									EnvoyGrpc: &envoy_api_v2_core.GrpcService_EnvoyGrpc{
+										ClusterName: "contour",
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		HttpFilters: []*http.HttpFilter{{
+			Name: wellknown.Gzip,
+		}, {
+			Name: wellknown.GRPCWeb,
+		}, {
+			Name: wellknown.Router,
+		}},
+		CommonHttpProtocolOptions: &envoy_api_v2_core.HttpProtocolOptions{
+			// Sets the idle timeout for HTTP connections to 60 seconds.
+			// This is chosen as a rough default to stop idle connections wasting resources,
+			// without stopping slow connections from being terminated too quickly.
+			IdleTimeout: protobuf.Duration(60 * time.Second),
+		},
+		HttpProtocolOptions: &envoy_api_v2_core.Http1ProtocolOptions{
+			// Enable support for HTTP/1.0 requests that carry
+			// a Host: header. See #537.
+			AcceptHttp_10: true,
+		},
+		UseRemoteAddress: protobuf.Bool(true),
+		NormalizePath:    protobuf.Bool(true),
+		RequestTimeout:   protobuf.Duration(b.requestTimeout),
+
+		// issue #1487 pass through X-Request-Id if provided.
+		PreserveExternalRequestId: true,
+	}
+
+	if len(b.accessLoggers) > 0 {
+		cm.AccessLog = b.accessLoggers
+	}
+
+	// If there's no explicit metrics prefix, default it to the
+	// route config name.
+	if b.metricsPrefix != "" {
+		cm.StatPrefix = b.metricsPrefix
+	} else {
+		cm.StatPrefix = b.routeConfigName
+	}
 
 	return &envoy_api_v2_listener.Filter{
 		Name: wellknown.HTTPConnectionManager,
 		ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-			TypedConfig: toAny(&http.HttpConnectionManager{
-				StatPrefix: routename,
-				RouteSpecifier: &http.HttpConnectionManager_Rds{
-					Rds: &http.Rds{
-						RouteConfigName: routename,
-						ConfigSource: &envoy_api_v2_core.ConfigSource{
-							ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_ApiConfigSource{
-								ApiConfigSource: &envoy_api_v2_core.ApiConfigSource{
-									ApiType: envoy_api_v2_core.ApiConfigSource_GRPC,
-									GrpcServices: []*envoy_api_v2_core.GrpcService{{
-										TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{
-											EnvoyGrpc: &envoy_api_v2_core.GrpcService_EnvoyGrpc{
-												ClusterName: "contour",
-											},
-										},
-									}},
-								},
-							},
-						},
-					},
-				},
-				HttpFilters: []*http.HttpFilter{{
-					Name: wellknown.Gzip,
-				}, {
-					Name: wellknown.GRPCWeb,
-				}, {
-					Name: wellknown.Router,
-				}},
-				CommonHttpProtocolOptions: &envoy_api_v2_core.HttpProtocolOptions{
-					// Sets the idle timeout for HTTP connections to 60 seconds.
-					// This is chosen as a rough default to stop idle connections wasting resources,
-					// without stopping slow connections from being terminated too quickly.
-					IdleTimeout: protobuf.Duration(60 * time.Second),
-				},
-				HttpProtocolOptions: &envoy_api_v2_core.Http1ProtocolOptions{
-					// Enable support for HTTP/1.0 requests that carry
-					// a Host: header. See #537.
-					AcceptHttp_10: true,
-				},
-				AccessLog:        accesslogger,
-				UseRemoteAddress: protobuf.Bool(true),
-				NormalizePath:    protobuf.Bool(true),
-				RequestTimeout:   protobuf.Duration(requestTimeout),
-
-				// issue #1487 pass through X-Request-Id if provided.
-				PreserveExternalRequestId: true,
-			}),
+			TypedConfig: toAny(cm),
 		},
 	}
+}
+
+// HTTPConnectionManager creates a new HTTP Connection Manager filter
+// for the supplied route, access log, and client request timeout.
+func HTTPConnectionManager(routename string, accesslogger []*accesslog.AccessLog, requestTimeout time.Duration) *envoy_api_v2_listener.Filter {
+	return HTTPConnectionManagerBuilder().
+		RouteConfigName(routename).
+		MetricsPrefix(routename).
+		AccessLoggers(accesslogger).
+		RequestTimeout(requestTimeout).
+		Get()
+}
+
+func HTTPConnectionManagerBuilder() *httpConnectionManagerBuilder {
+	return &httpConnectionManagerBuilder{}
 }
 
 // TCPProxy creates a new TCPProxy filter.

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -73,7 +73,6 @@ func TestExternalNameService(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -113,7 +112,6 @@ func TestExternalNameService(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -157,7 +155,6 @@ func TestExternalNameService(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math/rand"
 	"net"
+	"sort"
 	"testing"
 	"time"
 
@@ -34,6 +35,8 @@ import (
 	cgrpc "github.com/projectcontour/contour/internal/grpc"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/metrics"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/sorter"
 	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -221,6 +224,13 @@ func check(t *testing.T, err error) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// routeResources returns the given routes as a slice of any.Any
+// resources, appropriately sorted.
+func routeResources(t *testing.T, routes ...*v2.RouteConfiguration) []*any.Any {
+	sort.Stable(sorter.For(routes))
+	return resources(t, protobuf.AsMessages(routes)...)
 }
 
 func resources(t *testing.T, protos ...proto.Message) []*any.Any {

--- a/internal/featuretests/headercondition_test.go
+++ b/internal/featuretests/headercondition_test.go
@@ -134,7 +134,6 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -203,7 +202,6 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -272,7 +270,6 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -341,7 +338,6 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -408,7 +404,6 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -78,7 +78,6 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -125,7 +124,6 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -162,7 +160,6 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -221,7 +218,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	})
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
-		Resources: resources(t,
+		Resources: routeResources(t,
 			envoy.RouteConfiguration("ingress_http",
 				envoy.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
@@ -235,7 +232,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 						},
 					}),
 			),
-			envoy.RouteConfiguration("ingress_https",
+			envoy.RouteConfiguration("https/hello.world",
 				envoy.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -86,7 +86,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -110,7 +109,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -130,7 +128,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -148,7 +145,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -159,7 +155,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -202,7 +197,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -234,7 +228,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -266,7 +259,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -284,7 +276,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -295,7 +286,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -337,7 +327,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -370,7 +359,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -400,7 +388,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -418,7 +405,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -429,7 +415,6 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -484,7 +469,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -515,7 +499,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -538,7 +521,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -556,7 +538,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -567,7 +548,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -607,7 +587,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -647,7 +626,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -679,7 +657,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -697,7 +674,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -708,7 +684,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -747,7 +722,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -786,7 +760,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -819,7 +792,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -837,7 +809,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						},
 					),
 				),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -848,7 +819,6 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		c.Request(routeType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				envoy.RouteConfiguration("ingress_http"),
-				envoy.RouteConfiguration("ingress_https"),
 			),
 			TypeUrl: routeType,
 		})
@@ -907,7 +877,6 @@ func TestIngressClassUpdate(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
@@ -926,7 +895,6 @@ func TestIngressClassUpdate(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).NoStatus(vhost)

--- a/internal/featuretests/loadbalancerpolicy_test.go
+++ b/internal/featuretests/loadbalancerpolicy_test.go
@@ -80,7 +80,6 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -124,7 +123,6 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -177,7 +175,6 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -216,7 +213,6 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -261,7 +257,6 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/mirrorpolicy_test.go
+++ b/internal/featuretests/mirrorpolicy_test.go
@@ -85,7 +85,6 @@ func TestMirrorPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/replaceprefix_test.go
+++ b/internal/featuretests/replaceprefix_test.go
@@ -91,7 +91,6 @@ func basic(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
@@ -111,7 +110,6 @@ func basic(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Equals(projcontour.Status{
@@ -143,7 +141,6 @@ func basic(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
@@ -164,7 +161,6 @@ func basic(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Equals(projcontour.Status{
@@ -196,7 +192,6 @@ func basic(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
@@ -221,7 +216,6 @@ func basic(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
@@ -318,7 +312,6 @@ func multiInclude(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost1).Like(
@@ -356,7 +349,6 @@ func multiInclude(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost1).Like(
@@ -453,7 +445,6 @@ func replaceWithSlash(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost1).Like(
@@ -495,7 +486,6 @@ func replaceWithSlash(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	}).Status(vhost1).Like(
@@ -608,7 +598,6 @@ func artifactoryDocker(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/retrypolicy_test.go
+++ b/internal/featuretests/retrypolicy_test.go
@@ -73,7 +73,6 @@ func TestRetryPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -103,7 +102,6 @@ func TestRetryPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -133,7 +131,6 @@ func TestRetryPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -172,7 +169,6 @@ func TestRetryPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -210,7 +206,6 @@ func TestRetryPolicy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/rootnamespaces_test.go
+++ b/internal/featuretests/rootnamespaces_test.go
@@ -108,7 +108,6 @@ func TestRootNamespaces(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -158,7 +157,6 @@ func TestRootNamespaces(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -199,7 +197,6 @@ func TestRootNamespaces(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -251,7 +248,6 @@ func TestRootNamespaces(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -104,7 +104,6 @@ func TestTCPProxy(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -159,7 +158,6 @@ func TestTCPProxy(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -250,7 +248,6 @@ func TestTCPProxyDelegation(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -314,7 +311,6 @@ func TestTCPProxyDelegation(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -397,7 +393,6 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -459,7 +454,6 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -559,7 +553,6 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -662,8 +655,6 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 					upgradeHTTPS(routePrefix("/")),
 				),
 			),
-			// no route should not be present as tcpproxy is in use
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -771,8 +762,6 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 					},
 				),
 			),
-			// no route should not be present as tcpproxy is in use
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -873,7 +862,6 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 				),
 			),
 			// ingress_https should be empty.
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -981,7 +969,6 @@ func TestTCPProxyTLSPassthroughAndHTTPServicePermitInsecure(t *testing.T) {
 				),
 			),
 			// ingress_https should be empty.
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -1059,7 +1046,6 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 			// ingress_http and ingress_https should be empty
 			// as hp1 is not valid.
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -1106,7 +1092,6 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 			// ingress_http and ingress_https should be empty
 			// as hp2 is not valid.
 			envoy.RouteConfiguration("ingress_http"),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/timeoutpolicy_test.go
+++ b/internal/featuretests/timeoutpolicy_test.go
@@ -73,7 +73,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -101,7 +100,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -129,7 +127,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -158,7 +155,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -196,7 +192,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -230,7 +225,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -264,7 +258,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -302,7 +295,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -336,7 +328,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -370,7 +361,6 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -427,7 +417,6 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -461,7 +450,6 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -495,7 +483,6 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/internal/featuretests/websockets_test.go
+++ b/internal/featuretests/websockets_test.go
@@ -84,7 +84,6 @@ func TestWebsocketsIngress(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -127,7 +126,6 @@ func TestWebsocketsIngress(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -202,7 +200,6 @@ func TestWebsocketIngressRoute(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -298,7 +295,6 @@ func TestWebsocketIngressRoute_MultipleUpstreams(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -388,7 +384,6 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})
@@ -449,7 +444,6 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 					},
 				),
 			),
-			envoy.RouteConfiguration("ingress_https"),
 		),
 		TypeUrl: routeType,
 	})

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -198,11 +198,14 @@ spec:
 HTTPProxy follows a similar pattern to Ingress for configuring TLS credentials.
 
 You can secure a HTTPProxy by specifying a Secret that contains TLS private key and certificate information.
-Contour (via Envoy) uses the SNI TLS extension to handle this behavior.
-If multiple HTTPProxy's utilize the same Secret, the certificate must include the necessary Subject Authority Name (SAN) for each fqdn.
+If multiple HTTPProxies utilize the same Secret, the certificate must include the necessary Subject Authority Name (SAN) for each fqdn.
+
+Contour (via Envoy) requires that clients send the Server Name Indication (SNI) TLS extension so that requests can be routed to the correct virtual host.
+Virtual hosts are strongly bound to SNI names.
+This means that the Host header in HTTP requests must match the SNI name that was sent at the start of the TLS session.
 
 Contour also follows a "secure first" approach.
-When TLS is enabled for a virtual host any request to the insecure port is redirected to the secure interface with a 301 redirect.
+When TLS is enabled for a virtual host, any request to the insecure port is redirected to the secure interface with a 301 redirect.
 Specific routes can be configured to override this behavior and handle insecure requests by enabling the `spec.routes.permitInsecure` parameter on a Route.
 
 The TLS secret must contain keys named tls.crt and tls.key that contain the certificate and private key to use for TLS, e.g.:


### PR DESCRIPTION
reviously, Contour generates a single RouteConfiguration named
`ingress_https` that contained all the virtual hosts that were being
served over HTTPS. This meant that if the client request SNI name "A",
it could send a HTTP request for virtual host "B" and it would work.
This behaviour is generally unexpected and can violate security invariants
that we want to enforce, e.g. protecting virtual hosts with client
certificate validation.

The fix is to generate a unique route configuration for each virtual host
and match them to each unique SNI name. This means that once the SNI name
is matched, all the routes from the attached route aonfiguration belong
to the same virtual host. This enforces a one to one correspondence
between SNI names and virtual hosts.

After this, the well-known "ingress_https" route configuration no longer
exists, except for TCP proxying.

This fixes #2347.

Signed-off-by: James Peach <jpeach@vmware.com>