### PR TITLE
Add ingress class filtering to ingress status updating

### DIFF
--- a/internal/annotation/timeout.go
+++ b/internal/annotation/timeout.go
@@ -11,9 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8s
+package annotation
 
 import "time"
+
+// TODO(youngnick): This needs to move to another package, but we need to be careful
+// about the import graph, this must stay a leaf node.
 
 // ParseTimeout parses timeouts we pass in various places in a standard way.
 func ParseTimeout(timeout string) time.Duration {

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -18,6 +18,7 @@ import (
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -585,7 +586,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "incorrect",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": DEFAULT_INGRESS_CLASS,
+						"kubernetes.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -597,7 +598,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "incorrect",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"contour.heptio.com/ingress.class": DEFAULT_INGRESS_CLASS,
+						"contour.heptio.com/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -642,7 +643,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "kuard",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"contour.heptio.com/ingress.class": DEFAULT_INGRESS_CLASS,
+						"contour.heptio.com/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -654,7 +655,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "kuard",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": DEFAULT_INGRESS_CLASS,
+						"kubernetes.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -699,7 +700,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "kuard",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"contour.heptio.com/ingress.class": DEFAULT_INGRESS_CLASS,
+						"contour.heptio.com/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -711,7 +712,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Name:      "kuard",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": DEFAULT_INGRESS_CLASS,
+						"kubernetes.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -21,7 +21,6 @@ import (
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
-	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -136,7 +135,7 @@ func ingressrouteTimeoutPolicy(tp *ingressroutev1.TimeoutPolicy) *TimeoutPolicy 
 		// due to a misunderstanding the name of the field ingressroute is
 		// Request, however the timeout applies to the response resulting from
 		// a request.
-		ResponseTimeout: k8s.ParseTimeout(tp.Request),
+		ResponseTimeout: annotation.ParseTimeout(tp.Request),
 	}
 }
 
