### PR TITLE
internal/featuretests: add simple HTTPProxy fixtures

### DIFF
--- a/internal/featuretests/downstreamvalidation_test.go
+++ b/internal/featuretests/downstreamvalidation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,12 +69,8 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 	}
 	rh.OnAdd(service)
 
-	proxy := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example.com",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	proxy := fixture.NewProxy("example.com").
+		WithSpec(projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "example.com",
 				TLS: &projcontour.TLS{
@@ -89,8 +86,8 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 					Port: 8080,
 				}},
 			}},
-		},
-	}
+		})
+
 	rh.OnAdd(proxy)
 
 	ingress_http := &v2.Listener{

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -20,6 +20,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,21 +87,17 @@ func TestExternalNameService(t *testing.T) {
 
 	rh.OnDelete(i1)
 
-	hp1 := &projcontour.HTTPProxy{
-		ObjectMeta: i1.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.projectcontour.io",
-			},
+	rh.OnAdd(fixture.NewProxy("kuard").
+		WithFQDN("kuard.projectcontour.io").
+		WithSpec(projcontour.HTTPProxySpec{
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
 			}},
-		},
-	}
-	rh.OnAdd(hp1)
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
@@ -123,12 +120,9 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	hp2 := &projcontour.HTTPProxy{
-		ObjectMeta: i1.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
-				Fqdn: "kuard.projectcontour.io",
-			},
+	rh.OnAdd(fixture.NewProxy("kuard").
+		WithFQDN("kuard.projectcontour.io").
+		WithSpec(projcontour.HTTPProxySpec{
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
 					Name: s1.Name,
@@ -141,9 +135,8 @@ func TestExternalNameService(t *testing.T) {
 					}},
 				},
 			}},
-		},
-	}
-	rh.OnAdd(hp2)
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,

--- a/internal/featuretests/headercondition_test.go
+++ b/internal/featuretests/headercondition_test.go
@@ -21,6 +21,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -138,12 +139,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	proxy2 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	proxy2 := fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -169,8 +166,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					Port: 80,
 				}},
 			}},
-		},
-	}
+		})
 
 	rh.OnUpdate(proxy1, proxy2)
 
@@ -206,12 +202,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	proxy3 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	proxy3 := fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -237,8 +229,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					Port: 80,
 				}},
 			}},
-		},
-	}
+		})
 
 	rh.OnUpdate(proxy2, proxy3)
 
@@ -274,12 +265,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	proxy4 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	proxy4 := fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -305,8 +292,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					Port: 80,
 				}},
 			}},
-		},
-	}
+		})
 
 	rh.OnUpdate(proxy3, proxy4)
 
@@ -342,12 +328,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	proxy5 := &projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	proxy5 := fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -373,8 +355,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					Port: 80,
 				}},
 			}},
-		},
-	}
+		})
 
 	rh.OnUpdate(proxy4, proxy5)
 

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -18,6 +18,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 
 	"testing"
@@ -46,12 +47,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 		},
 	})
 
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -65,8 +62,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					}},
 				},
 			}},
-		},
-	})
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
@@ -83,12 +80,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	})
 
 	// Non-Host header
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -102,8 +95,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					}},
 				},
 			}},
-		},
-	})
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
@@ -129,12 +122,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	})
 
 	// Empty value for replaceHeader in HeadersPolicy
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
@@ -147,8 +136,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					}},
 				},
 			}},
-		},
-	})
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
@@ -193,12 +182,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	})
 
 	// Proxy with SNI
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "hello.world",
 				TLS:  &projcontour.TLS{SecretName: "foo"},
@@ -215,8 +200,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 					}},
 				},
 			}},
-		},
-	})
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: routeResources(t,

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	"github.com/projectcontour/contour/internal/fixture"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -294,15 +295,9 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 	// HTTPProxy
 	{
 		// --- ingress class matches explicitly
-		proxyValid := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"contour.heptio.com/ingress.class": "linkerd",
-				},
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyValid := fixture.NewProxy(HTTPProxyName).
+			Annotate("contour.heptio.com/ingress.class", "linkerd").
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -312,8 +307,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnAdd(proxyValid)
 
@@ -332,15 +326,9 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		})
 
 		// --- wrong ingress class specified
