### PR TITLE
add missing projectcontour.io/ingress.class annotation tests

### DIFF
--- a/internal/annotation/annotations_test.go
+++ b/internal/annotation/annotations_test.go
@@ -496,6 +496,18 @@ func TestMatchIngressClass(t *testing.T) {
 			},
 			want: []bool{false, false},
 		},
+		"ingress nginx projectcontour.io/ingress.class": {
+			fixture: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: []bool{false, false},
+		},
 		"ingress contour kubernetes.io/ingress.class": {
 			fixture: &v1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
@@ -515,6 +527,18 @@ func TestMatchIngressClass(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"contour.heptio.com/ingress.class": DEFAULT_INGRESS_CLASS,
+					},
+				},
+			},
+			want: []bool{true, true},
+		},
+		"ingress contour projectcontour.io/ingress.class": {
+			fixture: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -580,6 +580,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: false,
 		},
+		"insert ingress incorrect projectcontour.io/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
 		"insert ingress explicit kubernetes.io/ingress.class": {
 			obj: &v1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
@@ -599,6 +611,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"contour.heptio.com/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
+					},
+				},
+			},
+			want: true,
+		},
+		"insert ingress explicit projectcontour.io/ingress.class": {
+			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "incorrect",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -637,6 +661,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: false,
 		},
+		"insert ingressroute incorrect projectcontour.io/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
 		"insert ingressroute: explicit contour.heptio.com/ingress.class": {
 			obj: &ingressroutev1.IngressRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -656,6 +692,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"kubernetes.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
+					},
+				},
+			},
+			want: true,
+		},
+		"insert ingressroute explicit projectcontour.io/ingress.class": {
+			obj: &ingressroutev1.IngressRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},
@@ -694,6 +742,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: false,
 		},
+		"insert httpproxy incorrect projectcontour.io/ingress.class": {
+			obj: &projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "simple",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontour.io/ingress.class": "nginx",
+					},
+				},
+			},
+			want: false,
+		},
 		"insert httpproxy: explicit contour.heptio.com/ingress.class": {
 			obj: &projcontour.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
@@ -713,6 +773,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Namespace: "default",
 					Annotations: map[string]string{
 						"kubernetes.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
+					},
+				},
+			},
+			want: true,
+		},
+		"insert httpproxy explicit projectcontour.io/ingress.class": {
+			obj: &projcontour.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuard",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"projectcontours.io/ingress.class": annotation.DEFAULT_INGRESS_CLASS,
 					},
 				},
 			},


### PR DESCRIPTION
Working on `v1beta1.Ingress.Spec.IngressClassName`, found a bunch of missing tests for the `projectcontour.io/ingress.class` annotation. 

Signed-off-by: Steve Sloka <slokas@vmware.com>