### PR TITLE
Check for empty envoy TLS cert file during bootstrap

### DIFF
--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -100,8 +100,12 @@ func bootstrap(c *BootstrapConfig) ([]bootstrapf, error) {
 			// but there is no way to detect and fix that. If
 			// we check and fail here, that is visible in the
 			// Pod lifecycle and therefore fixable.
-			if _, err := os.Stat(f); err != nil {
+			fi, err := os.Stat(f)
+			if err != nil {
 				return nil, err
+			}
+			if fi.Size() == 0 {
+				return nil, fmt.Errorf("%q is empty", f)
 			}
 		}
 	}


### PR DESCRIPTION
Currently during envoy bootstrap, TLS cert file is checked for existence. Adding a check for empty file too since cert-manager generates secret with empty certificates first and then updates it.

Short term fix for: https://github.com/projectcontour/contour/issues/2602 . Long term fix is to come up with a liveness probe for envoy which can restart envoy if it fails to start.

Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>