### PR TITLE
internal/envoy: add common API for ClusterLoadAssignment names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/client-go v0.18.2
 	k8s.io/gengo v0.0.0-20191120174120-e74f70b9b27e // indirect
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	sigs.k8s.io/controller-tools v0.2.9
 	sigs.k8s.io/kustomize/kyaml v0.1.1
 	sigs.k8s.io/service-apis v0.0.0-20200213014236-51691dd89266

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -397,6 +398,12 @@ func TestCluster(t *testing.T) {
 			assert.Equal(t, want, got)
 		})
 	}
+}
+
+func TestClusterLoadAssignmentName(t *testing.T) {
+	assert.Equal(t, ClusterLoadAssignmentName(types.NamespacedName{Namespace: "ns", Name: "svc"}, "port"), "ns/svc/port")
+	assert.Equal(t, ClusterLoadAssignmentName(types.NamespacedName{Namespace: "ns", Name: "svc"}, ""), "ns/svc")
+	assert.Equal(t, ClusterLoadAssignmentName(types.NamespacedName{}, ""), "/")
 }
 
 func TestClustername(t *testing.T) {

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -82,7 +82,7 @@ func TestExternalNameService(t *testing.T) {
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 		),
 		TypeUrl: clusterType,
 	})
@@ -117,7 +117,7 @@ func TestExternalNameService(t *testing.T) {
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 		),
 		TypeUrl: clusterType,
 	})
@@ -160,7 +160,7 @@ func TestExternalNameService(t *testing.T) {
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		TypeUrl: clusterType,
 		Resources: resources(t,
-			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 		),
 	})
 
@@ -206,7 +206,7 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			DefaultCluster(
-				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&v2.Cluster{
 					Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
 				},
@@ -261,7 +261,7 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			DefaultCluster(
-				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard/", "default_kuard_80", "foo.io", 80),
+				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&v2.Cluster{
 					TransportSocket: envoy.UpstreamTLSTransportSocket(
 						envoy.UpstreamTLSContext(nil, "external.address"),


### PR DESCRIPTION
Various parts of an Envoy configuration depend upon the EDS service
emitting a ClusterLoadAssignment with a matching name. Hoist a common
function to generate a ClusterLoadAssignment name to (1) ensure that it
is generated consistently, and (2) make it easier to track the dependency.

Signed-off-by: James Peach <jpeach@vmware.com>