### PR TITLE
Fix Envoy service status watching

### DIFF
--- a/internal/k8s/syncer.go
+++ b/internal/k8s/syncer.go
@@ -26,7 +26,8 @@ type InformerSyncList struct {
 }
 
 // InformOnResources creates informers for each of the given resources and registers their sync callbacks.
-func (sl *InformerSyncList) InformOnResources(f InformerFactory, handler cache.ResourceEventHandler, resources ...schema.GroupVersionResource) {
+func (sl *InformerSyncList) InformOnResources(f InformerFactory, handler *DynamicClientHandler, resources ...schema.GroupVersionResource) {
+
 	for _, r := range resources {
 		informer := f.ForResource(r).Informer()
 		informer.AddEventHandler(handler)


### PR DESCRIPTION
We all missed in #2583 that not all informers handle Unstructured objects; wrap the service status informer in the dynamicHandler to ensure that no Unstructured objects make it through.

Service status watching was broken before this, as it didn't handle Unstructured.

Signed-off-by: Nick Young <ynick@vmware.com>