### PR TITLE
site: add `area/tls` label

### DIFF
--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -117,6 +117,11 @@ default:
       name: area/tooling
       target: both
       addedBy: label
+    - color: 0052cc
+      description: Issues or PRs related to TLS support.
+      name: area/tls
+      target: both
+      addedBy: label
 
 # Blocked.
     - color: "FF7B7B"


### PR DESCRIPTION
Add a label to manage issues related to TLS support.

Signed-off-by: James Peach <jpeach@vmware.com>