### PR TITLE
internal/envoy: use a consistent SNI server name for H2

### DIFF
--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -84,14 +84,14 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 			),
 		)
 	case "h2":
+		cluster.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				c.UpstreamValidation,
-				service.ExternalName,
+				c.SNI,
 				"h2",
 			),
 		)
-		fallthrough
 	case "h2c":
 		cluster.Http2ProtocolOptions = &envoy_api_v2_core.Http2ProtocolOptions{}
 	}

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -35,8 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DefaultCluster returns a copy of c, updated with default values.
-func DefaultCluster(c *v2.Cluster) *v2.Cluster {
+// DefaultCluster returns a copy of the default Cluster, with each
+// Cluster given in the parameter slice merged on top. This makes it
+// relatively fluent to compose Clusters by tweaking a few fields.
+func DefaultCluster(clusters ...*v2.Cluster) *v2.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &v2.Cluster{
 		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
@@ -44,7 +46,10 @@ func DefaultCluster(c *v2.Cluster) *v2.Cluster {
 		CommonLbConfig: envoy.ClusterCommonLBConfig(),
 	}
 
-	proto.Merge(defaults, c)
+	for _, c := range clusters {
+		proto.Merge(defaults, c)
+	}
+
 	return defaults
 }
 


### PR DESCRIPTION
When the SNI server name is overridden by rewriting the `Host` header,
Contour was updating the outbound SNI name for the `tls` protocol but
still using the external name value for the `h2` protocol. Since `h2`
implies TLS, Contour should do the same thing in both cases.

Signed-off-by: James Peach <jpeach@vmware.com>