### PR TITLE
Enable GitHub workflow to run label sync.

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,31 @@
+# This workflow runs the sync-repo-labels.sh script periodically.
+name: Sync Labels
+
+on:
+  # Run every hour.
+  schedule:
+  - cron: '5 */1 * * *'
+  # Run when a PR that touched the labels is closed (closed includes merges).
+  pull_request:
+    types: [closed]
+    paths:
+    - "site/_data/github-labels.yaml"
+
+jobs:
+  sync:
+    name: Sync Labels
+    runs-on: ubuntu-latest
+    steps:
+    # Note, we check out master. We don't want un-merged PRs to whack
+    # labels globally.
+    - name: Check out master
+      uses: actions/checkout@v2
+      with:
+        ref: master
+    # We need this token in a file so the syncer can consume it from
+    # within the Docker container.
+    - name: Export the GitHub token
+      run: 'echo "${{ secrets.GITHUB_TOKEN }}" > github-token'
+    - name: Run the label syncer
+      run: 'TOKEN="github-token" ./hack/release/sync-repo-labels.sh'
+

--- a/hack/release/sync-repo-labels.sh
+++ b/hack/release/sync-repo-labels.sh
@@ -16,9 +16,6 @@ set -o pipefail
 labelsync() {
     $DOCKER run \
         --rm \
-        --interactive \
-        --tty \
-        --env GITHUB_TOKEN \
         --volume "${REPO}:/$(basename "${REPO}")" \
         gcr.io/k8s-prow/label_sync:latest \
     "$@"
@@ -46,11 +43,14 @@ yaml=$(path::absolute "${LABELS}")
 # within the repository, which will resolve within the container.
 yaml=${yaml##$(dirname "${REPO}")}
 
+# Treat the token the same as the YAML path, which requires it to be a
+# file within the repository.
 token=$(path::absolute "${TOKEN}")
 token=${token##$(dirname "${REPO}")}
 
 labelsync \
     --debug \
+    --confirm \
     --orgs projectcontour \
     --skip projectcontour/toc \
     --config "${yaml}" \


### PR DESCRIPTION
Add a GitHub workflow to run the repository label sync tooling for the
"projectcontour" org. This runs when the labels YAML changes and every
hour in the meantime.

Signed-off-by: James Peach <jpeach@vmware.com>