### PR TITLE
site: update envoy support matrix for Envoy v1.14.1

### DIFF
--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -7,35 +7,30 @@ Due to the aggressive deprecation cycle of Envoy's xDS API, not all versions of 
 
 This page describes the compatibility matrix of Contour and Envoy versions.
 
-## Supported Envoy versions
+## Supported Contour/Envoy Versions
 
-| Envoy version | Contour v1.0.0<sup>5</sup>| Contour v1.0.1<sup>6</sup>| Contour v1.1.0<sup>7</sup>| Contour v1.2.0<sup>8</sup>| Contour v1.2.1            | Contour v1.3.0            |
-| ------------- | :-----------------------: | :-----------------------: | :-----------------------: | :-----------------------: | :-----------------------: | :-----------------------: |
-| 1.11.0        | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> | Not supported<sup>1</sup> |
-| 1.11.1        | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> | Not supported<sup>2</sup> |
-| 1.11.2        | *Supported*<sup>5</sup>   | Not supported             | Not supported             | Not supported             | Not supported             | Not supported             |
-| 1.12.0        | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> | Not supported<sup>3</sup> |
-| 1.12.1        | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> | Not supported<sup>4</sup> |
-| 1.12.2        | Not supported             | *Supported*<sup>6</sup>   | *Supported*<sup>7</sup>   | Not supported             | Not supported             | Not supported             |
-| 1.13.0        | Not supported<sup>9</sup> | Not supported<sup>9</sup> | Not Supported<sup>9</sup> | Not supported<sup>8,9</sup> | Not Supported<sup>9</sup>> | Not Supported<sup>9</sup> |
-| 1.13.1        | Not supported             | Not Supported             | Not supported             | Not supported             | *Supported*               | *Supported*               |
+| Contour Version | Envoy Version        |
+| --------------- | :------------------- |
+| 1.4.0           | 1.14.1               |
+| 1.3.0           | 1.13.1<sup>4</sup>   |
+| 1.2.1           | 1.13.1<sup>4</sup>   |
+| 1.2.0           | 1.13.0               |
+| 1.1.0           | 1.12.2<sup>2,3</sup> |
+| 1.0.1           | 1.12.2<sup>2,3</sup> |
+| 1.0.0           | 1.11.2<sup>1</sup>   |
 
+<br>
 #### Notes
 
-1. [CVE-2019-9512, CVE-2019-9513, CVE-2019-9514, CVE-2019-9515, CVE-2019-9518][1]
-2. [CVE-2019-15225, CVE-2019-15226][2]
-3. [CVE-2019-18836][3]
-4. [CVE-2019-18801. CVE-1019-18802, CVE-1019-18838][6]
-5. Contour v1.0.0 is no longer supported.
-6. Contour v1.0.1 is no longer supported.
-7. Contour v1.1.0 is no longer supported.
-8. Contour v1.2.0 is no longer supported.
-9. [CVE-2020-8659, CVE-2020-8661, CVE-2020-8664, CVE-2020-8660][7]
+1. [CVE-2019-15225, CVE-2019-15226][1]
+2. [CVE-2019-18836][2]
+3. [CVE-2019-18801. CVE-1019-18802, CVE-1019-18838][4]
+4. [CVE-2020-8659, CVE-2020-8661, CVE-2020-8664, CVE-2020-8660][5]
 
 ## Envoy extensions
 
 Contour requires the following extensions.
-If you are using the image recommended in our [example deployment][4] no action is required.
+If you are using the image recommended in our [example deployment][3] no action is required.
 If you are providing your own Envoy it must be compiled with the following extensions:
 
 - `access_loggers`: `envoy.access_loggers.file`,`envoy.access_loggers.http_grpc`,`envoy.access_loggers.tcp_grpc`
@@ -45,10 +40,8 @@ If you are providing your own Envoy it must be compiled with the following exten
 - `stat_sinks`: `envoy.metrics_service`
 - `transport_sockets`: `envoy.transport_sockets.alts`, `envoy.transport_sockets.raw_buffer`
 
-[1]: https://groups.google.com/forum/#!topic/envoy-announce/ZLchtraPYVk
-[2]: https://groups.google.com/forum/#!topic/envoy-announce/Zo3ZEFuPWec
-[3]: https://groups.google.com/d/msg/envoy-announce/3-8S992PUV4/t-egdelVDwAJ
-[4]: {{site.github.repository_url}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
-[5]: {% link _resources/support.md %}
-[6]: https://groups.google.com/d/msg/envoy-announce/BjgUTDTKAu8/DTfMMSyCAgAJ
-[7]: https://groups.google.com/forum/#!msg/envoy-announce/sVqmxy0un2s/8aq430xiHAAJ
+[1]: https://groups.google.com/forum/#!topic/envoy-announce/Zo3ZEFuPWec
+[2]: https://groups.google.com/d/msg/envoy-announce/3-8S992PUV4/t-egdelVDwAJ
+[3]: {{site.github.repository_url}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
+[4]: https://groups.google.com/d/msg/envoy-announce/BjgUTDTKAu8/DTfMMSyCAgAJ
+[5]: https://groups.google.com/forum/#!msg/envoy-announce/sVqmxy0un2s/8aq430xiHAAJ


### PR DESCRIPTION
Fixes #2435 by updating the Envoy support matrix for Envoy v1.14.1

Signed-off-by: Steve Sloka <slokas@vmware.com>