### PR TITLE
Testsuite: Add commonName to client certificates

### DIFF
--- a/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
+++ b/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
@@ -214,6 +214,7 @@ spec:
   - client auth
   emailSANs:
   - client@projectcontour.io
+  commonName: client
   secretName: echo-client
   issuerRef:
     name: ca-projectcontour-io
@@ -249,6 +250,7 @@ spec:
   - client auth
   emailSANs:
   - selfsigned-client@projectcontour.io
+  commonName: selfsigned-client
   secretName: echo-client-selfsigned
   issuerRef:
     name: selfsigned


### PR DESCRIPTION
_integration/testsuite: Add commonName to client certificates

Older versions of cert-manager dont have emailSANs. So, one of
commonName, dnsNames, uriSANs is required. Hence adding commonName
to client certificate to be backward compatible with older versions
of cert-manager

Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>