### PR TITLE
cmd/contour: add TimeoutConfig.RequestTimeout

### DIFF
--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -1,0 +1,71 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/timeout"
+	"github.com/sirupsen/logrus"
+)
+
+func TestGetRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *serveContext
+		want timeout.Setting
+	}{
+		{
+			name: "neither field set",
+			ctx:  &serveContext{},
+			want: timeout.DefaultSetting(),
+		},
+		{
+			name: "only deprecated field set",
+			ctx:  &serveContext{RequestTimeoutDeprecated: 7 * time.Second},
+			want: timeout.DurationSetting(7 * time.Second),
+		},
+		{
+			name: "only new field set",
+			ctx: &serveContext{
+				TimeoutConfig: TimeoutConfig{
+					RequestTimeout: "70s",
+				},
+			},
+			want: timeout.DurationSetting(70 * time.Second),
+		},
+		{
+			name: "both fields set, new field takes precedence",
+			ctx: &serveContext{
+				TimeoutConfig: TimeoutConfig{
+					RequestTimeout: "70s",
+				},
+				RequestTimeoutDeprecated: 7 * time.Second,
+			},
+			want: timeout.DurationSetting(70 * time.Second),
+		},
+	}
+
+	for _, tc := range tests {
+		log := logrus.New()
+		log.Out = ioutil.Discard
+		opt := cmp.AllowUnexported(timeout.Setting{})
+
+		assert.Equal(t, tc.want, getRequestTimeout(log, tc.ctx), opt)
+	}
+}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -118,8 +118,11 @@ type serveContext struct {
 	// be set in the config file.
 	TimeoutConfig `yaml:"timeouts,omitempty"`
 
-	// RequestTimeout sets the client request timeout globally for Contour.
-	RequestTimeout time.Duration `yaml:"request-timeout,omitempty"`
+	// RequestTimeoutDeprecated sets the client request timeout globally for Contour.
+	//
+	// Deprecated: this field has been replaced with TimeoutConfig.RequestTimeout,
+	// and will be removed in a future release.
+	RequestTimeoutDeprecated time.Duration `yaml:"request-timeout,omitempty"`
 
 	// Should Contour register to watch the new service-apis types?
 	// By default this value is false, meaning Contour will not do anything with any of the new
@@ -237,6 +240,14 @@ type LeaderElectionConfig struct {
 
 // TimeoutConfig holds various configurable proxy timeout values.
 type TimeoutConfig struct {
+	// RequestTimeout sets the client request timeout globally for Contour. Note that
+	// this is a timeout for the entire request, not an idle timeout. Omit or set to
+	// "infinity" to disable the timeout entirely.
+	//
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-request-timeout
+	// for more information.
+	RequestTimeout string `yaml:"request-timeout,omitempty"`
+
 	// ConnectionIdleTimeout defines how long the proxy should wait while there are
 	// no active requests (for HTTP/1.1) or streams (for HTTP/2) before terminating
 	// an HTTP connection. Set to "infinity" to disable the timeout entirely.

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -12,12 +12,6 @@ data:
     # path to kubeconfig (if not running inside a k8s cluster)
     # kubeconfig: /path/to/.kube/config
     #
-    # Client request timeout to be passed to Envoy
-    # as the connection manager request_timeout.
-    # Defaults to 0, which Envoy interprets as disabled.
-    # Note that this is the timeout for the whole request,
-    # not an idle timeout.
-    # request-timeout: 0s
     # disable HTTPProxy permitInsecure field
     disablePermitInsecure: false
     tls:
@@ -71,6 +65,7 @@ data:
     #
     # The following shows the default proxy timeout settings.
     # timeouts:
+    #   request-timeout: infinity
     #   connection-idle-timeout: 60s
     #   stream-idle-timeout: 5m
     #   max-connection-duration: infinity

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -46,12 +46,6 @@ data:
     # path to kubeconfig (if not running inside a k8s cluster)
     # kubeconfig: /path/to/.kube/config
     #
-    # Client request timeout to be passed to Envoy
-    # as the connection manager request_timeout.
-    # Defaults to 0, which Envoy interprets as disabled.
-    # Note that this is the timeout for the whole request,
-    # not an idle timeout.
-    # request-timeout: 0s
     # disable HTTPProxy permitInsecure field
     disablePermitInsecure: false
     tls:
@@ -105,6 +99,7 @@ data:
     #
     # The following shows the default proxy timeout settings.
     # timeouts:
+    #   request-timeout: infinity
     #   connection-idle-timeout: 60s
     #   stream-idle-timeout: 5m
     #   max-connection-duration: infinity

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -305,7 +305,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 	tests := map[string]struct {
 		routename                     string
 		accesslogger                  []*envoy_api_v2_accesslog.AccessLog
-		requestTimeout                time.Duration
+		requestTimeout                timeout.Setting
 		connectionIdleTimeout         timeout.Setting
 		streamIdleTimeout             timeout.Setting
 		maxConnectionDuration         timeout.Setting
@@ -313,9 +313,8 @@ func TestHTTPConnectionManager(t *testing.T) {
 		want                          *envoy_api_v2_listener.Filter
 	}{
 		"default": {
-			routename:      "default/kuard",
-			accesslogger:   FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout: 0,
+			routename:    "default/kuard",
+			accesslogger: FileAccessLogEnvoy("/dev/stdout"),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
@@ -356,7 +355,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -366,7 +364,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 		"request timeout of 10s": {
 			routename:      "default/kuard",
 			accesslogger:   FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout: 10 * time.Second,
+			requestTimeout: timeout.DurationSetting(10 * time.Second),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
 				ConfigType: &envoy_api_v2_listener.Filter_TypedConfig{
@@ -417,7 +415,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 		"connection idle timeout of 90s": {
 			routename:             "default/kuard",
 			accesslogger:          FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout:        0,
 			connectionIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
@@ -461,7 +458,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -471,7 +467,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 		"stream idle timeout of 90s": {
 			routename:         "default/kuard",
 			accesslogger:      FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout:    0,
 			streamIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
@@ -513,7 +508,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						StreamIdleTimeout:         protobuf.Duration(90 * time.Second),
@@ -524,7 +518,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 		"max connection duration of 90s": {
 			routename:             "default/kuard",
 			accesslogger:          FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout:        0,
 			maxConnectionDuration: timeout.DurationSetting(90 * time.Second),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
@@ -568,7 +561,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -578,7 +570,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 		"when max connection duration is disabled, it's omitted": {
 			routename:             "default/kuard",
 			accesslogger:          FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout:        0,
 			maxConnectionDuration: timeout.DisabledSetting(),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
@@ -620,17 +611,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
 				},
 			},
 		},
-		"connection shutdown grace period of 90s": {
+		"drain timeout of 90s": {
 			routename:                     "default/kuard",
 			accesslogger:                  FileAccessLogEnvoy("/dev/stdout"),
-			requestTimeout:                0,
 			connectionShutdownGracePeriod: timeout.DurationSetting(90 * time.Second),
 			want: &envoy_api_v2_listener.Filter{
 				Name: wellknown.HTTPConnectionManager,
@@ -672,7 +661,6 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
-						RequestTimeout:            protobuf.Duration(0),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						DrainTimeout:              protobuf.Duration(90 * time.Second),

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -251,7 +251,6 @@ func filterchaintlsfallback(fallbackSecret *v1.Secret, peerValidationContext *da
 				RouteConfigName(contour.ENVOY_FALLBACK_ROUTECONFIG).
 				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
 				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).
-				RequestTimeout(0).
 				Get(),
 		),
 	)

--- a/site/docs/master/configuration.md
+++ b/site/docs/master/configuration.md
@@ -26,7 +26,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | json-fields | string array | [fields][5]| This is the list the field names to include in the JSON [access log format][2]. |
 | kubeconfig | string | `$HOME/.kube/config` | Path to a Kubernetes [kubeconfig file][3] for when Contour is executed outside a cluster. |
 | leaderelection | leaderelection | | The [leader election configuration](#leader-election-configuration). |
-| request-timeout | [duration][4] | `0s` | This field specifies the default request timeout as a Go duration string. Zero means there is no timeout. |
+| request-timeout | [duration][4] | `0s` | **Deprecated and will be removed in a future release. Use [timeouts.request-timeout](#timeout-configuration) instead.**<br /><br /> This field specifies the default request timeout as a Go duration string. Zero means there is no timeout. |
 | tls | TLS | | The default [TLS configuration](#tls-configuration). |
 | timeouts | TimeoutConfig | | The [timeout configuration](#timeout-configuration). |
 {: class="table thead-dark table-bordered"}
@@ -75,6 +75,7 @@ The timeout configuration block can be used to configure various timeouts for th
 
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
+| request-timeout | string | none* | This field specifies the default request timeout. Note that this is a timeout for the entire request, not an idle timeout. Must be a [valid Go duration string][4], or omitted or set to `infinity` to disable the timeout entirely. See [the Envoy documentation][12] for more information.<br /><br />_Note: A value of `0s` previously disabled this timeout entirely. This is no longer the case. Use `infinity` or omit this field to disable the timeout._  |
 | connection-idle-timeout| string | `60s` | This field defines how long the proxy should wait while there are no active requests (for HTTP/1.1) or streams (for HTTP/2) before terminating an HTTP connection. Must be a [valid Go duration string][4], or `infinity` to disable the timeout entirely. See [the Envoy documentation][8] for more information. |
 | stream-idle-timeout| string | `5m`* |This field defines how long the proxy should wait while there is no request activity (for HTTP/1.1) or stream activity (for HTTP/2) before terminating the HTTP request or stream. Must be a [valid Go duration string][4], or `infinity` to disable the timeout entirely. See [the Envoy documentation][9] for more information. |
 | max-connection-duration | string | none* | This field defines the maximum period of time after an HTTP connection has been established from the client to the proxy before it is closed by the proxy, regardless of whether there has been activity or not. Must be a [valid Go duration string][4], or omitted or set to `infinity` for no max duration. See [the Envoy documentation][10] for more information. |
@@ -120,6 +121,7 @@ data:
     # - "HTTP/2"
     # The following shows the default proxy timeout settings.
     # timeouts:
+    #  request-timeout: infinity
     #  connection-idle-timeout: 60s
     #  stream-idle-timeout: 5m
     #  max-connection-duration: infinity
@@ -153,3 +155,4 @@ The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration
 [11]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-drain-timeout
+[12]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-request-timeout


### PR DESCRIPTION
updates #2690 

Adds a new RequestTimeout field to the TimeoutConfig struct. If
specified in the config file, this field takes precedence over
the now-deprecated RequestTimeout field in the root of the
serveContext struct.

Signed-off-by: Steve Kriss <krisss@vmware.com>