### PR TITLE
test: switch to IfNotPresent image pull policy

### DIFF
--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1455,7 +1455,7 @@ spec:
         # just by applying the deployment YAML.
         # See #2423, #2395, #2150, and #2030 for earlier questions about this.
         image: docker.io/projectcontour/contour:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         command:
         - contour
         - certgen


### PR DESCRIPTION
When deploying release builds, Contour images are tagged with the release
version and are intended to be immutable. This means we can generally use
the `IfNotPresent` image pull policy, except for cthe certgen job, which
needs to use `Always` because it pulls the mutable `:latest` image tag.

This fixes #2537.

Signed-off-by: James Peach <jpeach@vmware.com>