### PR TITLE
internal/dag: improve diagnostics for Secrets errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269
 	k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e // indirect
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/controller-tools v0.2.4
 	sigs.k8s.io/kustomize/kyaml v0.1.1
 	sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -14,6 +14,7 @@
 package dag
 
 import (
+	"fmt"
 	"testing"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
@@ -2084,7 +2085,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{Name: ir25.Name, Namespace: ir25.Namespace}: {
 					Object:      ir25,
 					Status:      k8s.StatusInvalid,
-					Description: sec2.Namespace + "/" + sec2.Name + ": certificate delegation not permitted",
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(sec2)),
 					Vhost:       ir25.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -2099,7 +2100,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{Name: ir26.Name, Namespace: ir26.Namespace}: {
 					Object:      ir26,
 					Status:      k8s.StatusInvalid,
-					Description: sec2.Namespace + "/" + sec2.Name + ": certificate delegation not permitted",
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(sec2)),
 					Vhost:       ir26.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -2114,7 +2115,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{Name: proxy19.Name, Namespace: proxy19.Namespace}: {
 					Object:      proxy19,
 					Status:      k8s.StatusInvalid,
-					Description: sec2.Namespace + "/" + sec2.Name + ": certificate delegation not permitted",
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(sec2)),
 					Vhost:       proxy19.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -2144,7 +2145,7 @@ func TestDAGIngressRouteStatus(t *testing.T) {
 				{Name: ir28.Name, Namespace: ir28.Namespace}: {
 					Object:      ir28,
 					Status:      k8s.StatusInvalid,
-					Description: "TLS Secret [heptio-contour/ssl-cert] not found or is malformed",
+					Description: "Spec.VirtualHost.TLS Secret \"heptio-contour/ssl-cert\" is invalid: Secret not found",
 					Vhost:       ir28.Spec.VirtualHost.Fqdn,
 				},
 			},

--- a/internal/k8s/objectmeta.go
+++ b/internal/k8s/objectmeta.go
@@ -15,6 +15,7 @@ package k8s
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings"
 )
 
 // Object is any Kubernetes object that has an ObjectMeta.
@@ -27,6 +28,20 @@ type Object interface {
 // FullName holds the name and namespace of a Kubernetes object.
 type FullName struct {
 	Name, Namespace string
+}
+
+// String returns a string representation of the name.
+func (f FullName) String() string {
+	if f.Name == "" {
+		return ""
+	}
+
+	ns := f.Namespace
+	if ns == "" {
+		ns = metav1.NamespaceDefault
+	}
+
+	return strings.JoinQualifiedName(ns, f.Name)
 }
 
 // ToFullName returns the FullName of any given Kubernetes object.

--- a/internal/k8s/objectmeta_test.go
+++ b/internal/k8s/objectmeta_test.go
@@ -1,0 +1,35 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+)
+
+func TestFullNameString(t *testing.T) {
+	cases := map[FullName]string{
+		FullName{}:                              "",
+		FullName{Namespace: "bar"}:              "",
+		FullName{Name: "foo"}:                   "default/foo",
+		FullName{Name: "foo", Namespace: "bar"}: "bar/foo",
+	}
+
+	for name, wanted := range cases {
+		got := name.String()
+		if got != wanted {
+			t.Errorf("name=%q namespace=%q, got %q wanted %q",
+				name.Name, name.Namespace, got, wanted)
+		}
+	}
+}


### PR DESCRIPTION
Capture the distinction between when Secrets are missing and when
they have some validation error. This is important to guide operators
when they are trying to figure out why a configuration isn't working
correctly. When we have an Ingress, log the information that we wold
otherwise send to status so that the error is not completely silent.

This fixes #2331.

Signed-off-by: James Peach <jpeach@vmware.com>