### PR TITLE
docs: fix inclusion example

### DIFF
--- a/examples/example-workload/httpproxy/04-inclusion/httpproxy-inclusion-samenamespace.yaml
+++ b/examples/example-workload/httpproxy/04-inclusion/httpproxy-inclusion-samenamespace.yaml
@@ -27,9 +27,7 @@ metadata:
   namespace: default
 spec:
   routes:
-    - conditions:
-      - prefix: /  # matches /service2
-      services:
+    - services:  # matches /service2
         - name: s2
           port: 80
     - conditions:

--- a/site/docs/master/httpproxy.md
+++ b/site/docs/master/httpproxy.md
@@ -1023,7 +1023,7 @@ It requires one field, `name`, and has two optional fields:
 HTTPProxies can include other HTTPProxy objects in the namespace by specifying the name of the object and its namespace in the top-level `includes` block.
 Note that `includes` is a list, and so it must use the YAML list construct.
 
-In this example, the HTTPProxy `include-root` has included the configuration for paths matching `/service2` from the HTTPPRoxy named `service2` in the same namespace as `include-root` (the `default` namespace).
+In this example, the HTTPProxy `include-root` has included the configuration for paths matching `/service2` from the HTTPProxy named `service2` in the same namespace as `include-root` (the `default` namespace).
 It's important to note that `service2` HTTPProxy has not defined a `virtualhost` property as it is NOT a root HTTPProxy.
 
 ```yaml
@@ -1038,7 +1038,7 @@ spec:
     fqdn: root.bar.com
   includes:
   # Includes the /service2 path from service2 in the same namespace
-  - name: www
+  - name: service2
     namespace: default
     conditions:
     - prefix: /service2
@@ -1056,9 +1056,7 @@ metadata:
   namespace: default
 spec:
   routes:
-    - conditions:
-      - prefix: / # matches /service2
-      services:
+    - services: # matches /service2
         - name: s2
           port: 80
     - conditions:


### PR DESCRIPTION
Uses the correct name to refer to the included HTTPProxy and removes an
incorrect prefix condition from the child proxy.

Signed-off-by: Steve Kriss <krisss@vmware.com>

The relevant scenarios are covered by [these test cases](https://github.com/projectcontour/contour/blob/master/internal/dag/builder_test.go#L4722-L4785) using [this test data](https://github.com/projectcontour/contour/blob/master/internal/dag/builder_test.go#L2394-L2479).