### PR TITLE
Pass `ingress.class` through to IngressStatusUpdater

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -296,10 +296,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// step 11. set up ingress load balancer status writer
 	lbsw := loadBalancerStatusWriter{
-		log:      log.WithField("context", "loadBalancerStatusWriter"),
-		clients:  clients,
-		isLeader: eventHandler.IsLeader,
-		lbStatus: make(chan v1.LoadBalancerStatus, 1),
+		log:          log.WithField("context", "loadBalancerStatusWriter"),
+		clients:      clients,
+		isLeader:     eventHandler.IsLeader,
+		lbStatus:     make(chan v1.LoadBalancerStatus, 1),
+		ingressClass: ctx.ingressClass,
 	}
 	g.Add(lbsw.Start)
 


### PR DESCRIPTION
Fixes #2481.

This is a missed bit of wiring to make the Ingress status updating work in the case
that you have supplied an ingress class that is not "contour".

Signed-off-by: Nick Young <ynick@vmware.com>