### PR TITLE
Add Ingress status management

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -1,0 +1,94 @@
+// Copyright © 2019 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sync"
+
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ingressStatusWriter manages the lifetime of StatusLoadBalancerUpdaters.
+//
+// The theory of operation of the ingressStatusWriter is as follows:
+// 1. On startup the ingressStatusWriter waits to be elected leader.
+// 2. Once elected leader, the ingressStatusWriter waits to receive a
+//    v1.LoadBalancerStatus value.
+// 3. Once a v1.LoadBalancerStatus value has been received, any existing informer
+//    is stopped and a new informer started in its place.
+// 4. Each informer is connected to a k8s.StatusLoadBalancerUpdater which reacts to
+//    OnAdd events for networking.k8s.io/ingress.v1beta1 objects. For each OnAdd
+//    the object is patched with the v1.LoadBalancerStatus value obtained on creation.
+//    OnUpdate and OnDelete events are ignored.If a new v1.LoadBalancerStatus value
+//    is been received, operation restarts at step 3.
+// 5. If the worker is stopped, any existing informer is stopped before the worker stops.
+type ingressStatusWriter struct {
+	log      logrus.FieldLogger
+	clients  *k8s.Clients
+	isLeader chan struct{}
+	lbStatus chan v1.LoadBalancerStatus
+}
+
+func (isw *ingressStatusWriter) Start(stop <-chan struct{}) error {
+
+	// await leadership election
+	isw.log.Info("awaiting leadership election")
+	select {
+	case <-stop:
+		// asked to stop before elected leader
+		return nil
+	case <-isw.isLeader:
+		isw.log.Info("elected leader")
+	}
+
+	var shutdown chan struct{}
+	var stopping sync.WaitGroup
+	for {
+		select {
+		case <-stop:
+			// stop existing informer and shut down
+			if shutdown != nil {
+				close(shutdown)
+			}
+			stopping.Wait()
+			return nil
+		case lbs := <-isw.lbStatus:
+			// stop existing informer
+			if shutdown != nil {
+				close(shutdown)
+			}
+			stopping.Wait()
+
+			// create informer for the new LoadBalancerStatus
+			factory := isw.clients.NewInformerFactory()
+			inf := factory.Networking().V1beta1().Ingresses().Informer()
+			log := isw.log.WithField("context", "IngressStatusLoadBalancerUpdater")
+			inf.AddEventHandler(&k8s.StatusLoadBalancerUpdater{
+				Client: isw.clients.ClientSet(),
+				Logger: log,
+				Status: lbs,
+			})
+
+			shutdown = make(chan struct{})
+			stopping.Add(1)
+			fn := startInformer(factory, log)
+			go func() {
+				defer stopping.Done()
+				fn(shutdown)
+			}()
+		}
+	}
+}

--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 VMware
+// Copyright © 2020 VMware
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -21,73 +21,78 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// ingressStatusWriter manages the lifetime of StatusLoadBalancerUpdaters.
+// loadBalancerStatusWriter manages the lifetime of IngressStatusUpdaters.
 //
-// The theory of operation of the ingressStatusWriter is as follows:
-// 1. On startup the ingressStatusWriter waits to be elected leader.
-// 2. Once elected leader, the ingressStatusWriter waits to receive a
+// The theory of operation of the loadBalancerStatusWriter is as follows:
+// 1. On startup the loadBalancerStatusWriter waits to be elected leader.
+// 2. Once elected leader, the loadBalancerStatusWriter waits to receive a
 //    v1.LoadBalancerStatus value.
 // 3. Once a v1.LoadBalancerStatus value has been received, any existing informer
-//    is stopped and a new informer started in its place.
-// 4. Each informer is connected to a k8s.StatusLoadBalancerUpdater which reacts to
+//    is stopped and a new informer started in its place. This ensures that all existing
+//    Ingress objects will have OnAdd events fired to the new event handler.
+// 4. Each informer is connected to a k8s.IngressStatusUpdater which reacts to
 //    OnAdd events for networking.k8s.io/ingress.v1beta1 objects. For each OnAdd
 //    the object is patched with the v1.LoadBalancerStatus value obtained on creation.
 //    OnUpdate and OnDelete events are ignored.If a new v1.LoadBalancerStatus value
 //    is been received, operation restarts at step 3.
 // 5. If the worker is stopped, any existing informer is stopped before the worker stops.
