### PR TITLE
doc: update TimeoutPolicy API documentation

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -279,19 +279,22 @@ type TCPHealthCheckPolicy struct {
 	HealthyThresholdCount uint32 `json:"healthyThresholdCount"`
 }
 
-// TimeoutPolicy defines the attributes associated with timeout.
+// TimeoutPolicy configures timeouts that are used for handling network requests.
+//
+// TimeoutPolicy durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+// The string "infinity" is also a valid input and specifies no timeout.
+//
+// Example input values: "300ms", "5s", "1m".
 type TimeoutPolicy struct {
-	// TimeoutPolicy durations are expressed as per the format specified in the ParseDuration documentation: https://godoc.org/time#ParseDuration
-	// Example input values: "300ms", "5s", "1m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	// The string 'infinity' is also a valid input and specifies no timeout.
-
 	// Timeout for receiving a response from the server after processing a request from client.
-	// If not supplied the timeout duration is undefined.
+	// If not supplied, the timeout duration is undefined.
 	// +optional
 	Response string `json:"response,omitempty"`
 
-	// Timeout after which if there are no active requests for this route, the connection between
-	// Envoy and the backend will be closed. If not specified, there is no per-route idle timeout.
+	// Timeout after which, if there are no active requests for this route, the connection between
+	// Envoy and the backend or Envoy and the external client will be closed.
+	// If not specified, there is no per-route idle timeout.
 	// +optional
 	Idle string `json:"idle,omitempty"`
 }

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -903,14 +903,14 @@ spec:
                     description: The timeout policy for this route.
                     properties:
                       idle:
-                        description: Timeout after which if there are no active requests
+                        description: Timeout after which, if there are no active requests
                           for this route, the connection between Envoy and the backend
-                          will be closed. If not specified, there is no per-route
-                          idle timeout.
+                          or Envoy and the external client will be closed. If not
+                          specified, there is no per-route idle timeout.
                         type: string
                       response:
                         description: Timeout for receiving a response from the server
-                          after processing a request from client. If not supplied
+                          after processing a request from client. If not supplied,
                           the timeout duration is undefined.
                         type: string
                     type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -995,14 +995,14 @@ spec:
                     description: The timeout policy for this route.
                     properties:
                       idle:
-                        description: Timeout after which if there are no active requests
+                        description: Timeout after which, if there are no active requests
                           for this route, the connection between Envoy and the backend
-                          will be closed. If not specified, there is no per-route
-                          idle timeout.
+                          or Envoy and the external client will be closed. If not
+                          specified, there is no per-route idle timeout.
                         type: string
                       response:
                         description: Timeout for receiving a response from the server
-                          after processing a request from client. If not supplied
+                          after processing a request from client. If not supplied,
                           the timeout duration is undefined.
                         type: string
                     type: object

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1653,7 +1653,11 @@ This setting:
 <a href="#projectcontour.io/v1.Route">Route</a>)
 </p>
 <p>
-<p>TimeoutPolicy defines the attributes associated with timeout.</p>
+<p>TimeoutPolicy configures timeouts that are used for handling network requests.</p>
+<p>TimeoutPolicy durations are expressed in the Go <a href="https://godoc.org/time#ParseDuration">Duration format</a>.
+Valid time units are &ldquo;ns&rdquo;, &ldquo;us&rdquo; (or &ldquo;µs&rdquo;), &ldquo;ms&rdquo;, &ldquo;s&rdquo;, &ldquo;m&rdquo;, &ldquo;h&rdquo;.
+The string &ldquo;infinity&rdquo; is also a valid input and specifies no timeout.</p>
+<p>Example input values: &ldquo;300ms&rdquo;, &ldquo;5s&rdquo;, &ldquo;1m&rdquo;.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">
 <thead class="border-bottom">
@@ -1674,7 +1678,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Timeout for receiving a response from the server after processing a request from client.
-If not supplied the timeout duration is undefined.</p>
+If not supplied, the timeout duration is undefined.</p>
 </td>
 </tr>
 <tr>
@@ -1687,8 +1691,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Timeout after which if there are no active requests for this route, the connection between
-Envoy and the backend will be closed. If not specified, there is no per-route idle timeout.</p>
+<p>Timeout after which, if there are no active requests for this route, the connection between
+Envoy and the backend or Envoy and the external client will be closed.
+If not specified, there is no per-route idle timeout.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Move the description of timeout duration strings into the TimeoutPolicy
strict documentation so that the API generator includes it in the
final output. Clarify how idle timeouts are applied.

Signed-off-by: James Peach <jpeach@vmware.com>