-		proxyWrongClass := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "contour",
-				},
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyWrongClass := fixture.NewProxy(HTTPProxyName).
+			Annotate("kubernetes.io/ingress.class", "contour").
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -350,8 +338,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnUpdate(proxyValid, proxyWrongClass)
 
@@ -364,12 +351,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		})
 
 		// --- no ingress class specified
-		proxyNoClass := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyNoClass := fixture.NewProxy(HTTPProxyName).
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -379,8 +362,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnUpdate(proxyWrongClass, proxyNoClass)
 
@@ -692,12 +674,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 	// HTTPProxy
 	{
 		// --- no ingress class specified
-		proxyNoClass := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyNoClass := fixture.NewProxy(HTTPProxyName).
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -707,8 +685,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnAdd(proxyNoClass)
 
@@ -727,15 +704,9 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		})
 
 		// --- matching ingress class specified
-		proxyMatchingClass := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "contour",
-				},
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyMatchingClass := fixture.NewProxy(HTTPProxyName).
+			Annotate("kubernetes.io/ingress.class", "contour").
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -745,8 +716,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnUpdate(proxyNoClass, proxyMatchingClass)
 
@@ -765,15 +735,9 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		})
 
 		// --- non-matching ingress class specified
-		proxyNonMatchingClass := &projcontour.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      HTTPProxyName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "invalid",
-				},
-			},
-			Spec: projcontour.HTTPProxySpec{
+		proxyNonMatchingClass := fixture.NewProxy(HTTPProxyName).
+			Annotate("kubernetes.io/ingress.class", "invalid").
+			WithSpec(projcontour.HTTPProxySpec{
 				VirtualHost: &projcontour.VirtualHost{
 					Fqdn: "www.example.com",
 				},
@@ -783,8 +747,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
 				}},
-			},
-		}
+			})
 
 		rh.OnUpdate(proxyMatchingClass, proxyNonMatchingClass)
 
@@ -834,7 +797,7 @@ func TestIngressClassUpdate(t *testing.T) {
 	defer done()
 
 	svc := &v1.Service{
-		ObjectMeta: meta("default/kuard"),
+		ObjectMeta: fixture.ObjectMeta("default/kuard"),
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Protocol:   "TCP",
@@ -846,7 +809,7 @@ func TestIngressClassUpdate(t *testing.T) {
 	rh.OnAdd(svc)
 
 	vhost := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/kuard"),
+		ObjectMeta: fixture.ObjectMeta("default/kuard"),
 		Spec: projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "kuard.projectcontour.io",

--- a/internal/featuretests/kubernetes.go
+++ b/internal/featuretests/kubernetes.go
@@ -16,12 +16,8 @@ package featuretests
 // kubernetes helpers
 
 import (
-	"fmt"
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -87,18 +83,5 @@ func secretdata(cert, key string) map[string][]byte {
 	return map[string][]byte{
 		v1.TLSCertKey:       []byte(cert),
 		v1.TLSPrivateKeyKey: []byte(key),
-	}
-}
-
-func meta(name string) metav1.ObjectMeta {
-	v := strings.SplitN(name, "/", 2)
-	switch len(v) {
-	case 2:
-		return metav1.ObjectMeta{
-			Name:      v[1],
-			Namespace: v[0],
-		}
-	default:
-		panic(fmt.Sprintf("object name '%s' omits namespace", name))
 	}
 }

--- a/internal/featuretests/replaceprefix_test.go
+++ b/internal/featuretests/replaceprefix_test.go
@@ -16,6 +16,7 @@ package featuretests
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/internal/fixture"
 	"k8s.io/client-go/tools/cache"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -42,7 +43,7 @@ func basic(t *testing.T) {
 	defer done()
 
 	rh.OnAdd(&v1.Service{
-		ObjectMeta: meta("default/kuard"),
+		ObjectMeta: fixture.ObjectMeta("default/kuard"),
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Protocol:   "TCP",
@@ -52,9 +53,8 @@ func basic(t *testing.T) {
 		},
 	})
 
-	vhost := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/kuard"),
-		Spec: projcontour.HTTPProxySpec{
+	vhost := fixture.NewProxy("kuard").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "kuard.projectcontour.io",
 			},
@@ -72,8 +72,7 @@ func basic(t *testing.T) {
 					},
 				},
 			}},
-		},
-	}
+		})
 
 	rh.OnAdd(vhost)
 