-type ingressStatusWriter struct {
+type loadBalancerStatusWriter struct {
 	log      logrus.FieldLogger
 	clients  *k8s.Clients
 	isLeader chan struct{}
 	lbStatus chan v1.LoadBalancerStatus
 }
 
-func (isw *ingressStatusWriter) Start(stop <-chan struct{}) error {
+func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 
-	// await leadership election
+	// Await leadership election.
 	isw.log.Info("awaiting leadership election")
 	select {
 	case <-stop:
-		// asked to stop before elected leader
+		// We were asked to stop before elected leader.
 		return nil
 	case <-isw.isLeader:
 		isw.log.Info("elected leader")
 	}
 
 	var shutdown chan struct{}
-	var stopping sync.WaitGroup
+	var ingressInformers sync.WaitGroup
 	for {
 		select {
 		case <-stop:
-			// stop existing informer and shut down
+			// Use the shutdown channel to stop existing informer and shut down
 			if shutdown != nil {
 				close(shutdown)
 			}
-			stopping.Wait()
+			ingressInformers.Wait()
 			return nil
 		case lbs := <-isw.lbStatus:
-			// stop existing informer
+			// Stop the existing informer.
 			if shutdown != nil {
 				close(shutdown)
 			}
-			stopping.Wait()
+			ingressInformers.Wait()
 
-			// create informer for the new LoadBalancerStatus
+			isw.log.Info("Received a new address for status.loadBalancer")
+
+			// Create new informer for the new LoadBalancerStatus
 			factory := isw.clients.NewInformerFactory()
 			inf := factory.Networking().V1beta1().Ingresses().Informer()
-			log := isw.log.WithField("context", "IngressStatusLoadBalancerUpdater")
-			inf.AddEventHandler(&k8s.StatusLoadBalancerUpdater{
+			log := isw.log.WithField("context", "IngressStatusUpdater")
+			inf.AddEventHandler(&k8s.IngressStatusUpdater{
 				Client: isw.clients.ClientSet(),
 				Logger: log,
 				Status: lbs,
 			})
 
 			shutdown = make(chan struct{})
-			stopping.Add(1)
+			ingressInformers.Add(1)
 			fn := startInformer(factory, log)
 			go func() {
-				defer stopping.Done()
-				fn(shutdown)
+				defer ingressInformers.Done()
+				if err := fn(shutdown); err != nil {
+					return
+				}
 			}()
 		}
 	}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -109,6 +109,14 @@ type serveContext struct {
 	// If the value is true, Contour will register for all the service-apis types
 	// (GatewayClass, Gateway, HTTPRoute, TCPRoute, and any more as they are added)
 	UseExperimentalServiceAPITypes bool `yaml:"-"`
+
+	// envoy service details
+
+	// Namespace of the envoy service
+	envoyServiceNamespace string `yaml:"-"`
+
+	// Name of the envoy service
+	envoyServiceName string `yaml:"-"`
 }
 
 // newServeContext returns a serveContext initialized to defaults.
@@ -165,6 +173,8 @@ func newServeContext() *serveContext {
 			Name:          "leader-elect",
 		},
 		UseExperimentalServiceAPITypes: false,
+		envoyServiceName:               "envoy",
+		envoyServiceNamespace:          "projectcontour",
 	}
 }
 

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -174,7 +174,7 @@ func newServeContext() *serveContext {
 		},
 		UseExperimentalServiceAPITypes: false,
 		envoyServiceName:               "envoy",
-		envoyServiceNamespace:          "projectcontour",
+		envoyServiceNamespace:          getEnv("CONTOUR_NAMESPACE", "projectcontour"),
 	}
 }
 

--- a/examples/contour/02-rbac.yaml
+++ b/examples/contour/02-rbac.yaml
@@ -60,6 +60,7 @@ rules:
   - watch
   - patch 
   - post
+  - update
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
   verbs:

--- a/examples/contour/02-rbac.yaml
+++ b/examples/contour/02-rbac.yaml
@@ -43,7 +43,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - "networking.k8s.io"
   resources:
   - ingresses
   verbs:
@@ -53,11 +53,13 @@ rules:
 - apiGroups:
   - "networking.k8s.io"
   resources:
-  - ingresses
+  - "ingresses/status"
   verbs:
   - get
   - list
   - watch
