### PR TITLE
Fix community footer to include the correct meeting times

### DIFF
--- a/site/_includes/blog-community-footer.html
+++ b/site/_includes/blog-community-footer.html
@@ -5,16 +5,19 @@
 		<ul>
 			<li>For Australia time zones:</li>
 			<ul>
-				<li>Every second Tuesday at 6:30 PM Eastern Time / 3:30 PM Pacific Time / Wednesday at 8:30 AM Australian Eastern Time
+				<li>Every first and third Tuesday at 6:30 PM Eastern Time / 3:30 PM Pacific Time / Wednesday at 9:30 AM Australian Eastern Time.
 				</li>
 			</ul>
 		</ul>
 		<ul>
 			<li>For Americas time zones:</li>
 			<ul>
-				<li>Every second Tuesday at 1 PM Eastern Time / 10 AM Pacific Time
+				<li>Every second and fourth Tuesday at 1 PM Eastern Time / 10 AM Pacific Time
 				</li>
 			</ul>
+		</ul>
+		<ul>
+			<li>Join the <a href="https://groups.google.com/forum/#!forum/projectcontour-announce">mailing list</a> to get an automated invitation to the meeting. This is a low-volume list that is only used for release announcements.</li>
 		</ul>
 	<li>Get updates on Twitter (<a href="https://twitter.com/projectcontour">@projectcontour</a>)</li>
 	<li>Chat with us in <a href="https://kubernetes.slack.com/messages/contour">#contour on the Kubernetes Slack</a></li>


### PR DESCRIPTION
This fixes the community footer that's included on the blog posts.

Signed-off-by: jonasrosland <jrosland@vmware.com>