### PR TITLE
doc: update HeadersPolicy documentation

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -357,12 +357,16 @@ type LoadBalancerPolicy struct {
 	Strategy string `json:"strategy,omitempty"`
 }
 
-// HeadersPolicy defines how headers are managed during forwarding
+// HeadersPolicy defines how headers are managed during forwarding.
+// The `Host` header is treated specially and if set in a HTTP response
+// will be used as the SNI server name when forwarding over TLS. It is an
+// error to attempt to set the `Host` header in a HTTP response.
 type HeadersPolicy struct {
-	// Set specifies a list of HTTP header values that will be set in the HTTP header
+	// Set specifies a list of HTTP header values that will be set in the HTTP header.
+	// If the header does not exist it will be added, otherwise it will be overwritten with the new value.
 	// +optional
 	Set []HeaderValue `json:"set,omitempty"`
-	// Remove specifies a list of HTTP header names to remove
+	// Remove specifies a list of HTTP header names to remove.
 	// +optional
 	Remove []string `json:"remove,omitempty"`
 }

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -707,13 +707,15 @@ spec:
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names
-                          to remove
+                          to remove.
                         items:
                           type: string
                         type: array
                       set:
                         description: Set specifies a list of HTTP header values that
-                          will be set in the HTTP header
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
                         items:
                           description: HeaderValue represents a header name/value
                             pair
@@ -738,13 +740,15 @@ spec:
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names
-                          to remove
+                          to remove.
                         items:
                           type: string
                         type: array
                       set:
                         description: Set specifies a list of HTTP header values that
-                          will be set in the HTTP header
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
                         items:
                           description: HeaderValue represents a header name/value
                             pair
@@ -813,13 +817,15 @@ spec:
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header
-                                names to remove
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
                               description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
                                 description: HeaderValue represents a header name/value
                                   pair
@@ -845,13 +851,15 @@ spec:
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header
-                                names to remove
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
                               description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
                                 description: HeaderValue represents a header name/value
                                   pair
@@ -1019,13 +1027,15 @@ spec:
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names
-                              to remove
+                              to remove.
                             items:
                               type: string
                             type: array
                           set:
                             description: Set specifies a list of HTTP header values
-                              that will be set in the HTTP header
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
                             items:
                               description: HeaderValue represents a header name/value
                                 pair
@@ -1051,13 +1061,15 @@ spec:
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names
-                              to remove
+                              to remove.
                             items:
                               type: string
                             type: array
                           set:
                             description: Set specifies a list of HTTP header values
-                              that will be set in the HTTP header
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
                             items:
                               description: HeaderValue represents a header name/value
                                 pair

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -799,13 +799,15 @@ spec:
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names
-                          to remove
+                          to remove.
                         items:
                           type: string
                         type: array
                       set:
                         description: Set specifies a list of HTTP header values that
-                          will be set in the HTTP header
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
                         items:
                           description: HeaderValue represents a header name/value
                             pair
@@ -830,13 +832,15 @@ spec:
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names
-                          to remove
+                          to remove.
                         items:
                           type: string
                         type: array
                       set:
                         description: Set specifies a list of HTTP header values that
-                          will be set in the HTTP header
+                          will be set in the HTTP header. If the header does not exist
+                          it will be added, otherwise it will be overwritten with
+                          the new value.
                         items:
                           description: HeaderValue represents a header name/value
                             pair
@@ -905,13 +909,15 @@ spec:
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header
-                                names to remove
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
                               description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
                                 description: HeaderValue represents a header name/value
                                   pair
@@ -937,13 +943,15 @@ spec:
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header
-                                names to remove
+                                names to remove.
                               items:
                                 type: string
                               type: array
                             set:
                               description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header
+                                that will be set in the HTTP header. If the header
+                                does not exist it will be added, otherwise it will
+                                be overwritten with the new value.
                               items:
                                 description: HeaderValue represents a header name/value
                                   pair
@@ -1111,13 +1119,15 @@ spec:
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names
-                              to remove
+                              to remove.
                             items:
                               type: string
                             type: array
                           set:
                             description: Set specifies a list of HTTP header values
-                              that will be set in the HTTP header
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
                             items:
                               description: HeaderValue represents a header name/value
                                 pair
@@ -1143,13 +1153,15 @@ spec:
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names
-                              to remove
+                              to remove.
                             items:
                               type: string
                             type: array
                           set:
                             description: Set specifies a list of HTTP header values
-                              that will be set in the HTTP header
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
                             items:
                               description: HeaderValue represents a header name/value
                                 pair

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -697,7 +697,10 @@ string
 <a href="#projectcontour.io/v1.Service">Service</a>)
 </p>
 <p>
-<p>HeadersPolicy defines how headers are managed during forwarding</p>
+<p>HeadersPolicy defines how headers are managed during forwarding.
+The <code>Host</code> header is treated specially and if set in a HTTP response
+will be used as the SNI server name when forwarding over TLS. It is an
+error to attempt to set the <code>Host</code> header in a HTTP response.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">
 <thead class="border-bottom">
@@ -719,7 +722,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Set specifies a list of HTTP header values that will be set in the HTTP header</p>
+<p>Set specifies a list of HTTP header values that will be set in the HTTP header.
+If the header does not exist it will be added, otherwise it will be overwritten with the new value.</p>
 </td>
 </tr>
 <tr>
@@ -732,7 +736,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Remove specifies a list of HTTP header names to remove</p>
+<p>Remove specifies a list of HTTP header names to remove.</p>
 </td>
 </tr>
 </tbody>

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -848,10 +848,12 @@ spec:
 
 ### Header Policy
 
-HTTPProxy supports rewriting the `Host` header after first handling a request and before proxying to an upstream service.
-A common use-case for this is to use Contour to proxy to a resource outside the cluster referenced by an `externalName` service.
+HTTPProxy supports rewriting HTTP request and response headers.
+The `Set` operation sets a HTTP header value, creating it if it doesn't already exist or overwriting it if it does.
+The `Remove` operation removes a HTTP header.
+The `requestHeadersPolicy` field is used to rewrite headers on a HTTP request, and the `responseHeadersPolicy` is used to rewrite headers on a HTTP response.
+These fields can be specified on a route or on a specific service, depending on the rewrite granularity you need.
 
-The `requestHeadersPolicy` supports a list of `Set` options that currently only supports rewriting `Host` headers defined via a `name` and `value`.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -869,14 +871,19 @@ spec:
       set:
       - name: Host
         value: external.dev
+      remove:
+      - Some-Header
+      - Some-Other-Header
 ```
 
 ### ExternalName
 
-HTTPProxy supports routing traffic to service types `ExternalName`.
+HTTPProxy supports routing traffic to `ExternalName` service types.
 Contour looks at the `spec.externalName` field of the service and configures the route to use that DNS name instead of utilizing EDS.
 
 There's nothing specific in the HTTPProxy object that needs to be configured other than referencing a service of type `ExternalName`.
+HTTPProxy supports the `requestHeadersPolicy` field to rewrite the `Host` header after first handling a request and before proxying to an upstream service.
+This field can be used to ensure that the forwarded HTTP request contains the hostname that the external resource is expecting.
 
 NOTE: The ports are required to be specified.
 


### PR DESCRIPTION
Update the API reference for `HeadersPolicy` to clarfy the semantics of
setting headers and to mention the special treatment of the `Host` header.

Rewrite the primary HTTPProxy guide to document that general header
rewriting is available in the `HeadersPolicy` fields.

This fixes #2462.

Signed-off-by: James Peach <jpeach@vmware.com>