### PR TITLE
envoy config: Don't mount service account token

### DIFF
--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -118,6 +118,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      automountServiceAccountToken: false
       serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1877,6 +1877,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      automountServiceAccountToken: false
       serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:


### PR DESCRIPTION
Envoy does not need to talk to kubernetes apiserver, hence disable
mounting service account in the envoy container.

This still enables the pod to acquire identity for mechanisms like
PodSecurityPolicy.

Related https://github.com/projectcontour/contour/issues/1896