### PR TITLE
internal/health: separate health and metrics services

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -52,6 +52,10 @@ type serveContext struct {
 	metricsAddr string
 	metricsPort int
 
+	// Contour's health handler parameters.
+	healthAddr string
+	healthPort int
+
 	// ingressroute root namespaces
 	rootNamespaces string
 
@@ -122,6 +126,8 @@ func newServeContext() *serveContext {
 		statsPort:             8002,
 		debugAddr:             "127.0.0.1",
 		debugPort:             6060,
+		healthAddr:            "0.0.0.0",
+		healthPort:            8000,
 		metricsAddr:           "0.0.0.0",
 		metricsPort:           8000,
 		httpAccessLog:         contour.DEFAULT_HTTP_ACCESS_LOG,

--- a/design/listener-design.md
+++ b/design/listener-design.md
@@ -1,0 +1,22 @@
+# Listener Design
+
+**Status**: _Draft_
+
+This document describes Contour's additional HTTP listener configuration for the purpose of separating host/port configuration for health checking and metrics services.
+
+# Goals
+
+- Provide support to define custom host/port for each of the health and metrics services within Contour
+- Maintain default backwards compatible configuration for how this is currently achieved
+
+# Non-goals
+
+- Build a method of authentication/authorization around supporting service listeners
+
+# Background
+
+Contour, provides listeners for health-checking (for liveness/readiness probes), and metrics(for observability). These services are often defaulted to be exposed. Allowing configuration for these additional services provides a more intentful deployment, and helps cluster operators run their application securely by default.
+
+# High-level design
+
+This document proposes Contour listener configuration that should allow for custom configuration of it's exposed services. This enables end-users to maintain separate models of authentication/authorization around these services, where each of the underlying services may only be intended for specific consumers.

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,37 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package health provides a health check service.
+package health
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// Handler returns a http Handler for a health endpoint.
+func Handler(client *kubernetes.Clientset) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Try and lookup Kubernetes server version as a quick and dirty check
+		_, err := client.ServerVersion()
+		if err != nil {
+			msg := fmt.Sprintf("Failed Kubernetes Check: %v", err)
+			http.Error(w, msg, http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,14 +15,10 @@
 package metrics
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/projectcontour/contour/internal/build"
-	"github.com/projectcontour/contour/internal/httpsvc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -347,39 +343,7 @@ func (m *Metrics) SetHTTPProxyMetric(metrics RouteMetric) {
 	}
 }
 
-// Service serves various metric and health checking endpoints
-type Service struct {
-	httpsvc.Service
-	*prometheus.Registry
-	Client *kubernetes.Clientset
-}
-
-// Start fulfills the g.Start contract.
-// When stop is closed the http server will shutdown.
-func (svc *Service) Start(stop <-chan struct{}) error {
-
-	registerHealthCheck(&svc.ServeMux, svc.Client)
-	registerMetrics(&svc.ServeMux, svc.Registry)
-
-	return svc.Service.Start(stop)
-}
-
-func registerHealthCheck(mux *http.ServeMux, client *kubernetes.Clientset) {
-	healthCheckHandler := func(w http.ResponseWriter, r *http.Request) {
-		// Try and lookup Kubernetes server version as a quick and dirty check
-		_, err := client.ServerVersion()
-		if err != nil {
-			msg := fmt.Sprintf("Failed Kubernetes Check: %v", err)
-			http.Error(w, msg, http.StatusServiceUnavailable)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "OK")
-	}
-	mux.HandleFunc("/health", healthCheckHandler)
-	mux.HandleFunc("/healthz", healthCheckHandler)
-}
-
-func registerMetrics(mux *http.ServeMux, registry *prometheus.Registry) {
-	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+// Handler returns a http Handler for a metrics endpoint.
+func Handler(registry *prometheus.Registry) http.Handler {
+	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 }

--- a/site/_guides/health-checking.md
+++ b/site/_guides/health-checking.md
@@ -1,0 +1,12 @@
+---
+title: Health Checking
+layout: page
+---
+
+Contour exposes two health endpoints `/health` and `/healthz`. By default these paths are serviced by `0.0.0.0:8000` and are configurable using the `--health-address` and `--health-port` flags.
+
+e.g. `--health-port 9999` would create a health listener of `0.0.0.0:9999`
+
+**Note:** the `Service` deployment manifest when installing Contour must be updated to represent the same port as the above configured flags.
+
+The health endpoints perform a connection to the Kubernetes cluster's API.

--- a/site/_guides/prometheus.md
+++ b/site/_guides/prometheus.md
@@ -21,8 +21,11 @@ port `8002`.
 
 ## Contour Metrics
 
-Contour exposes a Prometheus-compatible `/metrics` endpoint on port `8000` with
-the following metrics:
+Contour exposes a Prometheus-compatible `/metrics` endpoint that defaults to listening on port 8000. This can be configured by using the `--http-address` and `--http-port` flags for the `serve` command.
+
+**Note:** the `Service` deployment manifest when installing Contour must be updated to represent the same port as the configured flag.
+
+The metrics endpoint exposes the following metrics:
 
 {% include metrics.html %}
 


### PR DESCRIPTION
Fixes #2380

Signed-off-by: Peter Grant pegrant@vmware.com

Allows for separating health/metric services.