+  - patch 
+  - post
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
   verbs:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -1,16 +1,12 @@
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: envoy
   name: envoy
   namespace: projectcontour
 spec:
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 10%
   selector:
     matchLabels:
       app: envoy

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -1,12 +1,16 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     app: envoy
   name: envoy
   namespace: projectcontour
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   selector:
     matchLabels:
       app: envoy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1429,7 +1429,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
+  - "networking.k8s.io"
   resources:
   - ingresses
   verbs:
@@ -1439,11 +1439,14 @@ rules:
 - apiGroups:
   - "networking.k8s.io"
   resources:
-  - ingresses
+  - "ingresses/status"
   verbs:
   - get
   - list
   - watch
+  - patch 
+  - post
+  - update
 - apiGroups: ["contour.heptio.com"]
   resources: ["ingressroutes", "tlscertificatedelegations"]
   verbs:

--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -1,3 +1,5 @@
+// +build none
+
 package main
 
 import (

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -223,7 +223,7 @@ func (e *EventHandler) updateDAG() {
 		e.Metrics.SetIngressRouteMetric(metrics)
 		e.Metrics.SetHTTPProxyMetric(proxymetrics)
 	default:
-		e.Debug("skipping status update: not the leader")
+		e.Debug("skipping metrics and CRD status update, not leader")
 	}
 }
 

