### PR TITLE
api: add kubebuilder-compatible type registration exports

### DIFF
--- a/apis/contour/v1beta1/register.go
+++ b/apis/contour/v1beta1/register.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 VMware
+// Copyright © 2020
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,22 +24,43 @@ const (
 	GroupName = "contour.heptio.com"
 )
 
-// SchemeGroupVersion is the GroupVersion for the Contour API
-var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
-var IngressRouteGVR = SchemeGroupVersion.WithResource("ingressroutes")
-var TLSCertificateDelegationGVR = SchemeGroupVersion.WithResource("tlscertificatedelegations")
+// SchemeGroupVersion is a compatibility name for the GroupVersion.
+// New code should use GroupVersion.
+var SchemeGroupVersion = GroupVersion
+
+var IngressRouteGVR = GroupVersion.WithResource("ingressroutes")
+var TLSCertificateDelegationGVR = GroupVersion.WithResource("tlscertificatedelegations")
 
 // Resource gets an Contour GroupResource for a specified resource
 func Resource(resource string) schema.GroupResource {
-	return SchemeGroupVersion.WithResource(resource).GroupResource()
+	return GroupVersion.WithResource(resource).GroupResource()
 }
 
-func AddKnownTypes(scheme *runtime.Scheme) {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+// AddKnownTypes is exported for backwards compatibility with third
+// parties who depend on this symbol, but all new code should use
+// AddToScheme.
+func AddKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(
+		GroupVersion,
 		&IngressRoute{},
 		&IngressRouteList{},
 		&TLSCertificateDelegation{},
 		&TLSCertificateDelegationList{},
 	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
 }
+
+// The following declarations are kubebuilder-compatible and will be expected
+// by third parties who import the Contour API types.
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = runtime.NewSchemeBuilder(AddKnownTypes)
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -93,8 +93,13 @@ func NewUnstructuredConverter() (*UnstructuredConverter, error) {
 	}
 
 	// Setup converter to understand custom CRD types
-	projectcontour.AddKnownTypes(uc.scheme)
-	ingressroutev1.AddKnownTypes(uc.scheme)
+	if err := projectcontour.AddToScheme(uc.scheme); err != nil {
+		return nil, err
+	}
+
+	if err := ingressroutev1.AddToScheme(uc.scheme); err != nil {
+		return nil, err
+	}
 
 	// Add the core types we need
 	if err := scheme.AddToScheme(uc.scheme); err != nil {

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -46,8 +46,12 @@ func TestSetIngressRouteStatus(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
 			var gotPatchBytes []byte
+
 			s := runtime.NewScheme()
-			ingressroutev1.AddKnownTypes(s)
+			if err := ingressroutev1.AddToScheme(s); err != nil {
+				t.Fatalf("adding to scheme: %s", err)
+			}
+
 			client := fake.NewSimpleDynamicClient(s, tc.existing)
 
 			client.PrependReactor("patch", "ingressroutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -143,8 +147,12 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
 			var gotObj runtime.Object
+
 			s := runtime.NewScheme()
-			projcontour.AddKnownTypes(s)
+			if err := projcontour.AddToScheme(s); err != nil {
+				t.Fatalf("adding to scheme: %s", err)
+			}
+
 			usc, err := NewUnstructuredConverter()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Restore the kubebuilder-compatible API type registration exports for
IngressRoute and HTTPProxy. Keep exporting AddKnownTypes() for projects
that already started consuming this symmbol, but note that it is not
should no longer be used.

This updates #2487.

Signed-off-by: James Peach <jpeach@vmware.com>