@@ -228,7 +227,7 @@ func multiInclude(t *testing.T) {
 	defer done()
 
 	rh.OnAdd(&v1.Service{
-		ObjectMeta: meta("default/kuard"),
+		ObjectMeta: fixture.ObjectMeta("default/kuard"),
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Protocol:   "TCP",
@@ -238,9 +237,8 @@ func multiInclude(t *testing.T) {
 		},
 	})
 
-	vhost1 := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/host1"),
-		Spec: projcontour.HTTPProxySpec{
+	vhost1 := fixture.NewProxy("host1").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "host1.projectcontour.io",
 			},
@@ -249,12 +247,10 @@ func multiInclude(t *testing.T) {
 				Namespace:  "default",
 				Conditions: conditions(prefixCondition("/v1")),
 			}},
-		},
-	}
+		})
 
-	vhost2 := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/host2"),
-		Spec: projcontour.HTTPProxySpec{
+	vhost2 := fixture.NewProxy("host2").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "host2.projectcontour.io",
 			},
@@ -263,12 +259,10 @@ func multiInclude(t *testing.T) {
 				Namespace:  "default",
 				Conditions: conditions(prefixCondition("/v2")),
 			}},
-		},
-	}
+		})
 
-	app := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/app"),
-		Spec: projcontour.HTTPProxySpec{
+	app := fixture.NewProxy("app").WithSpec(
+		projcontour.HTTPProxySpec{
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
 					Name: "kuard",
@@ -281,8 +275,7 @@ func multiInclude(t *testing.T) {
 					},
 				},
 			}},
-		},
-	}
+		})
 
 	rh.OnAdd(vhost1)
 	rh.OnAdd(vhost2)
@@ -363,7 +356,7 @@ func replaceWithSlash(t *testing.T) {
 	defer done()
 
 	rh.OnAdd(&v1.Service{
-		ObjectMeta: meta("default/kuard"),
+		ObjectMeta: fixture.ObjectMeta("default/kuard"),
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Protocol:   "TCP",
@@ -373,9 +366,8 @@ func replaceWithSlash(t *testing.T) {
 		},
 	})
 
-	vhost1 := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/host1"),
-		Spec: projcontour.HTTPProxySpec{
+	vhost1 := fixture.NewProxy("host1").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "host1.projectcontour.io",
 			},
@@ -391,12 +383,10 @@ func replaceWithSlash(t *testing.T) {
 					},
 				},
 			}},
-		},
-	}
+		})
 
-	vhost2 := &projcontour.HTTPProxy{
-		ObjectMeta: meta("default/host2"),
-		Spec: projcontour.HTTPProxySpec{
+	vhost2 := fixture.NewProxy("host2").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "host2.projectcontour.io",
 			},
@@ -412,8 +402,7 @@ func replaceWithSlash(t *testing.T) {
 					},
 				},
 			}},
-		},
-	}
+		})
 
 	rh.OnAdd(vhost1)
 	rh.OnAdd(vhost2)
@@ -506,7 +495,7 @@ func artifactoryDocker(t *testing.T) {
 	defer done()
 
 	rh.OnAdd(&v1.Service{
-		ObjectMeta: meta("artifactory/service"),
+		ObjectMeta: fixture.ObjectMeta("artifactory/service"),
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Protocol:   "TCP",
@@ -516,9 +505,8 @@ func artifactoryDocker(t *testing.T) {
 		},
 	})
 
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: meta("artifactory/routes"),
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("artifactory/routes").WithSpec(
+		projcontour.HTTPProxySpec{
 			Routes: []projcontour.Route{{
 				Services: []projcontour.Service{{
 					Name: "service",
@@ -533,12 +521,11 @@ func artifactoryDocker(t *testing.T) {
 					},
 				},
 			}},
-		},
-	})
+		}),
+	)
 
