### PR TITLE
build: support older git versions to detect current branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,12 @@ LATEST_VERSION ?= NOLATEST
 # depending on GNU date.
 ISO_8601_DATE = $(shell TZ=GMT date '+%Y-%m-%dT%R:%S%z')
 
-# Sets the current Git sha
+# Sets the current Git sha.
 BUILD_SHA = $(shell git rev-parse --verify HEAD)
-# Sets the current branch
-BUILD_BRANCH = $(shell git branch --show-current)
-# Sets the current tagged git version
+# Sets the current branch. If we are on a detached header, filter it out so the
+# branch will be empty. This is similar to --show-current.
+BUILD_BRANCH = $(shell git branch | grep -v detached | awk '$$1=="*"{print $$2}')
+# Sets the current tagged git version.
 BUILD_VERSION = $(VERSION)
 
 GO_BUILD_VARS = \


### PR DESCRIPTION
Ubuntu 18.04 has git version 2.17.1 which doesn't have the --show-current
flag available (It's in a newer version of git). This causes builds to
throw an error when the makefile looks for the current branch. Go back to
the old method of parsing `git branch` output to get the current branch.

This fixes #2414.

Signed-off-by: James Peach <jpeach@vmware.com>