### PR TITLE
build: omit the DWARF symbol table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GO_BUILD_VARS = \
 	github.com/projectcontour/contour/internal/build.Branch=${BUILD_BRANCH}
 
 GO_TAGS := -tags "oidc gcp"
-GO_LDFLAGS := -s $(patsubst %,-X %, $(GO_BUILD_VARS))
+GO_LDFLAGS := -s -w $(patsubst %,-X %, $(GO_BUILD_VARS))
 
 export GO111MODULE=on
 


### PR DESCRIPTION
When Dockerfile build moved across the the Makefile, the `-w` Go linker
option was dropped. This option reduces the final binary size by 10MiB
on macOS, so it's probably worth keeping.

Signed-off-by: James Peach <jpeach@vmware.com>