### PR TITLE
use sni for clusters when requestHeaderPolicy is set

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -409,6 +409,13 @@ type Cluster struct {
 
 	// ResponseHeadersPolicy defines how headers are managed during forwarding
 	ResponseHeadersPolicy *HeadersPolicy
+
+	// SNI is used when a route proxies an upstream using tls.
+	// SNI describes how the SNI is set on a Cluster and is configured via RequestHeadersPolicy.Host key.
+	// Policies set on service are used before policies set on a route. Otherwise the value of the externalService
+	// is used if the route is configured to proxy to an externalService type.
+	// If the value is not set, then SNI is not changed.
+	SNI string
 }
 
 func (c Cluster) Visit(f func(Vertex)) {

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -80,7 +80,7 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				c.UpstreamValidation,
-				service.ExternalName,
+				c.SNI,
 			),
 		)
 	case "h2":

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -76,6 +76,7 @@ func TestCluster(t *testing.T) {
 				Port:       443,
 				TargetPort: intstr.FromInt(8080),
 			}},
+			Type: v1.ServiceTypeExternalName,
 		},
 	}
 
@@ -176,6 +177,7 @@ func TestCluster(t *testing.T) {
 			cluster: &dag.Cluster{
 				Upstream: service(svcExternal, "tls"),
 				Protocol: "tls",
+				SNI:      "projectcontour.local",
 			},
 			want: &v2.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -179,6 +179,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 				Port:     443,
 				Name:     "https",
 			}},
+			Type: v1.ServiceTypeExternalName,
 		},
 	})
 
@@ -245,7 +246,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/externalname/443/da39a3ee5e", "default/externalname/https", "default_externalname_443"), nil, "goodbye.planet", ""),
+			tlsCluster(externalNameCluster("default/externalname/443/da39a3ee5e", "default/externalname/https", "default_externalname_443", "goodbye.planet", 443), nil, "goodbye.planet", "goodbye.planet"),
 		),
 		TypeUrl: clusterType,
 	})


### PR DESCRIPTION
Fixes #2437 by setting the SNI for the request with the following rules:

1. If the requestHeadersPolicy.set.Host is set on the service
2. If the requestHeadersPolicy.set.Host is set on the route
3. If an externalName is defined 

//cc @jeremyrickard

Signed-off-by: Steve Sloka <slokas@vmware.com>