### PR TITLE
internal: adopt types.NamespacedName

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/projectcontour/contour/internal/envoy"
-	"github.com/projectcontour/contour/internal/k8s"
-
 	"github.com/projectcontour/contour/internal/contour"
+	"github.com/projectcontour/contour/internal/envoy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type serveContext struct {
@@ -211,7 +210,7 @@ type FallbackCertificate struct {
 	Namespace string `yaml:"namespace"`
 }
 
-func (ctx *serveContext) fallbackCertificate() (*k8s.FullName, error) {
+func (ctx *serveContext) fallbackCertificate() (*types.NamespacedName, error) {
 	if len(strings.TrimSpace(ctx.TLSConfig.FallbackCertificate.Name)) == 0 && len(strings.TrimSpace(ctx.TLSConfig.FallbackCertificate.Namespace)) == 0 {
 		return nil, nil
 	}
@@ -226,7 +225,7 @@ func (ctx *serveContext) fallbackCertificate() (*k8s.FullName, error) {
 		return nil, errors.New("name must be defined")
 	}
 
-	return &k8s.FullName{
+	return &types.NamespacedName{
 		Name:      ctx.TLSConfig.FallbackCertificate.Name,
 		Namespace: ctx.TLSConfig.FallbackCertificate.Namespace,
 	}, nil

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/projectcontour/contour/internal/envoy"
-	"github.com/projectcontour/contour/internal/k8s"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/projectcontour/contour/internal/assert"
@@ -222,7 +222,7 @@ default-http-versions:
 func TestFallbackCertificateParams(t *testing.T) {
 	tests := map[string]struct {
 		ctx         serveContext
-		want        *k8s.FullName
+		want        *types.NamespacedName
 		expecterror bool
 	}{
 		"fallback cert params passed correctly": {
@@ -234,7 +234,7 @@ func TestFallbackCertificateParams(t *testing.T) {
 					},
 				},
 			},
-			want: &k8s.FullName{
+			want: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "root-namespace",
 			},

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	k8s.io/client-go v0.18.2
 	k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e // indirect
 	k8s.io/klog v1.0.0
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	sigs.k8s.io/controller-tools v0.2.9
 	sigs.k8s.io/kustomize/kyaml v0.1.1
 	sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // EventHandler implements cache.ResourceEventHandler, filters k8s events towards
@@ -225,7 +226,7 @@ func (e *EventHandler) updateDAG() {
 }
 
 // setStatus updates the status of objects.
-func (e *EventHandler) setStatus(statuses map[k8s.FullName]dag.Status) {
+func (e *EventHandler) setStatus(statuses map[types.NamespacedName]dag.Status) {
 	for _, st := range statuses {
 		switch obj := st.Object.(type) {
 		case *projcontour.HTTPProxy:

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/k8s"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -32,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestListenerCacheContents(t *testing.T) {
@@ -152,7 +151,7 @@ func TestListenerVisit(t *testing.T) {
 
 	tests := map[string]struct {
 		ListenerVisitorConfig
-		fallbackCertificate *k8s.FullName
+		fallbackCertificate *types.NamespacedName
 		objs                []interface{}
 		want                map[string]*v2.Listener
 	}{
@@ -1107,7 +1106,7 @@ func TestListenerVisit(t *testing.T) {
 			}),
 		},
 		"httpproxy with fallback certificate": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},
@@ -1196,7 +1195,7 @@ func TestListenerVisit(t *testing.T) {
 			}),
 		},
 		"multiple httpproxies with fallback certificate": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},
@@ -1319,7 +1318,7 @@ func TestListenerVisit(t *testing.T) {
 			}),
 		},
 		"httpproxy with fallback certificate - no cert passed": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "",
 				Namespace: "",
 			},
@@ -1374,7 +1373,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(),
 		},
 		"httpproxy with fallback certificate - cert passed but vhost not enabled": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbackcert",
 				Namespace: "default",
 			},

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -55,7 +56,7 @@ func (e *EventRecorder) recordOperation(op string, obj interface{}) {
 	e.Counter.WithLabelValues(op, kind).Inc()
 }
 
-func calculateRouteMetric(statuses map[k8s.FullName]dag.Status) metrics.RouteMetric {
+func calculateRouteMetric(statuses map[types.NamespacedName]dag.Status) metrics.RouteMetric {
 	proxyMetricTotal := make(map[metrics.Meta]int)
 	proxyMetricValid := make(map[metrics.Meta]int)
 	proxyMetricInvalid := make(map[metrics.Meta]int)

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
-	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -136,7 +136,7 @@ func TestRouteCacheQuery(t *testing.T) {
 func TestRouteVisit(t *testing.T) {
 	tests := map[string]struct {
 		objs                []interface{}
-		fallbackCertificate *k8s.FullName
+		fallbackCertificate *types.NamespacedName
 		want                map[string]*v2.RouteConfiguration
 	}{
 		"nothing": {
@@ -2035,7 +2035,7 @@ func TestRouteVisit(t *testing.T) {
 			),
 		},
 		"httpproxy with fallback certificate": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},
@@ -2166,7 +2166,7 @@ func TestRouteVisit(t *testing.T) {
 			),
 		},
 		"httpproxy with fallback certificate - one enabled": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},
@@ -2355,7 +2355,7 @@ func TestRouteVisit(t *testing.T) {
 			),
 		},
 		"httpproxy with fallback certificate - two enabled": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},
