### PR TITLE
hack: Update  make-release-tag script to update certgen-job

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.5.0
+  name: contour-certgen-master
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1448,7 +1448,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.5.0
+  name: contour-certgen-master
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -38,14 +38,21 @@ run::sed() {
     esac
 }
 
-# NOTE(jpeach): this will go away or change once we move to kustomize
-# since at that point the versioned image name will appear exactly once.
-for example in examples/contour/03-envoy.yaml examples/contour/03-contour.yaml ; do
+# Update the image tags in the Contour & Envoy manifests to the new version.
+for example in examples/contour/03-envoy.yaml examples/contour/03-contour.yaml examples/contour/02-job-certgen.yaml ; do
     # The version might be master or OLDVERS depending on whether we are
     # tagging from the release branch or from master.
     run::sed \
         "-es|docker.io/projectcontour/contour:master|$IMG|" \
         "-es|docker.io/projectcontour/contour:$OLDVERS|$IMG|" \
+        "$example"
+done
+
+# Update the certgen job name to the new version.
+for example in examples/contour/02-job-certgen.yaml ; do
+    run::sed \
+        "-es|contour-certgen-master|contour-certgen-$NEWVERS|" \
+        "-es|contour-certgen-$OLDVERS|contour-certgen-$NEWVERS|" \
         "$example"
 done
 
@@ -58,6 +65,7 @@ if git status -s examples/contour 2>&1 | grep -E -q '^\s+[MADRCU]'; then
     git commit -s -m "Update Contour Docker image to $NEWVERS." \
         examples/contour/03-contour.yaml \
         examples/contour/03-envoy.yaml \
+        examples/contour/02-job-certgen.yaml \
         examples/render/contour.yaml
 fi
 


### PR DESCRIPTION
Updates the `hack/make-release-tag.sh` script to change the job name to match
the release being created.

Signed-off-by: Steve Sloka <slokas@vmware.com>