### PR TITLE
examples/contour: switch to reloadable xDS certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - $HOME/bin/kind create cluster --wait 2m
     - $HOME/bin/kind load docker-image docker.io/projectcontour/contour:master
     - $HOME/bin/kind load docker-image docker.io/projectcontour/contour:latest
-    - $HOME/bin/kubectl apply -f examples/render/contour.yaml
+    - '$HOME/bin/kubectl apply -f <(sed "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" < examples/render/contour.yaml)'
     - $HOME/bin/kubectl wait --timeout=2m -n projectcontour -l app=contour deployments --for=condition=Available
     - $HOME/bin/kubectl wait --timeout=2m -n projectcontour -l app=envoy pods --for=condition=Ready
     - $HOME/bin/kind delete cluster

--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen
+  name: contour-certgen-v1.5.0
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -56,8 +56,10 @@ spec:
         command:
         - contour
         - certgen
-        - --incluster
         - --kube
+        - --incluster
+        - --overwrite
+        - --secrets-format=compact
         - --namespace=$(CONTOUR_NAMESPACE)
         env:
         - name: CONTOUR_NAMESPACE

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -42,7 +42,7 @@ spec:
         - --xds-port=8001
         - --envoy-service-http-port=80
         - --envoy-service-https-port=443
-        - --contour-cafile=/ca/cacert.pem
+        - --contour-cafile=/certs/ca.crt
         - --contour-cert-file=/certs/tls.crt
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
@@ -70,9 +70,6 @@ spec:
           - name: contourcert
             mountPath: /certs
             readOnly: true
-          - name: cacert
-            mountPath: /ca
-            readOnly: true
           - name: contour-config
             mountPath: /config
             readOnly: true
@@ -97,9 +94,6 @@ spec:
         - name: contourcert
           secret:
             secretName: contourcert
-        - name: cacert
-          secret:
-            secretName: cacert
         - name: contour-config
           configMap:
             name: contour

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -86,8 +86,6 @@ spec:
             mountPath: /config
           - name: envoycert
             mountPath: /certs
-          - name: cacert
-            mountPath: /ca
         lifecycle:
           preStop:
             httpGet:
@@ -100,7 +98,8 @@ spec:
         - /config/envoy.json
         - --xds-address=contour
         - --xds-port=8001
-        - --envoy-cafile=/ca/cacert.pem
+        - --resources-dir=/config/resources
+        - --envoy-cafile=/certs/ca.crt
         - --envoy-cert-file=/certs/tls.crt
         - --envoy-key-file=/certs/tls.key
         command:
@@ -113,9 +112,6 @@ spec:
           mountPath: /config
         - name: envoycert
           mountPath: /certs
-          readOnly: true
-        - name: cacert
-          mountPath: /ca
           readOnly: true
         env:
         - name: CONTOUR_NAMESPACE
@@ -130,7 +126,4 @@ spec:
         - name: envoycert
           secret:
             secretName: envoycert
-        - name: cacert
-          secret:
-            secretName: cacert
       restartPolicy: Always

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1439,7 +1439,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen
+  name: contour-certgen-v1.5.0
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -1459,8 +1459,10 @@ spec:
         command:
         - contour
         - certgen
-        - --incluster
         - --kube
+        - --incluster
+        - --overwrite
+        - --secrets-format=compact
         - --namespace=$(CONTOUR_NAMESPACE)
         env:
         - name: CONTOUR_NAMESPACE
@@ -1696,7 +1698,7 @@ spec:
         - --xds-port=8001
         - --envoy-service-http-port=80
         - --envoy-service-https-port=443
-        - --contour-cafile=/ca/cacert.pem
+        - --contour-cafile=/certs/ca.crt
         - --contour-cert-file=/certs/tls.crt
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
@@ -1724,9 +1726,6 @@ spec:
           - name: contourcert
             mountPath: /certs
             readOnly: true
-          - name: cacert
-            mountPath: /ca
-            readOnly: true
           - name: contour-config
             mountPath: /config
             readOnly: true
@@ -1751,9 +1750,6 @@ spec:
         - name: contourcert
           secret:
             secretName: contourcert
-        - name: cacert
-          secret:
-            secretName: cacert
         - name: contour-config
           configMap:
             name: contour
@@ -1849,8 +1845,6 @@ spec:
             mountPath: /config
           - name: envoycert
             mountPath: /certs
-          - name: cacert
-            mountPath: /ca
         lifecycle:
           preStop:
             httpGet:
@@ -1863,7 +1857,8 @@ spec:
         - /config/envoy.json
         - --xds-address=contour
         - --xds-port=8001
-        - --envoy-cafile=/ca/cacert.pem
+        - --resources-dir=/config/resources
+        - --envoy-cafile=/certs/ca.crt
         - --envoy-cert-file=/certs/tls.crt
         - --envoy-key-file=/certs/tls.key
         command:
@@ -1876,9 +1871,6 @@ spec:
           mountPath: /config
         - name: envoycert
           mountPath: /certs
-          readOnly: true
-        - name: cacert
-          mountPath: /ca
           readOnly: true
         env:
         - name: CONTOUR_NAMESPACE
@@ -1893,7 +1885,4 @@ spec:
         - name: envoycert
           secret:
             secretName: envoycert
-        - name: cacert
-          secret:
-            secretName: cacert
       restartPolicy: Always


### PR DESCRIPTION
Switch the certgen xDS certificate generation over to using certificates
that are compatible with certificate-manager. This requires the certgen
job to run again, which means we have to give is a unique name. Using
a version-locked name will let it run on each upgrade, which will have
the beneficial side-effect of rotating the xDS certificates.

The envoy and contour pods will restart because the secrets mounts change,
but they will restart at release time anyway because the container image
will change.

After this change, re-running certgen to rotate the xDS certificates
will not require restarting and pods.

This fixes #2524.
This updates #2143.

Signed-off-by: James Peach <jpeach@vmware.com>