### PR TITLE
internal/annotation: Refactor annotations code from internal/dag

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/debug"
@@ -165,7 +166,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 				HTTPSAccessLog:         ctx.httpsAccessLog,
 				AccessLogType:          ctx.AccessLogFormat,
 				AccessLogFields:        ctx.AccessLogFields,
-				MinimumProtocolVersion: dag.MinProtoVersion(ctx.TLSConfig.MinimumProtocolVersion),
+				MinimumProtocolVersion: annotation.MinProtoVersion(ctx.TLSConfig.MinimumProtocolVersion),
 				RequestTimeout:         ctx.RequestTimeout,
 			},
 			ListenerCache: contour.NewListenerCache(ctx.statsAddr, ctx.statsPort),

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package dag
+package annotation
 
 import (
 	"fmt"
@@ -20,10 +20,12 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/api/networking/v1beta1"
 )
 
-func annotationIsKnown(key string) bool {
+// IsKnown checks if an annotation is one Contour knows about.
+func IsKnown(key string) bool {
 	// We should know about everything with a Contour prefix.
 	if strings.HasPrefix(key, "projectcontour.io/") ||
 		strings.HasPrefix(key, "contour.heptio.com/") {
@@ -77,7 +79,8 @@ var annotationsByKind = map[string]map[string]struct{}{
 	},
 }
 
-func validAnnotationForKind(kind string, key string) bool {
+// ValidForKind checks if a particular annotation is valid for a given Kind.
+func ValidForKind(kind string, key string) bool {
 	if a, ok := annotationsByKind[kind]; ok {
 		// Canonicalize the name while we still have legacy support.
 		key = strings.Replace(key, "contour.heptio.com/", "projectcontour.io/", -1)
@@ -95,10 +98,10 @@ func validAnnotationForKind(kind string, key string) bool {
 	return true
 }
 
-// compatAnnotation checks the Object for the given annotation, first with the
+// CompatAnnotation checks the Object for the given annotation, first with the
 // "projectcontour.io/" prefix, and then with the "contour.heptio.com/" prefix
 // if that is not found.
-func compatAnnotation(o Object, key string) string {
+func CompatAnnotation(o k8s.Object, key string) string {
 	a := o.GetObjectMeta().GetAnnotations()
 
 	if val, ok := a["projectcontour.io/"+key]; ok {
@@ -108,7 +111,7 @@ func compatAnnotation(o Object, key string) string {
 	return a["contour.heptio.com/"+key]
 }
 
-// parseUInt32 parses the supplied string as if it were a uint32.
+// ParseUInt32 parses the supplied string as if it were a uint32.
 // If the value is not present, or malformed, or outside uint32's range, zero is returned.
 func parseUInt32(s string) uint32 {
 	v, err := strconv.ParseUint(s, 10, 32)
@@ -118,10 +121,10 @@ func parseUInt32(s string) uint32 {
 	return uint32(v)
 }
 
-// parseUpstreamProtocols parses the annotations map for contour.heptio.com/upstream-protocol.{protocol}
+// ParseUpstreamProtocols parses the annotations map for contour.heptio.com/upstream-protocol.{protocol}
 // and projectcontour.io/upstream-protocol.{protocol} annotations.
 // 'protocol' identifies which protocol must be used in the upstream.
-func parseUpstreamProtocols(m map[string]string) map[string]string {
+func ParseUpstreamProtocols(m map[string]string) map[string]string {
 	annotations := []string{
 		"contour.heptio.com/upstream-protocol",
 		"projectcontour.io/upstream-protocol",
@@ -142,19 +145,21 @@ func parseUpstreamProtocols(m map[string]string) map[string]string {
 	return up
 }
 
-// httpAllowed returns true unless the kubernetes.io/ingress.allow-http annotation is
+// HTTPAllowed returns true unless the kubernetes.io/ingress.allow-http annotation is
 // present and set to false.
-func httpAllowed(i *v1beta1.Ingress) bool {
+func HTTPAllowed(i *v1beta1.Ingress) bool {
 	return !(i.Annotations["kubernetes.io/ingress.allow-http"] == "false")
 }
 
-// tlsRequired returns true if the ingress.kubernetes.io/force-ssl-redirect annotation is
+// TLSRequired returns true if the ingress.kubernetes.io/force-ssl-redirect annotation is
 // present and set to true.
-func tlsRequired(i *v1beta1.Ingress) bool {
+func TLSRequired(i *v1beta1.Ingress) bool {
 	return i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true"
 }
 
-func websocketRoutes(i *v1beta1.Ingress) map[string]bool {
+// WebsocketRoutes retrieves the details of routes that should have websockets enabled from the
+// associated websocket-routes annotation.
+func WebsocketRoutes(i *v1beta1.Ingress) map[string]bool {
 	routes := make(map[string]bool)
 	for _, v := range strings.Split(i.Annotations["projectcontour.io/websocket-routes"], ",") {
 		route := strings.TrimSpace(v)
@@ -171,23 +176,23 @@ func websocketRoutes(i *v1beta1.Ingress) map[string]bool {
 	return routes
 }
 
-// numRetries returns the number of retries specified by the "contour.heptio.com/num-retries"
+// NumRetries returns the number of retries specified by the "contour.heptio.com/num-retries"
 // or "projectcontour.io/num-retries" annotation.
-func numRetries(i *v1beta1.Ingress) uint32 {
-	return parseUInt32(compatAnnotation(i, "num-retries"))
+func NumRetries(i *v1beta1.Ingress) uint32 {
+	return parseUInt32(CompatAnnotation(i, "num-retries"))
 }
 
-// perTryTimeout returns the duration envoy will wait per retry cycle.
-func perTryTimeout(i *v1beta1.Ingress) time.Duration {
-	return parseTimeout(compatAnnotation(i, "per-try-timeout"))
+// PerTryTimeout returns the duration envoy will wait per retry cycle.
+func PerTryTimeout(i *v1beta1.Ingress) time.Duration {
+	return k8s.ParseTimeout(CompatAnnotation(i, "per-try-timeout"))
 }
 
-// ingressClass returns the first matching ingress class for the following
+// IngressClass returns the first matching ingress class for the following
 // annotations:
 // 1. projectcontour.io/ingress.class
 // 2. contour.heptio.com/ingress.class
 // 3. kubernetes.io/ingress.class
-func ingressClass(o Object) string {
+func IngressClass(o k8s.Object) string {
 	a := o.GetObjectMeta().GetAnnotations()
 	if class, ok := a["projectcontour.io/ingress.class"]; ok {
 		return class
@@ -215,24 +220,42 @@ func MinProtoVersion(version string) envoy_api_v2_auth.TlsParameters_TlsProtocol
 	}
 }
 
-// maxConnections returns the value of the first matching max-connections
+// MaxConnections returns the value of the first matching max-connections
 // annotation for the following annotations:
 // 1. projectcontour.io/max-connections
 // 2. contour.heptio.com/max-connections
 //
 // '0' is returned if the annotation is absent or unparseable.
-func maxConnections(o Object) uint32 {
-	return parseUInt32(compatAnnotation(o, "max-connections"))
+func MaxConnections(o k8s.Object) uint32 {
+	return parseUInt32(CompatAnnotation(o, "max-connections"))
 }
 
-func maxPendingRequests(o Object) uint32 {
-	return parseUInt32(compatAnnotation(o, "max-pending-requests"))
+// MaxPendingRequests returns the value of the first matching max-pending-requests
+// annotation for the following annotations:
+// 1. projectcontour.io/max-pending-requests
+// 2. contour.heptio.com/max-pending-requests
+//
+// '0' is returned if the annotation is absent or unparseable.
+func MaxPendingRequests(o k8s.Object) uint32 {
+	return parseUInt32(CompatAnnotation(o, "max-pending-requests"))
 }
 
-func maxRequests(o Object) uint32 {
-	return parseUInt32(compatAnnotation(o, "max-requests"))
+// MaxRequests returns the value of the first matching max-requests
+// annotation for the following annotations:
+// 1. projectcontour.io/max-requests
+// 2. contour.heptio.com/max-requests
+//
+// '0' is returned if the annotation is absent or unparseable.
+func MaxRequests(o k8s.Object) uint32 {
+	return parseUInt32(CompatAnnotation(o, "max-requests"))
 }
 
-func maxRetries(o Object) uint32 {
-	return parseUInt32(compatAnnotation(o, "max-retries"))
+// MaxRetries returns the value of the first matching max-retries
+// annotation for the following annotations:
+// 1. projectcontour.io/max-retries
+// 2. contour.heptio.com/max-retries
+//
+// '0' is returned if the annotation is absent or unparseable.
+func MaxRetries(o k8s.Object) uint32 {
+	return parseUInt32(CompatAnnotation(o, "max-retries"))
 }

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -228,7 +228,7 @@ func (e *EventHandler) updateDAG() {
 }
 
 // setStatus updates the status of objects.
-func (e *EventHandler) setStatus(statuses map[dag.Meta]dag.Status) {
+func (e *EventHandler) setStatus(statuses map[k8s.FullName]dag.Status) {
 	for _, st := range statuses {
 		switch obj := st.Object.(type) {
 		case *ingressroutev1.IngressRoute:

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -56,7 +56,7 @@ func (e *EventRecorder) recordOperation(op string, obj interface{}) {
 	e.Counter.WithLabelValues(op, kind).Inc()
 }
 
-func calculateRouteMetric(statuses map[dag.Meta]dag.Status) (metrics.RouteMetric, metrics.RouteMetric) {
+func calculateRouteMetric(statuses map[k8s.FullName]dag.Status) (metrics.RouteMetric, metrics.RouteMetric) {
 	irMetricTotal := make(map[metrics.Meta]int)
 	irMetricValid := make(map[metrics.Meta]int)
 	irMetricInvalid := make(map[metrics.Meta]int)

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 )
 
@@ -42,12 +43,12 @@ type Builder struct {
 	DisablePermitInsecure bool
 
 	services map[servicemeta]*Service
-	secrets  map[Meta]*Secret
+	secrets  map[k8s.FullName]*Secret
 
 	virtualhosts       map[string]*VirtualHost
 	securevirtualhosts map[string]*SecureVirtualHost
 
-	orphaned map[Meta]bool
+	orphaned map[k8s.FullName]bool
 
 	StatusWriter
 }
@@ -73,25 +74,25 @@ func (b *Builder) Build() *DAG {
 // reset (re)inialises the internal state of the builder.
 func (b *Builder) reset() {
 	b.services = make(map[servicemeta]*Service, len(b.services))
-	b.secrets = make(map[Meta]*Secret, len(b.secrets))
-	b.orphaned = make(map[Meta]bool, len(b.orphaned))
+	b.secrets = make(map[k8s.FullName]*Secret, len(b.secrets))
+	b.orphaned = make(map[k8s.FullName]bool, len(b.orphaned))
 
 	b.virtualhosts = make(map[string]*VirtualHost)
 	b.securevirtualhosts = make(map[string]*SecureVirtualHost)
 
-	b.statuses = make(map[Meta]Status, len(b.statuses))
+	b.statuses = make(map[k8s.FullName]Status, len(b.statuses))
 }
 
 // lookupService returns a Service that matches the Meta and Port of the Kubernetes' Service.
-func (b *Builder) lookupService(m Meta, port intstr.IntOrString) *Service {
+func (b *Builder) lookupService(m k8s.FullName, port intstr.IntOrString) *Service {
 	lookup := func() *Service {
 		if port.Type != intstr.Int {
 			// can't handle, give up
 			return nil
 		}
 		sm := servicemeta{
-			name:      m.name,
-			namespace: m.namespace,
+			name:      m.Name,
+			namespace: m.Namespace,
 			port:      int32(port.IntValue()),
 		}
 		return b.services[sm]
@@ -124,18 +125,18 @@ func (b *Builder) addService(svc *v1.Service, port *v1.ServicePort) *Service {
 		ServicePort: port,
 
 		Protocol:           upstreamProtocol(svc, port),
-		MaxConnections:     maxConnections(svc),
-		MaxPendingRequests: maxPendingRequests(svc),
-		MaxRequests:        maxRequests(svc),
-		MaxRetries:         maxRetries(svc),
+		MaxConnections:     annotation.MaxConnections(svc),
+		MaxPendingRequests: annotation.MaxPendingRequests(svc),
+		MaxRequests:        annotation.MaxRequests(svc),
+		MaxRetries:         annotation.MaxRetries(svc),
 		ExternalName:       externalName(svc),
 	}
-	b.services[s.toMeta()] = s
+	b.services[s.ToFullName()] = s
 	return s
 }
 
 func upstreamProtocol(svc *v1.Service, port *v1.ServicePort) string {
-	up := parseUpstreamProtocols(svc.Annotations)
+	up := annotation.ParseUpstreamProtocols(svc.Annotations)
 	protocol := up[port.Name]
 	if protocol == "" {
 		protocol = up[strconv.Itoa(int(port.Port))]
@@ -145,7 +146,7 @@ func upstreamProtocol(svc *v1.Service, port *v1.ServicePort) string {
 
 // lookupSecret returns a Secret if present or nil if the underlying kubernetes
 // secret fails validation or is missing.
-func (b *Builder) lookupSecret(m Meta, validate func(*v1.Secret) bool) *Secret {
+func (b *Builder) lookupSecret(m k8s.FullName, validate func(*v1.Secret) bool) *Secret {
 	sec, ok := b.Source.secrets[m]
 	if !ok {
 		return nil
@@ -156,7 +157,7 @@ func (b *Builder) lookupSecret(m Meta, validate func(*v1.Secret) bool) *Secret {
 	s := &Secret{
 		Object: sec,
 	}
-	b.secrets[toMeta(sec)] = s
+	b.secrets[k8s.ToFullName(sec)] = s
 	return s
 }
 
@@ -271,15 +272,15 @@ func (b *Builder) computeSecureVirtualhosts() {
 				for _, host := range tls.Hosts {
 					svhost := b.lookupSecureVirtualHost(host)
 					svhost.Secret = sec
-					version := compatAnnotation(ing, "tls-minimum-protocol-version")
-					svhost.MinProtoVersion = MinProtoVersion(version)
+					version := annotation.CompatAnnotation(ing, "tls-minimum-protocol-version")
+					svhost.MinProtoVersion = annotation.MinProtoVersion(version)
 				}
 			}
 		}
 	}
 }
 
-func (b *Builder) delegationPermitted(secret Meta, to string) bool {
+func (b *Builder) delegationPermitted(secret k8s.FullName, to string) bool {
 	contains := func(haystack []string, needle string) bool {
 		if len(haystack) == 1 && haystack[0] == "*" {
 			return true
@@ -292,18 +293,18 @@ func (b *Builder) delegationPermitted(secret Meta, to string) bool {
 		return false
 	}
 
-	if secret.namespace == to {
+	if secret.Namespace == to {
 		// secret is in the same namespace as target
 		return true
 	}
 
 	for _, d := range b.Source.httpproxydelegations {
-		if d.Namespace != secret.namespace {
+		if d.Namespace != secret.Namespace {
 			continue
 		}
 		for _, d := range d.Spec.Delegations {
 			if contains(d.TargetNamespaces, to) {
-				if secret.name == d.SecretName {
+				if secret.Name == d.SecretName {
 					return true
 				}
 			}
@@ -311,12 +312,12 @@ func (b *Builder) delegationPermitted(secret Meta, to string) bool {
 	}
 
 	for _, d := range b.Source.irdelegations {
-		if d.Namespace != secret.namespace {
+		if d.Namespace != secret.Namespace {
 			continue
 		}
 		for _, d := range d.Spec.Delegations {
 			if contains(d.TargetNamespaces, to) {
-				if secret.name == d.SecretName {
+				if secret.Name == d.SecretName {
 					return true
 				}
 			}
@@ -350,7 +351,7 @@ func (b *Builder) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1.IngressR
 	for _, httppath := range httppaths(rule) {
 		path := stringOrDefault(httppath.Path, "/")
 		be := httppath.Backend
-		m := Meta{name: be.ServiceName, namespace: ing.Namespace}
+		m := k8s.FullName{Name: be.ServiceName, Namespace: ing.Namespace}
 		s := b.lookupService(m, be.ServicePort)
 		if s == nil {
 			continue
@@ -359,7 +360,7 @@ func (b *Builder) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1.IngressR
 		r := route(ing, path, s)
 
 		// should we create port 80 routes for this ingress
-		if tlsRequired(ing) || httpAllowed(ing) {
+		if annotation.TLSRequired(ing) || annotation.HTTPAllowed(ing) {
 			b.lookupVirtualHost(host).addRoute(r)
 		}
 
@@ -418,7 +419,7 @@ func (b *Builder) computeIngressRoute(ir *ingressroutev1.IngressRoute) {
 			}
 			svhost := b.lookupSecureVirtualHost(ir.Spec.VirtualHost.Fqdn)
 			svhost.Secret = sec
-			svhost.MinProtoVersion = MinProtoVersion(ir.Spec.VirtualHost.TLS.MinimumProtocolVersion)
+			svhost.MinProtoVersion = annotation.MinProtoVersion(ir.Spec.VirtualHost.TLS.MinimumProtocolVersion)
 			enforceTLS = true
 		}
 		// passthrough is true if tls.secretName is not present, and
@@ -487,7 +488,7 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 			}
 			svhost := b.lookupSecureVirtualHost(host)
 			svhost.Secret = sec
-			svhost.MinProtoVersion = MinProtoVersion(proxy.Spec.VirtualHost.TLS.MinimumProtocolVersion)
+			svhost.MinProtoVersion = annotation.MinProtoVersion(proxy.Spec.VirtualHost.TLS.MinimumProtocolVersion)
 		}
 
 		if sec == nil && !tls.Passthrough {
@@ -667,7 +668,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			namespace = proxy.Namespace
 		}
 
-		delegate, ok := b.Source.httpproxies[Meta{name: include.Name, namespace: namespace}]
+		delegate, ok := b.Source.httpproxies[k8s.FullName{Name: include.Name, Namespace: namespace}]
 		if !ok {
 			sw.SetInvalid("include %s/%s not found", namespace, include.Name)
 			return nil
@@ -687,7 +688,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 		commit()
 
 		// dest is not an orphaned httpproxy, as there is an httpproxy that points to it
-		delete(b.orphaned, Meta{name: delegate.Name, namespace: delegate.Namespace})
+		delete(b.orphaned, k8s.FullName{Name: delegate.Name, Namespace: delegate.Namespace})
 	}
 
 	for _, route := range proxy.Spec.Routes {
@@ -774,7 +775,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				sw.SetInvalid("service %q: port must be in the range 1-65535", service.Name)
 				return nil
 			}
-			m := Meta{name: service.Name, namespace: proxy.Namespace}
+			m := k8s.FullName{Name: service.Name, Namespace: proxy.Namespace}
 			s := b.lookupService(m, intstr.FromInt(service.Port))
 
 			if s == nil {
@@ -939,10 +940,10 @@ func (b *Builder) buildHTTPSListener() *Listener {
 }
 
 // setOrphaned records an IngressRoute/HTTPProxy resource as orphaned.
-func (b *Builder) setOrphaned(obj Object) {
-	m := Meta{
-		name:      obj.GetObjectMeta().GetName(),
-		namespace: obj.GetObjectMeta().GetNamespace(),
+func (b *Builder) setOrphaned(obj k8s.Object) {
+	m := k8s.FullName{
+		Name:      obj.GetObjectMeta().GetName(),
+		Namespace: obj.GetObjectMeta().GetNamespace(),
 	}
 	b.orphaned[m] = true
 }
@@ -991,7 +992,7 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 					sw.SetInvalid("route %q: service %q: port must be in the range 1-65535", route.Match, service.Name)
 					return
 				}
-				m := Meta{name: service.Name, namespace: ir.Namespace}
+				m := k8s.FullName{Name: service.Name, Namespace: ir.Namespace}
 
 				s := b.lookupService(m, intstr.FromInt(service.Port))
 				if s == nil {
@@ -1039,14 +1040,14 @@ func (b *Builder) processIngressRoutes(sw *ObjectStatusWriter, ir *ingressroutev
 			namespace = ir.Namespace
 		}
 
-		if dest, ok := b.Source.ingressroutes[Meta{name: route.Delegate.Name, namespace: namespace}]; ok {
+		if dest, ok := b.Source.ingressroutes[k8s.FullName{Name: route.Delegate.Name, Namespace: namespace}]; ok {
 			if dest.Spec.VirtualHost != nil {
 				sw.SetInvalid("root ingressroute cannot delegate to another root ingressroute")
 				return
 			}
 
 			// dest is not an orphaned ingress route, as there is an IR that points to it
-			delete(b.orphaned, Meta{name: dest.Name, namespace: dest.Namespace})
+			delete(b.orphaned, k8s.FullName{Name: dest.Name, Namespace: dest.Namespace})
 
 			// ensure we are not following an edge that produces a cycle
 			var path []string
@@ -1076,7 +1077,7 @@ func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, n
 		return nil, nil
 	}
 
-	cacert := b.lookupSecret(Meta{name: uv.CACertificate, namespace: namespace}, validCA)
+	cacert := b.lookupSecret(k8s.FullName{Name: uv.CACertificate, Namespace: namespace}, validCA)
 	if cacert == nil {
 		// UpstreamValidation is requested, but cert is missing or not configured
 		return nil, errors.New("secret not found or misconfigured")
@@ -1106,7 +1107,7 @@ func (b *Builder) processIngressRouteTCPProxy(sw *ObjectStatusWriter, ir *ingres
 	if len(tcpproxy.Services) > 0 {
 		var proxy TCPProxy
 		for _, service := range tcpproxy.Services {
-			m := Meta{name: service.Name, namespace: ir.Namespace}
+			m := k8s.FullName{Name: service.Name, Namespace: ir.Namespace}
 			s := b.lookupService(m, intstr.FromInt(service.Port))
 			if s == nil {
 				sw.SetInvalid("tcpproxy: service %s/%s/%d: not found", ir.Namespace, service.Name, service.Port)
@@ -1136,9 +1137,9 @@ func (b *Builder) processIngressRouteTCPProxy(sw *ObjectStatusWriter, ir *ingres
 		namespace = ir.Namespace
 	}
 
-	if dest, ok := b.Source.ingressroutes[Meta{name: tcpproxy.Delegate.Name, namespace: namespace}]; ok {
+	if dest, ok := b.Source.ingressroutes[k8s.FullName{Name: tcpproxy.Delegate.Name, Namespace: namespace}]; ok {
 		// dest is not an orphaned ingress route, as there is an IR that points to it
-		delete(b.orphaned, Meta{name: dest.Name, namespace: dest.Namespace})
+		delete(b.orphaned, k8s.FullName{Name: dest.Name, Namespace: dest.Namespace})
 
 		// ensure we are not following an edge that produces a cycle
 		var path []string
@@ -1188,7 +1189,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 	if len(tcpproxy.Services) > 0 {
 		var proxy TCPProxy
 		for _, service := range httpproxy.Spec.TCPProxy.Services {
-			m := Meta{name: service.Name, namespace: httpproxy.Namespace}
+			m := k8s.FullName{Name: service.Name, Namespace: httpproxy.Namespace}
 			s := b.lookupService(m, intstr.FromInt(service.Port))
 			if s == nil {
 				sw.SetInvalid("tcpproxy: service %s/%s/%d: not found", httpproxy.Namespace, service.Name, service.Port)
@@ -1217,10 +1218,10 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 		namespace = httpproxy.Namespace
 	}
 
-	m := Meta{name: tcpProxyInclude.Name, namespace: namespace}
+	m := k8s.FullName{Name: tcpProxyInclude.Name, Namespace: namespace}
 	dest, ok := b.Source.httpproxies[m]
 	if !ok {
-		sw.SetInvalid("tcpproxy: include %s/%s not found", m.namespace, m.name)
+		sw.SetInvalid("tcpproxy: include %s/%s not found", m.Namespace, m.Name)
 		return false
 	}
 
@@ -1230,7 +1231,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 	}
 
 	// dest is no longer an orphan
-	delete(b.orphaned, toMeta(dest))
+	delete(b.orphaned, k8s.ToFullName(dest))
 
 	// ensure we are not following an edge that produces a cycle
 	var path []string
@@ -1264,9 +1265,9 @@ func externalName(svc *v1.Service) string {
 
 // route builds a dag.Route for the supplied Ingress.
 func route(ingress *v1beta1.Ingress, path string, service *Service) *Route {
-	wr := websocketRoutes(ingress)
+	wr := annotation.WebsocketRoutes(ingress)
 	r := &Route{
-		HTTPSUpgrade:  tlsRequired(ingress),
+		HTTPSUpgrade:  annotation.TLSRequired(ingress),
 		Websocket:     wr[path],
 		TimeoutPolicy: ingressTimeoutPolicy(ingress),
 		RetryPolicy:   ingressRetryPolicy(ingress),
@@ -1293,19 +1294,19 @@ func isBlank(s string) bool {
 
 // splitSecret splits a secretName into its namespace and name components.
 // If there is no namespace prefix, the default namespace is returned.
-func splitSecret(secret, defns string) Meta {
+func splitSecret(secret, defns string) k8s.FullName {
 	v := strings.SplitN(secret, "/", 2)
 	switch len(v) {
 	case 1:
 		// no prefix
-		return Meta{
-			name:      v[0],
-			namespace: defns,
+		return k8s.FullName{
+			Name:      v[0],
+			Namespace: defns,
 		}
 	default:
-		return Meta{
-			name:      v[1],
-			namespace: stringOrDefault(v[0], defns),
+		return k8s.FullName{
+			Name:      v[1],
+			Namespace: stringOrDefault(v[0], defns),
 		}
 	}
 }

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4401,7 +4402,7 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-		"insert ingress with invalid perTryTimeout": {
+		"insert ingress with invalid PerTryTimeout": {
 			objs: []interface{}{
 				ir15a,
 				s1,
@@ -6211,34 +6212,34 @@ func TestBuilderLookupService(t *testing.T) {
 			}},
 		},
 	}
-	services := map[Meta]*v1.Service{
-		{name: "service1", namespace: "default"}: s1,
+	services := map[k8s.FullName]*v1.Service{
+		{Name: "service1", Namespace: "default"}: s1,
 	}
 
 	tests := map[string]struct {
-		Meta
+		k8s.FullName
 		port intstr.IntOrString
 		want *Service
 	}{
 		"lookup service by port number": {
-			Meta: Meta{name: "service1", namespace: "default"},
-			port: intstr.FromInt(8080),
-			want: service(s1),
+			FullName: k8s.FullName{Name: "service1", Namespace: "default"},
+			port:     intstr.FromInt(8080),
+			want:     service(s1),
 		},
 		"lookup service by port name": {
-			Meta: Meta{name: "service1", namespace: "default"},
-			port: intstr.FromString("http"),
-			want: service(s1),
+			FullName: k8s.FullName{Name: "service1", Namespace: "default"},
+			port:     intstr.FromString("http"),
+			want:     service(s1),
 		},
 		"lookup service by port number (as string)": {
-			Meta: Meta{name: "service1", namespace: "default"},
-			port: intstr.Parse("8080"),
-			want: service(s1),
+			FullName: k8s.FullName{Name: "service1", Namespace: "default"},
+			port:     intstr.Parse("8080"),
+			want:     service(s1),
 		},
 		"lookup service by port number (from string)": {
-			Meta: Meta{name: "service1", namespace: "default"},
-			port: intstr.FromString("8080"),
-			want: service(s1),
+			FullName: k8s.FullName{Name: "service1", Namespace: "default"},
+			port:     intstr.FromString("8080"),
+			want:     service(s1),
 		},
 	}
 
@@ -6251,7 +6252,7 @@ func TestBuilderLookupService(t *testing.T) {
 				},
 			}
 			b.reset()
-			got := b.lookupService(tc.Meta, tc.port)
+			got := b.lookupService(tc.FullName, tc.port)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Fatal(diff)
 			}
@@ -6666,38 +6667,38 @@ func TestEnforceRoute(t *testing.T) {
 func TestSplitSecret(t *testing.T) {
 	tests := map[string]struct {
 		secret, defns string
-		want          Meta
+		want          k8s.FullName
 	}{
 		"no namespace": {
 			secret: "secret",
 			defns:  "default",
-			want: Meta{
-				name:      "secret",
-				namespace: "default",
+			want: k8s.FullName{
+				Name:      "secret",
+				Namespace: "default",
 			},
 		},
 		"with namespace": {
 			secret: "ns1/secret",
 			defns:  "default",
-			want: Meta{
-				name:      "secret",
-				namespace: "ns1",
+			want: k8s.FullName{
+				Name:      "secret",
+				Namespace: "ns1",
 			},
 		},
 		"missing namespace": {
 			secret: "/secret",
 			defns:  "default",
-			want: Meta{
-				name:      "secret",
-				namespace: "default",
+			want: k8s.FullName{
+				Name:      "secret",
+				Namespace: "default",
 			},
 		},
 		"missing secret name": {
 			secret: "secret/",
 			defns:  "default",
-			want: Meta{
-				name:      "",
-				namespace: "secret",
+			want: k8s.FullName{
+				Name:      "",
+				Namespace: "secret",
 			},
 		},
 	}
@@ -6706,7 +6707,7 @@ func TestSplitSecret(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := splitSecret(tc.secret, tc.defns)
 			opts := []cmp.Option{
-				cmp.AllowUnexported(Meta{}),
+				cmp.AllowUnexported(k8s.FullName{}),
 			}
 			if diff := cmp.Diff(tc.want, got, opts...); diff != "" {
 				t.Fatal(diff)

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,6 +14,7 @@
 package dag
 
 import (
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +27,7 @@ import (
 	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
 )
 
+// DEFAULT_INGRESS_CLASS is the Contour default.
 const DEFAULT_INGRESS_CLASS = "contour"
 
 // A KubernetesCache holds Kubernetes objects and associated configuration and produces
@@ -40,38 +42,25 @@ type KubernetesCache struct {
 	// If not set, defaults to DEFAULT_INGRESS_CLASS.
 	IngressClass string
 
-	ingresses            map[Meta]*v1beta1.Ingress
-	ingressroutes        map[Meta]*ingressroutev1.IngressRoute
-	httpproxies          map[Meta]*projectcontour.HTTPProxy
-	secrets              map[Meta]*v1.Secret
-	irdelegations        map[Meta]*ingressroutev1.TLSCertificateDelegation
-	httpproxydelegations map[Meta]*projectcontour.TLSCertificateDelegation
-	services             map[Meta]*v1.Service
-	gatewayclasses       map[Meta]*serviceapis.GatewayClass
-	gateways             map[Meta]*serviceapis.Gateway
-	httproutes           map[Meta]*serviceapis.HTTPRoute
-	tcproutes            map[Meta]*serviceapis.TcpRoute
+	ingresses            map[k8s.FullName]*v1beta1.Ingress
+	ingressroutes        map[k8s.FullName]*ingressroutev1.IngressRoute
+	httpproxies          map[k8s.FullName]*projectcontour.HTTPProxy
+	secrets              map[k8s.FullName]*v1.Secret
+	irdelegations        map[k8s.FullName]*ingressroutev1.TLSCertificateDelegation
+	httpproxydelegations map[k8s.FullName]*projectcontour.TLSCertificateDelegation
+	services             map[k8s.FullName]*v1.Service
+	gatewayclasses       map[k8s.FullName]*serviceapis.GatewayClass
+	gateways             map[k8s.FullName]*serviceapis.Gateway
+	httproutes           map[k8s.FullName]*serviceapis.HTTPRoute
+	tcproutes            map[k8s.FullName]*serviceapis.TcpRoute
 
 	logrus.FieldLogger
 }
 
-// Meta holds the name and namespace of a Kubernetes object.
-type Meta struct {
-	name, namespace string
-}
-
-func toMeta(obj Object) Meta {
-	m := obj.GetObjectMeta()
-	return Meta{
-		name:      m.GetName(),
-		namespace: m.GetNamespace(),
-	}
-}
-
 // matchesIngressClass returns true if the given Kubernetes object
 // belongs to the Ingress class that this cache is using.
-func (kc *KubernetesCache) matchesIngressClass(obj Object) bool {
-	objectClass := ingressClass(obj)
+func (kc *KubernetesCache) matchesIngressClass(obj k8s.Object) bool {
+	objectClass := annotation.IngressClass(obj)
 
 	switch objectClass {
 	case kc.IngressClass:
@@ -102,15 +91,15 @@ func (kc *KubernetesCache) matchesIngressClass(obj Object) bool {
 // is not interesting to the cache. If an object with a matching type, name,
 // and namespace exists, it will be overwritten.
 func (kc *KubernetesCache) Insert(obj interface{}) bool {
-	if obj, ok := obj.(Object); ok {
+	if obj, ok := obj.(k8s.Object); ok {
 		kind := k8s.KindOf(obj)
 		for key := range obj.GetObjectMeta().GetAnnotations() {
 			// Emit a warning if this is a known annotation that has
 			// been applied to an invalid object kind. Note that we
 			// only warn for known annotations because we want to
 			// allow users to add arbitrary orthogonal annotations
-			// to object that we inspect.
-			if annotationIsKnown(key) && !validAnnotationForKind(kind, key) {
+			// to objects that we inspect.
+			if annotation.IsKnown(key) && !annotation.ValidForKind(kind, key) {
 				// TODO(jpeach): this should be exposed
 				// to the user as a status condition.
 				om := obj.GetObjectMeta()
@@ -139,98 +128,98 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			return false
 		}
 
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.secrets == nil {
-			kc.secrets = make(map[Meta]*v1.Secret)
+			kc.secrets = make(map[k8s.FullName]*v1.Secret)
 		}
 		kc.secrets[m] = obj
 		return kc.secretTriggersRebuild(obj)
 	case *v1.Service:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.services == nil {
-			kc.services = make(map[Meta]*v1.Service)
+			kc.services = make(map[k8s.FullName]*v1.Service)
 		}
 		kc.services[m] = obj
 		return kc.serviceTriggersRebuild(obj)
 	case *v1beta1.Ingress:
 		if kc.matchesIngressClass(obj) {
-			m := toMeta(obj)
+			m := k8s.ToFullName(obj)
 			if kc.ingresses == nil {
-				kc.ingresses = make(map[Meta]*v1beta1.Ingress)
+				kc.ingresses = make(map[k8s.FullName]*v1beta1.Ingress)
 			}
 			kc.ingresses[m] = obj
 			return true
 		}
 	case *ingressroutev1.IngressRoute:
 		if kc.matchesIngressClass(obj) {
-			m := toMeta(obj)
+			m := k8s.ToFullName(obj)
 			if kc.ingressroutes == nil {
-				kc.ingressroutes = make(map[Meta]*ingressroutev1.IngressRoute)
+				kc.ingressroutes = make(map[k8s.FullName]*ingressroutev1.IngressRoute)
 			}
 			kc.ingressroutes[m] = obj
 			return true
 		}
 	case *projectcontour.HTTPProxy:
 		if kc.matchesIngressClass(obj) {
-			m := toMeta(obj)
+			m := k8s.ToFullName(obj)
 			if kc.httpproxies == nil {
-				kc.httpproxies = make(map[Meta]*projectcontour.HTTPProxy)
+				kc.httpproxies = make(map[k8s.FullName]*projectcontour.HTTPProxy)
 			}
 			kc.httpproxies[m] = obj
 			return true
 		}
 	case *ingressroutev1.TLSCertificateDelegation:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.irdelegations == nil {
-			kc.irdelegations = make(map[Meta]*ingressroutev1.TLSCertificateDelegation)
+			kc.irdelegations = make(map[k8s.FullName]*ingressroutev1.TLSCertificateDelegation)
 		}
 		kc.irdelegations[m] = obj
 		return true
 	case *projectcontour.TLSCertificateDelegation:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.httpproxydelegations == nil {
-			kc.httpproxydelegations = make(map[Meta]*projectcontour.TLSCertificateDelegation)
+			kc.httpproxydelegations = make(map[k8s.FullName]*projectcontour.TLSCertificateDelegation)
 		}
 		kc.httpproxydelegations[m] = obj
 		return true
 	case *serviceapis.GatewayClass:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.gatewayclasses == nil {
-			kc.gatewayclasses = make(map[Meta]*serviceapis.GatewayClass)
+			kc.gatewayclasses = make(map[k8s.FullName]*serviceapis.GatewayClass)
 		}
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Adding GatewayClass")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding GatewayClass")
 		kc.gatewayclasses[m] = obj
 		return true
 	case *serviceapis.Gateway:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.gateways == nil {
-			kc.gateways = make(map[Meta]*serviceapis.Gateway)
+			kc.gateways = make(map[k8s.FullName]*serviceapis.Gateway)
 		}
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Adding Gateway")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding Gateway")
 		kc.gateways[m] = obj
 		return true
 	case *serviceapis.HTTPRoute:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.httproutes == nil {
-			kc.httproutes = make(map[Meta]*serviceapis.HTTPRoute)
+			kc.httproutes = make(map[k8s.FullName]*serviceapis.HTTPRoute)
 		}
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Adding HTTPRoute")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding HTTPRoute")
 		kc.httproutes[m] = obj
 		return true
 	case *serviceapis.TcpRoute:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		if kc.tcproutes == nil {
-			kc.tcproutes = make(map[Meta]*serviceapis.TcpRoute)
+			kc.tcproutes = make(map[k8s.FullName]*serviceapis.TcpRoute)
 		}
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Adding TcpRoute")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding TcpRoute")
 		kc.tcproutes[m] = obj
 		return true
 
@@ -257,70 +246,70 @@ func (kc *KubernetesCache) Remove(obj interface{}) bool {
 func (kc *KubernetesCache) remove(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Secret:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.secrets[m]
 		delete(kc.secrets, m)
 		return ok
 	case *v1.Service:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.services[m]
 		delete(kc.services, m)
 		return ok
 	case *v1beta1.Ingress:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
 		return ok
 	case *ingressroutev1.IngressRoute:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.ingressroutes[m]
 		delete(kc.ingressroutes, m)
 		return ok
 	case *projectcontour.HTTPProxy:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.httpproxies[m]
 		delete(kc.httpproxies, m)
 		return ok
 	case *ingressroutev1.TLSCertificateDelegation:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.irdelegations[m]
 		delete(kc.irdelegations, m)
 		return ok
 	case *projectcontour.TLSCertificateDelegation:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.httpproxydelegations[m]
 		delete(kc.httpproxydelegations, m)
 		return ok
 	case *serviceapis.GatewayClass:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.gatewayclasses[m]
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Removing GatewayClass")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing GatewayClass")
 		delete(kc.gatewayclasses, m)
 		return ok
 	case *serviceapis.Gateway:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.gateways[m]
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Removing Gateway")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing Gateway")
 		delete(kc.gateways, m)
 		return ok
 	case *serviceapis.HTTPRoute:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.httproutes[m]
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Removing HTTPRoute")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing HTTPRoute")
 		delete(kc.httproutes, m)
 		return ok
 	case *serviceapis.TcpRoute:
-		m := toMeta(obj)
+		m := k8s.ToFullName(obj)
 		_, ok := kc.tcproutes[m]
 		// TODO(youngnick): Remove this once service-apis actually have behavior
 		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.name).WithField("namespace", m.namespace).Debug("Removing TcpRoute")
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing TcpRoute")
 		delete(kc.tcproutes, m)
 		return ok
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -32,7 +33,7 @@ type DAG struct {
 	roots []Vertex
 
 	// status computed while building this dag.
-	statuses map[Meta]Status
+	statuses map[k8s.FullName]Status
 }
 
 // Visit calls fn on each root of this DAG.
@@ -44,7 +45,7 @@ func (d *DAG) Visit(fn func(Vertex)) {
 
 // Statuses returns a slice of Status objects associated with
 // the computation of this DAG.
-func (d *DAG) Statuses() map[Meta]Status {
+func (d *DAG) Statuses() map[k8s.FullName]Status {
 	return d.statuses
 }
 
@@ -364,7 +365,7 @@ type servicemeta struct {
 	port      int32
 }
 
-func (s *Service) toMeta() servicemeta {
+func (s *Service) ToFullName() servicemeta {
 	return servicemeta{
 		name:      s.Name,
 		namespace: s.Namespace,

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -20,6 +20,8 @@ import (
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/annotation"
+	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -91,30 +93,30 @@ func headersPolicy(policy *projcontour.HeadersPolicy, allowHostRewrite bool) (*H
 
 // ingressRetryPolicy builds a RetryPolicy from ingress annotations.
 func ingressRetryPolicy(ingress *v1beta1.Ingress) *RetryPolicy {
-	retryOn := compatAnnotation(ingress, "retry-on")
+	retryOn := annotation.CompatAnnotation(ingress, "retry-on")
 	if len(retryOn) < 1 {
 		return nil
 	}
 	// if there is a non empty retry-on annotation, build a RetryPolicy manually.
 	return &RetryPolicy{
 		RetryOn: retryOn,
-		// TODO(dfc) numRetries may parse as 0, which is inconsistent with
+		// TODO(dfc) k8s.NumRetries may parse as 0, which is inconsistent with
 		// retryPolicyIngressRoute()'s default value of 1.
-		NumRetries: numRetries(ingress),
-		// TODO(dfc) perTryTimeout will parse to -1, infinite, in the case of
+		NumRetries: annotation.NumRetries(ingress),
+		// TODO(dfc) k8s.PerTryTimeout will parse to -1, infinite, in the case of
 		// invalid data, this is inconsistent with retryPolicyIngressRoute()'s default value
 		// of 0 duration.
-		PerTryTimeout: perTryTimeout(ingress),
+		PerTryTimeout: annotation.PerTryTimeout(ingress),
 	}
 }
 
 func ingressTimeoutPolicy(ingress *v1beta1.Ingress) *TimeoutPolicy {
-	response := compatAnnotation(ingress, "response-timeout")
+	response := annotation.CompatAnnotation(ingress, "response-timeout")
 	if len(response) == 0 {
 		// Note: due to a misunderstanding the name of the annotation is
 		// request timeout, but it is actually applied as a timeout on
 		// the response body.
-		response = compatAnnotation(ingress, "request-timeout")
+		response = annotation.CompatAnnotation(ingress, "request-timeout")
 		if len(response) == 0 {
 			return nil
 		}
@@ -134,7 +136,7 @@ func ingressrouteTimeoutPolicy(tp *ingressroutev1.TimeoutPolicy) *TimeoutPolicy 
 		// due to a misunderstanding the name of the field ingressroute is
 		// Request, however the timeout applies to the response resulting from
 		// a request.
-		ResponseTimeout: parseTimeout(tp.Request),
+		ResponseTimeout: k8s.ParseTimeout(tp.Request),
 	}
 }
 
@@ -143,8 +145,8 @@ func timeoutPolicy(tp *projcontour.TimeoutPolicy) *TimeoutPolicy {
 		return nil
 	}
 	return &TimeoutPolicy{
-		ResponseTimeout: parseTimeout(tp.Response),
-		IdleTimeout:     parseTimeout(tp.Idle),
+		ResponseTimeout: k8s.ParseTimeout(tp.Response),
+		IdleTimeout:     k8s.ParseTimeout(tp.Idle),
 	}
 }
 func ingressrouteHealthCheckPolicy(hc *ingressroutev1.HealthCheck) *HTTPHealthCheckPolicy {
@@ -203,32 +205,6 @@ func loadBalancerPolicy(lbp *projcontour.LoadBalancerPolicy) string {
 	default:
 		return ""
 	}
-}
-
-func parseTimeout(timeout string) time.Duration {
-	if timeout == "" {
-		// Blank is interpreted as no timeout specified, use envoy defaults
-		// By default envoy applies a 15 second timeout to all backend requests.
-		// The explicit value 0 turns off the timeout, implying "never time out"
-		// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
-		return 0
-	}
-
-	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
-	// expects as a timeout of 0. This could be specified with the duration string
-	// "0s" but want to give an explicit out for operators.
-	if timeout == "infinity" {
-		return -1
-	}
-
-	d, err := time.ParseDuration(timeout)
-	if err != nil {
-		// TODO(cmalonty) plumb a logger in here so we can log this error.
-		// Assuming infinite duration is going to surprise people less for
-		// a not-parseable duration than a implicit 15 second one.
-		return -1
-	}
-	return d
 }
 
 func max(a, b uint32) uint32 {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -20,6 +20,7 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -412,7 +413,7 @@ func TestParseTimeout(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := parseTimeout(tc.duration)
+			got := k8s.ParseTimeout(tc.duration)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/dag/secret.go
+++ b/internal/dag/secret.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// CaCertificateKey is the key name for accessing TLS CA certificate bundles in Kubernetes Secrets.
+// CACertificateKey is the key name for accessing TLS CA certificate bundles in Kubernetes Secrets.
 const CACertificateKey = "ca.crt"
 
 // isValidSecret returns true if the secret is interesting and well

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -19,39 +19,34 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Status contains the status for an IngressRoute (valid / invalid / orphan, etc)
 type Status struct {
-	Object      Object
+	Object      k8s.Object
 	Status      string
 	Description string
 	Vhost       string
 }
 
 type StatusWriter struct {
-	statuses map[Meta]Status
-}
-
-type Object interface {
-	metav1.ObjectMetaAccessor
+	statuses map[k8s.FullName]Status
 }
 
 type ObjectStatusWriter struct {
 	sw     *StatusWriter
-	obj    Object
+	obj    k8s.Object
 	values map[string]string
 }
 
 // WithObject returns an ObjectStatusWriter that can be used to set the state of
-// the Object. The state can be set as many times as necessary. The state of the
+// the object. The state can be set as many times as necessary. The state of the
 // object can be made permanent by calling the commit function returned from WithObject.
 // The caller should pass the ObjectStatusWriter to functions interested in writing status,
 // but keep the commit function for itself. The commit function should be either called
 // via a defer, or directly if statuses are being set in a loop (as defers will not fire
 // until the end of the function).
-func (sw *StatusWriter) WithObject(obj Object) (_ *ObjectStatusWriter, commit func()) {
+func (sw *StatusWriter) WithObject(obj k8s.Object) (_ *ObjectStatusWriter, commit func()) {
 	osw := &ObjectStatusWriter{
 		sw:     sw,
 		obj:    obj,
@@ -68,9 +63,9 @@ func (sw *StatusWriter) commit(osw *ObjectStatusWriter) {
 		return
 	}
 
-	m := Meta{
-		name:      osw.obj.GetObjectMeta().GetName(),
-		namespace: osw.obj.GetObjectMeta().GetNamespace(),
+	m := k8s.FullName{
+		Name:      osw.obj.GetObjectMeta().GetName(),
+		Namespace: osw.obj.GetObjectMeta().GetNamespace(),
 	}
 	if _, ok := sw.statuses[m]; !ok {
 		// only record the first status event
@@ -106,7 +101,7 @@ func (osw *ObjectStatusWriter) SetValid() {
 // ObjectStatusWriter's values, including its status if set. This is convenient if
 // the object shares a relationship with its parent. The caller should arrange for
 // the commit function to be called to write the final status of the object.
-func (osw *ObjectStatusWriter) WithObject(obj Object) (_ *ObjectStatusWriter, commit func()) {
+func (osw *ObjectStatusWriter) WithObject(obj k8s.Object) (_ *ObjectStatusWriter, commit func()) {
 	m := make(map[string]string)
 	for k, v := range osw.values {
 		m[k] = v

--- a/internal/k8s/objectmeta.go
+++ b/internal/k8s/objectmeta.go
@@ -1,0 +1,37 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Object is any Kubernetes object that has an ObjectMeta.
+type Object interface {
+	metav1.ObjectMetaAccessor
+}
+
+// FullName holds the name and namespace of a Kubernetes object.
+type FullName struct {
+	Name, Namespace string
+}
+
+// ToFullName returns the FullName of any given Kubernetes object.
+func ToFullName(obj Object) FullName {
+	m := obj.GetObjectMeta()
+	return FullName{
+		Name:      m.GetName(),
+		Namespace: m.GetNamespace(),
+	}
+}

--- a/internal/k8s/timeout.go
+++ b/internal/k8s/timeout.go
@@ -1,0 +1,43 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import "time"
+
+// ParseTimeout parses timeouts we pass in various places in a standard way.
+func ParseTimeout(timeout string) time.Duration {
+	if timeout == "" {
+		// Blank is interpreted as no timeout specified, use envoy defaults
+		// By default envoy applies a 15 second timeout to all backend requests.
+		// The explicit value 0 turns off the timeout, implying "never time out"
+		// https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/rds.proto#routeaction
+		return 0
+	}
+
+	// Interpret "infinity" explicitly as an infinite timeout, which envoy config
+	// expects as a timeout of 0. This could be specified with the duration string
+	// "0s" but want to give an explicit out for operators.
+	if timeout == "infinity" {
+		return -1
+	}
+
+	d, err := time.ParseDuration(timeout)
+	if err != nil {
+		// TODO(cmalonty) plumb a logger in here so we can log this error.
+		// Assuming infinite duration is going to surprise people less for
+		// a not-parseable duration than a implicit 15 second one.
+		return -1
+	}
+	return d
+}


### PR DESCRIPTION
Updates #2388
Update #403

Refactor annotations code from `internal/dag` into `internal/annotation` so that
code dealing with ingress status will be able to use it.

This includes moving some generic Kubernetes structs (`Object` and `Meta`) into
`k8s` from `dag`. `Meta` has also been renamed to `FullName` for greater clarity.

Signed-off-by: Nick Young <ynick@vmware.com>