### PR TITLE
cmd/contour: exclusively use dynamic Informers

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -97,7 +97,7 @@ func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 			}
 
 			// Create new informer for the new LoadBalancerStatus
-			factory := isw.clients.NewDynamicInformerFactory()
+			factory := isw.clients.NewInformerFactory()
 			factory.ForResource(v1beta1.SchemeGroupVersion.WithResource("ingresses")).Informer().AddEventHandler(sau)
 			factory.ForResource(projcontour.HTTPProxyGVR).Informer().AddEventHandler(sau)
 

--- a/internal/k8s/clients.go
+++ b/internal/k8s/clients.go
@@ -18,7 +18,6 @@ import (
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -71,22 +70,17 @@ func newRestConfig(kubeconfig string, inCluster bool) (*rest.Config, error) {
 // note: 0 means resync timers are disabled
 const resyncInterval time.Duration = 0
 
-// NewInformerFactory returns a new SharedInformerFactory for the core
-// Kubernetes API types.
-func (c *Clients) NewInformerFactory() informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactory(c.core, resyncInterval)
-}
+type InformerFactory = dynamicinformer.DynamicSharedInformerFactory
 
-// NewInformerFactoryForNamespace returns a new SharedInformerFactory
-// for the core Kubernetes API types for the namespace supplied.
-func (c *Clients) NewInformerFactoryForNamespace(namespace string) informers.SharedInformerFactory {
-	return informers.NewSharedInformerFactoryWithOptions(c.core, resyncInterval, informers.WithNamespace(namespace))
-}
-
-// NewDynamicInformerFactory returns a new DynamicSharedInformerFactory for
+// NewInformerFactory returns a new InformerFactory for
 // use with any registered Kubernetes API type.
-func (c *Clients) NewDynamicInformerFactory() dynamicinformer.DynamicSharedInformerFactory {
+func (c *Clients) NewInformerFactory() InformerFactory {
 	return dynamicinformer.NewDynamicSharedInformerFactory(c.dynamic, resyncInterval)
+}
+
+// NewInformerFactoryForNamespace returns a new InformerFactory bound to the given namespace.
+func (c *Clients) NewInformerFactoryForNamespace(ns string) InformerFactory {
+	return dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.dynamic, resyncInterval, ns, nil)
 }
 
 // ClientSet returns the Kubernetes Core v1 ClientSet.
@@ -94,12 +88,12 @@ func (c *Clients) ClientSet() *kubernetes.Clientset {
 	return c.core
 }
 
-// CoordinationClient returns the Kubernets Core v1 coordination client.
+// CoordinationClient returns the Kubernetes Core v1 coordination client.
 func (c *Clients) CoordinationClient() *coordinationv1.CoordinationV1Client {
 	return c.coordination
 }
 
-// DynamicClient returns the Dyanmic client.
+// DynamicClient returns the dynamic client.
 func (c *Clients) DynamicClient() dynamic.Interface {
 	return c.dynamic
 }

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -15,12 +15,10 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 
 	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,31 +86,19 @@ type UnstructuredConverter struct {
 
 // NewUnstructuredConverter returns a new UnstructuredConverter initialized
 func NewUnstructuredConverter() (*UnstructuredConverter, error) {
+	schemeBuilder := runtime.SchemeBuilder{
+		ingressroutev1.AddToScheme,
+		projectcontour.AddToScheme,
+		scheme.AddToScheme,
+		serviceapis.AddToScheme,
+		v1beta1.AddToScheme,
+	}
+
 	uc := &UnstructuredConverter{
 		scheme: runtime.NewScheme(),
 	}
 
-	// Setup converter to understand custom CRD types
-	if err := projectcontour.AddToScheme(uc.scheme); err != nil {
-		return nil, err
-	}
-
-	if err := ingressroutev1.AddToScheme(uc.scheme); err != nil {
-		return nil, err
-	}
-
-	// Add the core types we need
-	if err := scheme.AddToScheme(uc.scheme); err != nil {
-		return nil, err
-	}
-
-	// Setup converter to understand Ingress types
-	if err := v1beta1.AddToScheme(uc.scheme); err != nil {
-		return nil, err
-	}
-
-	// The kubebuilder tools' contract here is different, yay.
-	if err := serviceapis.AddToScheme(uc.scheme); err != nil {
+	if err := schemeBuilder.AddToScheme(uc.scheme); err != nil {
 		return nil, err
 	}
 
@@ -122,68 +108,22 @@ func NewUnstructuredConverter() (*UnstructuredConverter, error) {
 // FromUnstructured converts an unstructured.Unstructured to typed struct. If obj
 // is not an unstructured.Unstructured it is returned without further processing.
 func (c *UnstructuredConverter) FromUnstructured(obj interface{}) (interface{}, error) {
-	unstructured, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return obj, nil
 	}
-	switch unstructured.GetKind() {
-	case "Ingress":
-		// TODO(youngnick): Have this check for v1 or v1beta1
-		// Currently we have no support for v1.
-		// unstructured.GetObjectKind().GroupVersionKind() will probably be useful.
-		i := &v1beta1.Ingress{}
-		err := c.scheme.Convert(obj, i, nil)
-		return i, err
-	case "Service":
-		s := &v1.Service{}
-		err := c.scheme.Convert(obj, s, nil)
-		return s, err
-	case "HTTPProxy":
-		proxy := &projectcontour.HTTPProxy{}
-		err := c.scheme.Convert(obj, proxy, nil)
-		return proxy, err
-	case "IngressRoute":
-		ir := &ingressroutev1.IngressRoute{}
-		err := c.scheme.Convert(obj, ir, nil)
-		return ir, err
-	case "TLSCertificateDelegation":
-		switch unstructured.GroupVersionKind().Group {
-		case ingressroutev1.GroupName:
-			cert := &ingressroutev1.TLSCertificateDelegation{}
-			err := c.scheme.Convert(obj, cert, nil)
-			return cert, err
-		case projectcontour.GroupName:
-			cert := &projectcontour.TLSCertificateDelegation{}
-			err := c.scheme.Convert(obj, cert, nil)
-			return cert, err
-		default:
-			return nil, fmt.Errorf("unsupported object type: %T", obj)
-		}
-	case "GatewayClass":
-		gc := &serviceapis.GatewayClass{}
-		err := c.scheme.Convert(obj, gc, nil)
-		return gc, err
-	case "Gateway":
-		g := &serviceapis.Gateway{}
-		err := c.scheme.Convert(obj, g, nil)
-		return g, err
-	case "HTTPRoute":
-		hr := &serviceapis.HTTPRoute{}
-		err := c.scheme.Convert(obj, hr, nil)
-		return hr, err
-	case "TcpRoute":
-		tr := &serviceapis.TcpRoute{}
-		err := c.scheme.Convert(obj, tr, nil)
-		return tr, err
-	default:
-		return nil, fmt.Errorf("unsupported object type: %T", obj)
+
+	newObj, err := c.scheme.New(u.GetObjectKind().GroupVersionKind())
+	if err != nil {
+		return nil, err
 	}
+
+	return newObj, c.scheme.Convert(obj, newObj, nil)
 }
 
 // ToUnstructured converts the supplied object to Unstructured, provided it's one of the types
 // registered in the UnstructuredConverter's Scheme.
 func (c *UnstructuredConverter) ToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
-
 	u := &unstructured.Unstructured{}
 
 	if err := c.scheme.Convert(obj, u, context.TODO()); err != nil {

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -48,7 +48,17 @@ func TestConvertUnstructured(t *testing.T) {
 			}
 			got, err := converter.FromUnstructured(tc.obj)
 
-			assert.Equal(t, tc.wantError, err)
+			// Note we don't match error string values
+			// because the actual values come from Kubernetes
+			// internals and may not be stable.
+			if tc.wantError == nil && err != nil {
+				t.Errorf("wanted no error, got error %q", err)
+			}
+
+			if tc.wantError != nil && err == nil {
+				t.Errorf("wanted error %q, got no error", tc.wantError)
+			}
+
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -357,7 +367,7 @@ func TestConvertUnstructured(t *testing.T) {
 	run(t, "unknownunstructured", testcase{
 		obj:       unknownUnstructured,
 		want:      nil,
-		wantError: errors.New("unsupported object type: *unstructured.Unstructured"),
+		wantError: errors.New(`no kind "Broken" is registered for version "invalid/-1" in scheme "pkg/runtime/scheme.go:101"`),
 	})
 
 	run(t, "invalidunstructured", testcase{

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -16,48 +16,44 @@ package k8s
 import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 
-	"k8s.io/api/networking/v1beta1"
-
-	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/tools/cache"
+	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
 )
 
-type gvrmap map[schema.GroupVersionResource]cache.SharedIndexInformer
-
-// InformerSet stores a table of Kubernetes GVR objects to their associated informers.
-type InformerSet struct {
-	Informers gvrmap
-}
-
-// DefaultInformerSet creates a new InformerSet lookup table and populates with the default
-// GVRs that Contour will try to watch.
-func DefaultInformerSet(inffactory dynamicinformer.DynamicSharedInformerFactory, serviceAPIs bool) InformerSet {
-
-	defaultGVRs := []schema.GroupVersionResource{
+func DefaultResources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
 		projectcontour.HTTPProxyGVR,
 		projectcontour.TLSCertificateDelegationGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 		v1beta1.SchemeGroupVersion.WithResource("ingresses"),
 	}
+}
 
-	// TODO(youngnick): Remove this boolean once we have autodetection of available types (Further work on #2219).
-	if serviceAPIs {
-		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("gatewayclasses"))
-		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("gateways"))
-		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("httproutes"))
-		defaultGVRs = append(defaultGVRs, serviceapis.GroupVersion.WithResource("tcproutes"))
+func ServiceAPIResources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		serviceapis.GroupVersion.WithResource("gatewayclasses"),
+		serviceapis.GroupVersion.WithResource("gateways"),
+		serviceapis.GroupVersion.WithResource("httproutes"),
+		serviceapis.GroupVersion.WithResource("tcproutes"),
 	}
+}
 
-	gvri := InformerSet{
-		Informers: make(gvrmap),
+func SecretsResources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		corev1.SchemeGroupVersion.WithResource("secrets"),
 	}
+}
 
-	for _, gvr := range defaultGVRs {
-		gvri.Informers[gvr] = inffactory.ForResource(gvr).Informer()
+func EndpointsResources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		corev1.SchemeGroupVersion.WithResource("endpoints"),
 	}
-	return gvri
+}
+
+func ServicesResources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		corev1.SchemeGroupVersion.WithResource("services"),
+	}
 }

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -18,6 +18,7 @@ import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // KindOf returns the kind string for the given Kubernetes object.
@@ -26,11 +27,13 @@ import (
 // objects, so we have to use a type assertion to detect kinds that
 // we care about.
 func KindOf(obj interface{}) string {
-	switch obj.(type) {
+	switch obj := obj.(type) {
 	case *v1.Secret:
 		return "Secret"
 	case *v1.Service:
 		return "Service"
+	case *v1.Endpoints:
+		return "Endpoints"
 	case *v1beta1.Ingress:
 		return "Ingress"
 	case *ingressroutev1.IngressRoute:
@@ -41,6 +44,8 @@ func KindOf(obj interface{}) string {
 		return "TLSCertificateDelegation"
 	case *projectcontour.TLSCertificateDelegation:
 		return "TLSCertificateDelegation"
+	case *unstructured.Unstructured:
+		return obj.GetKind()
 	default:
 		return ""
 	}

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"testing"
+
+	ingressroutev1 "github.com/projectcontour/contour/apis/contour/v1beta1"
+	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestKindOf(t *testing.T) {
+	cases := []struct {
+		Kind string
+		Obj  interface{}
+	}{
+		{"Secret", &v1.Secret{}},
+		{"Service", &v1.Service{}},
+		{"Endpoints", &v1.Endpoints{}},
+		{"", &v1.Pod{}},
+		{"Ingress", &v1beta1.Ingress{}},
+		{"IngressRoute", &ingressroutev1.IngressRoute{}},
+		{"HTTPProxy", &projectcontour.HTTPProxy{}},
+		{"TLSCertificateDelegation", &ingressroutev1.TLSCertificateDelegation{}},
+		{"TLSCertificateDelegation", &projectcontour.TLSCertificateDelegation{}},
+		{"Foo", &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.projectcontour.io/v1",
+				"kind":       "Foo",
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		kindOf := KindOf(c.Obj)
+		if kindOf != c.Kind {
+			t.Errorf("got %q for KindOf(%T), wanted %q",
+				kindOf, c.Obj, c.Kind)
+		}
+	}
+}


### PR DESCRIPTION
This change standardizes Contour to always use dynamic Informers. This
makes the startup code path a little simpler, and lets us consolidate
on a single method of handling object updates. Update the downstream
handlers to fully support unstructured objects.

Signed-off-by: James Peach <jpeach@vmware.com>