### PR TITLE
examples/contour: grant update to certgen RBAC

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -30,13 +30,8 @@ rules:
   resources:
   - secrets
   verbs:
-  - list
-  - watch
   - create
-  - get
-  - put
-  - post
-  - patch
+  - update
 ---
 apiVersion: batch/v1
 kind: Job

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1387,13 +1387,8 @@ rules:
   resources:
   - secrets
   verbs:
-  - list
-  - watch
   - create
-  - get
-  - put
-  - post
-  - patch
+  - update
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
The RBAC verbs for certgen are both too permissive (e.g. it doesn't
need watch or list) and too restrictive (and upcoming change will let
it update secrets).

This fixes #2538.

Signed-off-by: James Peach <jpeach@vmware.com>