### PR TITLE
Add github label automation.

### DIFF
--- a/hack/release/sync-repo-labels.sh
+++ b/hack/release/sync-repo-labels.sh
@@ -1,0 +1,59 @@
+#! /usr/bin/env bash
+
+readonly PROGNAME=$(basename "$0")
+readonly HERE=$(cd "$(dirname "$0")" && pwd)
+readonly REPO=$(cd "${HERE}/../.." && pwd)
+
+readonly TOKEN=${TOKEN:-}
+
+readonly DOCKER=${DOCKER:-docker}
+readonly LABELS=${LABELS:-${REPO}/site/_data/github-labels.yaml}
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+labelsync() {
+    $DOCKER run \
+        --rm \
+        --interactive \
+        --tty \
+        --env GITHUB_TOKEN \
+        --volume "${REPO}:/$(basename "${REPO}")" \
+        gcr.io/k8s-prow/label_sync:latest \
+    "$@"
+}
+
+path::absolute() {
+    local -r p="$1"
+    local dir
+
+    dir=$(cd "$(dirname "$p")" && pwd)
+
+    echo "${dir}/$(basename "$p")"
+}
+
+# NOTE: $TOKEN has to be a file that is inside $REPO.
+if [ -z "${TOKEN}" ]; then
+    echo "$PROGNAME: missing \$TOKEN"
+    exit 2
+fi
+
+# Make the path absolute.
+yaml=$(path::absolute "${LABELS}")
+
+# Remove up to the basename of the repo. We have have an absolute path
+# within the repository, which will resolve within the container.
+yaml=${yaml##$(dirname "${REPO}")}
+
+token=$(path::absolute "${TOKEN}")
+token=${token##$(dirname "${REPO}")}
+
+labelsync \
+    --debug \
+    --orgs projectcontour \
+    --skip projectcontour/toc \
+    --config "${yaml}" \
+    --token "${token}"
+
+# TODO(jpeach): add the -confirm flag to enable changes.

--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -1,0 +1,308 @@
+# default: global configuration to be applied to all repos
+# repos: list of repos with specific configuration to be applied in addition to default
+#   labels: list of labels - keys for each item: color, description, name, target, deleteAfter, previously
+#     deleteAfter: 2006-01-02T15:04:05Z (rfc3339)
+#     previously: list of previous labels (color name deleteAfter, previously)
+#     target: one of issues, prs, or both (also TBD)
+#     addedBy: human? prow plugin? other?
+---
+default:
+  labels:
+
+# Generally well-knownm widely recognized labels.
+    - color: 7057ff
+      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+      name: 'good first issue'
+      target: issues
+      addedBy: anyone
+    - color: 006b75
+      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
+      name: 'help wanted'
+      target: issues
+      addedBy: anyone
+
+# Release notes.
+    - color: c2e0c6
+      description: Denotes a PR that will be considered when it comes time to generate release notes.
+      name: release-note
+      target: prs
+      addedBy: prow
+      previously:
+        - name: "release note"
+    - color: c2e0c6
+      description: Denotes a PR that introduces potentially breaking changes that require user action. # These actions will be specifically called out when it comes time to generate release notes.
+      name: release-note-action-required
+      target: prs
+      addedBy: prow
+
+# Area.
+    - color: 0052cc
+      description: Issues or PRs related to dependency changes.
+      name: area/dependency
+      target: both
+      addedBy: label
+      previously:
+        - name: dependencies
+    - color: 0052cc
+      description: Issues or PRs related to deployment tooling or infrastructure.
+      name: area/deployment
+      target: both
+      addedBy: label
+      previously:
+        - name: deployment
+    - color: 0052cc
+      description: Issues or PRs related to documentation.
+      name: area/documentation
+      target: both
+      addedBy: label
+      previously:
+        - name: documentation
+    - color: 0052cc
+      description: Issues or PRs related to the HTTPProxy API.
+      name: area/httpproxy
+      target: both
+      addedBy: label
+      previously:
+        - name: HTTPProxy
+    - color: 0052cc
+      description: Issues or PRs related to the IngressRoute API.
+      name: area/ingressroute
+      target: both
+      addedBy: label
+      previously:
+        - name: IngressRoute
+    - color: 0052cc
+      description: Issues or PRs related to the Ingress API.
+      name: area/ingress
+      target: both
+      addedBy: label
+      previously:
+        - name: Ingress
+    - color: 0052cc
+      description: Issues or PRs related to the Gateway (Service APIs working group) API.
+      name: area/service-apis
+      target: both
+      addedBy: label
+      previously:
+        - name: service-apis
+    - color: 0052cc
+      description: Issues or PRs related to the web site.
+      name: area/website
+      target: both
+      addedBy: label
+      previously:
+        - name: website
+    - color: 0052cc
+      description: Issues or PRs related to tests or testing tools.
+      name: area/testing
+      target: both
+      addedBy: label
+      previously:
+        - name: integration-testing
+    - color: 0052cc
+      description: Issues or PRs related to exposing status for APIs.
+      name: area/status
+      target: both
+      addedBy: label
+      previously:
+        - name: status
+    - color: 0052cc
+      description: Issues or PRs related to exposing time series metrics.
+      name: area/metrics
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to project tools and automation.
+      name: area/tooling
+      target: both
+      addedBy: label
+
+# Blocked.
+    - color: "FF7B7B"
+      description: Categorizes the issue or PR as blocked because there is insufficient information to advance it.
+      name: blocked/needs-info
+      target: both
+      addedBy: label
+      previously:
+        - name: "waiting for info"
+    - color: "FF7B7B"
+      description: Categorizes the issue or PR as blocked because it needs a decision from product management.
+      name: blocked/needs-product
+      target: both
+      addedBy: label
+      previously:
+        - name: "Needs Product"
+    - color: "FF7B7B"
+      description: Categorizes the issue or PR as blocked because it needs a design document.
+      name: blocked/needs-design
+      target: both
+      addedBy: label
+      previously:
+        - name: "needs-design-doc"
+    - color: "FF7B7B"
+      description: Categorizes the issue or PR as blocked because it needs changes in Envoy.
+      name: blocked/needs-envoy
+      target: both
+      addedBy: label
+      previously:
+        - name: "waiting for upstream"
+
+# Kind.
+    - color: e11d21
+      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+      name: kind/api-change
+      target: both
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a bug.
+      name: kind/bug
+      target: both
+      addedBy: anyone
+      previously:
+        - name: bug
+    - color: c7def8
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      name: kind/cleanup
+      target: both
+      addedBy: anyone
+      previously:
+        - name: "tech-debt"
+    - color: e11d21
+      description: Categorizes issue or PR as related to a feature/enhancement marked for deprecation.
+      name: kind/deprecation
+      target: both
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to design.
+      name: kind/design
+      target: both
+      addedBy: anyone
+      previously:
+        - name: design
+    - color: c7def8
+      description: Categorizes issue or PR as related to documentation.
+      name: kind/documentation
+      target: both
+      addedBy: anyone
+      previously:
+        - name: documentation
+    - color: e11d21
+      description: Categorizes issue or PR as related to a consistently or frequently failing test.
+      name: kind/failing-test
+      target: both
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to a new feature.
+      name: kind/feature
+      target: both
+      addedBy: anyone
+      previously:
+        - name: enhancement
+    - color: f7c6c7
+      description: Categorizes issue or PR as related to a flaky test.
+      name: kind/flake
+      target: both
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a regression from a prior release.
+      name: kind/regression
+      target: both
+      addedBy: anyone
+    - color: "FFDC73"
+      description: Categorizes an issue as a user question.
+      name: kind/question
+      target: both
+      addedBy: anyone
+      previously:
+        - name: question
+
+# Lifecycle.
+    - color: d3e2f0
+      description: Indicates that an issue or PR should not be auto-closed due to staleness.
+      name: lifecycle/frozen
+      target: both
+      addedBy: anyone
+    - color: "795548"
+      description: Denotes an issue or PR has remained open with no activity and has become stale.
+      name: lifecycle/stale
+      target: both
+      addedBy: anyone
+      previously:
+        - name: stale
+    - color: "F58C28"
+      description: Denotes an issue that is assigned and is being actively investigated by the issue owner.
+      name: lifecycle/investigating
+      target: both
+      addedBy: anyone
+    - color: "90A8E4"
+      description: Denotes an issue that has been triaged and determined to be valid.
+      name: lifecycle/accepted
+      target: both
+      addedBy: anyone
+
+# Priority.
+    - color: fef2c0
+      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done. # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
+      name: priority/awaiting-more-evidence
+      target: both
+      addedBy: anyone
+    - color: fbca04
+      description: Higher priority than priority/awaiting-more-evidence. # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
+      name: priority/backlog
+      target: both
+      addedBy: anyone
+    - color: e11d21
+      description: Highest priority. Must be actively worked on as someone's top priority right now. # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.  name: priority/critical-urgent
+      name: priority/critical-urgent
+      target: both
+      addedBy: anyone
+      previously:
+        - name: "p0 - Hair On Fire"
+    - color: eb6420
+      description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+      name: priority/important-soon
+      target: both
+      addedBy: anyone
+      previously:
+        - name: "p1 - Important"
+    - color: eb6420
+      description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
+      name: priority/important-longterm
+      target: both
+      addedBy: anyone
+      previously:
+        - name: "p2 - Long-term Important"
+
+# Size.
+    - color: ee9900
+      description: Denotes a PR that changes 100-499 lines, ignoring generated files.
+      name: size/L
+      target: prs
+      addedBy: prow
+    - color: eebb00
+      description: Denotes a PR that changes 30-99 lines, ignoring generated files.
+      name: size/M
+      target: prs
+      addedBy: prow
+    - color: 77bb00
+      description: Denotes a PR that changes 10-29 lines, ignoring generated files.
+      name: size/S
+      target: prs
+      addedBy: prow
+    - color: ee5500
+      description: Denotes a PR that changes 500-999 lines, ignoring generated files.
+      name: size/XL
+      target: prs
+      addedBy: prow
+    - color: "009900"
+      description: Denotes a PR that changes 0-9 lines, ignoring generated files.
+      name: size/XS
+      target: prs
+      addedBy: prow
+    - color: ee0000
+      description: Denotes a PR that changes 1000+ lines, ignoring generated files.
+      name: size/XXL
+      target: prs
+      addedBy: prow
+
+repos:

--- a/site/_resources/how-we-work.md
+++ b/site/_resources/how-we-work.md
@@ -5,6 +5,8 @@ layout: page
 
 This page captures how we work on Contour.
 
+## Github Issue Management
+
 - When you pick up an issue, assign it to yourself.
 When you stop working, unassigned yourself.
 While you hold an issue, you are responsible for giving status reports on it; over communicate, don’t let others speak for you, or worse, guess.
@@ -14,6 +16,12 @@ While you hold an issue, you are responsible for giving status reports on it; ov
 - Don't assign an issue to someone else without talking to them directly.
 
 - Hoarding issues is not saving for a rainy day, you can only work on one thing at a time, you should avoid holding more than one issue at a time.
+
+- Log an issue or it didn’t happen. 
+
+- When submitting a PR add the appropriate release milestone and also add the appropriate Github "release-note" label if this PR warrants getting called out in the next release.
+
+## Code reviews
 
 - Everyone is responsible for code reviews.
 If someone asks you for a review, or they use GitHub for the same, you should aim to review it (timezones permitting) promptly.
@@ -25,16 +33,52 @@ Everything flows from this statement.
 - [Talk about what you intend to do, then do the thing you talked about.][1]
 GitHub review tools suck for extended debate, if you find you’re taking past your reviewer, its a sign that more design is needed.
 
-- Log an issue or it didn’t happen. 
+## Coding Practices
 
 - Before you fix a bug, write a test to show you fixed it.
 
 - Before you add a feature, write a test so someone else doesn’t break your feature by accident.
 
-- When submitting a PR add the appropriate release milestone and also add the Github label "release note" if this PR warrants getting called out in the next release.
-
 - You are permitted to refactor as much as you like to achieve these goals.
 As Kent beck said, ["make the change easy, then make the easy change."][2]
+
+## Github Labels
+
+Github issues should be triaged and have their status recorded.
+Triaging issues and labeling them appropriately makes it easy for the issue submitter and other contributors to see what the state of an issue is at any time.
+The goal of triaging an issue is to make a decision about what should be done with it.
+The issue should investigated enough to fully understand and document the problem and then decide whether the issue should be addressed by the project.
+It may not be necessary to decide how an issue should be addressed during triage, since that could involve substantial research and design.
+
+- To be considered triaged, an issue must have the "lifecycle/accepted" label.
+- If you are in the process of investigating an issue, assign it to yourself and apply the "lifecycle/investigating" label.
+- In almost all cases, triaged issues should have kind and area labels. 
+- The priority and size labels are informative. Contributors should apply them at their discretion.
+
+<table class="table thead-dark table-striped table-bordered">
+
+<tr>
+    <th> Label </th>
+    <th> Description </th>
+</tr>
+
+{% for label in site.data["github-labels"].default.labels %}
+
+<tr>
+
+    <td>  
+    <div style="background-color:#{{label.color}}; width:20px; height:20px; float: left"></div>
+    &nbsp;
+    <a href="https://github.com/projectcontour/contour/labels/{{label.name | cgi_escape}}">{{label.name}}</a>
+    </td>
+
+    <td> {{label.description}} </td>
+</tr>
+
+{% endfor %}
+
+</table>
+
 
 [1]: https://dave.cheney.net/2019/02/18/talk-then-code
 [2]: https://twitter.com/kentbeck/status/250733358307500032?lang=en


### PR DESCRIPTION
Pull in a Github labels configuration file based on the Kubernetes labels
configuration. This enables a single source of truth for labels within
the projectcontour organization, and lets us document the purpose of
each label.

Add a proposed wrapper script that can be run in a scheduled Github
Action to periodically sync the labels.

Update the process documentation to show the labels and give advice on
how they should be used in the triage process.

Signed-off-by: James Peach <jpeach@vmware.com>