### PR TITLE
internal/build: Add contour version as a CLI option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ TAG_LATEST ?= false
 # LOCALIP as an env var before running 'make local' will solve that.
 LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v 127.0.0.1 | head -n1 | awk '{print $$2}')
 
-# Sets GIT_REF to a tag if it's present, otherwise the short rev.
-GIT_REF = $(shell git describe --tags || git rev-parse --short=8 --verify HEAD)
+# Sets GIT_REF to a tag if it's present, otherwise the short git sha will be used.
+GIT_REF = $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=8 --verify HEAD)
 VERSION ?= $(GIT_REF)
 # Used for the tag-latest action.
 # The tag-latest action will be a noop unless this is explicitly

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/projectcontour/contour/internal/build"
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/klog"
@@ -61,6 +62,7 @@ func main() {
 	sds.Arg("resources", "SDS resource filter").StringsVar(&resources)
 
 	serve, serveCtx := registerServe(app)
+	version := app.Command("version", "Build information for Contour.")
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {
@@ -95,10 +97,13 @@ func main() {
 		}
 		log.Infof("args: %v", args)
 		check(doServe(log, serveCtx))
+	case version.FullCommand():
+		println(build.PrintBuildInfo())
 	default:
 		app.Usage(args)
 		os.Exit(2)
 	}
+
 }
 
 func check(err error) {

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -13,6 +13,17 @@
 
 package build
 
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// BuildInfo is a struct for build information.
+type BuildInfo struct {
+	Branch  string `yaml:"branch,omitempty"`
+	Sha     string `yaml:"sha,omitempty"`
+	Version string `yaml:"version,omitempty"`
+}
+
 // Branch allows for a queryable branch name set at build time.
 var Branch string
 
@@ -21,3 +32,13 @@ var Sha string
 
 // Version allows for a queryable version set at build time.
 var Version string
+
+// PrintBuildInfo prints the build information.
+func PrintBuildInfo() string {
+	buildInfo := &BuildInfo{Branch, Sha, Version}
+	out, err := yaml.Marshal(buildInfo)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
Fixes #2396

Signed-off-by: Peter Grant <pegrant@vmware.com>

Allows for a CLI option to print build and version information.