### PR TITLE
TestServeContextCertificateHandling: fix data race on err variable

### DIFF
--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -349,7 +349,7 @@ func TestServeContextCertificateHandling(t *testing.T) {
 	checkFatalErr(t, err)
 
 	go func() {
-		err = g.Serve(l)
+		err := g.Serve(l)
 		checkFatalErr(t, err)
 	}()
 	defer g.Stop()


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Fix data race on the err variable.