### PR TITLE
site: remove `kind/documentation` label

### DIFF
--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -57,6 +57,7 @@ default:
       addedBy: label
       previously:
         - name: documentation
+        - name: kind/documentation
     - color: 0052cc
       description: Issues or PRs related to the HTTPProxy API.
       name: area/httpproxy
@@ -179,13 +180,6 @@ default:
       addedBy: anyone
       previously:
         - name: design
-    - color: c7def8
-      description: Categorizes issue or PR as related to documentation.
-      name: kind/documentation
-      target: both
-      addedBy: anyone
-      previously:
-        - name: documentation
     - color: e11d21
       description: Categorizes issue or PR as related to a consistently or frequently failing test.
       name: kind/failing-test


### PR DESCRIPTION
There's no obvious distinction between `kind/documentation` and
`area/documentation`. Since `area` scopes the part of the project
an issue applies to, that seems lke the better choice, so move all
the `kind/documentation` issues to `area/documentation`.

Signed-off-by: James Peach <jpeach@vmware.com>