### PR TITLE
cmd/contour: add -h as a short flag for --help

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -36,6 +36,7 @@ func init() {
 func main() {
 	log := logrus.StandardLogger()
 	app := kingpin.New("contour", "Contour Kubernetes ingress controller.")
+	app.HelpFlag.Short('h')
 
 	envoyCmd := app.Command("envoy", "Sub-command for envoy actions.")
 	shutdownManager, shutdownManagerCtx := registerShutdownManager(envoyCmd, log)


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>