### PR TITLE
Fix site proofing on master builds

### DIFF
--- a/hack/site-proofing/cibuild
+++ b/hack/site-proofing/cibuild
@@ -15,4 +15,6 @@ htmlproofer ./_site \
     --empty-alt-ignore \
     --assume-extension \
     --allow-missing-href \
-    --allow-hash-href
+    --allow-hash-href \
+    --http-status-ignore 429 \
+    --url-ignore /www.haproxy.org/ # gives false positive timeouts

--- a/site/docs/v1.1.0/api-reference.html
+++ b/site/docs/v1.1.0/api-reference.html
@@ -48,7 +48,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -181,7 +181,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/site/docs/v1.2.0/api-reference.html
+++ b/site/docs/v1.2.0/api-reference.html
@@ -48,7 +48,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -181,7 +181,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/site/docs/v1.2.1/api-reference.html
+++ b/site/docs/v1.2.1/api-reference.html
@@ -48,7 +48,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -181,7 +181,7 @@ string
 <td style="white-space:nowrap">
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/site/docs/v1.3.0/api-reference.html
+++ b/site/docs/v1.3.0/api-reference.html
@@ -51,7 +51,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -193,7 +193,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/site/docs/v1.4.0/api-reference.html
+++ b/site/docs/v1.4.0/api-reference.html
@@ -51,7 +51,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -193,7 +193,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/site/docs/v1.5.0/api-reference.html
+++ b/site/docs/v1.5.0/api-reference.html
@@ -51,7 +51,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -193,7 +193,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -1330,7 +1330,7 @@ string
 <code>loadBalancer</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#loadbalancerstatus-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#loadbalancerstatus-v1-core">
 Kubernetes core/v1.LoadBalancerStatus
 </a>
 </em>

--- a/site/docs/v1.5.1/api-reference.html
+++ b/site/docs/v1.5.1/api-reference.html
@@ -51,7 +51,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -193,7 +193,7 @@ string
 <code>metadata</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -1330,7 +1330,7 @@ string
 <code>loadBalancer</code>
 <br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#loadbalancerstatus-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#loadbalancerstatus-v1-core">
 Kubernetes core/v1.LoadBalancerStatus
 </a>
 </em>


### PR DESCRIPTION
closes #2624 

Due to #2031 the updated job won't run for this PR, but you can see a passing build on my fork [here](https://travis-ci.org/github/skriss/contour/jobs/702120241).

For now, I opted to update the broken links in the old versioned docs. We can decide down the road to exclude those subdirs from the site proofing job if they continue to create more issues that we don't want to fix.

The haproxy.org link appears to be unresponsive when requested from Travis workers - even a simple curl times out - so I added it to the excludes list for the proofer.