### PR TITLE
travis: Run integration tests on each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,22 +36,12 @@ jobs:
 
   # Build the Contour container image with the local Docker. Create a kind
   # cluster, push the image we built into it, and verify that both Contour
-  # and Envoy come up. This is an initial placeholder as we experiment with
-  # different approaches to integration testing.
+  # and Envoy come up. Then execute the integration tests against the cluster.
   - name: integration
     install:
     - ./hack/travis/install-kubernetes-toolchain.sh $HOME/bin
-    - make container IMAGE=docker.io/projectcontour/contour VERSION=ci
-    - docker tag docker.io/projectcontour/contour:ci docker.io/projectcontour/contour:master
-    - docker tag docker.io/projectcontour/contour:ci docker.io/projectcontour/contour:latest
     script:
-    - $HOME/bin/kind create cluster --wait 2m
-    - $HOME/bin/kind load docker-image docker.io/projectcontour/contour:master
-    - $HOME/bin/kind load docker-image docker.io/projectcontour/contour:latest
-    - '$HOME/bin/kubectl apply -f <(sed "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g" < examples/render/contour.yaml)'
-    - $HOME/bin/kubectl wait --timeout=2m -n projectcontour -l app=contour deployments --for=condition=Available
-    - $HOME/bin/kubectl wait --timeout=2m -n projectcontour -l app=envoy pods --for=condition=Ready
-    - $HOME/bin/kind delete cluster
+    - make integration
 
   - name: lint
     install:

--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,11 @@ site-check: ## Test the site's links
 	docker run --rm -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
 		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll build && htmlproofer --assume-extension /site/_site"
 
+integration: ## Run integration tests against a real k8s cluster
+	./_integration/testsuite/make-kind-cluster.sh
+	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml
+	./_integration/testsuite/cleanup.sh
+
 help: ## Display this help
 	@echo Contour high performance Ingress controller for Kubernetes
 	@echo

--- a/_integration/testsuite/cleanup.sh
+++ b/_integration/testsuite/cleanup.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+readonly KIND=${KIND:-kind}
+readonly CLUSTERNAME=${CLUSTER:-contour-integration}
+
+kind::cluster::delete() {
+    ${KIND} delete cluster --name "${CLUSTERNAME}"
+}
+
+# Delete existing kind cluster
+kind::cluster::delete

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -74,6 +74,10 @@ for t in $TAGS ; do
     kind::cluster::load docker.io/projectcontour/contour:$t
 done
 
+# Pull the util image & push image into the cluster.
+docker pull docker.io/kennethreitz/httpbin
+kind::cluster::load docker.io/kennethreitz/httpbin
+
 # Install Contour.
 #
 # NOTE(jpeach): The certgen job uses the ":latest" tag with the

--- a/hack/travis/install-kubernetes-toolchain.sh
+++ b/hack/travis/install-kubernetes-toolchain.sh
@@ -7,6 +7,7 @@ set -o pipefail
 readonly KUSTOMIZE_VERS="v3.5.4"
 readonly KUBECTL_VERS="v1.18.2"
 readonly KIND_VERS="v0.8.1"
+readonly INTEGRATION_TESTER_VERS="2.0.0"
 
 readonly PROGNAME=$(basename $0)
 readonly CURL=${CURL:-curl}
@@ -56,3 +57,10 @@ download \
 
 tar -C "${DESTDIR}" -xf "${DESTDIR}/kustomize.tgz" kustomize
 rm "${DESTDIR}/kustomize.tgz"
+
+download \
+    "https://github.com/projectcontour/integration-tester/releases/download/v${INTEGRATION_TESTER_VERS}/integration-tester_${INTEGRATION_TESTER_VERS}_${OS}_x86_64.tar.gz" \
+    "${DESTDIR}/integration-tester.tgz"
+
+tar -C "${DESTDIR}" -xf "${DESTDIR}/integration-tester.tgz"
+rm "${DESTDIR}/integration-tester.tgz"


### PR DESCRIPTION
Adds a `makefile` task which spins up a kind cluster, loads in a Contour build and runs all the integrations tests. 