### PR TITLE
Contour namespace

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -44,7 +44,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 	// The precedence of configuration for contour serve is as follows:
 	// config file, overridden by env vars, overridden by cli flags.
-	// however, as -c is a cli flag, we don't know its valye til cli flags
+	// however, as -c is a cli flag, we don't know its value til cli flags
 	// have been parsed. To correct this ordering we assign a post parse
 	// action to -c, then parse cli flags twice (see main.main). On the second
 	// parse our action will return early, resulting in the precedence order

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -161,7 +161,7 @@ func newServeContext() *serveContext {
 			LeaseDuration: time.Second * 15,
 			RenewDeadline: time.Second * 10,
 			RetryPeriod:   time.Second * 2,
-			Namespace:     "projectcontour",
+			Namespace:     getEnv("CONTOUR_NAMESPACE", "projectcontour"),
 			Name:          "leader-elect",
 		},
 		UseExperimentalServiceAPITypes: false,
@@ -285,4 +285,12 @@ func (ctx *serveContext) ingressRouteRootNamespaces() []string {
 		ns = append(ns, strings.TrimSpace(s))
 	}
 	return ns
+}
+
+// Simple helper function to read an environment or return a default value
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
 }

--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -59,6 +59,7 @@ spec:
         - certgen
         - --incluster
         - --kube
+        - --namespace=$(CONTOUR_NAMESPACE)
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -77,6 +77,11 @@ spec:
             mountPath: /config
             readOnly: true
         env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1369,6 +1369,7 @@ spec:
         - certgen
         - --incluster
         - --kube
+        - --namespace=$(CONTOUR_NAMESPACE)
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:
@@ -1629,6 +1630,11 @@ spec:
             mountPath: /config
             readOnly: true
         env:
+        - name: CONTOUR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Fixes #2255 by using the downward api to give the default namespace for configuration variables. They are still able to be overridden/configured as before but are no longer hardcoded to `projectcontour`. 