### PR TITLE
cmd/contour: Add flag to specify status.loadbalancer address statically

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"net"
 	"sync"
 
 	"github.com/projectcontour/contour/internal/k8s"
@@ -95,5 +96,28 @@ func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 				}
 			}()
 		}
+	}
+}
+
+func parseStatusFlag(status string) v1.LoadBalancerStatus {
+
+	// Use the parseability by net.ParseIP as a signal, since we need
+	// to pass a string into the v1.LoadBalancerIngress anyway.
+	if ip := net.ParseIP(status); ip != nil {
+		return v1.LoadBalancerStatus{
+			Ingress: []v1.LoadBalancerIngress{
+				{
+					IP: status,
+				},
+			},
+		}
+	}
+
+	return v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{
+			{
+				Hostname: status,
+			},
+		},
 	}
 }

--- a/cmd/contour/ingressstatus_test.go
+++ b/cmd/contour/ingressstatus_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+func Test_parseStatusFlag(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   v1.LoadBalancerStatus
+	}{
+		{
+			name:   "IPv4",
+			status: "10.0.0.1",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+				},
+			},
+		},
+		{
+			name:   "IPv6",
+			status: "2001:4860:4860::8888",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "2001:4860:4860::8888",
+					},
+				},
+			},
+		},
+		{
+			name:   "arbitrary string",
+			status: "anarbitrarystring",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						Hostname: "anarbitrarystring",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(parseStatusFlag(tt.status), tt.want); diff != "" {
+				t.Errorf("parseStatusFlag failed: %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -62,6 +62,9 @@ type serveContext struct {
 	// ingress class
 	ingressClass string
 
+	// Address to be placed in status.loadbalancer field of Ingress objects.
+	ingressStatusAddress string
+
 	// envoy's stats listener parameters
 	statsAddr string
 	statsPort int


### PR DESCRIPTION
Adds the `--ingress-status-address` flag to specify what address should be added to Ingress `status.loadbalancer` stanza by Contour.

Setting this flag will disable the automatic Envoy service watching for those details.

Fixes #2387
Updates #403

Further documentation to come under #403.

Signed-off-by: Nick Young <ynick@vmware.com>