### PR TITLE
site: update labels for stale issue workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,7 +20,7 @@ jobs:
           Marking this PR stale since there has been no activity for 14
           days. It will be closed if there is no activity for another
           90 days.
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-label: 'lifecycle/stale'
         days-before-stale: 14
         days-before-close: 90


### PR DESCRIPTION
Now that the labels sync tooling is running, the `stale` label has been
renamed to `lifecycle/stale`. Update the GitHub stale issue workflow to
use the new label name.

This updates #2436.

Signed-off-by: James Peach <jpeach@vmware.com>