### PR TITLE
internal/dag: update TLS fallbackCertificate logic to require tlscertificatedelegation

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -534,11 +534,17 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 					return
 				}
 
-				sec, err = b.lookupSecret(k8s.FullName{Name: b.FallbackCertificate.Name, Namespace: b.FallbackCertificate.Namespace}, validSecret)
+				sec, err = b.lookupSecret(*b.FallbackCertificate, validSecret)
 				if err != nil {
-					sw.SetInvalid("Spec.Virtualhost.TLS fallback certificate Secret %q is invalid: %s", b.FallbackCertificate, err)
+					sw.SetInvalid("Spec.Virtualhost.TLS Secret %q fallback certificate is invalid: %s", b.FallbackCertificate, err)
 					return
 				}
+
+				if !b.delegationPermitted(*b.FallbackCertificate, proxy.Namespace) {
+					sw.SetInvalid("Spec.VirtualHost.TLS fallback Secret %q is not configured for certificate delegation", b.FallbackCertificate)
+					return
+				}
+
 				svhost.FallbackCertificate = sec
 			}
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2653,7 +2653,7 @@ func TestDAGStatus(t *testing.T) {
 			},
 			objs: []interface{}{fallbackCertificate, fallbackSecret, sec1, s4},
 			want: map[k8s.FullName]Status{
-				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS fallback certificate Secret \"invalid/invalid\" is invalid: Secret not found", Vhost: "example.com"},
+				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS Secret \"invalid/invalid\" fallback certificate is invalid: Secret not found", Vhost: "example.com"},
 			},
 		},
 		"fallback certificate requested but cert not configured in contour": {


### PR DESCRIPTION
Updates #1503 by requiring TLSCertificateDelegation to each namespace where a root HTTPProxy enables tls fallback certificate.

Signed-off-by: Steve Sloka <slokas@vmware.com>