### PR TITLE
Fix the PR template with new links and frontmatter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,10 +1,15 @@
+---
+name: Pull request
+about: Tell us about your contribution
+---
+
 <!--  Thanks for contributing to Contour!
 
-Before submitting a pull request, make sure you read about our Contribution Workflow here: https://github.com/heptio/contour/blob/master/CONTRIBUTING.md#contribution-workflow
+Before submitting a pull request, make sure you read about our Contribution Workflow here: https://github.com/projectcontour/contour/blob/master/CONTRIBUTING.md#contribution-workflow
 
 Some notable call outs from our Contribution Workflow:
 
 1. All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request description. Contour operates according to the talk, then code rule. If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
-2. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/heptio/contour/blob/master/CONTRIBUTING.md#dco-sign-off
+2. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/projectcontour/contour/blob/master/CONTRIBUTING.md#dco-sign-off
 
 -->


### PR DESCRIPTION
This will make sure that the PR template is recognized properly by GitHub's community health metrics, and I've also updated the links to the correct repo org.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>