### PR TITLE
site: tune codecov settings

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,26 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  # https://docs.codecov.io/docs/commit-status#informational
+  status:
+    project:
+      default:
+        informational: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Add a default codecov settings file, and make the `codecov/project`
status informational, since it otherwise makes CI look broken.

Signed-off-by: James Peach <jpeach@vmware.com>