### PR TITLE
site: add versioned quickstart redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,3 +16,20 @@
 # Reference documentation
 # Optimization blog post: https://www.netlify.com/blog/2019/08/05/control-your-asset-optimization-settings-from-netlify.toml/
 # How to guide: https://docs.netlify.com/configure-builds/file-based-configuration/#post-processing
+
+# Redirect /quickstart/contour.yaml to the deployment that matches :latest.
+#
+# kubectl apply https://projectcontour.io/quickstart/contour.yaml
+[[redirects]]
+  from = "/quickstart/contour.yaml"
+  to = "https://raw.githubusercontent.com/projectcontour/contour/release-1.4/examples/render/contour.yaml"
+  status = 302
+
+# Redirect versioned quickstarts so that they can easily be referenced by
+# operators or for upgrade testing.
+#
+# kubectl apply https://projectcontour.io/quickstart/v1.4.0/contour.yaml
+[[redirects]]
+  from = "/quickstart/*/contour.yaml"
+  to = "https://raw.githubusercontent.com/projectcontour/contour/:splat/examples/render/contour.yaml"
+  status = 302

--- a/site/_redirects
+++ b/site/_redirects
@@ -1,3 +1,0 @@
-# redirect /quickstart/contour.yaml to the deployment that matches :latest
-# kubectl apply https://projectcontour.io/quickstart/contour.yaml
-/quickstart/contour.yaml	https://raw.githubusercontent.com/projectcontour/contour/release-1.4/examples/render/contour.yaml	302

--- a/site/_resources/release-process.md
+++ b/site/_resources/release-process.md
@@ -143,7 +143,7 @@ If you've made a production release (that is, a final release or a patch release
 ### Updating site details
 
 The quickstart url, https://projectcontour.io/quickstart/contour.yaml redirects to the current stable release.
-This is controlled by a line in `site/_redirects`. If the definition of `:latest` has changed, update the quickstart redirector to match.
+This is controlled by the `[[redirects]]` section in `netlify.toml`. If the definition of `:latest` has changed, update the quickstart redirector to match.
 
 You also need to set the variable `latest` in `site/_config.yml` to the released version for the site to work correctly.
 

--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -39,7 +39,7 @@ Then the simplest way to upgrade to 1.4.0 is to delete the `projectcontour` name
 
 ```
 $ kubectl delete namespace projectcontour
-$ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+$ kubectl apply -f {{site.url}}/quickstart/v1.4.0/contour.yaml
 ```
 
 This will remove both the Envoy and Contour pods from your cluster and recreate them with the updated configuration.
@@ -96,7 +96,7 @@ Then the simplest way to upgrade to 1.3.0 is to delete the `projectcontour` name
 
 ```
 $ kubectl delete namespace projectcontour
-$ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+$ kubectl apply -f {{site.url}}/quickstart/v1.3.0/contour.yaml
 ```
 
 This will remove both the Envoy and Contour pods from your cluster and recreate them with the updated configuration.
@@ -135,7 +135,7 @@ From the root directory of the repository:
 
 ```
 $ kubectl delete namespace projectcontour
-$ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+$ kubectl apply -f {{site.url}}/quickstart/v1.2.1/contour.yaml
 ```
 
 This will remove both the Envoy and Contour pods from your cluster and recreate them with the updated configuration.
@@ -181,7 +181,7 @@ From the root directory of the repository:
 
 ```
 $ kubectl delete namespace projectcontour
-$ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+$ kubectl apply -f {{site.url}}/quickstart/v1.2.1/contour.yaml
 ```
 
 This will remove both the Envoy and Contour pods from your cluster and recreate them with the updated configuration.
@@ -269,7 +269,7 @@ Contour 1.0.1 is the current stable release.
 If you are running Contour 1.0.0, the easy way to upgrade to Contour 1.0.1 is to reapply the [quickstart yaml][16].
 
 ```bash
-$ kubectl apply -f {{ site.url }}/quickstart/contour.yaml
+$ kubectl apply -f {{site.url}}/quickstart/v1.0.1/contour.yaml
 ```
 
 ## The less easy way
@@ -618,6 +618,6 @@ $ kubectl get configmap -n heptio-contour -o yaml contour
 [15]: https://www.envoyproxy.io/docs/envoy/v1.12.2/intro/version_history
 [16]: {% link getting-started.md %}
 [17]: https://www.envoyproxy.io/docs/envoy/v1.13.1/intro/version_history
-[18]: https://projectcontour.io/quickstart/contour.yaml
+[18]: https://projectcontour.io/quickstart/{{site.latest}}/contour.yaml
 [19]: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/envoy-announce/sVqmxy0un2s/8aq430xiHAAJ
 [20]: https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/version_history


### PR DESCRIPTION
Add netlify redirects to the versioned quickstart YAML. This improves
the deployment experience for operators pinning to Contour versions,
and for testers verifying upgrades.

Signed-off-by: James Peach <jpeach@vmware.com>