### PR TITLE
internal/contour: simplify the endpoints translator

### DIFF
--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -399,7 +399,7 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var et EndpointsTranslator
-			et.recomputeClusterLoadAssignment(tc.oldep, tc.newep)
+			recomputeClusterLoadAssignment(&et, tc.oldep, tc.newep)
 			got := et.Contents()
 			assert.Equal(t, tc.want, got)
 		})


### PR DESCRIPTION
Breaking EndpointsTranslator into two parts doesn't provide any benefits
and we can make the code easier to follow by removing all the indirection.

Signed-off-by: James Peach <jpeach@vmware.com>