### PR TITLE
site: update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Contour [![Build Status](https://travis-ci.org/projectcontour/contour.svg?branch=master)](https://travis-ci.org/projectcontour/contour) [![Go Report Card](https://goreportcard.com/badge/github.com/projectcontour/contour)](https://goreportcard.com/report/github.com/projectcontour/contour) ![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+# Contour [![Build Status](https://travis-ci.org/projectcontour/contour.svg?branch=master)](https://travis-ci.org/projectcontour/contour) [![Go Report Card](https://goreportcard.com/badge/github.com/projectcontour/contour)](https://goreportcard.com/report/github.com/projectcontour/contour) ![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Slack](https://img.shields.io/badge/slack-join%20chat-e01563.svg?logo=slack)](https://kubernetes.slack.com/messages/contour)
 
 ![Contour is fun at parties!](contour.png)
 
@@ -32,7 +32,7 @@ Thanks for taking the time to join our community and start contributing!
 - Please familiarize yourself with the [Code of Conduct](/CODE_OF_CONDUCT.md) before contributing.
 - See [CONTRIBUTING.md](/CONTRIBUTING.md) for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues](https://github.com/projectcontour/contour/issues).
-- Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
+- Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/contour/)
 - Join the **Contour Community Meetings** - [schedule, notes, and recordings can be found here](https://projectcontour.io/community)
 
 ## Changelog

--- a/site/docs/master/start-contributing.md
+++ b/site/docs/master/start-contributing.md
@@ -5,7 +5,7 @@ Thanks for taking the time to join our community and start contributing!
 - Please familiarize yourself with the [Code of Conduct][1] before contributing.
 - See [CONTRIBUTING.md][2] for information about setting up your environment, the workflow that we expect, and instructions on the developer certificate of origin that we require.
 - Check out the [open issues][3].
-- Join our Kubernetes Slack channel: [#contour](https://kubernetes.slack.com/messages/C8XRH2R4J/)
+- Join our Kubernetes Slack channel: [#contour][4]
 - Join the [Contour Community Meetings](https://vmware.zoom.us/j/347232187), every third Tuesday at 6PM ET / 3PM PT / Wednesday at 8AM Australian Eastern Time.
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
@@ -13,3 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{site.github.repository_url}}/blob/master/CODE_OF_CONDUCT.md
 [2]: {{site.github.repository_url}}/blob/master/CONTRIBUTING.md
 [3]: {{site.github.repository_url}}/issues
+[4]: {{site.footer_social_links.Slack.url}}


### PR DESCRIPTION
Update current slack links to use the canonical one from the site
config. Add a slack badge to Github.

Signed-off-by: James Peach <jpeach@vmware.com>