### PR TITLE
Add status subresource to HTTPProxy

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -423,6 +423,7 @@ type Status struct {
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.currentStatus",description="The current status of the HTTPProxy"
 // +kubebuilder:printcolumn:name="Status Description",type="string",JSONPath=".status.description",description="Description of the current status"
 // +kubebuilder:resource:scope=Namespaced,path=httpproxies,shortName=proxy;proxies,singular=httpproxy
+// +kubebuilder:subresource:status
 type HTTPProxy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -180,7 +180,8 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		HoldoffDelay:    100 * time.Millisecond,
 		HoldoffMaxDelay: 500 * time.Millisecond,
 		StatusClient: &k8s.StatusWriter{
-			Client: clients.DynamicClient(),
+			Client:    clients.DynamicClient(),
+			Converter: converter,
 		},
 		Builder: dag.Builder{
 			Source: dag.KubernetesCache{

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -479,7 +479,8 @@ spec:
     - proxies
     singular: httpproxy
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: HTTPProxy is an Ingress CRD specification

--- a/examples/contour/02-rbac.yaml
+++ b/examples/contour/02-rbac.yaml
@@ -79,6 +79,12 @@ rules:
   - put
   - post
   - patch
+- apiGroups:
+  - "projectcontour.io"
+  resources:
+  - "httpproxies/status"
+  verbs:
+  - update
 - apiGroups: ["networking.x.k8s.io"]
   resources: ["gatewayclasses", "gateways", "httproutes", "tcproutes"]
   verbs:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -571,7 +571,8 @@ spec:
     - proxies
     singular: httpproxy
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: HTTPProxy is an Ingress CRD specification
@@ -1521,6 +1522,12 @@ rules:
   - put
   - post
   - patch
+- apiGroups:
+  - "projectcontour.io"
+  resources:
+  - "httpproxies/status"
+  verbs:
+  - update
 - apiGroups: ["networking.x.k8s.io"]
   resources: ["gatewayclasses", "gateways", "httproutes", "tcproutes"]
   verbs:

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -46,7 +46,7 @@ func TestConvertUnstructured(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := converter.Convert(tc.obj)
+			got, err := converter.FromUnstructured(tc.obj)
 
 			assert.Equal(t, tc.wantError, err)
 			assert.Equal(t, tc.want, got)

--- a/internal/k8s/syncer.go
+++ b/internal/k8s/syncer.go
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package k8s
 
 import (


### PR DESCRIPTION
This commit enables the status subresource for HTTPProxy.
This means that:
- normal HTTPProxy changes that include updates to the `status` stanza will have the status updates dropped
- updates to `status` can only be made using requests to the status subresource.

Also changes the HTTPProxy status updating to use the status subresource,
and adds RBAC for Contour to be able to update it.

Having the status subresource enabled is best-practice for CRDs and will be a foundation for further status work.

It also means that HTTPProxy objects no longer need to include the `status` stanza to be valid.

Updates #2495

Signed-off-by: Nick Young <ynick@vmware.com>