### PR TITLE
cmd/contour: support comma-separated ingress-status-address

### DIFF
--- a/cmd/contour/ingressstatus_test.go
+++ b/cmd/contour/ingressstatus_test.go
@@ -59,6 +59,94 @@ func Test_parseStatusFlag(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "WhitespacePadded",
+			status: "  anarbitrarystring      ",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						Hostname: "anarbitrarystring",
+					},
+				},
+			},
+		},
+		{
+			name:   "Empty",
+			status: "",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{},
+			},
+		},
+		{
+			name:   "EmptyComma",
+			status: ",",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{},
+			},
+		},
+		{
+			name:   "EmptySpace",
+			status: "    ",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{},
+			},
+		},
+		{
+			name:   "SingleComma",
+			status: "10.0.0.1,",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+				},
+			},
+		},
+		{
+			name:   "SingleCommaBefore",
+			status: ",10.0.0.1",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+				},
+			},
+		},
+		{
+			name:   "Multi",
+			status: "10.0.0.1,2001:4860:4860::8888,anarbitrarystring",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+					{
+						IP: "2001:4860:4860::8888",
+					},
+					{
+						Hostname: "anarbitrarystring",
+					},
+				},
+			},
+		},
+		{
+			name:   "MultiSpace",
+			status: "10.0.0.1, 2001:4860:4860::8888, anarbitrarystring",
+			want: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+					{
+						IP: "2001:4860:4860::8888",
+					},
+					{
+						Hostname: "anarbitrarystring",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When using a cluster without a LoadBalancer, it's common to configure
Envoy to use host networking and to run on some number of nodes (maybe
all of them, using a DaemonSet).

In that case, Contour won't pick up the IP addresses automatically as
there's no LoadBalancer; one approach to working around this is to
supply the --ingress-status-address argument, but this only supported
a single address.

This changeset adds support for multiple addresses, separated by
commas.

Fixes #2540

Signed-off-by: Alastair Houghton <alastair@alastairs-place.net>