### PR TITLE
internal/dag: allow routes with overlapping header conditions

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -17,6 +17,7 @@ package dag
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,7 +80,14 @@ type HeaderCondition struct {
 }
 
 func (hc *HeaderCondition) String() string {
-	return "header: " + hc.Name
+	details := strings.Join([]string{
+		"name=" + hc.Name,
+		"value=" + hc.Value,
+		"matchtype=", hc.MatchType,
+		"invert=", strconv.FormatBool(hc.Invert),
+	}, "&")
+
+	return "header: " + details
 }
 
 // Route defines the properties of a route to a Cluster.


### PR DESCRIPTION
closes #2597 

Fixes a bug where an HTTPProxy with multiple routes with the same prefixes
and conditions on the same headers, differing only on the condition operators
or values, would result in only the last route being configured in Envoy and
all others being dropped.

Signed-off-by: Steve Kriss <krisss@vmware.com>