### PR TITLE
doc: improve TLS API documentation formatting

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -122,7 +122,9 @@ type TLS struct {
 	Passthrough bool `json:"passthrough,omitempty"`
 	// ClientValidation defines how to verify the client certificate
 	// when an external client establishes a TLS connection to Envoy.
+	//
 	// This setting:
+	//
 	// 1. Enables TLS client certificate validation.
 	// 2. Requires clients to present a TLS certificate (i.e. not optional validation).
 	// 3. Specifies how the client certificate will be validated.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -312,12 +312,12 @@ spec:
                     secret must contain a matching certificate
                   properties:
                     clientValidation:
-                      description: 'ClientValidation defines how to verify the client
+                      description: "ClientValidation defines how to verify the client
                         certificate when an external client establishes a TLS connection
-                        to Envoy. This setting: 1. Enables TLS client certificate
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
                         validation. 2. Requires clients to present a TLS certificate
                         (i.e. not optional validation). 3. Specifies how the client
-                        certificate will be validated.'
+                        certificate will be validated."
                       properties:
                         caSecret:
                           description: Name of a Kubernetes secret that contains a
@@ -1135,12 +1135,12 @@ spec:
                     secret must contain a matching certificate
                   properties:
                     clientValidation:
-                      description: 'ClientValidation defines how to verify the client
+                      description: "ClientValidation defines how to verify the client
                         certificate when an external client establishes a TLS connection
-                        to Envoy. This setting: 1. Enables TLS client certificate
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
                         validation. 2. Requires clients to present a TLS certificate
                         (i.e. not optional validation). 3. Specifies how the client
-                        certificate will be validated.'
+                        certificate will be validated."
                       properties:
                         caSecret:
                           description: Name of a Kubernetes secret that contains a

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -404,12 +404,12 @@ spec:
                     secret must contain a matching certificate
                   properties:
                     clientValidation:
-                      description: 'ClientValidation defines how to verify the client
+                      description: "ClientValidation defines how to verify the client
                         certificate when an external client establishes a TLS connection
-                        to Envoy. This setting: 1. Enables TLS client certificate
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
                         validation. 2. Requires clients to present a TLS certificate
                         (i.e. not optional validation). 3. Specifies how the client
-                        certificate will be validated.'
+                        certificate will be validated."
                       properties:
                         caSecret:
                           description: Name of a Kubernetes secret that contains a
@@ -1227,12 +1227,12 @@ spec:
                     secret must contain a matching certificate
                   properties:
                     clientValidation:
-                      description: 'ClientValidation defines how to verify the client
+                      description: "ClientValidation defines how to verify the client
                         certificate when an external client establishes a TLS connection
-                        to Envoy. This setting: 1. Enables TLS client certificate
+                        to Envoy. \n This setting: \n 1. Enables TLS client certificate
                         validation. 2. Requires clients to present a TLS certificate
                         (i.e. not optional validation). 3. Specifies how the client
-                        certificate will be validated.'
+                        certificate will be validated."
                       properties:
                         caSecret:
                           description: Name of a Kubernetes secret that contains a

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1609,11 +1609,13 @@ DownstreamValidation
 <td>
 <em>(Optional)</em>
 <p>ClientValidation defines how to verify the client certificate
-when an external client establishes a TLS connection to Envoy.
-This setting:
-1. Enables TLS client certificate validation.
-2. Requires clients to present a TLS certificate (i.e. not optional validation).
-3. Specifies how the client certificate will be validated.</p>
+when an external client establishes a TLS connection to Envoy.</p>
+<p>This setting:</p>
+<ol>
+<li>Enables TLS client certificate validation.</li>
+<li>Requires clients to present a TLS certificate (i.e. not optional validation).</li>
+<li>Specifies how the client certificate will be validated.</li>
+</ol>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
The CRD documentation generator inteprets Godoc comments as markdown,
so by adding som paragraph breaks, it will also turn list items into
proper HTML lists.

Signed-off-by: James Peach <jpeach@vmware.com>