@@ -2561,7 +2561,7 @@ func TestRouteVisit(t *testing.T) {
 			),
 		},
 		"httpproxy with fallback certificate - bad global cert": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "badnamespace",
 			},
@@ -2639,7 +2639,7 @@ func TestRouteVisit(t *testing.T) {
 			want: routeConfigurations(envoy.RouteConfiguration("ingress_http")),
 		},
 		"httpproxy with fallback certificate - no fqdn enabled": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "fallbacksecret",
 				Namespace: "default",
 			},

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -22,10 +22,10 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
-	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -490,7 +490,7 @@ func buildDAG(t *testing.T, objs ...interface{}) *dag.DAG {
 }
 
 // buildDAGFallback produces a dag.DAG from the supplied objects with a fallback cert configured.
-func buildDAGFallback(t *testing.T, fallbackCertificate *k8s.FullName, objs ...interface{}) *dag.DAG {
+func buildDAGFallback(t *testing.T, fallbackCertificate *types.NamespacedName, objs ...interface{}) *dag.DAG {
 	builder := dag.Builder{
 		Source: dag.KubernetesCache{
 			FieldLogger: testLogger(t),

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,14 +43,14 @@ type Builder struct {
 	DisablePermitInsecure bool
 
 	services map[servicemeta]*Service
-	secrets  map[k8s.FullName]*Secret
+	secrets  map[types.NamespacedName]*Secret
 
 	virtualhosts       map[string]*VirtualHost
 	securevirtualhosts map[string]*SecureVirtualHost
 
-	orphaned map[k8s.FullName]bool
+	orphaned map[types.NamespacedName]bool
 
-	FallbackCertificate *k8s.FullName
+	FallbackCertificate *types.NamespacedName
 
 	StatusWriter
 }
@@ -73,18 +74,18 @@ func (b *Builder) Build() *DAG {
 // reset (re)inialises the internal state of the builder.
 func (b *Builder) reset() {
 	b.services = make(map[servicemeta]*Service, len(b.services))
-	b.secrets = make(map[k8s.FullName]*Secret, len(b.secrets))
-	b.orphaned = make(map[k8s.FullName]bool, len(b.orphaned))
+	b.secrets = make(map[types.NamespacedName]*Secret, len(b.secrets))
+	b.orphaned = make(map[types.NamespacedName]bool, len(b.orphaned))
 
 	b.virtualhosts = make(map[string]*VirtualHost)
 	b.securevirtualhosts = make(map[string]*SecureVirtualHost)
 
-	b.statuses = make(map[k8s.FullName]Status, len(b.statuses))
+	b.statuses = make(map[types.NamespacedName]Status, len(b.statuses))
 }
 
 // lookupService returns a Service that matches the Meta and Port of the Kubernetes' Service,
 // or an error if the service or port can't be located.
-func (b *Builder) lookupService(m k8s.FullName, port intstr.IntOrString) (*Service, error) {
+func (b *Builder) lookupService(m types.NamespacedName, port intstr.IntOrString) (*Service, error) {
 	lookup := func() *Service {
 		if port.Type != intstr.Int {
 			// can't handle, give up
@@ -146,7 +147,7 @@ func upstreamProtocol(svc *v1.Service, port *v1.ServicePort) string {
 
 // lookupSecret returns a Secret if present or nil if the underlying kubernetes
 // secret fails validation or is missing.
-func (b *Builder) lookupSecret(m k8s.FullName, validate func(*v1.Secret) error) (*Secret, error) {
+func (b *Builder) lookupSecret(m types.NamespacedName, validate func(*v1.Secret) error) (*Secret, error) {
 	sec, ok := b.Source.secrets[m]
 	if !ok {
 		return nil, fmt.Errorf("Secret not found")
@@ -160,7 +161,7 @@ func (b *Builder) lookupSecret(m k8s.FullName, validate func(*v1.Secret) error) 
 		Object: sec,
 	}
 
-	b.secrets[k8s.ToFullName(sec)] = s
+	b.secrets[k8s.NamespacedNameOf(sec)] = s
 	return s, nil
 }
 
@@ -232,8 +233,7 @@ func (b *Builder) validHTTPProxies() []*projcontour.HTTPProxy {
 func (b *Builder) computeSecureVirtualhosts() {
 	for _, ing := range b.Source.ingresses {
 		for _, tls := range ing.Spec.TLS {
-			secretName := splitSecret(tls.SecretName, ing.GetNamespace())
-
+			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(ing.GetNamespace()))
 			sec, err := b.lookupSecret(secretName, validSecret)
 			if err != nil {
 				b.Source.WithField("name", ing.GetName()).
@@ -264,7 +264,7 @@ func (b *Builder) computeSecureVirtualhosts() {
 	}
 }
 
-func (b *Builder) delegationPermitted(secret k8s.FullName, to string) bool {
+func (b *Builder) delegationPermitted(secret types.NamespacedName, to string) bool {
 	contains := func(haystack []string, needle string) bool {
 		if len(haystack) == 1 && haystack[0] == "*" {
 			return true
@@ -322,7 +322,7 @@ func (b *Builder) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1.IngressR
 	for _, httppath := range httppaths(rule) {
 		path := stringOrDefault(httppath.Path, "/")
 		be := httppath.Backend
-		m := k8s.FullName{Name: be.ServiceName, Namespace: ing.Namespace}
+		m := types.NamespacedName{Name: be.ServiceName, Namespace: ing.Namespace}
 		s, err := b.lookupService(m, be.ServicePort)
 		if err != nil {
 			continue
@@ -385,8 +385,7 @@ func (b *Builder) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 
 		// Attach secrets to TLS enabled vhosts.
 		if !tls.Passthrough {
-
-			secretName := splitSecret(tls.SecretName, proxy.Namespace)
+			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(proxy.Namespace))
 			sec, err := b.lookupSecret(secretName, validSecret)
 			if err != nil {
 				sw.SetInvalid("Spec.VirtualHost.TLS Secret %q is invalid: %s", tls.SecretName, err)
@@ -615,7 +614,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 			namespace = proxy.Namespace
 		}
 
-		delegate, ok := b.Source.httpproxies[k8s.FullName{Name: include.Name, Namespace: namespace}]
+		delegate, ok := b.Source.httpproxies[types.NamespacedName{Name: include.Name, Namespace: namespace}]
 		if !ok {
 			sw.SetInvalid("include %s/%s not found", namespace, include.Name)
 			return nil
@@ -635,7 +634,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 		commit()
 
 		// dest is not an orphaned httpproxy, as there is an httpproxy that points to it
-		delete(b.orphaned, k8s.FullName{Name: delegate.Name, Namespace: delegate.Namespace})
+		delete(b.orphaned, types.NamespacedName{Name: delegate.Name, Namespace: delegate.Namespace})
 	}
 
 	for _, route := range proxy.Spec.Routes {
@@ -722,7 +721,7 @@ func (b *Builder) computeRoutes(sw *ObjectStatusWriter, proxy *projcontour.HTTPP
 				sw.SetInvalid("service %q: port must be in the range 1-65535", service.Name)
 				return nil
 			}
-			m := k8s.FullName{Name: service.Name, Namespace: proxy.Namespace}
+			m := types.NamespacedName{Name: service.Name, Namespace: proxy.Namespace}
 			s, err := b.lookupService(m, intstr.FromInt(service.Port))
 			if err != nil {
 				sw.SetInvalid("Spec.Routes unresolved service reference: %s", err)
@@ -903,7 +902,7 @@ func (b *Builder) buildHTTPSListener() *Listener {
 
 // setOrphaned records an HTTPProxy resource as orphaned.
 func (b *Builder) setOrphaned(obj k8s.Object) {
-	m := k8s.FullName{
+	m := types.NamespacedName{
 		Name:      obj.GetObjectMeta().GetName(),
 		Namespace: obj.GetObjectMeta().GetNamespace(),
 	}
@@ -929,7 +928,7 @@ func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, n
 		return nil, nil
 	}
 
-	secretName := k8s.FullName{Name: uv.CACertificate, Namespace: namespace}
+	secretName := types.NamespacedName{Name: uv.CACertificate, Namespace: namespace}
 	cacert, err := b.lookupSecret(secretName, validCA)
 	if err != nil {
 		// UpstreamValidation is requested, but cert is missing or not configured
@@ -948,7 +947,7 @@ func (b *Builder) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, n
 }
 
 func (b *Builder) lookupDownstreamValidation(vc *projcontour.DownstreamValidation, namespace string) (*PeerValidationContext, error) {
-	secretName := k8s.FullName{Name: vc.CACertificate, Namespace: namespace}
+	secretName := types.NamespacedName{Name: vc.CACertificate, Namespace: namespace}
 	cacert, err := b.lookupSecret(secretName, validCA)
 	if err != nil {
 		// PeerValidationContext is requested, but cert is missing or not configured.
@@ -988,7 +987,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 	if len(tcpproxy.Services) > 0 {
 		var proxy TCPProxy
 		for _, service := range httpproxy.Spec.TCPProxy.Services {
-			m := k8s.FullName{Name: service.Name, Namespace: httpproxy.Namespace}
+			m := types.NamespacedName{Name: service.Name, Namespace: httpproxy.Namespace}
 			s, err := b.lookupService(m, intstr.FromInt(service.Port))
 			if err != nil {
 				sw.SetInvalid("Spec.TCPProxy unresolved service reference: %s", err)
@@ -1017,7 +1016,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 		namespace = httpproxy.Namespace
 	}
 
-	m := k8s.FullName{Name: tcpProxyInclude.Name, Namespace: namespace}
+	m := types.NamespacedName{Name: tcpProxyInclude.Name, Namespace: namespace}
 	dest, ok := b.Source.httpproxies[m]
 	if !ok {
 		sw.SetInvalid("tcpproxy: include %s/%s not found", m.Namespace, m.Name)
@@ -1030,7 +1029,7 @@ func (b *Builder) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *pr
 	}
 
 	// dest is no longer an orphan
-	delete(b.orphaned, k8s.ToFullName(dest))
+	delete(b.orphaned, k8s.NamespacedNameOf(dest))
 
 	// ensure we are not following an edge that produces a cycle
 	var path []string
@@ -1089,25 +1088,6 @@ func route(ingress *v1beta1.Ingress, path string, service *Service) *Route {
 // isBlank indicates if a string contains nothing but blank characters.
 func isBlank(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
-}
-
-// splitSecret splits a secretName into its namespace and name components.
-// If there is no namespace prefix, the default namespace is returned.
-func splitSecret(secret, defns string) k8s.FullName {
-	v := strings.SplitN(secret, "/", 2)
-	switch len(v) {
-	case 1:
-		// no prefix
-		return k8s.FullName{
-			Name:      v[0],
-			Namespace: defns,
-		}
-	default:
-		return k8s.FullName{
-			Name:      v[1],
-			Namespace: stringOrDefault(v[0], defns),
-		}
-	}
 }
 
 func stringOrDefault(s, def string) string {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // A DAG represents a directed acylic graph of objects representing the relationship
@@ -34,7 +34,7 @@ type DAG struct {
 	roots []Vertex
 
 	// status computed while building this dag.
-	statuses map[k8s.FullName]Status
+	statuses map[types.NamespacedName]Status
 }
 
 // Visit calls fn on each root of this DAG.
@@ -46,7 +46,7 @@ func (d *DAG) Visit(fn func(Vertex)) {
 
 // Statuses returns a slice of Status objects associated with
 // the computation of this DAG.
-func (d *DAG) Statuses() map[k8s.FullName]Status {
+func (d *DAG) Statuses() map[types.NamespacedName]Status {
 	return d.statuses
 }
 

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -18,6 +18,7 @@ import (
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Status contains the status for an HTTPProxy (valid / invalid / orphan, etc)
@@ -29,7 +30,7 @@ type Status struct {
 }
 
 type StatusWriter struct {
-	statuses map[k8s.FullName]Status
+	statuses map[types.NamespacedName]Status
 }
 
 type ObjectStatusWriter struct {
@@ -62,7 +63,7 @@ func (sw *StatusWriter) commit(osw *ObjectStatusWriter) {
 		return
 	}
 
-	m := k8s.FullName{
+	m := types.NamespacedName{
 		Name:      osw.obj.GetObjectMeta().GetName(),
 		Namespace: osw.obj.GetObjectMeta().GetNamespace(),
 	}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -1637,12 +1638,12 @@ func TestDAGStatus(t *testing.T) {
 
 	tests := map[string]struct {
 		objs                []interface{}
-		fallbackCertificate *k8s.FullName
-		want                map[k8s.FullName]Status
+		fallbackCertificate *types.NamespacedName
+		want                map[types.NamespacedName]Status
 	}{
 		"proxy has multiple includes, one is invalid": {
 			objs: []interface{}{proxyMultiIncludeOneInvalid, proxyChildValidFoo2, proxyChildInvalidBadPort, serviceFoo2, serviceFoo3InvalidPort},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyChildValidFoo2.Name, Namespace: proxyChildValidFoo2.Namespace}:                 {Object: proxyChildValidFoo2, Status: "valid", Description: "valid HTTPProxy"},
 				{Name: proxyChildInvalidBadPort.Name, Namespace: proxyChildInvalidBadPort.Namespace}:       {Object: proxyChildInvalidBadPort, Status: "invalid", Description: `service "foo3": port must be in the range 1-65535`},
 				{Name: proxyMultiIncludeOneInvalid.Name, Namespace: proxyMultiIncludeOneInvalid.Namespace}: {Object: proxyMultiIncludeOneInvalid, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
@@ -1650,7 +1651,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"multi-parent children is not orphaned when one of the parents is invalid": {
 			objs: []interface{}{proxyNoFQDN, proxyChildValidFoo2, proxyIncludeValidChild, serviceKuard, serviceFoo2},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyNoFQDN.Name, Namespace: proxyNoFQDN.Namespace}:                       {Object: proxyNoFQDN, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 				{Name: proxyChildValidFoo2.Name, Namespace: proxyChildValidFoo2.Namespace}:       {Object: proxyChildValidFoo2, Status: "valid", Description: "valid HTTPProxy"},
 				{Name: proxyIncludeValidChild.Name, Namespace: proxyIncludeValidChild.Namespace}: {Object: proxyIncludeValidChild, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
@@ -1661,7 +1662,7 @@ func TestDAGStatus(t *testing.T) {
 			objs: []interface{}{
 				secretRootsNS, serviceNginx, ingressSharedService, proxyTCPSharedService,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyTCPSharedService.Name, Namespace: proxyTCPSharedService.Namespace}: {
 					Object:      proxyTCPSharedService,
 					Status:      k8s.StatusValid,
@@ -1676,11 +1677,11 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxyDelegatedTCPTLS,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyDelegatedTCPTLS.Name, Namespace: proxyDelegatedTCPTLS.Namespace}: {
 					Object:      proxyDelegatedTCPTLS,
 					Status:      k8s.StatusInvalid,
-					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(secretContourNS)),
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.NamespacedNameOf(secretContourNS)),
 					Vhost:       proxyDelegatedTCPTLS.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -1691,11 +1692,11 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxyDelegatedTLS,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyDelegatedTLS.Name, Namespace: proxyDelegatedTLS.Namespace}: {
 					Object:      proxyDelegatedTLS,
 					Status:      k8s.StatusInvalid,
-					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(secretContourNS)),
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.NamespacedNameOf(secretContourNS)),
 					Vhost:       proxyDelegatedTLS.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -1706,11 +1707,11 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxy19,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy19.Name, Namespace: proxy19.Namespace}: {
 					Object:      proxy19,
 					Status:      k8s.StatusInvalid,
-					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.ToFullName(secretContourNS)),
+					Description: fmt.Sprintf("Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", k8s.NamespacedNameOf(secretContourNS)),
 					Vhost:       proxy19.Spec.VirtualHost.Fqdn,
 				},
 			},
@@ -1721,7 +1722,7 @@ func TestDAGStatus(t *testing.T) {
 				s10,
 				proxyPassthroughProxyNonSecure,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyPassthroughProxyNonSecure.Name, Namespace: proxyPassthroughProxyNonSecure.Namespace}: {
 					Object:      proxyPassthroughProxyNonSecure,
 					Status:      k8s.StatusValid,
@@ -1734,7 +1735,7 @@ func TestDAGStatus(t *testing.T) {
 			objs: []interface{}{
 				serviceKuard, proxyMultipleIncludersSite1, proxyMultipleIncludersSite2, proxyMultiIncludeChild,
 			},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyMultipleIncludersSite1.Name, Namespace: proxyMultipleIncludersSite1.Namespace}: {
 					Object:      proxyMultipleIncludersSite1,
 					Status:      "valid",
@@ -1756,31 +1757,31 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"valid proxy": {
 			objs: []interface{}{proxy1, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy1.Name, Namespace: proxy1.Namespace}: {Object: proxy1, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 			},
 		},
 		"proxy invalid port in service": {
 			objs: []interface{}{proxy2},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy2.Name, Namespace: proxy2.Namespace}: {Object: proxy2, Status: "invalid", Description: `service "home": port must be in the range 1-65535`, Vhost: "example.com"},
 			},
 		},
 		"root proxy outside of roots namespace": {
 			objs: []interface{}{proxy3},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy3.Name, Namespace: proxy3.Namespace}: {Object: proxy3, Status: "invalid", Description: "root HTTPProxy cannot be defined in this namespace"},
 			},
 		},
 		"root proxy does not specify FQDN": {
 			objs: []interface{}{proxyNoFQDN},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyNoFQDN.Name, Namespace: proxyNoFQDN.Namespace}: {Object: proxyNoFQDN, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 			},
 		},
 		"proxy self-edge produces a cycle": {
 			objs: []interface{}{proxy6, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy6.Name, Namespace: proxy6.Namespace}: {
 					Object:      proxy6,
 					Status:      "invalid",
@@ -1791,7 +1792,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy child delegates to parent, producing a cycle": {
 			objs: []interface{}{proxy7, proxy8},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy7.Name, Namespace: proxy7.Namespace}: {
 					Object:      proxy7,
 					Status:      "valid",
@@ -1807,26 +1808,26 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy orphaned route": {
 			objs: []interface{}{proxy8},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy8.Name, Namespace: proxy8.Namespace}: {Object: proxy8, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy"},
 			},
 		},
 		"proxy invalid parent orphans children": {
 			objs: []interface{}{proxy14, proxy11},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy14.Name, Namespace: proxy14.Namespace}: {Object: proxy14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 				{Name: proxy11.Name, Namespace: proxy11.Namespace}: {Object: proxy11, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy"},
 			},
 		},
 		"proxy invalid FQDN contains wildcard": {
 			objs: []interface{}{proxy15},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy15.Name, Namespace: proxy15.Namespace}: {Object: proxy15, Status: "invalid", Description: `Spec.VirtualHost.Fqdn "example.*.com" cannot use wildcards`, Vhost: "example.*.com"},
 			},
 		},
 		"proxy missing service shows invalid status": {
 			objs: []interface{}{proxy16},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy16.Name, Namespace: proxy16.Namespace}: {
 					Object:      proxy16,
 					Status:      "invalid",
@@ -1837,7 +1838,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with service missing port shows invalid status": {
 			objs: []interface{}{proxy16a, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy16a.Name, Namespace: proxy16a.Namespace}: {
 					Object:      proxy16a,
 					Status:      "invalid",
@@ -1848,7 +1849,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"insert conflicting proxies due to fqdn reuse": {
 			objs: []interface{}{proxy17, proxy18},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy17.Name, Namespace: proxy17.Namespace}: {
 					Object:      proxy17,
 					Status:      k8s.StatusInvalid,
@@ -1865,7 +1866,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"root proxy including another root": {
 			objs: []interface{}{proxy20, proxy21},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy20.Name, Namespace: proxy20.Namespace}: {
 					Object:      proxy20,
 					Status:      k8s.StatusInvalid,
@@ -1882,7 +1883,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"root proxy including another root w/ different hostname": {
 			objs: []interface{}{proxy22, proxy23, serviceGreenMarketing},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy22.Name, Namespace: proxy22.Namespace}: {
 					Object:      proxy22,
 					Status:      k8s.StatusInvalid,
@@ -1899,7 +1900,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy includes another": {
 			objs: []interface{}{proxyBlogMarketing, proxy25, serviceKuard, serviceGreenMarketing},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxyBlogMarketing.Name, Namespace: proxyBlogMarketing.Namespace}: {
 					Object:      proxyBlogMarketing,
 					Status:      "valid",
@@ -1915,7 +1916,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with mirror": {
 			objs: []interface{}{proxy26, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy26.Name, Namespace: proxy26.Namespace}: {
 					Object:      proxy26,
 					Status:      "valid",
@@ -1926,7 +1927,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two mirrors": {
 			objs: []interface{}{proxy27, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy27.Name, Namespace: proxy27.Namespace}: {
 					Object:      proxy27,
 					Status:      "invalid",
@@ -1937,7 +1938,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two prefix conditions on route": {
 			objs: []interface{}{proxy32, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy32.Name, Namespace: proxy32.Namespace}: {
 					Object:      proxy32,
 					Status:      "invalid",
@@ -1948,7 +1949,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two prefix conditions as an include": {
 			objs: []interface{}{proxy33, proxy34, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy33.Name, Namespace: proxy33.Namespace}: {
 					Object:      proxy33,
 					Status:      "invalid",
@@ -1963,7 +1964,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with prefix conditions on route that does not start with slash": {
 			objs: []interface{}{proxy35, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy35.Name, Namespace: proxy35.Namespace}: {
 					Object:      proxy35,
 					Status:      "invalid",
@@ -1974,7 +1975,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with include prefix that does not start with slash": {
 			objs: []interface{}{proxy36, proxy34, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy36.Name, Namespace: proxy36.Namespace}: {
 					Object:      proxy36,
 					Status:      "invalid",
@@ -1989,26 +1990,26 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate route condition headers": {
 			objs: []interface{}{proxy28, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy28.Name, Namespace: proxy28.Namespace}: {Object: proxy28, Status: "invalid", Description: "cannot specify duplicate header 'exact match' conditions in the same route", Vhost: "example.com"},
 			},
 		},
 		"duplicate valid route condition headers": {
 			objs: []interface{}{proxy31, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy31.Name, Namespace: proxy31.Namespace}: {Object: proxy31, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 			},
 		},
 		"duplicate include condition headers": {
 			objs: []interface{}{proxy29, proxy30, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy29.Name, Namespace: proxy29.Namespace}: {Object: proxy29, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 				{Name: proxy30.Name, Namespace: proxy30.Namespace}: {Object: proxy30, Status: "invalid", Description: "cannot specify duplicate header 'exact match' conditions in the same route", Vhost: ""},
 			},
 		},
 		"duplicate path conditions on an include": {
 			objs: []interface{}{proxy41, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy41.Name, Namespace: proxy41.Namespace}:   {Object: proxy41, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2016,7 +2017,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate header conditions on an include": {
 			objs: []interface{}{proxy42, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy42.Name, Namespace: proxy42.Namespace}:   {Object: proxy42, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2024,7 +2025,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate header+path conditions on an include": {
 			objs: []interface{}{proxy43, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy43.Name, Namespace: proxy43.Namespace}:   {Object: proxy43, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2032,7 +2033,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy with invalid tcpproxy": {
 			objs: []interface{}{proxy37, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy37.Name, Namespace: proxy37.Namespace}: {
 					Object:      proxy37,
 					Status:      "invalid",
@@ -2043,7 +2044,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy with empty tcpproxy": {
 			objs: []interface{}{proxy37a, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy37a.Name, Namespace: proxy37a.Namespace}: {
 					Object:      proxy37a,
 					Status:      "invalid",
@@ -2054,7 +2055,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ missing include": {
 			objs: []interface{}{proxy38, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "invalid",
@@ -2065,7 +2066,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ includes another root": {
 			objs: []interface{}{proxy38, proxy39, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "invalid",
@@ -2082,7 +2083,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ includes valid child": {
 			objs: []interface{}{proxy38, proxy40, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "valid",
@@ -2099,7 +2100,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ missing include": {
 			objs: []interface{}{proxy44, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy44.Name, Namespace: proxy44.Namespace}: {
 					Object:      proxy44,
 					Status:      "invalid",
@@ -2110,7 +2111,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ missing service": {
 			objs: []interface{}{proxy45},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy45.Name, Namespace: proxy45.Namespace}: {
 					Object:      proxy45,
 					Status:      "invalid",
@@ -2121,7 +2122,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ service missing port": {
 			objs: []interface{}{proxy45a, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy45a.Name, Namespace: proxy45a.Namespace}: {
 					Object:      proxy45a,
 					Status:      "invalid",
@@ -2132,7 +2133,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing tls": {
 			objs: []interface{}{proxy46},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy46.Name, Namespace: proxy46.Namespace}: {
 					Object:      proxy46,
 					Status:      "invalid",
@@ -2143,7 +2144,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing service": {
 			objs: []interface{}{secretRootsNS, serviceKuard, proxy47},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy47.Name, Namespace: proxy47.Namespace}: {
 					Object:      proxy47,
 					Status:      "invalid",
@@ -2154,7 +2155,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing service port": {
 			objs: []interface{}{secretRootsNS, serviceKuard, proxy47a},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy47a.Name, Namespace: proxy47a.Namespace}: {
 					Object:      proxy47a,
 					Status:      "invalid",
@@ -2165,14 +2166,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"valid HTTPProxy.TCPProxy": {
 			objs: []interface{}{proxy48root, proxy48child, serviceKuard, secretRootsNS},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy48root.Name, Namespace: proxy48root.Namespace}:   {Object: proxy48root, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 				{Name: proxy48child.Name, Namespace: proxy48child.Namespace}: {Object: proxy48child, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 			},
 		},
 		"valid HTTPProxy.TCPProxy - plural": {
 			objs: []interface{}{proxy48rootplural, proxy48child, serviceKuard, secretRootsNS},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy48rootplural.Name, Namespace: proxy48rootplural.Namespace}: {Object: proxy48rootplural, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 				{Name: proxy48child.Name, Namespace: proxy48child.Namespace}:           {Object: proxy48child, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 			},
@@ -2180,7 +2181,7 @@ func TestDAGStatus(t *testing.T) {
 		// issue 2309, each route must have at least one service
 		"invalid HTTPProxy due to empty route.service": {
 			objs: []interface{}{proxy49, serviceKuard},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: proxy49.Name, Namespace: proxy49.Namespace}: {
 					Object:      proxy49,
 					Status:      "invalid",
@@ -2190,24 +2191,24 @@ func TestDAGStatus(t *testing.T) {
 			},
 		},
 		"invalid fallback certificate passed to contour": {
-			fallbackCertificate: &k8s.FullName{
+			fallbackCertificate: &types.NamespacedName{
 				Name:      "invalid",
 				Namespace: "invalid",
 			},
 			objs: []interface{}{fallbackCertificate, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS Secret \"invalid/invalid\" fallback certificate is invalid: Secret not found", Vhost: "example.com"},
 			},
 		},
 		"fallback certificate requested but cert not configured in contour": {
 			objs: []interface{}{fallbackCertificate, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS enabled fallback but the fallback Certificate Secret is not configured in Contour configuration file", Vhost: "example.com"},
 			},
 		},
 		"fallback certificate requested and clientValidation also configured": {
 			objs: []interface{}{fallbackCertificateWithClientValidation, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[k8s.FullName]Status{
+			want: map[types.NamespacedName]Status{
 				{Name: fallbackCertificateWithClientValidation.Name, Namespace: fallbackCertificateWithClientValidation.Namespace}: {Object: fallbackCertificateWithClientValidation, Status: "invalid", Description: "Spec.Virtualhost.TLS fallback & client validation are incompatible together", Vhost: "example.com"},
 			},
 		},

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -97,7 +98,7 @@ func setupWithFallbackCert(t *testing.T, fallbackCertName, fallbackCertNamespace
 			Source: dag.KubernetesCache{
 				FieldLogger: log,
 			},
-			FallbackCertificate: &k8s.FullName{
+			FallbackCertificate: &types.NamespacedName{
 				Name:      fallbackCertName,
 				Namespace: fallbackCertNamespace,
 			},

--- a/internal/fixture/meta.go
+++ b/internal/fixture/meta.go
@@ -14,26 +14,17 @@
 package fixture
 
 import (
-	"strings"
-
+	"github.com/projectcontour/contour/internal/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ObjectMeta cracks a Kubernetes object name string of the form
 // "namespace/name" into a metav1.ObjectMeta struct. If the namespace
 // portion is omitted, then the default namespace is filled in.
-func ObjectMeta(name string) metav1.ObjectMeta {
-	v := strings.SplitN(name, "/", 2)
-	switch len(v) {
-	case 2:
-		return metav1.ObjectMeta{
-			Name:      v[1],
-			Namespace: v[0],
-		}
-	default:
-		return metav1.ObjectMeta{
-			Name:      v[0],
-			Namespace: metav1.NamespaceDefault,
-		}
+func ObjectMeta(nameStr string) metav1.ObjectMeta {
+	name := k8s.NamespacedNameFrom(nameStr)
+	return metav1.ObjectMeta{
+		Name:      name.Name,
+		Namespace: name.Namespace,
 	}
 }

--- a/internal/k8s/objectmeta_test.go
+++ b/internal/k8s/objectmeta_test.go
@@ -1,35 +1,71 @@
-// Copyright Project Contour Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package k8s
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestFullNameString(t *testing.T) {
-	cases := map[FullName]string{
-		FullName{}:                              "",
-		FullName{Namespace: "bar"}:              "",
-		FullName{Name: "foo"}:                   "default/foo",
-		FullName{Name: "foo", Namespace: "bar"}: "bar/foo",
+func TestNamespacedNameFrom(t *testing.T) {
+	run := func(testName string, got types.NamespacedName, want types.NamespacedName) {
+		t.Helper()
+		t.Run(testName, func(t *testing.T) {
+			t.Helper()
+			opts := []cmp.Option{
+				cmp.AllowUnexported(types.NamespacedName{}),
+			}
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 
-	for name, wanted := range cases {
-		got := name.String()
-		if got != wanted {
-			t.Errorf("name=%q namespace=%q, got %q wanted %q",
-				name.Name, name.Namespace, got, wanted)
-		}
-	}
+	run("no namespace",
+		NamespacedNameFrom("secret", DefaultNamespace("defns")),
+		types.NamespacedName{
+			Name:      "secret",
+			Namespace: "defns",
+		},
+	)
+
+	run("with namespace",
+		NamespacedNameFrom("ns1/secret", DefaultNamespace("defns")),
+		types.NamespacedName{
+			Name:      "secret",
+			Namespace: "ns1",
+		},
+	)
+
+	run("missing namespace",
+		NamespacedNameFrom("/secret", DefaultNamespace("defns")),
+		types.NamespacedName{
+			Name:      "secret",
+			Namespace: "defns",
+		},
+	)
+
+	run("missing secret name",
+		NamespacedNameFrom("secret/", DefaultNamespace("defns")),
+		types.NamespacedName{
+			Name:      "",
+			Namespace: "secret",
+		},
+	)
+
+	run("missing default namespace",
+		NamespacedNameFrom("secret"),
+		types.NamespacedName{
+			Name:      "secret",
+			Namespace: "default",
+		},
+	)
+
+	run("empty resource",
+		NamespacedNameFrom(""),
+		types.NamespacedName{
+			Name:      "",
+			Namespace: "default",
+		},
+	)
 }


### PR DESCRIPTION
The client-go type `types.NamespacedName` is almost identical to our
`k8s.FullName`, so switch to it everywhere. The difference is that
`NamespacedName` doesn't implicitly fill in the default namespace
when stringifying, so we need to make sure that we always add
this explicitly.

Signed-off-by: James Peach <jpeach@vmware.com>