-	rh.OnAdd(&projcontour.HTTPProxy{
-		ObjectMeta: meta("artifactory/artifactory"),
-		Spec: projcontour.HTTPProxySpec{
+	rh.OnAdd(fixture.NewProxy("artifactory/artifactory").WithSpec(
+		projcontour.HTTPProxySpec{
 			VirtualHost: &projcontour.VirtualHost{
 				Fqdn: "artifactory.projectcontour.io",
 			},
@@ -548,8 +535,8 @@ func artifactoryDocker(t *testing.T) {
 				{Name: "routes", Conditions: conditions(prefixCondition("/v2/container-external"))},
 				{Name: "routes", Conditions: conditions(prefixCondition("/v2/container-public"))},
 			},
-		},
-	})
+		}),
+	)
 
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,

--- a/internal/fixture/httpproxy.go
+++ b/internal/fixture/httpproxy.go
@@ -1,0 +1,69 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+)
+
+// ProxyBuilder is a builder object to make creating HTTPProxy fixtures more succinct.
+type ProxyBuilder v1.HTTPProxy
+
+// NewProxy creates a new ProxyBuilder with the specified object name.
+func NewProxy(name string) *ProxyBuilder {
+	b := &ProxyBuilder{
+		ObjectMeta: ObjectMeta(name),
+	}
+
+	b.ObjectMeta.Annotations = map[string]string{}
+	b.ObjectMeta.Labels = map[string]string{}
+
+	return b
+}
+
+// Label adds the given values as metadata annotations.
+func (b *ProxyBuilder) Annotate(k string, v string) *ProxyBuilder {
+	b.ObjectMeta.Annotations[k] = v
+	return b
+}
+
+// Label adds the given values as metadata labels.
+func (b *ProxyBuilder) Label(k string, v string) *ProxyBuilder {
+	b.ObjectMeta.Labels[k] = v
+	return b
+}
+
+// WithSpec updates the builder's Spec field, returning the build proxy.
+func (b *ProxyBuilder) WithSpec(spec v1.HTTPProxySpec) *v1.HTTPProxy {
+	oldSpec := b.Spec
+
+	b.Spec = spec
+
+	// TODO(jpeach): use a full merge library so that updating
+	// fields then finishing with a spec is ordering insensitive.
+	if b.Spec.VirtualHost == nil {
+		b.Spec.VirtualHost = oldSpec.VirtualHost
+	}
+
+	return (*v1.HTTPProxy)(b)
+}
+
+func (b *ProxyBuilder) WithFQDN(fqdn string) *ProxyBuilder {
+	if b.Spec.VirtualHost == nil {
+		b.Spec.VirtualHost = &v1.VirtualHost{}
+	}
+
+	b.Spec.VirtualHost.Fqdn = fqdn
+	return b
+}

--- a/internal/fixture/meta.go
+++ b/internal/fixture/meta.go
@@ -1,0 +1,39 @@
+// Copyright © 2020 VMware
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ObjectMeta cracks a Kubernetes object name string of the form
+// "namespace/name" into a metav1.ObjectMeta struct. If the namespace
+// portion is omitted, then the default namespace is filled in.
+func ObjectMeta(name string) metav1.ObjectMeta {
+	v := strings.SplitN(name, "/", 2)
+	switch len(v) {
+	case 2:
+		return metav1.ObjectMeta{
+			Name:      v[1],
+			Namespace: v[0],
+		}
+	default:
+		return metav1.ObjectMeta{
+			Name:      v[0],
+			Namespace: metav1.NamespaceDefault,
+		}
+	}
+}


### PR DESCRIPTION
Add some simple helpers to generate HTTPProxy test fixtures. This
helps reduce some boilerplate in setting up test cases.

Signed-off-by: James Peach <jpeach@vmware.com>