### PR TITLE
Send DAG status updates via StatusUpdateHandler

### DIFF
--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -73,7 +73,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 			WithField("ingress-class", annotation.IngressClass(typed)).
 			WithField("defined-ingress-class", s.IngressClass).
 			WithField("kind", kind).
-			Debug("unmatched ingress class, skip status update")
+			Debug("unmatched ingress class, skipping status address update")
 		return
 	}
 
@@ -83,7 +83,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		WithField("ingress-class", annotation.IngressClass(typed)).
 		WithField("kind", kind).
 		WithField("defined-ingress-class", s.IngressClass).
-		Debug("Received an object, sending status update")
+		Debug("received an object, sending status address update")
 
 	s.StatusUpdater.Update(
 		typed.GetObjectMeta().GetName(),
@@ -128,6 +128,7 @@ func (s *StatusAddressUpdater) OnDelete(obj interface{}) {
 type ServiceStatusLoadBalancerWatcher struct {
 	ServiceName string
 	LBStatus    chan v1.LoadBalancerStatus
+	Log         logrus.FieldLogger
 }
 
 func (s *ServiceStatusLoadBalancerWatcher) OnAdd(obj interface{}) {
@@ -139,6 +140,10 @@ func (s *ServiceStatusLoadBalancerWatcher) OnAdd(obj interface{}) {
 	if svc.Name != s.ServiceName {
 		return
 	}
+	s.Log.WithField("name", svc.Name).
+		WithField("namespace", svc.Namespace).
+		Debug("received new service address")
+
 	s.notify(svc.Status.LoadBalancer)
 }
 
@@ -151,6 +156,10 @@ func (s *ServiceStatusLoadBalancerWatcher) OnUpdate(oldObj, newObj interface{}) 
 	if svc.Name != s.ServiceName {
 		return
 	}
+	s.Log.WithField("name", svc.Name).
+		WithField("namespace", svc.Namespace).
+		Debug("received new service address")
+
 	s.notify(svc.Status.LoadBalancer)
 }
 

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -26,11 +26,27 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func testLogger(t *testing.T) logrus.FieldLogger {
+	log := logrus.New()
+	log.Out = &testWriter{t}
+	return log
+}
+
+type testWriter struct {
+	*testing.T
+}
+
+func (t *testWriter) Write(buf []byte) (int, error) {
+	t.Logf("%s", buf)
+	return len(buf), nil
+}
+
 func TestServiceStatusLoadBalancerWatcherOnAdd(t *testing.T) {
 	lbstatus := make(chan v1.LoadBalancerStatus, 1)
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
+		Log:         testLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {
@@ -74,9 +90,11 @@ func TestServiceStatusLoadBalancerWatcherOnAdd(t *testing.T) {
 
 func TestServiceStatusLoadBalancerWatcherOnUpdate(t *testing.T) {
 	lbstatus := make(chan v1.LoadBalancerStatus, 1)
+
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
+		Log:         testLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {
@@ -122,9 +140,11 @@ func TestServiceStatusLoadBalancerWatcherOnUpdate(t *testing.T) {
 
 func TestServiceStatusLoadBalancerWatcherOnDelete(t *testing.T) {
 	lbstatus := make(chan v1.LoadBalancerStatus, 1)
+
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
+		Log:         testLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {

--- a/internal/k8s/statusupdater.go
+++ b/internal/k8s/statusupdater.go
@@ -78,7 +78,9 @@ func (suh *StatusUpdateHandler) Start(stop <-chan struct{}) error {
 				continue
 			}
 
-			suh.Log.WithField("fullname", upd.FullName).Debug("received a status update")
+			suh.Log.WithField("name", upd.FullName.Name).
+				WithField("namespace", upd.FullName.Namespace).
+				Debug("received a status update")
 			uObj, err := suh.Clients.DynamicClient().
 				Resource(upd.Resource).
 				Namespace(upd.FullName.Namespace).Get(context.TODO(), upd.FullName.Name, metav1.GetOptions{})


### PR DESCRIPTION
Updates the DAG StatusClient to use the StatusUpdateWriter pattern.

Fixes #2560
Fixes #2580 - I *think* it fixes it, but I haven't been able to reproduce, even with the excellent script provided by @primeroz. 
Fixes #2522 - I've confirmed this one with testing.

We should be able to remove the StatusClient eventually, but that API also needs refactoring for adding Conditions (currently under #2495), so for now I've just updated it to send updates via the StatusUpdateWriter rather than make API calls directly.

Signed-off-by: Nick Young <ynick@vmware.com>