### PR TITLE
internal/dag: cache ExtensionService resources

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"time"
 
+	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
@@ -240,6 +241,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	var informerSyncList k8s.InformerSyncList
 
 	informerSyncList.InformOnResources(clusterInformerFactory, dynamicHandler, k8s.DefaultResources()...)
+
+	// Inform on ExtensionService resources if they are installed
+	// in the cluster. TODO(jpeach) remove the resource check as part of #2711.
+	if gvr := projectcontourv1alpha1.GroupVersion.WithResource("extensionservices"); clients.ResourceExists(gvr) {
+		informerSyncList.InformOnResources(clusterInformerFactory, dynamicHandler, gvr)
+	}
 
 	if ctx.UseExperimentalServiceAPITypes {
 		// Check if the resource exists in the API server before setting up the informer.

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -17,7 +17,9 @@ import (
 	"testing"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -724,6 +726,12 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert extension service": {
+			obj: &projectcontourv1alpha1.ExtensionService{
+				ObjectMeta: fixture.ObjectMeta("default/extension"),
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range tests {
@@ -923,6 +931,15 @@ func TestKubernetesCacheRemove(t *testing.T) {
 					Name:      "tcproute",
 					Namespace: "default",
 				},
+			},
+			want: true,
+		},
+		"remove extension service": {
+			cache: cache(&projectcontourv1alpha1.ExtensionService{
+				ObjectMeta: fixture.ObjectMeta("default/extension"),
+			}),
+			obj: &projectcontourv1alpha1.ExtensionService{
+				ObjectMeta: fixture.ObjectMeta("default/extension"),
 			},
 			want: true,
 		},

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,6 +88,7 @@ type UnstructuredConverter struct {
 func NewUnstructuredConverter() (*UnstructuredConverter, error) {
 	schemeBuilder := runtime.SchemeBuilder{
 		projectcontour.AddToScheme,
+		projectcontourv1alpha1.AddToScheme,
 		scheme.AddToScheme,
 		serviceapis.AddToScheme,
 		v1beta1.AddToScheme,

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -17,15 +17,13 @@ import (
 	"errors"
 	"testing"
 
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
-
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
-
-	"github.com/projectcontour/contour/internal/assert"
 )
 
 func TestConvertUnstructured(t *testing.T) {
@@ -273,7 +271,7 @@ func TestConvertUnstructured(t *testing.T) {
 
 	run(t, "invalidunstructured", testcase{
 		obj:       proxyInvalidUnstructured,
-		want:      &projectcontour.HTTPProxy{},
+		want:      &projcontour.HTTPProxy{},
 		wantError: errors.New("unable to convert unstructured object to projectcontour.io/v1, Kind=HTTPProxy: cannot convert int to string"),
 	})
 
@@ -304,6 +302,26 @@ func TestConvertUnstructured(t *testing.T) {
 	run(t, "tcproute", testcase{
 		obj:       tcpRouteUnstructured,
 		want:      tr1,
+		wantError: nil,
+	})
+
+	run(t, "extensionservice", testcase{
+		obj: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "projectcontour.io/v1alpha1",
+				"kind":       "ExtensionService",
+				"metadata": map[string]interface{}{
+					"name":      "extension",
+					"namespace": "default",
+				},
+			},
+		},
+		want: &projectcontourv1alpha1.ExtensionService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension",
+				Namespace: "default",
+			},
+		},
 		wantError: nil,
 	})
 


### PR DESCRIPTION
If the cluster has the ExtensionService CRD installed, inform on
ExtensionService resources and update the DAG cache.

This fixes #2712.

Signed-off-by: James Peach <jpeach@vmware.com>