### PR TITLE
internal/dag: improve validation status for invalid Secrets

### DIFF
--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -14,6 +14,7 @@
 package annotation
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -276,4 +277,12 @@ func MaxRequests(o metav1.ObjectMetaAccessor) uint32 {
 // '0' is returned if the annotation is absent or unparseable.
 func MaxRetries(o metav1.ObjectMetaAccessor) uint32 {
 	return parseUInt32(CompatAnnotation(o, "max-retries"))
+}
+
+func Tombstone(o metav1.ObjectMetaAccessor) error {
+	if s := CompatAnnotation(o, "tombstone"); s != "" {
+		return errors.New(s)
+	}
+
+	return nil
 }

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -1144,31 +1144,6 @@ func defaultBackendRule(be *v1beta1.IngressBackend) v1beta1.IngressRule {
 	}
 }
 
-// validSecret returns true if the Secret contains certificate and private key material.
-func validSecret(s *v1.Secret) error {
-	if s.Type != v1.SecretTypeTLS {
-		return fmt.Errorf("Secret type is not %q", v1.SecretTypeTLS)
-	}
-
-	if len(s.Data[v1.TLSCertKey]) == 0 {
-		return fmt.Errorf("empty %q key", v1.TLSCertKey)
-	}
-
-	if len(s.Data[v1.TLSPrivateKeyKey]) == 0 {
-		return fmt.Errorf("empty %q key", v1.TLSPrivateKeyKey)
-	}
-
-	return nil
-}
-
-func validCA(s *v1.Secret) error {
-	if len(s.Data[CACertificateKey]) == 0 {
-		return fmt.Errorf("empty %q key", CACertificateKey)
-	}
-
-	return nil
-}
-
 // routeEnforceTLS determines if the route should redirect the user to a secure TLS listener
 func routeEnforceTLS(enforceTLS, permitInsecure bool) bool {
 	return enforceTLS && !permitInsecure

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -29,42 +29,30 @@ func TestIsValidSecret(t *testing.T) {
 		err       error
 	}{
 		"normal": {
-			cert:  CERTIFICATE,
-			key:   RSA_PRIVATE_KEY,
-			valid: true,
-			err:   nil,
+			cert: CERTIFICATE,
+			key:  RSA_PRIVATE_KEY,
+			err:  nil,
 		},
 		"missing CN": {
-			cert:  MISSING_CN_CERT,
-			key:   MISSING_CN_KEY,
-			valid: false,
-			err:   errors.New("certificate has no common name or subject alt name"),
+			cert: MISSING_CN_CERT,
+			key:  MISSING_CN_KEY,
+			err:  errors.New("certificate has no common name or subject alt name"),
 		},
 		"EC cert with SubjectAltName only": {
-			cert:  EC_CERTIFICATE,
-			key:   EC_PRIVATE_KEY,
-			valid: true,
-			err:   nil,
+			cert: EC_CERTIFICATE,
+			key:  EC_PRIVATE_KEY,
+			err:  nil,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			type Result struct {
-				Valid bool
-				Err   error
-			}
-
-			want := Result{Valid: tc.valid, Err: tc.err}
-
-			valid, err := isValidSecret(&v1.Secret{
+			err := isValidSecret(&v1.Secret{
 				// objectmeta omitted
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(tc.cert, tc.key),
 			})
-			got := Result{Valid: valid, Err: err}
-
-			assert.Equal(t, want, got)
+			assert.Equal(t, tc.err, err)
 		})
 	}
 }


### PR DESCRIPTION
Secrets validation is performed before a Secrets is accepted into
the cache. This means that if you make an error in a Secret, Contour
typically describes that as "secret not found", and you have to dig
in logs to figure out the real problem.

This change accepts otherwise invalid Secrets into the cache, but
tracks them as invalid. When another resource uses an invalid Secret,
the validation error can be regurgitated and presented in status.

This fixes #2616.

Signed-off-by: James Peach <jpeach@vmware.com>