--- a/internal/k8s/ingressstatus.go
+++ b/internal/k8s/ingressstatus.go
@@ -23,13 +23,13 @@ import (
 // StatusLoadbalancerUpdater observes informer OnAdd events and
 // updates the ingress.status.loadBalancer field on all Ingress
 // objects that match the ingress class (if used).
-type StatusLoadBalancerUpdater struct {
+type IngressStatusUpdater struct {
 	Client clientset.Interface
 	Logger logrus.FieldLogger
 	Status v1.LoadBalancerStatus
 }
 
-func (s *StatusLoadBalancerUpdater) OnAdd(obj interface{}) {
+func (s *IngressStatusUpdater) OnAdd(obj interface{}) {
 	ing := obj.(*v1beta1.Ingress).DeepCopy()
 
 	// TODO(dfc) check ingress class
@@ -44,7 +44,7 @@ func (s *StatusLoadBalancerUpdater) OnAdd(obj interface{}) {
 	}
 }
 
-func (s *StatusLoadBalancerUpdater) OnUpdate(oldObj, newObj interface{}) {
+func (s *IngressStatusUpdater) OnUpdate(oldObj, newObj interface{}) {
 	// Ignoring OnUpdate allows us to avoid the message generated
 	// from the status update.
 
@@ -55,7 +55,7 @@ func (s *StatusLoadBalancerUpdater) OnUpdate(oldObj, newObj interface{}) {
 	// of scope.
 }
 
-func (s *StatusLoadBalancerUpdater) OnDelete(obj interface{}) {
+func (s *IngressStatusUpdater) OnDelete(obj interface{}) {
 	// we don't need to update the status on resources that
 	// have been deleted.
 }

--- a/internal/k8s/ingressstatus.go
+++ b/internal/k8s/ingressstatus.go
@@ -1,0 +1,110 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// StatusLoadbalancerUpdater observes informer OnAdd events and
+// updates the ingress.status.loadBalancer field on all Ingress
+// objects that match the ingress class (if used).
+type StatusLoadBalancerUpdater struct {
+	Client clientset.Interface
+	Logger logrus.FieldLogger
+	Status v1.LoadBalancerStatus
+}
+
+func (s *StatusLoadBalancerUpdater) OnAdd(obj interface{}) {
+	ing := obj.(*v1beta1.Ingress).DeepCopy()
+
+	// TODO(dfc) check ingress class
+
+	ing.Status.LoadBalancer = s.Status
+	_, err := s.Client.NetworkingV1beta1().Ingresses(ing.GetNamespace()).UpdateStatus(ing)
+	if err != nil {
+		s.Logger.
+			WithField("name", ing.GetName()).
+			WithField("namespace", ing.GetNamespace()).
+			WithError(err).Error("unable to update status")
+	}
+}
+
+func (s *StatusLoadBalancerUpdater) OnUpdate(oldObj, newObj interface{}) {
+	// Ignoring OnUpdate allows us to avoid the message generated
+	// from the status update.
+
+	// TODO(dfc) handle these cases:
+	// - OnUpdate transitions from an ingress class which is out of scope
+	// to one in scope.
+	// - OnUpdate transitions from an ingress class in scope to one out
+	// of scope.
+}
+
+func (s *StatusLoadBalancerUpdater) OnDelete(obj interface{}) {
+	// we don't need to update the status on resources that
+	// have been deleted.
+}
+
+// ServiceStatusLoadBalancerWatcher implements ResourceEventHandler and
+// watches for changes to the status.loadbalancer field
+type ServiceStatusLoadBalancerWatcher struct {
+	ServiceName string
+	LBStatus    chan v1.LoadBalancerStatus
+}
+
+func (s *ServiceStatusLoadBalancerWatcher) OnAdd(obj interface{}) {
+	svc, ok := obj.(*v1.Service)
+	if !ok {
+		// not a service
+		return
+	}
+	if svc.Name != s.ServiceName {
+		return
+	}
+	s.notify(svc.Status.LoadBalancer)
+}
+
+func (s *ServiceStatusLoadBalancerWatcher) OnUpdate(oldObj, newObj interface{}) {
+	svc, ok := newObj.(*v1.Service)
+	if !ok {
+		// not a service
+		return
+	}
+	if svc.Name != s.ServiceName {
+		return
+	}
+	s.notify(svc.Status.LoadBalancer)
+}
+
+func (s *ServiceStatusLoadBalancerWatcher) OnDelete(obj interface{}) {
+	svc, ok := obj.(*v1.Service)
+	if !ok {
+		// not a service
+		return
+	}
+	if svc.Name != s.ServiceName {
+		return
+	}
+	s.notify(v1.LoadBalancerStatus{
+		Ingress: nil,
+	})
+}
+
+func (s *ServiceStatusLoadBalancerWatcher) notify(lbstatus v1.LoadBalancerStatus) {
+	s.LBStatus <- lbstatus
+}

--- a/internal/k8s/ingressstatus_test.go
+++ b/internal/k8s/ingressstatus_test.go
@@ -1,0 +1,161 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/projectcontour/contour/internal/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestServiceStatusLoadBalancerWatcherOnAdd(t *testing.T) {
+	lbstatus := make(chan v1.LoadBalancerStatus, 1)
+	sw := ServiceStatusLoadBalancerWatcher{
+		ServiceName: "envoy",
+		LBStatus:    lbstatus,
+	}
+
+	recv := func() (v1.LoadBalancerStatus, bool) {
+		select {
+		case lbs := <-sw.LBStatus:
+			return lbs, true
+		default:
+			return v1.LoadBalancerStatus{}, false
+		}
+	}
+
+	// assert adding something other than a service generates no notification.
+	sw.OnAdd(&v1.Pod{})
+	_, ok := recv()
+	if ok {
+		t.Fatalf("expected no result when adding")
+	}
+
+	// assert adding a service with an different name generates no notification
+	var svc v1.Service
+	svc.Name = "potato"
+	sw.OnAdd(&svc)
+	_, ok = recv()
+	if ok {
+		t.Fatalf("expected no result when adding a service with a different name")
+	}
+
+	// assert adding a service with the correct name generates a notification
+	svc.Name = sw.ServiceName
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	sw.OnAdd(&svc)
+	got, ok := recv()
+	if !ok {
+		t.Fatalf("expected result when adding a service with the correct name")
+	}
+	want := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{{Hostname: "vmware.com"}},
+	}
+	assert.Equal(t, got, want)
+}
+
+func TestServiceStatusLoadBalancerWatcherOnUpdate(t *testing.T) {
+	lbstatus := make(chan v1.LoadBalancerStatus, 1)
+	sw := ServiceStatusLoadBalancerWatcher{
+		ServiceName: "envoy",
+		LBStatus:    lbstatus,
+	}
+
+	recv := func() (v1.LoadBalancerStatus, bool) {
+		select {
+		case lbs := <-sw.LBStatus:
+			return lbs, true
+		default:
+			return v1.LoadBalancerStatus{}, false
+		}
+	}
+
+	// assert updating something other than a service generates no notification.
+	sw.OnUpdate(&v1.Pod{}, &v1.Pod{})
+	_, ok := recv()
+	if ok {
+		t.Fatalf("expected no result when updating")
+	}
+
+	// assert updating a service with an different name generates no notification
+	var oldSvc, newSvc v1.Service
+	oldSvc.Name = "potato"
+	newSvc.Name = "elephant"
+	sw.OnUpdate(&oldSvc, &newSvc)
+	_, ok = recv()
+	if ok {
+		t.Fatalf("expected no result when updating a service with a different name")
+	}
+
+	// assert updating a service with the correct name generates a notification
+	var svc v1.Service
+	svc.Name = sw.ServiceName
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	sw.OnUpdate(&oldSvc, &svc)
+	got, ok := recv()
+	if !ok {
+		t.Fatalf("expected result when updating a service with the correct name")
+	}
+	want := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{{Hostname: "vmware.com"}},
+	}
+	assert.Equal(t, got, want)
+}
+
+func TestServiceStatusLoadBalancerWatcherOnDelete(t *testing.T) {
+	lbstatus := make(chan v1.LoadBalancerStatus, 1)
+	sw := ServiceStatusLoadBalancerWatcher{
+		ServiceName: "envoy",
+		LBStatus:    lbstatus,
+	}
+
+	recv := func() (v1.LoadBalancerStatus, bool) {
+		select {
+		case lbs := <-sw.LBStatus:
+			return lbs, true
+		default:
+			return v1.LoadBalancerStatus{}, false
+		}
+	}
+
+	// assert deleting something other than a service generates no notification.
+	sw.OnDelete(&v1.Pod{})
+	_, ok := recv()
+	if ok {
+		t.Fatalf("expected no result when deleting")
+	}
+
+	// assert adding a service with an different name generates no notification
+	var svc v1.Service
+	svc.Name = "potato"
+	sw.OnDelete(&svc)
+	_, ok = recv()
+	if ok {
+		t.Fatalf("expected no result when deleting a service with a different name")
+	}
+
+	// assert deleting a service with the correct name generates a blank notification
+	svc.Name = sw.ServiceName
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	sw.OnDelete(&svc)
+	got, ok := recv()
+	if !ok {
+		t.Fatalf("expected result when deleting a service with the correct name")
+	}
+	want := v1.LoadBalancerStatus{
+		Ingress: nil,
+	}
+	assert.Equal(t, got, want)
+}

--- a/internal/k8s/ingressstatus_test.go
+++ b/internal/k8s/ingressstatus_test.go
@@ -54,14 +54,14 @@ func TestServiceStatusLoadBalancerWatcherOnAdd(t *testing.T) {
 
 	// assert adding a service with the correct name generates a notification
 	svc.Name = sw.ServiceName
-	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "projectcontour.io"}}
 	sw.OnAdd(&svc)
 	got, ok := recv()
 	if !ok {
 		t.Fatalf("expected result when adding a service with the correct name")
 	}
 	want := v1.LoadBalancerStatus{
-		Ingress: []v1.LoadBalancerIngress{{Hostname: "vmware.com"}},
+		Ingress: []v1.LoadBalancerIngress{{Hostname: "projectcontour.io"}},
 	}
 	assert.Equal(t, got, want)
 }
@@ -102,14 +102,14 @@ func TestServiceStatusLoadBalancerWatcherOnUpdate(t *testing.T) {
 	// assert updating a service with the correct name generates a notification
 	var svc v1.Service
 	svc.Name = sw.ServiceName
-	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "projectcontour.io"}}
 	sw.OnUpdate(&oldSvc, &svc)
 	got, ok := recv()
 	if !ok {
 		t.Fatalf("expected result when updating a service with the correct name")
 	}
 	want := v1.LoadBalancerStatus{
-		Ingress: []v1.LoadBalancerIngress{{Hostname: "vmware.com"}},
+		Ingress: []v1.LoadBalancerIngress{{Hostname: "projectcontour.io"}},
 	}
 	assert.Equal(t, got, want)
 }
@@ -148,7 +148,7 @@ func TestServiceStatusLoadBalancerWatcherOnDelete(t *testing.T) {
 
 	// assert deleting a service with the correct name generates a blank notification
 	svc.Name = sw.ServiceName
-	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "vmware.com"}}
+	svc.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{{Hostname: "projectcontour.io"}}
 	sw.OnDelete(&svc)
 	got, ok := recv()
 	if !ok {


### PR DESCRIPTION
Updates #403.

This version of Ingress status adds the wiring to manage Ingress status, and allows the configuration of an Envoy service and namespace to watch for addresses to publish into the `status.Loadbalancer` stanza of Ingress objects.

There are still TODOs, #2387 and #2388 amongst them.