### PR TITLE
internal/contour: Add contour version to metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,18 @@ RUN go mod download
 COPY cmd cmd
 COPY internal internal
 COPY apis apis
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/contour -ldflags=-s -v github.com/projectcontour/contour/cmd/contour
+COPY Makefile Makefile
+
+ARG BUILD_BRANCH
+ARG BUILD_SHA
+ARG BUILD_VERSION
+
+RUN make install \
+	    CGO_ENABLED=0 \
+	    GOOS=linux \
+	    BUILD_VERSION=${BUILD_VERSION} \
+	    BUILD_SHA=${BUILD_SHA} \
+	    BUILD_BRANCH=${BUILD_BRANCH}
 
 FROM scratch AS final
 COPY --from=build /go/bin/contour /bin/contour

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -1,0 +1,23 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+// Branch allows for a queryable branch name set at build time.
+var Branch string
+
+// Sha allows for a queryable git sha set at build time.
+var Sha string
+
+// Version allows for a queryable version set at build time.
+var Version string

--- a/site/_metrics/contour_build_info.md
+++ b/site/_metrics/contour_build_info.md
@@ -1,0 +1,7 @@
+---
+name: 'contour_build_info'
+type: '[GAUGE](https://prometheus.io/docs/concepts/metric_types/#gauge)'
+labels: 'branch, revision, version'
+---
+
+Build information for Contour. Labels include the branch and git SHA that Contour was built from, and the Contour version.


### PR DESCRIPTION
Fixes #2378

Signed-off-by: Peter Grant <pegrant@vmware.com>

Allows for passing version at build time and exposes build information as a metric.