### PR TITLE
apis/projectcontour: add Service port range validation

### DIFF
--- a/_integration/testsuite/httpproxy/001-required-field-validation.yaml
+++ b/_integration/testsuite/httpproxy/001-required-field-validation.yaml
@@ -100,3 +100,27 @@ $check: |
     msg := "No error cause matched FieldValueRequired/spec.includes.name"
   }
 
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: service-port-range
+spec:
+  virtualhost:
+    fqdn: ports.projectcontour.io
+  routes:
+  - services:
+    - name: any-service-name
+      port: 80000
+$check: |
+  matched_cause {
+    cause := input.error.details.causes[_]
+    cause.reason == "FieldValueInvalid"
+    cause.field == "spec.routes.services.port"
+  }
+
+  error[msg] {
+    not matched_cause
+    msg := "No error cause matched FieldValueInvalid/spec.routes.services.port"
+  }

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -223,6 +223,12 @@ type Service struct {
 	// Names defined here will be used to look up corresponding endpoints which contain the ips to route.
 	Name string `json:"name"`
 	// Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+	//
+	// +required
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65536
+	// +kubebuilder:validation:ExclusiveMinimum=false
+	// +kubebuilder:validation:ExclusiveMaximum=true
 	Port int `json:"port"`
 	// Protocol may be used to specify (or override) the protocol used to reach this Service.
 	// Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -807,6 +807,9 @@ spec:
                         port:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
+                          exclusiveMaximum: true
+                          maximum: 65536
+                          minimum: 1
                           type: integer
                         protocol:
                           description: Protocol may be used to specify (or override)
@@ -1017,6 +1020,9 @@ spec:
                       port:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
                         type: integer
                       protocol:
                         description: Protocol may be used to specify (or override)

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -905,6 +905,9 @@ spec:
                         port:
                           description: Port (defined as Integer) to proxy traffic
                             to since a service can have multiple defined.
+                          exclusiveMaximum: true
+                          maximum: 65536
+                          minimum: 1
                           type: integer
                         protocol:
                           description: Protocol may be used to specify (or override)
@@ -1115,6 +1118,9 @@ spec:
                       port:
                         description: Port (defined as Integer) to proxy traffic to
                           since a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
                         type: integer
                       protocol:
                         description: Protocol may be used to specify (or override)


### PR DESCRIPTION
Add Kubebuilder annotations to validate the Service port range.

Signed-off-by: James Peach <jpeach@vmware.com>