### PR TITLE
build: run misspell across the whole repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ lint-misspell:
 		-locale US \
 		-error \
 		-i mitre \
-		design/* site/*.md site/_{guides,posts,resources} site/docs/**/* *.md
+		-source=text \
+		$$(git ls-files | grep -E '(md|html)$$')
 
 .PHONY: check-golint
 lint-golint:

--- a/site/css/fonts/Metropolis/README.md
+++ b/site/css/fonts/Metropolis/README.md
@@ -2,7 +2,7 @@
 
 The Vision
 ---
-To create a modern, geometric typeface. Open sourced, and openly available. Influenced by other popular geometric, minimalist sans-serif typefaces of the new millenium. Designed for optimal readability at small point sizes while beautiful at large point sizes.
+To create a modern, geometric typeface. Open sourced, and openly available. Influenced by other popular geometric, minimalist sans-serif typefaces of the new millennium. Designed for optimal readability at small point sizes while beautiful at large point sizes.
 
 December 2017 update
 ---


### PR DESCRIPTION
Since files move around in the repository and it's hard to keep the glob
patterns for misspell up to date, just use `git ls-files` to find all
the markdown and html in the repository and check everything.

This updates #2130.

Signed-off-by: James Peach <jpeach@vmware.com>