### PR TITLE
internal/k8s: remove redundant coordination client

### DIFF
--- a/cmd/contour/leadership.go
+++ b/cmd/contour/leadership.go
@@ -128,7 +128,7 @@ func newResourceLock(ctx *serveContext, clients *k8s.Clients) resourcelock.Inter
 		ctx.LeaderElectionConfig.Namespace,
 		ctx.LeaderElectionConfig.Name,
 		clients.ClientSet().CoreV1(),
-		clients.CoordinationClient(),
+		clients.ClientSet().CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			Identity: resourceLockID,
 		},

--- a/internal/k8s/clients.go
+++ b/internal/k8s/clients.go
@@ -21,15 +21,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 )
 
 // Clients holds the various API clients required by Contour.
 type Clients struct {
-	core         *kubernetes.Clientset
-	coordination *coordinationv1.CoordinationV1Client
-	dynamic      dynamic.Interface
+	core    *kubernetes.Clientset
+	dynamic dynamic.Interface
 }
 
 // NewClients returns a new set of the various API clients required
@@ -43,11 +40,6 @@ func NewClients(kubeconfig string, inCluster bool) (*Clients, error) {
 
 	var clients Clients
 	clients.core, err = kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	clients.coordination, err = coordinationv1.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +78,6 @@ func (c *Clients) NewInformerFactoryForNamespace(ns string) InformerFactory {
 // ClientSet returns the Kubernetes Core v1 ClientSet.
 func (c *Clients) ClientSet() *kubernetes.Clientset {
 	return c.core
-}
-
-// CoordinationClient returns the Kubernetes Core v1 coordination client.
-func (c *Clients) CoordinationClient() *coordinationv1.CoordinationV1Client {
-	return c.coordination
 }
 
 // DynamicClient returns the dynamic client.


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

`Clients` currently instantiates a Kubernetes clientset plus a `CoordinationV1` client. Since the former already contains a `CoordinationV1` client, the latter is redundant, so this PR removes it.

