### PR TITLE
test: add initial integration test scripts

### DIFF
--- a/_integration/testsuite/README.md
+++ b/_integration/testsuite/README.md
@@ -1,0 +1,19 @@
+# Contour integration tests
+
+For now, run integration tests manually.
+
+The [make-kind-cluster.sh](./make-kind-cluster.sh) script will bring up
+a local kind cluster. It will build Contour from the working repository
+and install it, along with [cert-manager](https://cert-manager.io),
+which is needed for tests that use TLS.
+
+You will need to install the [Integration Tester for Kubernetes](https://github.com/projectcontour/integration-tester).
+
+To run the tests, use the [run-test-case.sh](./run-test-case.sh)
+script. The test output can be verbose, so prefer to run one at a time.
+
+The tests for for the HTTPProxy API are in the [httpproxy](./httpproxy)
+directory, with one feature tested per test document. The
+[fixtures](./fixtures) and [policies](./policies) directories contain YAML
+fixtures and Rego helpers respectively.
+

--- a/_integration/testsuite/fixtures/httpbin.yaml
+++ b/_integration/testsuite/fixtures/httpbin.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: *name
+    spec:
+      containers:
+      - name: httpbin
+        image: docker.io/kennethreitz/httpbin
+        ports:
+        - name: http
+          containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /status/200
+            port: 80
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: &name httpbin
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: *name

--- a/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
+++ b/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
@@ -1,0 +1,56 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name ingress-conformance-echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: *name
+    spec:
+      containers:
+      - name: conformance-echo
+        image: agervais/ingress-conformance-echo:latest
+        env:
+        - name: TEST_ID
+          value: *name
+        ports:
+        - name: http-api
+          containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: &name ingress-conformance-echo
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http-api
+  selector:
+    app.kubernetes.io/name: *name
+

--- a/_integration/testsuite/httpproxy/001-required-field-validation.yaml
+++ b/_integration/testsuite/httpproxy/001-required-field-validation.yaml
@@ -1,0 +1,102 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: missing-condition-header
+spec:
+  routes:
+  - conditions:
+    - header:
+        present: true
+    services:
+    - name: foo
+      port: 80
+$check: |
+  matched_cause {
+    cause := input.error.details.causes[_]
+    cause.reason == "FieldValueRequired"
+    cause.field == "spec.routes.conditions.header.name"
+  }
+
+  error[msg] {
+    not matched_cause
+    msg := "No error cause matched FieldValueRequired/spec.routes.conditions.header.name"
+  }
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: missing-virtualhost-name
+spec:
+  virtualhost:
+    tls:
+      passthrough: true
+$check: |
+  matched_cause {
+    cause := input.error.details.causes[_]
+    cause.reason == "FieldValueRequired"
+    cause.field == "spec.virtualhost.fqdn"
+  }
+
+  error[msg] {
+    not matched_cause
+    msg := "No error cause matched FieldValueRequired/spec.virtualhost.fqdn"
+  }
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: missing-tcp-services
+spec:
+  tcpproxy:
+    services:
+$check: |
+  matched_cause {
+    cause := input.error.details.causes[_]
+    cause.reason == "FieldValueInvalid"
+    cause.field == "spec.tcpproxy.services"
+  }
+
+  error[msg] {
+    not matched_cause
+    msg := "No error cause matched FieldValueInvalid/spec.tcpproxy.services"
+  }
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: missing-includes-name
+spec:
+  includes:
+  - namespace: foo
+$check: |
+  matched_cause {
+    cause := input.error.details.causes[_]
+    cause.reason == "FieldValueRequired"
+    cause.field == "spec.includes.name"
+  }
+
+  error[msg] {
+    not matched_cause
+    msg := "No error cause matched FieldValueRequired/spec.includes.name"
+  }
+

--- a/_integration/testsuite/httpproxy/002-header-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/002-header-condition-match.yaml
@@ -1,0 +1,273 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-present
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-present
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-contains
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-contains
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-notcontains
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-notcontains
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-exact
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-exact
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-notexact
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-notexact
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: header-conditions
+spec:
+  virtualhost:
+    fqdn: conditions.projectcontour.io
+  routes:
+  - services:
+    - name: echo-header-present
+      port: 80
+    conditions:
+    - header:
+        name: Target-Present
+        present: true
+  - services:
+    - name: echo-header-contains
+      port: 80
+    conditions:
+    - header:
+        name: Target-Contains
+        contains: ContainsValue
+  - services:
+    - name: echo-header-notcontains
+      port: 80
+    conditions:
+    - header:
+        name: Target-NotContains
+        notcontains: ContainsValue
+  - services:
+    - name: echo-header-exact
+      port: 80
+    conditions:
+    - header:
+        name: Target-Exact
+        exact: ExactValue
+  - services:
+    - name: echo-header-notexact
+      port: 80
+    conditions:
+    - header:
+        name: Target-NotExact
+        notexact: ExactValue
+
+---
+
+# Wait for HTTPProxies to sync.
+
+default http_proxy_count = 0
+http_proxy_count = n {
+  n := count(data.resources.httpproxies[_])
+}
+
+error[msg] {
+  http_proxy_count < 1
+  msg := "No HTTPProxies created"
+}
+
+---
+
+# Ensure that the proxy is valid.
+
+error[msg] {
+  not data.resources.httpproxies["header-conditions"]
+  msg := "Proxy 'header-conditions' not present"
+}
+
+error[msg] {
+  proxy := data.resources.httpproxies["header-conditions"]
+  proxy.spec.virtualhost.fqdn
+  proxy.status.currentStatus != "valid"
+  msg := sprintf("HTTP proxy for '%s' is not valid\nstatus: %s\ndesc: %s", [
+    proxy.spec.virtualhost.fqdn,
+    proxy.status.currentStatus,
+    proxy.status.description,
+  ])
+}
+
+---
+
+import data.contour.http.client
+
+random := sprintf("%d", [time.now_ns()])
+
+cases := {
+  { "header": "Target-Present", "value": random, "status": 200, "testid": "echo-header-present" },
+
+  { "header": "Target-Contains", "value": random, "status": 404 },
+  { "header": "Target-Contains", "value": "ContainsValue", "status": 200, "testid": "echo-header-contains" },
+  { "header": "Target-Contains", "value": "xxx ContainsValue xxx", "status": 200, "testid": "echo-header-contains" },
+
+  { "header": "Target-NotContains", "value": "ContainsValue", "status": 404 },
+  { "header": "Target-NotContains", "value": "xxx ContainsValue xxx", "status": 404 },
+  { "header": "Target-NotContains", "value": random , "status": 200, "testid": "echo-header-notcontains" },
+
+  { "header": "Target-Exact", "value": random , "status": 404 },
+  { "header": "Target-Exact", "value": "NotExactValue", "status": 404 },
+  { "header": "Target-Exact", "value": "ExactValue", "status": 200, "testid": "echo-header-exact" },
+
+  { "header": "Target-NotExact", "value": random , "status": 200, "testid": "echo-header-notexact" },
+  { "header": "Target-NotExact", "value": "NotExactValue" , "status": 200, "testid": "echo-header-notexact" },
+  { "header": "Target-NotExact", "value": "ExactValue" , "status": 404 },
+
+}
+
+requests[{ "req": req, "wanted_status": status, "wanted_testid": testid }] {
+  case := cases[_]
+
+  req := {
+    "method": "GET",
+    "url": sprintf("http://%s/header-condition-match/%d", [
+      client.target_addr, time.now_ns()
+    ]),
+    "headers": {
+      "Host": "conditions.projectcontour.io",
+      "User-Agent": client.ua("header-condition-match"),
+      case.header: case.value,
+    }
+  }
+
+  status := case.status
+  testid := case.testid
+}
+
+error_if_wrong_status[msg] {
+  request := requests[_]
+  response := http.send(request.req)
+
+  response.status_code != request.wanted_status
+  msg := sprintf("got status %d, wanted %d", [
+    response.status_code,
+    request.wanted_status,
+  ])
+}
+
+error_if_missing_testid[msg] {
+  request := requests[_]
+  response := http.send(request.req)
+
+  response.status_code == 200
+  not response.body.TestId
+
+  msg := sprintf("got status %d, but no testid", [
+    response.status_code,
+  ])
+}
+
+error_if_wrong_testid[msg] {
+  request := requests[_]
+  response := http.send(request.req)
+
+  response.status_code == 200
+  response.body.TestId != request.wanted_testid
+
+  msg := sprintf("got testid %s, wanted %s", [
+    response.body.TestId,
+    request.wanted_testid,
+  ])
+}

--- a/_integration/testsuite/httpproxy/003-path-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/003-path-condition-match.yaml
@@ -1,0 +1,183 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: path-conditions
+spec:
+  virtualhost:
+    fqdn: conditions.projectcontour.io
+  routes:
+  - services:
+    - name: echo-slash-prefix
+      port: 80
+    conditions:
+    - prefix: /path/prefix/
+  - services:
+    - name: echo-slash-noprefix
+      port: 80
+    conditions:
+    - prefix: /path/prefix
+  - services:
+    - name: echo-slash-default
+      port: 80
+
+---
+
+error_proxy_is_not_present {
+  not data.resources.httpproxies
+}
+
+error_proxy_is_not_present {
+  not data.resources.httpproxies["path-conditions"]
+}
+
+---
+
+error_proxy_is_not_valid[msg] {
+  proxy := data.resources.httpproxies["path-conditions"]
+
+  proxy.spec.virtualhost.fqdn
+  proxy.status.currentStatus != "valid"
+
+  msg := sprintf("HTTP proxy for '%s' is not valid\nstatus: %s\ndesc: %s", [
+    proxy.spec.virtualhost.fqdn,
+    proxy.status.currentStatus,
+    proxy.status.description,
+  ])
+}
+
+---
+
+import data.contour.http.client
+
+cases := [
+  [ "/", "echo-slash-default" ],
+  [ "/foo", "echo-slash-default" ],
+  [ "/path/prefix", "echo-slash-noprefix" ],
+  [ "/path/prefixfoo", "echo-slash-noprefix" ],
+  [ "/path/prefix/", "echo-slash-prefix" ],
+  [ "/path/prefix/foo", "echo-slash-prefix" ],
+]
+
+# NOTE(jpeach): the path formatting matters in the request contruction
+# below, since we are testing for specific matches.
+request_for_path[path] = request {
+  path := cases[_][0]
+  request := {
+    "method": "GET",
+    "url": sprintf("http://%s%s", [
+      client.target_addr, path
+    ]),
+    "headers": {
+      "Host": "conditions.projectcontour.io",
+      "User-Agent": client.ua("path-condition-match"),
+    }
+  }
+}
+
+response_for_path[path] = response {
+  path := cases[_][0]
+  request := request_for_path[path]
+  response := http.send(request)
+}
+
+# Ensure that we get a response for each test case.
+error_missing_responses {
+  count(cases) != count(response_for_path)
+}
+
+error_non_200_response [msg] {
+  path := cases[_][0]
+  response := response_for_path[path]
+
+  response.status_code != 200
+  msg :=  sprintf("got status %d for path %q, wanted %d", [
+    response.status_code, path, 200,
+  ])
+}
+
+error_path_routing_mismatch[msg] {
+  c := cases[_]
+
+  path := c[0]
+  testid := c[1]
+  response := response_for_path[path]
+
+  response.body.TestId != testid
+  msg :=  sprintf("got wrong service %q for path %q, wanted %q", [
+    response.body.TestId, path, testid,
+  ])
+}

--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -1,0 +1,370 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import data.contour.resources
+
+# Ensure that cert-manager is installed.
+# Version check the certificates resource.
+
+Group := "cert-manager.io"
+Version := "v1alpha2"
+
+have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+    sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+    "available versions:",
+    yaml.marshal(avail)
+  ])
+}
+
+---
+
+# Create a self-signed issuer to give us secrets.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-one
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-one
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-one-cert
+spec:
+  dnsNames:
+  - echo-one.projectcontour.io
+  secretName: echo-one
+  issuerRef:
+    name: selfsigned
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo-one
+spec:
+  virtualhost:
+    fqdn: echo-one.projectcontour.io
+    tls:
+      secretName: echo-one
+  routes:
+  - services:
+    - name: echo-one
+      port: 80
+
+---
+
+fqdn := "echo-one.projectcontour.io"
+
+default proxy_is_present = false
+proxy_is_present {
+  data.resources.httpproxies["echo-one"]
+}
+
+fatal_proxy_is_not_present[msg] {
+  not proxy_is_present
+  msg := sprintf("HTTPProxy for %q is not present", [ fqdn ])
+}
+
+--- 
+
+Name := "echo-one"
+
+default proxy_is_valid = false
+proxy_is_valid {
+  proxy := data.resources.httpproxies[Name]
+  proxy.status.currentStatus == "valid"
+}
+
+fatal_proxy_is_not_valid[msg] {
+  not proxy_is_valid
+  msg := "Invalid proxy"
+}
+
+fatal_proxy_is_not_valid[msg] {
+  proxy := data.resources.httpproxies[Name]
+  fqdn := proxy.spec.virtualhost.fqdn
+  status := proxy.status
+
+  status.currentStatus != "valid"
+
+  msg := sprintf("HTTP proxy for '%s' is not valid\n%s", [
+    fqdn, yaml.marshal(status)
+  ])
+}
+
+---
+
+import data.contour.http.client
+
+TestID := "echo-one"
+
+Response := client.Get({
+  "url": sprintf("https://%s/https-sni-enforcement/%d", [
+    client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo-one.projectcontour.io",
+    "User-Agent": client.ua("https-sni-enforcement"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_no_response {
+  not Response
+}
+
+error_non_200_response [msg] {
+  Response.status_code != 200
+
+  msg :=  sprintf("got status %d, wanted %d", [
+    Response.status_code, 200
+  ])
+}
+
+error_path_routing_mismatch[msg] {
+  Response.body.TestId != TestID
+
+  msg :=  sprintf("got wrong service %q, wanted %q", [
+    Response.body.TestId, TestID,
+  ])
+}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-two
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-two
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-two-cert
+spec:
+  dnsNames:
+  - echo-two.jpeach.org
+  secretName: echo-two
+  issuerRef:
+    name: selfsigned
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo-two
+spec:
+  virtualhost:
+    fqdn: echo-two.projectcontour.io
+    tls:
+      secretName: echo-two
+  routes:
+  - services:
+    - name: echo-two
+      port: 80
+
+---
+
+fqdn := "echo-two.projectcontour.io"
+
+default proxy_is_present = false
+proxy_is_present {
+  data.resources.httpproxies["echo-two"]
+}
+
+fatal_proxy_is_not_present[msg] {
+  not proxy_is_present
+  msg := sprintf("HTTPProxy for %q is not present", [ fqdn ])
+}
+
+--- 
+
+Name := "echo-two"
+
+default proxy_is_valid = false
+proxy_is_valid {
+  proxy := data.resources.httpproxies[Name]
+  proxy.status.currentStatus == "valid"
+}
+
+fatal_proxy_is_not_valid[msg] {
+  not proxy_is_valid
+  msg := "Invalid proxy"
+}
+
+fatal_proxy_is_not_valid[msg] {
+  proxy := data.resources.httpproxies[Name]
+  fqdn := proxy.spec.virtualhost.fqdn
+  status := proxy.status
+
+  not proxy_is_valid
+
+  msg := sprintf("HTTP proxy for '%s' is not valid\n%s", [
+    fqdn, yaml.marshal(status)
+  ])
+}
+
+---
+
+import data.contour.http.client
+
+TestID := "echo-two"
+
+Response := client.Get({
+  "url": sprintf("https://%s/https-sni-enforcement/%d", [
+    client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo-two.projectcontour.io",
+    "User-Agent": client.ua("https-sni-enforcement"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_no_response {
+  not Response
+}
+
+error_non_200_response [msg] {
+  Response.status_code != 200
+
+  msg :=  sprintf("got status %d, wanted %d", [
+    Response.status_code, 200
+  ])
+}
+
+error_path_routing_mismatch[msg] {
+  Response.body.TestId != TestID
+
+  msg :=  sprintf("got wrong service %q, wanted %q", [
+    Response.body.TestId, TestID,
+  ])
+}
+
+---
+
+import data.contour.http.client
+
+# Ensure that sending a request to "echo-one" with the SNI from "echo-two"
+# generates a 404.
+
+Response := client.Get({
+  "url": sprintf("https://%s/https-sni-enforcement/%d", [
+    client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo-one.projectcontour.io",
+    "User-Agent": client.ua("https-sni-enforcement"),
+  },
+  "tls_insecure_skip_verify": true,
+  "tls_server_name": "echo-two.projectcontour.io",
+})
+
+Wanted := 404
+
+error_non_404_response [msg] {
+  Response.status_code != Wanted
+
+  msg :=  sprintf("got status %d, wanted %d", [
+    Response.status_code, Wanted
+  ])
+}
+
+
+---
+
+import data.contour.http.client
+
+# Ensure that sending a request to "echo-two" with the SNI from "echo-one"
+# generates a 404.
+
+Response := client.Get({
+  "url": sprintf("https://%s/https-sni-enforcement/%d", [
+    client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo-two.projectcontour.io",
+    "User-Agent": client.ua("https-sni-enforcement"),
+  },
+  "tls_insecure_skip_verify": true,
+  "tls_server_name": "echo-one.projectcontour.io",
+})
+
+Wanted := 404
+
+error_no_response {
+  not Response
+}
+
+error_non_404_response [msg] {
+  Response.status_code != Wanted
+
+  msg :=  sprintf("got status %d, wanted %d", [
+    Response.status_code, Wanted
+  ])
+}
+
+

--- a/_integration/testsuite/httpproxy/005-pod-restart.yaml
+++ b/_integration/testsuite/httpproxy/005-pod-restart.yaml
@@ -1,0 +1,166 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name ingress-conformance-echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: *name
+    spec:
+      containers:
+      - name: conformance-echo
+        image: agervais/ingress-conformance-echo:latest
+        env:
+        - name: TEST_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - name: http-api
+          containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply: fixture
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: echo.projectcontour.io
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: ingress-conformance-echo
+          port: 80
+
+---
+
+RunId := data.test.params["run-id"]
+
+error_pod_unready [msg] {
+  pod := data.resources.pods[_]
+
+  pod.metadata.labels["app.kubernetes.io/name"] == "ingress-conformance-echo"
+  pod.metadata.annotations["modden/run-id"] == RunId
+
+  # Find combinations of _ and i where the condition is Ready/True.
+  cond := pod.status.conditions[i]
+  cond.type == "Ready"
+  cond.status != "True"
+
+  msg := sprintf("pod %s is not ready: %s", [pod.metadata.name, cond.message])
+}
+
+---
+
+import data.contour.http.response
+import data.contour.http.client
+
+Response := client.Get({
+  "url": sprintf("http://%s/pre-delete/%d", [client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("pod-restart"),
+  },
+})
+
+error_non_200_response [msg] {
+  Response.status_code != 200
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_missing_testid [msg] {
+  not response.has_testid(Response)
+  msg := "response has missing body or test ID"
+}
+
+error[msg] {
+  testid := response.testid(Response)
+  not data.resources.pods[testid]
+
+  msg := sprintf("no pod for test ID %q", [testid])
+}
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-conformance-echo
+$apply: delete
+
+---
+
+# Wait for the deleted pod to actually delete.
+error_pod_exists [msg] {
+  last := data.resources.applied.last
+  pod := data.resources.pods[_]
+
+  pod.metadata.name == last.metadata.name
+
+  msg := sprintf("pod %s still exists", [pod.metadata.name])
+}
+
+---
+
+import data.contour.http.response
+import data.contour.http.client
+
+Response := client.Get({
+  "url": sprintf("http://%s/post-delete/%d", [client.target_addr, time.now_ns()]),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("pod-restart"),
+  },
+})
+
+error_non_200_response [msg] {
+  Response.status_code != 200
+  msg :=  sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_missing_testid [msg] {
+  not response.has_testid(Response)
+  msg := "response has missing body or test ID"
+}
+
+error[msg] {
+  testid := response.testid(Response)
+  not data.resources.pods[testid]
+
+  msg := sprintf("no pod for test ID %q", [testid])
+}

--- a/_integration/testsuite/httpproxy/006-merge-slash.yaml
+++ b/_integration/testsuite/httpproxy/006-merge-slash.yaml
@@ -1,0 +1,104 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+$apply: fixture
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+$apply: fixture
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: httpbin
+spec:
+  virtualhost:
+    fqdn: httpbin.projectcontour.io
+  routes:
+    - conditions:
+      - prefix: /
+      services:
+        - name: httpbin
+          port: 80
+
+---
+
+import data.contour.resources
+
+fatal_proxy_is_not_valid[msg] {
+  name := "httpbin"
+  proxy := resources.get("httpproxies", name)
+  status := object.get(proxy, "status", {})
+
+  object.get(status, "currentStatus", "") != "valid"
+
+  msg := sprintf("HTTP proxy for '%s' is not valid\n%s", [
+    name, yaml.marshal(status)
+  ])
+}
+
+---
+
+import data.contour.http.response
+import data.contour.http.client
+
+Path := "this//has//lots////of/slashes"
+
+Response := client.Get({
+  "url": sprintf("http://%s/anything/%s/%d", [
+    client.target_addr, Path, time.now_ns()
+  ]),
+  "headers": {
+    "Host": "httpbin.projectcontour.io",
+    "User-Agent": client.ua("merge-slash"),
+  },
+})
+
+error_non_200_response [msg] {
+  Response.status_code != 200
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_unexpected_body [msg] {
+  body := response.body(Response)
+  not body.url
+  msg := sprintf("response body has no %q field: %s", [
+    "url", body
+  ])
+}
+
+error_unexpected_path [msg] {
+  body := response.body(Response)
+
+  # Split the path by "/", which leaves empty elements.
+  parts := split(Path, "/")
+  # Collect non-empty elements and join them with "/".
+  merged := concat("/", [ p | parts[i] != ""; p := parts[i] ])
+
+  not contains(body.url, merged)
+
+  msg := sprintf("response body URL %q doesn't contain the merged path %q", [
+    body.url, merged
+  ])
+}

--- a/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
+++ b/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
@@ -1,0 +1,449 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import data.contour.resources
+
+# Ensure that cert-manager is installed.
+# Version check the certificates resource.
+
+Group := "cert-manager.io"
+Version := "v1alpha2"
+
+have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+    sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+    "available versions:",
+    yaml.marshal(avail)
+  ])
+}
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: 007-client-cert-auth
+spec:
+  selfSigned: {}
+
+---
+
+# Using the selfsigned issuer, create a CA signing certificate for the
+# test issuer.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: ca-projectcontour-io
+  namespace: 007-client-cert-auth
+spec:
+  isCA: true
+  usages:
+  - signing
+  - cert sign
+  subject:
+    organizationalUnits:
+    - io
+    - projectcontour
+    - testsuite
+  commonName: issuer
+  secretName: ca-projectcontour-io
+  issuerRef:
+    name: selfsigned
+
+---
+
+# Create a local CA issuer with the CA certificate that the selfsigned
+# issuer gave us.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: ca-projectcontour-io
+  namespace: 007-client-cert-auth
+spec:
+  ca:
+    secretName: ca-projectcontour-io
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: 007-client-cert-auth/echo-no-auth
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: 007-client-cert-auth/echo-no-auth
+
+---
+
+# Get a server certificate for echo-no-auth.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-no-auth-cert
+  namespace: 007-client-cert-auth
+spec:
+  usages:
+  - server auth
+  dnsNames:
+  - echo-no-auth.projectcontour.io
+  secretName: echo-no-auth
+  issuerRef:
+    name: ca-projectcontour-io
+
+---
+
+import data.contour.resources
+
+Name := "007-client-cert-auth/echo-no-auth"
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := sprintf("Secret %q is not present", [ Name ])
+}
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := json.marshal(data.resources)
+}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: 007-client-cert-auth/echo-with-auth
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: 007-client-cert-auth/echo-with-auth
+
+---
+
+# Get a server certificate for echo-with-auth.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-with-auth-cert
+  namespace: 007-client-cert-auth
+spec:
+  usages:
+  - server auth
+  dnsNames:
+  - echo-with-auth.projectcontour.io
+  secretName: echo-with-auth
+  issuerRef:
+    name: ca-projectcontour-io
+
+---
+
+import data.contour.resources
+
+Name := "007-client-cert-auth/echo-with-auth"
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := sprintf("Secret %q is not present", [ Name ])
+}
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := json.marshal(data.resources)
+}
+
+---
+
+# Get a client certificate.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-client-cert
+  namespace: 007-client-cert-auth
+spec:
+  usages:
+  - client auth
+  emailSANs:
+  - client@projectcontour.io
+  secretName: echo-client
+  issuerRef:
+    name: ca-projectcontour-io
+
+---
+
+import data.contour.resources
+
+Name := "007-client-cert-auth/echo-client"
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := sprintf("Secret %q is not present", [ Name ])
+}
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := json.marshal(data.resources)
+}
+
+---
+
+# Get a self-signed client certificate. We will use this to ensure that
+# the server is validating the signing CA correctly.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-client-cert-selfsigned
+  namespace: 007-client-cert-auth
+spec:
+  usages:
+  - client auth
+  emailSANs:
+  - selfsigned-client@projectcontour.io
+  secretName: echo-client-selfsigned
+  issuerRef:
+    name: selfsigned
+
+---
+
+import data.contour.resources
+
+Name := "007-client-cert-auth/echo-client-selfsigned"
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := sprintf("Secret %q is not present", [ Name ])
+}
+
+fatal [msg] {
+  not resources.is_present("secrets", Name)
+  msg := json.marshal(data.resources)
+}
+
+---
+
+# This proxy does not require client certificate auth.
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo-no-auth
+  namespace: 007-client-cert-auth
+spec:
+  virtualhost:
+    fqdn: echo-no-auth.projectcontour.io
+    tls:
+      secretName: echo-no-auth
+  routes:
+  - services:
+    - name: echo-no-auth
+      port: 80
+
+---
+
+# This proxy requires client certificate auth.
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo-with-auth
+  namespace: 007-client-cert-auth
+spec:
+  virtualhost:
+    fqdn: echo-with-auth.projectcontour.io
+    tls:
+      secretName: echo-with-auth
+      clientValidation:
+        caSecret: echo-with-auth
+  routes:
+  - services:
+    - name: echo-with-auth
+      port: 80
+
+---
+
+import data.contour.resources
+
+Names := [
+  "007-client-cert-auth/echo-with-auth",
+  "007-client-cert-auth/echo-no-auth",
+]
+
+fatal [msg] {
+  name := Names[_]
+  not resources.is_present("httpproxies", name)
+  msg := sprintf("HTTPProxy %q is not present", [ name ])
+}
+
+fatal [msg] {
+  name := Names[_]
+  not resources.is_present("httpproxies", name)
+  msg := json.marshal(data.resources)
+}
+
+---
+
+import data.contour.resources
+
+Names := [
+  "007-client-cert-auth/echo-with-auth",
+  "007-client-cert-auth/echo-no-auth",
+]
+
+fatal_proxy_is_not_valid[msg] {
+  name := Names[_]
+  proxy := resources.get("httpproxies", name)
+  status := object.get(proxy, "status", {})
+
+  object.get(status, "currentStatus", "") != "valid"
+
+  msg := sprintf("HTTP proxy for '%s' is not valid\n%s", [
+    name, yaml.marshal(status)
+  ])
+}
+
+---
+
+# Verify that we reach the echo-no-auth service without a client
+# certificate. This tests that client  certificate auth is specific
+# to a particular proxy.
+
+import data.contour.resources
+import data.contour.http.client
+import data.contour.http.response
+
+ServerSecret := resources.get("secrets", "007-client-cert-auth/echo-no-auth")
+
+Response := client.Get({
+  "url": sprintf("https://%s/echo-no-auth/%d", [
+    client.target_addr, time.now_ns()
+  ]),
+  "headers": {
+    "Host": "echo-no-auth.projectcontour.io",
+    "User-Agent": client.ua("client-cert-auth"),
+  },
+  "tls_ca_cert": base64.decode(ServerSecret.data["ca.crt"]),
+})
+
+error_non_200_response [msg] {
+  not Response
+  msg := "no response"
+}
+
+error_non_200_response [msg] {
+  status := object.get(Response, "status_code", 000)
+  status != 200
+  msg := sprintf("got status %d, wanted %d", [status, 200])
+}
+
+error_wrong_routing [msg] {
+  not response.has_testid(Response)
+  msg := "response has missing body or test ID"
+}
+
+error_wrong_routing[msg] {
+  wanted := "echo-no-auth"
+  testid := response.testid(Response)
+  testid != wanted
+  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+}
+
+---
+
+# Using the client-cert certificate to echo-with-auth should succeed.
+
+import data.contour.resources
+import data.contour.http.response
+import data.contour.http.client
+
+ServerSecret := resources.get("secrets", "007-client-cert-auth/echo-with-auth")
+ClientSecret := resources.get("secrets", "007-client-cert-auth/echo-client")
+
+Response := client.Get({
+  "url": sprintf("https://%s/echo-client/%d", [
+    client.target_addr, time.now_ns()
+  ]),
+  "headers": {
+    "Host": "echo-with-auth.projectcontour.io",
+    "User-Agent": client.ua("client-cert-auth"),
+  },
+  "tls_ca_cert": base64.decode(ServerSecret.data["ca.crt"]),
+  "tls_client_cert": base64.decode(ClientSecret.data["tls.crt"]),
+  "tls_client_key": base64.decode(ClientSecret.data["tls.key"]),
+})
+
+error_non_200_response [msg] {
+  not Response
+  msg := "no response"
+}
+
+error_non_200_response [msg] {
+  status := object.get(Response, "status_code", 000)
+  status != 200
+  msg := sprintf("got status %d, wanted %d", [status, 200])
+}
+
+error_wrong_routing [msg] {
+  not response.has_testid(Response)
+  msg := "response has missing body or test ID"
+}
+
+error_wrong_routing[msg] {
+  wanted := "echo-with-auth"
+  testid := response.testid(Response)
+  testid != wanted
+  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+}
+
+# TODO(jpeach): Need to test that requests without a client certificate
+# are rejected. This requires in-band handling of HTTP errors, see
+# https://github.com/open-policy-agent/opa/issues/2187

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -1,0 +1,71 @@
+#! /usr/bin/env bash
+
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+readonly KIND=${KIND:-kind}
+readonly KUBECTL=${KUBECTL:-kubectl}
+
+readonly CLUSTERNAME=${CLUSTER:-contour-integration}
+readonly WAITTIME=${WAITTIME:-5m}
+
+readonly HERE=$(cd $(dirname $0) && pwd)
+readonly REPO=$(cd ${HERE}/../.. && pwd)
+
+kind::cluster::exists() {
+    ${KIND} get clusters | grep -q "$1"
+}
+
+kind::cluster::create() {
+    ${KIND} create cluster \
+        --name "${CLUSTERNAME}" \
+        --wait "${WAITTIME}" \
+        --config "${REPO}/examples/kind/kind-expose-port.yaml"
+}
+
+kind::cluster::load() {
+    ${KIND} load docker-image \
+        --name "${CLUSTERNAME}" \
+        "$@"
+}
+
+if kind::cluster::exists "$CLUSTERNAME" ; then
+    echo "cluster $CLUSTERNAME already exists"
+    exit 2
+fi
+
+# Build the current version of Contour.
+make -C ${REPO} container IMAGE=docker.io/projectcontour/contour VERSION="v$$"
+docker tag docker.io/projectcontour/contour:"v$$" docker.io/projectcontour/contour:master
+docker tag docker.io/projectcontour/contour:"v$$" docker.io/projectcontour/contour:latest
+
+# Create a fresh kind cluster.
+kind::cluster::create
+
+# Push the Contour build image into the cluster.
+kind::cluster::load docker.io/projectcontour/contour:master
+kind::cluster::load docker.io/projectcontour/contour:latest
+
+# Install Contour.
+${KUBECTL} apply -f ${REPO}/examples/render/contour.yaml
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=contour deployments --for=condition=Available
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=envoy pods --for=condition=Ready
+
+# Install cert-manager.
+${KUBECTL} apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.1/cert-manager.yaml
+${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=cert-manager deployments --for=condition=Available

--- a/_integration/testsuite/policies/contour-client.rego
+++ b/_integration/testsuite/policies/contour-client.rego
@@ -1,0 +1,41 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+package contour.http.client
+
+# target_addr returns the IP address for the proxy that tests should
+# send requests through.
+target_addr = "0.0.0.0" {
+  not data.test.params.proxy.address
+}
+
+# target_addr returns the IP address for the proxy that tests should
+# send requests through.
+target_addr = ip {
+  ip := data.test.params.proxy.address
+}
+
+# ua returns a user agent string specific to this test run.
+ua(prefix) = useragent {
+  useragent := sprintf("%s/%s", [prefix, data.test.params["run-id"]])
+}
+
+# Get take a http.send argument and sends a GET request.
+Get(params) = response {
+  to_send := {
+    "method": "GET",
+  }
+
+  response := http.send(object.union(to_send, params))
+}

--- a/_integration/testsuite/policies/contour-resources.rego
+++ b/_integration/testsuite/policies/contour-resources.rego
@@ -1,0 +1,83 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+package contour.resources
+
+# The `supported' rule lists the resources that are supported by the
+# API server.
+supported[r]  = true {
+    data.resources[r][".versions"]
+}
+
+# is_supported returns whether the names resource is supported. This is
+# a functional variable of the `supported` rule.
+is_supported(resource) = true {
+  supported[resource]
+} else = false {
+  true
+}
+
+# The `versions` rule returns an array of GroupVersionKind structures
+# for the resource `r`.
+versions[r] = v {
+    v := data.resources[r][".versions"]
+}
+
+# is_present is true if the named resource exists in the data document.
+#
+# Examples:
+#   resources.is_present("httproxies", "proxy-name")
+#   resources.is_present("httproxies", "namespace/proxy-name")
+is_present(resource, name) = true {
+  parts = split(name, "/")
+  count(parts) == 2
+  # Look up data.resources.$NS.$RESOURCE.$NAME.
+  data.resources[parts[0]][resource][parts[1]]
+} else = true {
+  parts = split(name, "/")
+  count(parts) == 1
+  data.resources[resource][name]
+} else = false {
+  true
+}
+
+# get returns the named resource from the data document. If the resource
+# is not present, an empty object is returned.
+#
+# Examples:
+#   resources.get("secrets", "foo")
+#   resources.get("pods", "namespace-name/foo")
+get(resource, name) = obj {
+  parts = split(name, "/")
+
+  # This is namespace/name syntax.
+  count(parts) == 2
+
+  # Look up data.resources.$NS.$RESOURCE.$NAME.
+  ns := object.get(data.resources, parts[0], {})
+  res := object.get(ns, resource, {})
+  obj := object.get(res, parts[1], {})
+
+} else = obj {
+  parts = split(name, "/")
+
+  # This is a name in the default namespace.
+  count(parts) == 1
+
+  # Look up data.resources.$RESOURCE.$NAME.
+  res := object.get(data.resources, resource, {})
+  obj := object.get(res, name, {})
+} else = obj {
+  obj := {}
+}

--- a/_integration/testsuite/policies/contour-response.rego
+++ b/_integration/testsuite/policies/contour-response.rego
@@ -1,0 +1,46 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+package contour.http.response
+
+has_testid(resp) = true {
+  resp.body.TestId
+}
+
+has_testid(resp) = false {
+  not resp.body
+}
+
+has_testid(resp) = false {
+  not resp.body.TestId
+}
+
+# Return the HTTP response body, or an empty object if there is no body.
+body(resp) = value {
+  is_null(resp.body)
+  value := {}
+}
+
+# Return the HTTP response body, or an empty object if there is no body.
+body(resp) = value {
+  not is_null(resp.body)
+  value := resp.body
+}
+
+# Get the TestId element from a ingress-conformance-echo response
+# body. Returns "" if there is no body or no TestId response.
+testid(resp) = value {
+  b := body(resp)
+  value := object.get(b, "TestId", "")
+}

--- a/_integration/testsuite/run-test-case.sh
+++ b/_integration/testsuite/run-test-case.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+readonly HERE=$(cd $(dirname $0) && pwd)
+
+readonly TESTER=${TESTER:-integration-tester}
+readonly ADDR=${ADDR:-"127.0.0.1"}
+
+exec "$TESTER" run \
+    --format=tap \
+    --fixtures ${HERE}/fixtures \
+    --policies ${HERE}/policies \
+    --param proxy.address=$ADDR \
+    --watch pods,secrets \
+    "$@"


### PR DESCRIPTION
Add an initial set of integration test documents, along with
helper scripts to install a kind cluster and to run the tests.

This updates #2223.

Signed-off-by: James Peach <jpeach@vmware.com>