### PR TITLE
docs: make proofing changes to TLS howto

### DIFF
--- a/examples/contour/README.md
+++ b/examples/contour/README.md
@@ -12,12 +12,9 @@ This configuration has several advantages:
 - Contour is run as Deployment and Envoy as a Daemonset
 - Envoy runs on host networking
 - Envoy runs on ports 80 & 443
-- In our example deployment, the following certificates must be present as Secrets in the `projectcontour` namespace for the example YAMLs to apply:
-  - `cacert`: must contain a `cacert.pem` key that contains a CA certificate that signs the other certificates.
-  - `contourcert`: be a Secret of type `kubernetes.io/tls` and must contain `tls.crt` and `tls.key` keys that contain a certificate and key for Contour. The certificate must be valid for the name `contour` either via CN or SAN.
-  - `envoycert`: be a Secret of type `kubernetes.io/tls` and must contain `tls.crt` and `tls.key` keys that contain a certificate and key for Envoy.
 
-For detailed instructions on how to configure the required certs manually, see the [step-by-step TLS HOWTO](https://projectcontour.io/docs/master/grpc-tls-howto).
+The TLS secrets used to secure the gRPC session between Contour and Envoy are generated using a Job that runs `contour certgen`.
+For detailed instructions on how to configure the required secrets manually, see the [step-by-step TLS HOWTO](https://projectcontour.io/docs/master/grpc-tls-howto).
 
 ## Deploy Contour
 


### PR DESCRIPTION
This makes some purely proofreading changes to the TLS howto, making
minor grammar and formatting improvements.

Signed-off-by: James Peach <jpeach@vmware.com>