### PR TITLE
makefile: Fix broken reference to script in check-generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ generate-metrics-docs:
 
 .PHONY: check-generate
 check-generate: generate
-	@./hack/travis/check-uncommitted-codegen.sh
+	@./hack/actions/check-uncommitted-codegen.sh
 
 # TODO(youngnick): Move these local bootstrap config files out of the repo root dir.
 $(LOCAL_BOOTSTRAP_CONFIG): install


### PR DESCRIPTION
After update to use Github actions, there was a broken reference to a travis link. This updates that path to the script. 

Signed-off-by: Steve Sloka <slokas@vmware.com>