### PR TITLE
docs: add fallback certificate docs

### DIFF
--- a/site/docs/master/configuration.md
+++ b/site/docs/master/configuration.md
@@ -24,6 +24,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | request-timeout | [duration][4] | `0s` | This field specifies the default request timeout as a Go duration string. Zero means there is no timeout. |
 | tls | TLS | | The default [TLS configuration](#tls-configuration). |
 {: class="table thead-dark table-bordered"}
+<br>
 
 ### TLS Configuration
 
@@ -33,7 +34,18 @@ Contour should provision TLS hosts.
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | minimum-protocol-version| string | `""` | This field specifies the minimum TLS protocol version that is allowed. Valid options are `1.2` and `1.3`. Any other value defaults to TLS 1.1. |
+| fallback-certificate | | | [Fallback certificate configuration](#fallback-certificate). |
 {: class="table thead-dark table-bordered"}
+<br>
+
+### Fallback Certificate
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| name       | string | `""` | This field specifies the name of the Kubernetes secret to use as the fallback certificate.      |
+| namespace  | string | `""` | This field specifies the namespace of the Kubernetes secret to use as the fallback certificate. |
+{: class="table thead-dark table-bordered"}
+<br>
 
 ### Leader Election Configuration
 
@@ -49,6 +61,7 @@ In the vast majority of deployments, only the `configmap-name` and `configmap-na
 | renew-deadline | [duration][4] | `10s` | The length of time that the leader will retry refreshing leadership before giving up. |
 | retry-period | [duration][4] | `2s` | The interval at which Contour will attempt to the acquire leadership lease. |
 {: class="table thead-dark table-bordered"}
+<br>
 
 ### Configuration Example
 
@@ -73,6 +86,9 @@ data:
     tls:
       # minimum TLS version that Contour will negotiate
       # minimumProtocolVersion: "1.1"
+      fallback-certificate:
+      # name: fallback-secret-name
+      # namespace: projectcontour
     # The following config shows the defaults for the leader election.
     # leaderelection:
       # configmap-name: leader-elect


### PR DESCRIPTION
Updates #1503 by adding fallback certificate documentation.

Signed-off-by: Steve Sloka <slokas@vmware.com>