### PR TITLE
internal: filter misdirected TLS requests

### DIFF
--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -117,7 +117,7 @@ fatal_proxy_is_not_present[msg] {
   msg := sprintf("HTTPProxy for %q is not present", [ fqdn ])
 }
 
---- 
+---
 
 Name := "echo-one"
 
@@ -243,7 +243,7 @@ fatal_proxy_is_not_present[msg] {
   msg := sprintf("HTTPProxy for %q is not present", [ fqdn ])
 }
 
---- 
+---
 
 Name := "echo-two"
 
@@ -309,9 +309,10 @@ error_path_routing_mismatch[msg] {
 ---
 
 import data.contour.http.client
+import data.contour.http.response
 
 # Ensure that sending a request to "echo-one" with the SNI from "echo-two"
-# generates a 404.
+# generates a 4xx response status.
 
 Response := client.Get({
   "url": sprintf("https://%s/https-sni-enforcement/%d", [
@@ -324,23 +325,18 @@ Response := client.Get({
   "tls_server_name": "echo-two.projectcontour.io",
 })
 
-Wanted := 404
-
-error_non_404_response [msg] {
-  Response.status_code != Wanted
-
-  msg :=  sprintf("got status %d, wanted %d", [
-    Response.status_code, Wanted
-  ])
+error_non_400_response [msg] {
+  not response.is_4xx(Response)
+  msg :=  sprintf("got status %d, wanted 4xx", [ Response.status_code ])
 }
-
 
 ---
 
 import data.contour.http.client
+import data.contour.http.response
 
 # Ensure that sending a request to "echo-two" with the SNI from "echo-one"
-# generates a 404.
+# generates a 4xx response status.
 
 Response := client.Get({
   "url": sprintf("https://%s/https-sni-enforcement/%d", [
@@ -353,18 +349,7 @@ Response := client.Get({
   "tls_server_name": "echo-one.projectcontour.io",
 })
 
-Wanted := 404
-
-error_no_response {
-  not Response
-}
-
 error_non_404_response [msg] {
-  Response.status_code != Wanted
-
-  msg :=  sprintf("got status %d, wanted %d", [
-    Response.status_code, Wanted
-  ])
+  not response.is_4xx(Response)
+  msg :=  sprintf("got status %d, wanted 4xx", [ Response.status_code ])
 }
-
-

--- a/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
+++ b/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
@@ -1,0 +1,192 @@
+# Copyright 2020 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import data.contour.resources
+
+# Ensure that cert-manager is installed.
+# Version check the certificates resource.
+
+Group := "cert-manager.io"
+Version := "v1alpha2"
+
+have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+    sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+    "available versions:",
+    yaml.marshal(avail)
+  ])
+}
+
+---
+
+# Create a self-signed issuer to give us secrets.
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-cert
+spec:
+  dnsNames:
+  - echo.projectcontour.io
+  secretName: echo
+  issuerRef:
+    name: selfsigned
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: echo.projectcontour.io
+    tls:
+      secretName: echo
+  routes:
+  - services:
+    - name: echo
+      port: 80
+
+---
+
+import data.contour.resources
+
+Name := "echo"
+
+fatal_proxy_is_not_present[msg] {
+  not resources.is_present("httpproxies", Name)
+  msg := sprintf("HTTPProxy for %q is not present", [ Name ])
+}
+
+---
+
+import data.contour.resources
+
+Name := "echo"
+
+fatal_proxy_is_not_valid[msg] {
+  status := resources.status("httpproxies", Name)
+
+  object.get(status, "currentStatus", "") != "valid"
+
+  msg := sprintf("HTTPProxy %q is not valid\n%s", [
+    Name, yaml.marshal(status)
+  ])
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.request
+import data.contour.http.response
+
+Response := client.Get({
+  "url": sprintf("https://%s/misdirected/%d", [
+     client.target_addr, time.now_ns()
+  ]),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("misdirected-request"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_200_response [msg] {
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_wrong_routing [msg] {
+  not response.has_testid(Response)
+  msg := "response has missing body or test ID"
+}
+
+error_wrong_routing[msg] {
+  wanted := "echo"
+  testid := response.testid(Response)
+  testid != wanted
+  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.request
+import data.contour.http.response
+
+# Send a request with a Host header that doesn't match the SNI name that
+# we have for the proxy document. We expect the mismatch will generate a
+# 421 response, not 404.
+
+Response := client.Get({
+  "url": sprintf("https://%s/misdirected/%d", [
+     client.target_addr, time.now_ns()
+  ]),
+  "headers": {
+    "Host": "echo-two.projectcontour.io",
+    "User-Agent": client.ua("misdirected-request"),
+  },
+  "tls_server_name": "echo.projectcontour.io",
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_421_response [msg] {
+  not response.status_is(Response, 421)
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 421])
+}

--- a/_integration/testsuite/policies/contour-client.rego
+++ b/_integration/testsuite/policies/contour-client.rego
@@ -38,4 +38,12 @@ Get(params) = response {
   }
 
   response := http.send(object.union(to_send, params))
+} else = response {
+  # If the Get wasn't evaluated for any reason, return a dummy object to ensure
+  # subsequent field references are valid.
+  response := {
+    "status_code": 0,
+    "body": {},
+    "headers": {},
+  }
 }

--- a/_integration/testsuite/policies/contour-resources.rego
+++ b/_integration/testsuite/policies/contour-resources.rego
@@ -81,3 +81,14 @@ get(resource, name) = obj {
 } else = obj {
   obj := {}
 }
+
+# status returns the status field of the named resource. If the resource
+# is not present, and empty object is returned. Implemented in terms of
+# 'get', so namespace syntax works for the object name.
+#
+# Examples:
+#   resources.status("httpproxies", "foo")
+status(resource, name) = s {
+  r := get(resource, name)
+  s := object.get(r, "status", {})
+}

--- a/_integration/testsuite/policies/contour-response.rego
+++ b/_integration/testsuite/policies/contour-response.rego
@@ -44,3 +44,20 @@ testid(resp) = value {
   b := body(resp)
   value := object.get(b, "TestId", "")
 }
+
+# Return true if the response status matches.
+status_is(resp, expected_code) = true {
+  status_code := object.get(resp, "status_code", 0)
+  status_code == expected_code
+} else = false {
+  true
+}
+
+# Return true if the response status is in the 4xx range.
+is_4xx(resp) = true {
+  status_code := object.get(resp, "status_code", 0)
+  status_code >= 400
+  status_code < 500
+} else = false {
+  true
+}

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 VMware
+// Copyright © 2020 VMware
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -129,6 +129,8 @@ func TestListenerCacheQuery(t *testing.T) {
 func TestListenerVisit(t *testing.T) {
 	httpsFilterFor := func(vhost string) *envoy_api_v2_listener.Filter {
 		return envoy.HTTPConnectionManagerBuilder().
+			AddFilter(envoy.FilterMisdirectedRequests(vhost)).
+			DefaultFilters().
 			MetricsPrefix(ENVOY_HTTPS_LISTENER).
 			RouteConfigName(path.Join("https", vhost)).
 			AccessLoggers(envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
@@ -790,6 +792,8 @@ func TestListenerVisit(t *testing.T) {
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
 					Filters: envoy.Filters(envoy.HTTPConnectionManagerBuilder().
+						AddFilter(envoy.FilterMisdirectedRequests("whatever.example.com")).
+						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "whatever.example.com")).
 						AccessLoggers(envoy.FileAccessLogEnvoy("/tmp/https_access.log")).

--- a/internal/featuretests/downstreamvalidation_test.go
+++ b/internal/featuretests/downstreamvalidation_test.go
@@ -18,7 +18,6 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -104,18 +103,16 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("example.com", serverTLSSecret,
-			envoy.HTTPConnectionManagerBuilder().
-				RouteConfigName("https/example.com").
-				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
-				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
-				Get(),
-			&dag.PeerValidationContext{
-				CACertificate: &dag.Secret{
-					Object: clientCASecret,
+		FilterChains: appendFilterChains(
+			filterchaintls("example.com", serverTLSSecret,
+				httpsFilterFor("example.com"),
+				&dag.PeerValidationContext{
+					CACertificate: &dag.Secret{
+						Object: clientCASecret,
+					},
 				},
-			},
-			"h2", "http/1.1",
+				"h2", "http/1.1",
+			),
 		),
 	}
 

--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 VMware
+// Copyright © 2020 VMware
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -88,9 +88,11 @@ func TestTCPProxy(t *testing.T) {
 	c.Request(listenerType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			&v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -142,9 +144,11 @@ func TestTCPProxy(t *testing.T) {
 	c.Request(listenerType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			&v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -232,9 +236,11 @@ func TestTCPProxyDelegation(t *testing.T) {
 	c.Request(listenerType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			&v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -295,9 +301,11 @@ func TestTCPProxyDelegation(t *testing.T) {
 	c.Request(listenerType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			&v2.Listener{
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -523,11 +531,10 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 			&v2.Listener{
 				Name:    "ingress_https",
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls(
-					"k8s.run.ubisoft.org",
-					s1,
-					tcpproxy("ingress_https", svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e"),
-					nil),
+				FilterChains: appendFilterChains(
+					filterchaintls("k8s.run.ubisoft.org", s1,
+						tcpproxy("ingress_https", svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -630,9 +637,11 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 			&v2.Listener{
 				// ingress_https is present for
 				// kuard-tcp.example.com:443 terminated at envoy then forwarded to default/backend:80
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -733,9 +742,11 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 			&v2.Listener{
 				// ingress_https is present for
 				// kuard-tcp.example.com:443 terminated at envoy then tcpproxied to default/backend:80
-				Name:         "ingress_https",
-				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				Name:    "ingress_https",
+				Address: envoy.SocketAddress("0.0.0.0", 8443),
+				FilterChains: appendFilterChains(
+					filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),

--- a/internal/featuretests/tlscertificatedelegation_test.go
+++ b/internal/featuretests/tlscertificatedelegation_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 VMware
+// Copyright © 2020 VMware
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,14 +126,11 @@ func TestTLSCertificateDelegation(t *testing.T) {
 		ListenerFilters: envoy.ListenerFilters(
 			envoy.TLSInspector(),
 		),
-		FilterChains: filterchaintls("example.com", sec1,
-			envoy.HTTPConnectionManagerBuilder().
-				RouteConfigName("https/example.com").
-				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
-				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
-				Get(),
-			nil,
-			"h2", "http/1.1"),
+		FilterChains: appendFilterChains(
+			filterchaintls("example.com", sec1,
+				httpsFilterFor("example.com"),
+				nil, "h2", "http/1.1"),
+		),
 	}
 
 	c.Request(listenerType).Equals(&v2.DiscoveryResponse{

--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -34,7 +34,7 @@ If you are using the image recommended in our [example deployment][3] no action 
 If you are providing your own Envoy it must be compiled with the following extensions:
 
 - `access_loggers`: `envoy.access_loggers.file`,`envoy.access_loggers.http_grpc`,`envoy.access_loggers.tcp_grpc`
-- `filters.http`: `envoy.buffer`,`envoy.cors`,`envoy.csrf`,`envoy.fault`,`envoy.filters.http.adaptive_concurrency`,`envoy.filters.http.dynamic_forward_proxy`,`envoy.filters.http.grpc_http1_reverse_bridge`,`envoy.filters.http.grpc_stats`,`envoy.filters.http.header_to_metadata`,`envoy.filters.http.original_src`,`envoy.grpc_http1_bridge`,`envoy.grpc_json_transcoder`,`envoy.grpc_web`,`envoy.gzip`,`envoy.health_check`,`envoy.ip_tagging`,`envoy.router`
+- `filters.http`: `envoy.buffer`, `envoy.cors`, `envoy.csrf`, `envoy.fault`, `envoy.filters.http.adaptive_concurrency`, `envoy.filters.http.dynamic_forward_proxy`, `envoy.filters.http.grpc_http1_reverse_bridge`, `envoy.filters.http.grpc_stats`, `envoy.filters.http.header_to_metadata`, `envoy.filters.http.lua`, `envoy.filters.http.original_src`, `envoy.grpc_http1_bridge`, `envoy.grpc_json_transcoder`, `envoy.grpc_web`, `envoy.gzip`, `envoy.health_check`, `envoy.ip_tagging`, `envoy.router`
 - `filters.listener`: `envoy.listener.http_inspector`,`envoy.listener.original_dst`,`envoy.listener.original_src`,`envoy.listener.proxy_protocol`,`envoy.listener.tls_inspector`
 - `filters.network`: `envoy.echo`,`envoy.filters.network.sni_cluster`,`envoy.http_connection_manager`,`envoy.tcp_proxy`
 - `stat_sinks`: `envoy.metrics_service`


### PR DESCRIPTION
TLS routes are specialized to a unique virtual hostname. However, if
wildcard certificates are being used, browsers will aggressively coalesce
and reuse server connections even when the full origin hostname doesn't
match. This results on 404 responses because each TLS virtual host only
has routes for one host.

We can avoid this behaviour bleeding out to users by generating a 421
Misdirected Request response if the request authority doesn't match
the FQDN of the virtual host. In this case, the browser is supposed
to understand that the request wasn't processed and re-send it on a
new connection.

Signed-off-by: James Peach <jpeach@vmware.com>