### PR TITLE
Remove public Zoom link from Community page

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -12,22 +12,21 @@ If you’re a newcomer, check out the “[Good first issue][1]” and “[Help w
 
 * Join our Kubernetes Slack channel and chat with over 500 other community members: [#contour​][4]
 
-* Join the [Project Contour Announce][8] mailing list for release notifications and other important news.
+* Join the [Project Contour Announce][7] mailing list for release notifications and to get the invites for the community meetings.
 
-* Join the [Contour Community Meetings][5] on Zoom
+* Join the Contour Community Meetings on Zoom: 
   * For Australia time zones:
     * Every first and third Tuesday at 6:30 PM Eastern Time / 3:30 PM Pacific Time / Wednesday at 9:30 AM Australian Eastern Time.
   * For Americas time zones:
     * Every second and fourth Tuesday at 1 PM Eastern Time / 10 AM Pacific Time
-  * Meeting notes can be found [here][6].
-  * Meetings are recorded and can be found [here][7].
-  * Join the [mailing list](https://groups.google.com/forum/#!forum/projectcontour-announce) to get an automated invitation to the meeting.
+  * Join the [mailing list][7] to get an automated invitation to the meeting. This is a low-volume list that is only used for release announcements.
+  * Meeting notes can be found [here][5].
+  * Meetings are recorded and can be found [here][6].  
 
 [1]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22
 [2]: {{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+
 [3]: {{site.footer_social_links.Twitter.url}}
 [4]: {{site.footer_social_links.Slack.url}}
-[5]: https://vmware.zoom.us/j/347232187
-[6]: https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw
-[7]: https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj
-[8]: https://groups.google.com/forum/#!forum/projectcontour-announce
+[5]: https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw
+[6]: https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj
+[7]: https://groups.google.com/forum/#!forum/projectcontour-announce


### PR DESCRIPTION
Zoom links should not be published directly to prevent zoom-bombing.

Signed-off-by: Nick Young <ynick@vmware.com>