@@ -145,8 +144,8 @@ func timeoutPolicy(tp *projcontour.TimeoutPolicy) *TimeoutPolicy {
 		return nil
 	}
 	return &TimeoutPolicy{
-		ResponseTimeout: k8s.ParseTimeout(tp.Response),
-		IdleTimeout:     k8s.ParseTimeout(tp.Idle),
+		ResponseTimeout: annotation.ParseTimeout(tp.Response),
+		IdleTimeout:     annotation.ParseTimeout(tp.Idle),
 	}
 }
 func ingressrouteHealthCheckPolicy(hc *ingressroutev1.HealthCheck) *HTTPHealthCheckPolicy {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -19,8 +19,8 @@ import (
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/assert"
-	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -413,7 +413,7 @@ func TestParseTimeout(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := k8s.ParseTimeout(tc.duration)
+			got := annotation.ParseTimeout(tc.duration)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/k8s/ingressstatus.go
+++ b/internal/k8s/ingressstatus.go
@@ -14,25 +14,34 @@
 package k8s
 
 import (
+	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
-// StatusLoadbalancerUpdater observes informer OnAdd events and
+// IngressStatusUpdater observes informer OnAdd events and
 // updates the ingress.status.loadBalancer field on all Ingress
 // objects that match the ingress class (if used).
 type IngressStatusUpdater struct {
-	Client clientset.Interface
-	Logger logrus.FieldLogger
-	Status v1.LoadBalancerStatus
+	Client       clientset.Interface
+	Logger       logrus.FieldLogger
+	Status       v1.LoadBalancerStatus
+	IngressClass string
 }
 
 func (s *IngressStatusUpdater) OnAdd(obj interface{}) {
-	ing := obj.(*v1beta1.Ingress).DeepCopy()
 
-	// TODO(dfc) check ingress class
+	ing := obj.(*v1beta1.Ingress).DeepCopy()
+	if !annotation.MatchesIngressClass(ing, s.IngressClass) {
+		s.Logger.
+			WithField("name", ing.GetName()).
+			WithField("namespace", ing.GetNamespace()).
+			WithField("ingress-class", annotation.IngressClass(ing)).
+			Debug("unmatched ingress class, skip status update")
+		return
+	}
 
 	ing.Status.LoadBalancer = s.Status
 	_, err := s.Client.NetworkingV1beta1().Ingresses(ing.GetNamespace()).UpdateStatus(ing)
@@ -45,14 +54,35 @@ func (s *IngressStatusUpdater) OnAdd(obj interface{}) {
 }
 
 func (s *IngressStatusUpdater) OnUpdate(oldObj, newObj interface{}) {
-	// Ignoring OnUpdate allows us to avoid the message generated
-	// from the status update.
 
-	// TODO(dfc) handle these cases:
-	// - OnUpdate transitions from an ingress class which is out of scope
-	// to one in scope.
-	// - OnUpdate transitions from an ingress class in scope to one out
-	// of scope.
+	oldIng := oldObj.(*v1beta1.Ingress).DeepCopy()
+	newIng := newObj.(*v1beta1.Ingress).DeepCopy()
+
+	// We need to only act when things come *into* our ingressclass scope. When they fall out, we don't care about them any
+	// more, and it's the new controller's job to fix things.
+	// Note that this also handles the case where someone deletes the annotation
+	if !annotation.MatchesIngressClass(oldIng, s.IngressClass) && annotation.MatchesIngressClass(newIng, s.IngressClass) {
+		// Add status because we started matching ingress-class.
+		s.Logger.
+			WithField("name", newIng.GetName()).
+			WithField("namespace", newIng.GetNamespace()).
+			WithField("ingress-class", annotation.IngressClass(newIng)).
+			Debug("Updated Ingress is in scope, updating")
+		newIng.Status.LoadBalancer = s.Status
+		_, err := s.Client.NetworkingV1beta1().Ingresses(newIng.GetNamespace()).UpdateStatus(newIng)
+		if err != nil {
+			s.Logger.
+				WithField("name", newIng.GetName()).
+				WithField("namespace", newIng.GetNamespace()).
+				WithError(err).Error("unable to update status")
+		}
+	}
+
+	// TODO(youngnick): There is a possibility that someone else may have edited the status, and we would then have
+	// no way to fix the object, because we're only operating on ingress-class change. After consideration, we've decided that
+	// editing the status subresource is hard enough that if someone does, they must have a reason. We can revisit if required.
+	// Checking annotation.MatchesIngressClass(newIng, s.IngressClass) && !reflect.DeepEqual(newIng.Status.Loadbalancer, s.Status)
+	// would probably do it, but we have no way to verify for now.
 }
 
 func (s *IngressStatusUpdater) OnDelete(obj interface{}) {

--- a/internal/k8s/objectmeta.go
+++ b/internal/k8s/objectmeta.go
@@ -18,6 +18,8 @@ import (
 )
 
 // Object is any Kubernetes object that has an ObjectMeta.
+// TODO(youngnick): Review references to this and replace them
+// with straight metav1.ObjectMetaAccessor calls if we can.
 type Object interface {
 	metav1.ObjectMetaAccessor
 }


### PR DESCRIPTION
Fixes #2388
Updates #403

Move annotations to use upstream `ObjectMetaAccessor` instead of `k8s.Object`, removes an import cycle.

Copy `KindOf` from k8s to `annotations_test.go` for use in the tests only, also prevents an import cycle.

Move `ParseTimeout` from `k8s` to `annotation` for now as well, more import cycles.

Move ingress class matching code from `dag` to `annotation`, so it's only in one place.

Add ingress class filtering to `k8s.IngressStatusUpdater` `OnAdd` and `OnUpdate`.

I spent some time looking into adding Informer tests, but that requires a lot more fakeclient usage than I am comfortable with right now.

Signed-off-by: Nick Young <ynick@vmware.com>