### PR TITLE
internal/contour: ensure the http.Router filter is present

### DIFF
--- a/_integration/testsuite/run-test-case.sh
+++ b/_integration/testsuite/run-test-case.sh
@@ -33,5 +33,5 @@ exec "$TESTER" run \
     --param proxy.address="$ADDRESS" \
     --param proxy.http_port="$HTTP_PORT" \
     --param proxy.https_port="$HTTPS_PORT" \
-    --watch pods,secrets \
+    --watch pods,secrets,configmaps \
     "$@"

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -454,6 +454,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			// Default filter chain
 			filters = envoy.Filters(
 				envoy.HTTPConnectionManagerBuilder().
+					DefaultFilters().
 					RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
 					MetricsPrefix(ENVOY_HTTPS_LISTENER).
 					AccessLoggers(v.ListenerVisitorConfig.newSecureAccessLog()).

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -145,6 +145,7 @@ func TestListenerVisit(t *testing.T) {
 	}
 
 	fallbackCertFilter := envoy.HTTPConnectionManagerBuilder().
+		DefaultFilters().
 		MetricsPrefix(ENVOY_HTTPS_LISTENER).
 		RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
 		AccessLoggers(envoy.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -803,3 +803,19 @@ func TestProtoNamesForVersions(t *testing.T) {
 	assert.Equal(t, ProtoNamesForVersions(HTTPVersion3), []string(nil))
 	assert.Equal(t, ProtoNamesForVersions(HTTPVersion1, HTTPVersion2), []string{"h2", "http/1.1"})
 }
+
+// TestBuilderValidation tests that validation checks that
+// DefaultFilters adds the required HTTP connection manager filters.
+func TestBuilderValidation(t *testing.T) {
+	if err := HTTPConnectionManagerBuilder().Validate(); err == nil {
+		t.Errorf("ConnectionManager with no filters passed validation")
+	}
+
+	if err := HTTPConnectionManagerBuilder().AddFilter(&http.HttpFilter{Name: "foo"}).Validate(); err == nil {
+		t.Errorf("ConnectionManager with no filters passed validation")
+	}
+
+	if err := HTTPConnectionManagerBuilder().DefaultFilters().Validate(); err != nil {
+		t.Errorf("ConnectionManager with default filters failed validation: %s", err)
+	}
+}

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -248,6 +248,7 @@ func filterchaintlsfallback(fallbackSecret *v1.Secret, peerValidationContext *da
 			alpn...),
 		envoy.Filters(
 			envoy.HTTPConnectionManagerBuilder().
+				DefaultFilters().
 				RouteConfigName(contour.ENVOY_FALLBACK_ROUTECONFIG).
 				MetricsPrefix(contour.ENVOY_HTTPS_LISTENER).
 				AccessLoggers(envoy.FileAccessLogEnvoy("/dev/stdout")).


### PR DESCRIPTION
Ensure that the `http.Router` filter is present whenever we build a
HTTP Connection Manager. The `Router` filter is responsible for actually
forwarding HTTP requests, so omitting it leads to configurations that
are syntactically valid but otherwise inoperable.

This fixes #2733.

Signed-off-by: James Peach <jpeach@vmware.com>