### PR TITLE
Add flag to restrict Contour to a single namespace

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -38,11 +38,12 @@ import (
 //    is been received, operation restarts at step 3.
 // 5. If the worker is stopped, any existing informer is stopped before the worker stops.
 type loadBalancerStatusWriter struct {
-	log          logrus.FieldLogger
-	clients      *k8s.Clients
-	isLeader     chan struct{}
-	lbStatus     chan v1.LoadBalancerStatus
-	ingressClass string
+	log               logrus.FieldLogger
+	clients           *k8s.Clients
+	isLeader          chan struct{}
+	lbStatus          chan v1.LoadBalancerStatus
+	ingressClass      string
+	informerNamespace string
 }
 
 func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
@@ -84,7 +85,7 @@ func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 			}
 
 			// Create new informer for the new LoadBalancerStatus
-			factory := isw.clients.NewInformerFactory()
+			factory := isw.clients.NewInformerFactoryForNamespace(isw.informerNamespace)
 			inf := factory.Networking().V1beta1().Ingresses().Informer()
 			inf.AddEventHandler(&k8s.IngressStatusUpdater{
 				Client:       isw.clients.ClientSet(),

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -62,6 +62,9 @@ type serveContext struct {
 	// ingressroute root namespaces
 	rootNamespaces string
 
+	// Only operate in the Contour namespace
+	singleNamespace bool
+
 	// ingress class
 	ingressClass string
 

--- a/internal/k8s/clients.go
+++ b/internal/k8s/clients.go
@@ -85,8 +85,8 @@ func (c *Clients) NewInformerFactoryForNamespace(namespace string) informers.Sha
 
 // NewDynamicInformerFactory returns a new DynamicSharedInformerFactory for
 // use with any registered Kubernetes API type.
-func (c *Clients) NewDynamicInformerFactory() dynamicinformer.DynamicSharedInformerFactory {
-	return dynamicinformer.NewDynamicSharedInformerFactory(c.dynamic, resyncInterval)
+func (c *Clients) NewDynamicInformerFactory(namespace string) dynamicinformer.DynamicSharedInformerFactory {
+	return dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.dynamic, resyncInterval, namespace, nil)
 }
 
 // ClientSet returns the Kubernetes Core v1 ClientSet.


### PR DESCRIPTION
The `--single-namespace` flag can be enabled to restrict Contour to searching and modifying resources in only the namespace it's deployed in.

This is especially useful in environment where it's desirable to run multiple instances of Contour, for instance one per namespace, each with their own Envoy deployments without conflicting with each other.