### PR TITLE
internal: consolidate duplicate toAny functions

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -25,7 +25,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/contour"
@@ -33,6 +32,7 @@ import (
 	cgrpc "github.com/projectcontour/contour/internal/grpc"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/metrics"
+	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -208,16 +208,9 @@ func resources(t *testing.T, protos ...proto.Message) []*any.Any {
 	t.Helper()
 	var anys []*any.Any
 	for _, a := range protos {
-		anys = append(anys, toAny(t, a))
+		anys = append(anys, protobuf.MustMarshalAny(a))
 	}
 	return anys
-}
-
-func toAny(t *testing.T, pb proto.Message) *any.Any {
-	t.Helper()
-	a, err := ptypes.MarshalAny(pb)
-	check(t, err)
-	return a
 }
 
 type grpcStream interface {

--- a/internal/envoy/accesslog.go
+++ b/internal/envoy/accesslog.go
@@ -18,6 +18,7 @@ import (
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 //JSONFields is the canonical translation table for JSON fields to Envoy log template formats,
@@ -80,7 +81,7 @@ func FileAccessLogEnvoy(path string) []*accesslog.AccessLog {
 	return []*accesslog.AccessLog{{
 		Name: wellknown.FileAccessLog,
 		ConfigType: &accesslog.AccessLog_TypedConfig{
-			TypedConfig: toAny(&accesslogv2.FileAccessLog{
+			TypedConfig: protobuf.MustMarshalAny(&accesslogv2.FileAccessLog{
 				Path: path,
 				// AccessLogFormat left blank to defer to Envoy's default log format.
 			}),
@@ -108,7 +109,7 @@ func FileAccessLogJSON(path string, keys []string) []*accesslog.AccessLog {
 	return []*accesslog.AccessLog{{
 		Name: wellknown.FileAccessLog,
 		ConfigType: &accesslog.AccessLog_TypedConfig{
-			TypedConfig: toAny(&accesslogv2.FileAccessLog{
+			TypedConfig: protobuf.MustMarshalAny(&accesslogv2.FileAccessLog{
 				Path: path,
 				AccessLogFormat: &accesslogv2.FileAccessLog_JsonFormat{
 					JsonFormat: jsonformat,

--- a/internal/envoy/accesslog_test.go
+++ b/internal/envoy/accesslog_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 func TestFileAccessLog(t *testing.T) {
@@ -33,7 +34,7 @@ func TestFileAccessLog(t *testing.T) {
 			want: []*envoy_accesslog.AccessLog{{
 				Name: wellknown.FileAccessLog,
 				ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
-					TypedConfig: toAny(&accesslog_v2.FileAccessLog{
+					TypedConfig: protobuf.MustMarshalAny(&accesslog_v2.FileAccessLog{
 						Path: "/dev/stdout",
 					}),
 				},
@@ -60,7 +61,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 			want: []*envoy_accesslog.AccessLog{{
 				Name: wellknown.FileAccessLog,
 				ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
-					TypedConfig: toAny(&accesslog_v2.FileAccessLog{
+					TypedConfig: protobuf.MustMarshalAny(&accesslog_v2.FileAccessLog{
 						Path: "/dev/stdout",
 						AccessLogFormat: &accesslog_v2.FileAccessLog_JsonFormat{
 							JsonFormat: &_struct.Struct{
@@ -84,7 +85,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 			want: []*envoy_accesslog.AccessLog{{
 				Name: wellknown.FileAccessLog,
 				ConfigType: &envoy_accesslog.AccessLog_TypedConfig{
-					TypedConfig: toAny(&accesslog_v2.FileAccessLog{
+					TypedConfig: protobuf.MustMarshalAny(&accesslog_v2.FileAccessLog{
 						Path: "/dev/stdout",
 						AccessLogFormat: &accesslog_v2.FileAccessLog_JsonFormat{
 							JsonFormat: &_struct.Struct{

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -46,9 +46,6 @@ const sdsTLSCertificateFile = "xds-tls-certicate.json"
 // CA certificates for Envoy to use for the XDS gRPC connection.
 const sdsValidationContextFile = "xds-validation-context.json"
 
-// ConfigFiles is a map from configuration filename to configuration file content.
-type ConfigFiles map[string]proto.Message
-
 // WriteBootstrap writes bootstrap configuration to files.
 func WriteBootstrap(c *BootstrapConfig) error {
 	// Create Envoy bootstrap config and associated resource files.
@@ -58,7 +55,7 @@ func WriteBootstrap(c *BootstrapConfig) error {
 	}
 
 	if c.ResourcesDir != "" {
-		if err := os.MkdirAll(path.Join(c.ResourcesDir, "sds"), 0755); err != nil {
+		if err := os.MkdirAll(path.Join(c.ResourcesDir, "sds"), 0750); err != nil {
 			return err
 		}
 	}
@@ -283,7 +280,7 @@ func tlsCertificateSdsSecretConfig(c *BootstrapConfig) *api.DiscoveryResponse {
 	}
 
 	return &api.DiscoveryResponse{
-		Resources: []*any.Any{toAny(secret)},
+		Resources: []*any.Any{protobuf.MustMarshalAny(secret)},
 	}
 }
 
@@ -308,7 +305,7 @@ func validationContextSdsSecretConfig(c *BootstrapConfig) *api.DiscoveryResponse
 	}
 
 	return &api.DiscoveryResponse{
-		Resources: []*any.Any{toAny(secret)},
+		Resources: []*any.Any{protobuf.MustMarshalAny(secret)},
 	}
 }
 

--- a/internal/envoy/listener.go
+++ b/internal/envoy/listener.go
@@ -25,9 +25,6 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
@@ -156,7 +153,7 @@ func (b *httpConnectionManagerBuilder) Get() *envoy_api_v2_listener.Filter {
 	return &envoy_api_v2_listener.Filter{
 		Name: wellknown.HTTPConnectionManager,
 		ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-			TypedConfig: toAny(cm),
+			TypedConfig: protobuf.MustMarshalAny(cm),
 		},
 	}
 }
@@ -189,7 +186,7 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accesslogger []*accesslog.
 		return &envoy_api_v2_listener.Filter{
 			Name: wellknown.TCPProxy,
 			ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-				TypedConfig: toAny(&tcp.TcpProxy{
+				TypedConfig: protobuf.MustMarshalAny(&tcp.TcpProxy{
 					StatPrefix: statPrefix,
 					ClusterSpecifier: &tcp.TcpProxy_Cluster{
 						Cluster: Clustername(proxy.Clusters[0]),
@@ -215,7 +212,7 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accesslogger []*accesslog.
 		return &envoy_api_v2_listener.Filter{
 			Name: wellknown.TCPProxy,
 			ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-				TypedConfig: toAny(&tcp.TcpProxy{
+				TypedConfig: protobuf.MustMarshalAny(&tcp.TcpProxy{
 					StatPrefix: statPrefix,
 					ClusterSpecifier: &tcp.TcpProxy_WeightedClusters{
 						WeightedClusters: &tcp.TcpProxy_WeightedCluster{
@@ -303,12 +300,4 @@ func FilterChainTLS(domain string, downstream *envoy_api_v2_auth.DownstreamTlsCo
 // ListenerFilters returns a []*envoy_api_v2_listener.ListenerFilter for the supplied listener filters.
 func ListenerFilters(filters ...*envoy_api_v2_listener.ListenerFilter) []*envoy_api_v2_listener.ListenerFilter {
 	return filters
-}
-
-func toAny(pb proto.Message) *any.Any {
-	a, err := ptypes.MarshalAny(pb)
-	if err != nil {
-		panic(err.Error())
-	}
-	return a
 }

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -310,7 +310,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-					TypedConfig: toAny(&http.HttpConnectionManager{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
 						StatPrefix: "default/kuard",
 						RouteSpecifier: &http.HttpConnectionManager_Rds{
 							Rds: &http.Rds{
@@ -363,7 +363,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-					TypedConfig: toAny(&http.HttpConnectionManager{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
 						StatPrefix: "default/kuard",
 						RouteSpecifier: &http.HttpConnectionManager_Rds{
 							Rds: &http.Rds{
@@ -459,7 +459,7 @@ func TestTCPProxy(t *testing.T) {
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.TCPProxy,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-					TypedConfig: toAny(&envoy_config_v2_tcpproxy.TcpProxy{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_config_v2_tcpproxy.TcpProxy{
 						StatPrefix: statPrefix,
 						ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
 							Cluster: Clustername(c1),
@@ -477,7 +477,7 @@ func TestTCPProxy(t *testing.T) {
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.TCPProxy,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-					TypedConfig: toAny(&envoy_config_v2_tcpproxy.TcpProxy{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_config_v2_tcpproxy.TcpProxy{
 						StatPrefix: statPrefix,
 						ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_WeightedClusters{
 							WeightedClusters: &envoy_config_v2_tcpproxy.TcpProxy_WeightedCluster{

--- a/internal/envoy/socket.go
+++ b/internal/envoy/socket.go
@@ -16,6 +16,7 @@ package envoy
 import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 // UpstreamTLSTransportSocket returns a custom transport socket using the UpstreamTlsContext provided.
@@ -23,7 +24,7 @@ func UpstreamTLSTransportSocket(tls *envoy_api_v2_auth.UpstreamTlsContext) *envo
 	return &envoy_api_v2_core.TransportSocket{
 		Name: "envoy.transport_sockets.tls",
 		ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-			TypedConfig: toAny(tls),
+			TypedConfig: protobuf.MustMarshalAny(tls),
 		},
 	}
 }
@@ -33,7 +34,7 @@ func DownstreamTLSTransportSocket(tls *envoy_api_v2_auth.DownstreamTlsContext) *
 	return &envoy_api_v2_core.TransportSocket{
 		Name: "envoy.transport_sockets.tls",
 		ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-			TypedConfig: toAny(tls),
+			TypedConfig: protobuf.MustMarshalAny(tls),
 		},
 	}
 }

--- a/internal/envoy/socket_test.go
+++ b/internal/envoy/socket_test.go
@@ -20,6 +20,7 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,7 +35,7 @@ func TestUpstreamTLSTransportSocket(t *testing.T) {
 			want: &envoy_api_v2_core.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-					TypedConfig: toAny(UpstreamTLSContext(nil, "", "h2")),
+					TypedConfig: protobuf.MustMarshalAny(UpstreamTLSContext(nil, "", "h2")),
 				},
 			},
 		},
@@ -70,7 +71,7 @@ func TestDownstreamTLSTransportSocket(t *testing.T) {
 			want: &envoy_api_v2_core.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-					TypedConfig: toAny(DownstreamTLSContext(serverSecret, envoy_api_v2_auth.TlsParameters_TLSv1_1, nil, "client-subject-name", "h2", "http/1.1")),
+					TypedConfig: protobuf.MustMarshalAny(DownstreamTLSContext(serverSecret, envoy_api_v2_auth.TlsParameters_TLSv1_1, nil, "client-subject-name", "h2", "http/1.1")),
 				},
 			},
 		},

--- a/internal/envoy/stats.go
+++ b/internal/envoy/stats.go
@@ -32,7 +32,7 @@ func StatsListener(address string, port int) *v2.Listener {
 			&envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-					TypedConfig: toAny(&http.HttpConnectionManager{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
 						StatPrefix: "stats",
 						RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
 							RouteConfig: &v2.RouteConfiguration{

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -41,7 +41,7 @@ func TestStatsListener(t *testing.T) {
 					&envoy_api_v2_listener.Filter{
 						Name: wellknown.HTTPConnectionManager,
 						ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-							TypedConfig: toAny(&http.HttpConnectionManager{
+							TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
 								StatPrefix: "stats",
 								RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
 									RouteConfig: &v2.RouteConfiguration{

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -16,7 +16,6 @@ package featuretests
 // envoy helpers
 
 import (
-	"testing"
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -233,11 +232,11 @@ func filterchaintls(domain string, secret *v1.Secret, filter *envoy_api_v2_liste
 	}
 }
 
-func tcpproxy(t *testing.T, statPrefix, cluster string) *envoy_api_v2_listener.Filter {
+func tcpproxy(statPrefix, cluster string) *envoy_api_v2_listener.Filter {
 	return &envoy_api_v2_listener.Filter{
 		Name: wellknown.TCPProxy,
 		ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
-			TypedConfig: toAny(t, &envoy_config_v2_tcpproxy.TcpProxy{
+			TypedConfig: protobuf.MustMarshalAny(&envoy_config_v2_tcpproxy.TcpProxy{
 				StatPrefix: statPrefix,
 				ClusterSpecifier: &envoy_config_v2_tcpproxy.TcpProxy_Cluster{
 					Cluster: cluster,

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -26,7 +26,6 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
@@ -237,16 +236,9 @@ func resources(t *testing.T, protos ...proto.Message) []*any.Any {
 	t.Helper()
 	anys := make([]*any.Any, 0, len(protos))
 	for _, pb := range protos {
-		anys = append(anys, toAny(t, pb))
+		anys = append(anys, protobuf.MustMarshalAny(pb))
 	}
 	return anys
-}
-
-func toAny(t *testing.T, pb proto.Message) *any.Any {
-	t.Helper()
-	a, err := ptypes.MarshalAny(pb)
-	check(t, err)
-	return a
 }
 
 type grpcStream interface {

--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -90,7 +90,7 @@ func TestTCPProxy(t *testing.T) {
 			&v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -144,7 +144,7 @@ func TestTCPProxy(t *testing.T) {
 			&v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -234,7 +234,7 @@ func TestTCPProxyDelegation(t *testing.T) {
 			&v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -297,7 +297,7 @@ func TestTCPProxyDelegation(t *testing.T) {
 			&v2.Listener{
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "app/backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "app/backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -374,7 +374,7 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					Filters: envoy.Filters(
-						tcpproxy(t, "ingress_https", "default/correct-backend/80/da39a3ee5e"),
+						tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"),
 					),
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"kuard-tcp.example.com"},
@@ -435,7 +435,7 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					Filters: envoy.Filters(
-						tcpproxy(t, "ingress_https", "default/correct-backend/80/da39a3ee5e"),
+						tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"),
 					),
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"kuard-tcp.example.com"},
@@ -526,10 +526,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 				FilterChains: filterchaintls(
 					"k8s.run.ubisoft.org",
 					s1,
-					tcpproxy(t,
-						"ingress_https",
-						svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e",
-					),
+					tcpproxy("ingress_https", svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e"),
 					nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
@@ -635,7 +632,7 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 				// kuard-tcp.example.com:443 terminated at envoy then forwarded to default/backend:80
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -738,7 +735,7 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 				// kuard-tcp.example.com:443 terminated at envoy then tcpproxied to default/backend:80
 				Name:         "ingress_https",
 				Address:      envoy.SocketAddress("0.0.0.0", 8443),
-				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy(t, "ingress_https", "default/backend/80/da39a3ee5e"), nil),
+				FilterChains: filterchaintls("kuard-tcp.example.com", s1, tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"), nil),
 				ListenerFilters: envoy.ListenerFilters(
 					envoy.TLSInspector(),
 				),
@@ -836,7 +833,7 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					Filters: envoy.Filters(
-						tcpproxy(t, "ingress_https", "default/backend/80/da39a3ee5e"),
+						tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"),
 					),
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"kuard-tcp.example.com"},
@@ -940,7 +937,7 @@ func TestTCPProxyTLSPassthroughAndHTTPServicePermitInsecure(t *testing.T) {
 				Address: envoy.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					Filters: envoy.Filters(
-						tcpproxy(t, "ingress_https", "default/backend/80/da39a3ee5e"),
+						tcpproxy("ingress_https", "default/backend/80/da39a3ee5e"),
 					),
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"kuard-tcp.example.com"},

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
 )
@@ -61,4 +63,15 @@ func AsMessages(messages interface{}) []proto.Message {
 	}
 
 	return protos
+}
+
+// MustMarshalAny marshals a protobug into an any.Any type, panicing
+// if that operation fails.
+func MustMarshalAny(pb proto.Message) *any.Any {
+	a, err := ptypes.MarshalAny(pb)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return a
 }


### PR DESCRIPTION
Create a `protobuf.MustMarshalAny` wrapper and use it to replace
local copies of the `toAny` helper function.

This fixes #2493.

Signed-off-by: James Peach <jpeach@vmware.com>