### PR TITLE
Add GitHub links to team member list

### DIFF
--- a/site/_contributors/01-nick-young.md
+++ b/site/_contributors/01-nick-young.md
@@ -2,5 +2,6 @@
 first_name: Nick
 last_name: Young
 image: /img/contributors/nick-young.png
+github_handle: youngnick
 ---
 Tech Lead / Maintainer

--- a/site/_contributors/02-james-peach.md
+++ b/site/_contributors/02-james-peach.md
@@ -2,5 +2,6 @@
 first_name: James
 last_name: Peach
 image: /img/contributors/jpeach.png
+github_handle: jpeach
 ---
 Maintainer

--- a/site/_contributors/02-steve-sloka.md
+++ b/site/_contributors/02-steve-sloka.md
@@ -2,5 +2,6 @@
 first_name: Steve
 last_name: Sloka
 image: /img/contributors/steve-sloka.png
+github_handle: stevesloka
 ---
 Maintainer

--- a/site/_contributors/03-tim-hinderliter.md
+++ b/site/_contributors/03-tim-hinderliter.md
@@ -2,5 +2,6 @@
 first_name: Tim
 last_name: Hinderliter
 image: /img/contributors/tim-hinderliter.png
+github_handle: timh
 ---
 Engineering Manager

--- a/site/_contributors/04-michael-michael.md
+++ b/site/_contributors/04-michael-michael.md
@@ -2,5 +2,6 @@
 first_name: Michael
 last_name: Michael
 image: /img/contributors/michael-michael.png
+github_handle: michmike
 ---
 Product Manager / Maintainer

--- a/site/_contributors/05-dave-cheney.md
+++ b/site/_contributors/05-dave-cheney.md
@@ -2,5 +2,6 @@
 first_name: Dave
 last_name: Cheney
 image: /img/contributors/dave-cheney.png
+github_handle: davecheney
 ---
 Emeritus Maintainer

--- a/site/_includes/contributors.html
+++ b/site/_includes/contributors.html
@@ -17,7 +17,7 @@
       <div class="media thumbnail-item">
         <img src="{{ person.image }}" class="rounded-circle" alt="Person" />
         <div class="media-body align-self-center">
-          <h6>{{ person.first_name }} {{ person.last_name }}</h6>
+          <h6><a href="https://github.com/{{ person.github_handle }}">{{ person.first_name }} {{ person.last_name }}</a></h6>
         {{ person.content | markdownify }}    
         </div>
       </div>


### PR DESCRIPTION
This will change the non-relevant links for each team member to proper links to GitHub user pages.

Signed-off-by: jonasrosland <jrosland@vmware.com>