### PR TITLE
makefile: allow lint-yamllint to be run from binary and not require docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ lint-golint:
 .PHONY: check-yamllint
 lint-yamllint:
 	@echo Running YAML linter ...
-	@docker run --rm -ti -v $(CURDIR):/workdir giantswarm/yamllint examples/ site/examples/
+	@./hack/yamllint examples/ site/examples/
 
 # Check that CLI flags are formatted consistently. We are checking
 # for calls to Kingping Flags() and Command() APIs where the 2nd

--- a/hack/yamllint
+++ b/hack/yamllint
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+readonly PROGNAME="yamllint"
+
+if command -v ${PROGNAME} >/dev/null; then
+	exec ${PROGNAME} "$@"
+fi
+
+if command -v docker >/dev/null; then
+	exec docker run --rm -ti \
+		-v $(pwd):/workdir \
+		giantswarm/yamllint "$@"
+fi
+
+# @docker run --rm -ti -v $(CURDIR):/workdir giantswarm/yamllint examples/ site/examples/
+
+cat <<EOF
+Unable to run yamllint. Please check installation instructions:
+	https://github.com/adrienverge/yamllint#installation
+EOF
+
+exit 69 # EX_UNAVAILABLE


### PR DESCRIPTION
When running `make checkall`, the task`lint-yamllint` required docker. For users not wanting to keep docker running locally, this change allows to run the same command from a binary without a docker container. 

Signed-off-by: Steve Sloka <slokas@vmware.com>