### PR TITLE
internal: add gosec to the linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,12 @@ run:
 
 linters:
   enable:
-  - goimports
-  - misspell
-  - unparam
-  - unconvert
   - bodyclose
+  - goimports
+  - gosec
+  - misspell
+  - unconvert
+  - unparam
 
 # TODO(jpeach): enable these later:
 #  - gocyclo

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -332,7 +332,7 @@ func tryConnect(address string, clientCredentialsDir string) (*x509.Certificate,
 	clientConfig := &tls.Config{
 		ServerName:         "localhost",
 		Certificates:       []tls.Certificate{cert},
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // nolint:gosec
 	}
 	conn, err := tls.Dial("tcp", address, clientConfig)
 	if err != nil {

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -12,7 +12,7 @@ if command -v docker >/dev/null; then
 		--rm \
 		--volume $(pwd):/app \
 		--workdir /app \
-		golangci/golangci-lint:v1.23.8 ${PROGNAME} "$@"
+		golangci/golangci-lint:v1.27.0 ${PROGNAME} "$@"
 fi
 
 cat <<EOF

--- a/internal/certgen/makecerts.go
+++ b/internal/certgen/makecerts.go
@@ -16,7 +16,7 @@ package certgen
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -129,8 +129,16 @@ func newSerial(now time.Time) *big.Int {
 	return big.NewInt(int64(now.Nanosecond()))
 }
 
+// bigIntHash generates a SubjectKeyId by hashing the modulus of the private
+// key. This isn't one of the methods listed in RFC 5280 4.2.1.2, but that also
+// notes that other methods are acceptable.
+//
+// gosec makes a blanket claim that SHA-1 is unacceptable, which is
+// false here. The core Go method of generations the SubjectKeyId (see
+// https://github.com/golang/go/issues/26676) also uses SHA-1, as recommended
+// by RFC 5280.
 func bigIntHash(n *big.Int) []byte {
-	h := sha1.New()
+	h := sha1.New()    // nolint:gosec
 	h.Write(n.Bytes()) // nolint:errcheck
 	return h.Sum(nil)
 }

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -14,7 +14,7 @@
 package envoy
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"crypto/sha256"
 	"fmt"
 	"strconv"
@@ -182,7 +182,9 @@ func Clustername(cluster *dag.Cluster) string {
 		buf += uv.SubjectName
 	}
 
-	hash := sha1.Sum([]byte(buf))
+	// This isn't a crypto hash, we just want a unique name.
+	hash := sha1.Sum([]byte(buf)) // nolint:gosec
+
 	ns := service.Namespace
 	name := service.Name
 	return hashname(60, ns, name, strconv.Itoa(int(service.Port)), fmt.Sprintf("%x", hash[:5]))

--- a/internal/envoy/secret.go
+++ b/internal/envoy/secret.go
@@ -14,7 +14,7 @@
 package envoy
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"fmt"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -24,7 +24,8 @@ import (
 
 // Secretname returns the name of the SDS secret for this secret.
 func Secretname(s *dag.Secret) string {
-	hash := sha1.Sum(s.Cert())
+	// This isn't a crypto hash, we just want a unique name.
+	hash := sha1.Sum(s.Cert()) // nolint:gosec
 	ns := s.Namespace()
 	name := s.Name()
 	return hashname(60, ns, name, fmt.Sprintf("%x", hash[:5]))

--- a/internal/workgroup/example_test.go
+++ b/internal/workgroup/example_test.go
@@ -83,7 +83,7 @@ func ExampleGroup_Run_multipleListeners() {
 
 	// listen on port 80
 	g.Add(func(stop <-chan struct{}) error {
-		l, err := net.Listen("tcp", ":80")
+		l, err := net.Listen("tcp", ":80") // nolint:gosec
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func ExampleGroup_Run_multipleListeners() {
 
 	// listen on port 443
 	g.Add(func(stop <-chan struct{}) error {
-		l, err := net.Listen("tcp", ":443")
+		l, err := net.Listen("tcp", ":443") // nolint:gosec
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
All the issues currently flagged by gosec are false positives,
but there's no real harm in adding it to the lint checks.

This fixes #2525.

Signed-off-by: James Peach <jpeach@vmware.com>