### PR TITLE
[RELEASE 1.4] Optimistically add dummy.go to release-1.4

### DIFF
--- a/examples/contour/dummy.go
+++ b/examples/contour/dummy.go
@@ -1,0 +1,16 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contour contains a dummy Go file that enables the Contour
+// configuration files to be pulled in via go mod vendoring.
+package contour

--- a/examples/contour/dummy.go
+++ b/examples/contour/dummy.go
@@ -1,3 +1,5 @@
+// +build vendormagic
+
 // Copyright © 2020 VMware
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
While kustomize is explored at HEAD, this adds dummy.go to the 1.4 release branch to unblock consuming the example configurations through `go mod` vendoring.

Related: https://github.com/projectcontour/contour/issues/2486