### PR TITLE
Change order of creation of echo http proxy resource in 010-include-prefix-condition test

### DIFF
--- a/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
+++ b/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
@@ -55,25 +55,6 @@ $apply:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-   name: echo
-spec:
-  virtualhost:
-    fqdn: echo.projectcontour.io
-  includes:
-  - name: echo-app
-    namespace: app
-    conditions:
-    - prefix: /
-  - name: echo-admin
-    namespace: admin
-    conditions:
-    - prefix: /admin
-
----
-
-apiVersion: projectcontour.io/v1
-kind: HTTPProxy
-metadata:
   name: echo-app
   namespace: app
 spec:
@@ -94,6 +75,25 @@ spec:
   - services:
     - name: echo-admin
       port: 80
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+   name: echo
+spec:
+  virtualhost:
+    fqdn: echo.projectcontour.io
+  includes:
+  - name: echo-app
+    namespace: app
+    conditions:
+    - prefix: /
+  - name: echo-admin
+    namespace: admin
+    conditions:
+    - prefix: /admin
 
 ---
 


### PR DESCRIPTION
In 010-include-prefix-condition.yaml test , echo http proxy is created before echo-admin and echo-app which are its dependencies. So, the echo http proxy resource initially goes into invalid state since its dependencies are not there. Changing the order of creation of echo http proxy resource avoids the echo http proxy going into invalid state .