### PR TITLE
cmd/contour: refactor shutdown-manager to initiate shutdown using an Exec command

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -39,7 +39,10 @@ func main() {
 	app.HelpFlag.Short('h')
 
 	envoyCmd := app.Command("envoy", "Sub-command for envoy actions.")
-	shutdownManager, shutdownManagerCtx := registerShutdownManager(envoyCmd, log)
+	sdm, shutdownManagerCtx := registerShutdownManager(envoyCmd, log)
+
+	// Add a "shutdown" command which initiates an Envoy shutdown sequence.
+	sdmShutdown := envoyCmd.Command("shutdown", "Initiate an shutdown sequence which configures Envoy to begin draining connections.")
 
 	bootstrap, bootstrapCtx := registerBootstrap(app)
 	certgenApp, certgenConfig := registerCertGen(app)
@@ -68,8 +71,10 @@ func main() {
 
 	args := os.Args[1:]
 	switch kingpin.MustParse(app.Parse(args)) {
-	case shutdownManager.FullCommand():
+	case sdm.FullCommand():
 		doShutdownManager(shutdownManagerCtx)
+	case sdmShutdown.FullCommand():
+		shutdownManagerCtx.shutdownHandler()
 	case bootstrap.FullCommand():
 		check(envoy.WriteBootstrap(bootstrapCtx))
 	case certgenApp.FullCommand():

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -33,10 +33,11 @@ spec:
         imagePullPolicy: Always
         lifecycle:
           preStop:
-            httpGet:
-              path: /shutdown
-              port: 8090
-              scheme: HTTP
+            exec:
+              command:
+                - /bin/contour
+                - envoy
+                - shutdown
         livenessProbe:
           httpGet:
             path: /healthz

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1773,10 +1773,11 @@ spec:
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
-            httpGet:
-              path: /shutdown
-              port: 8090
-              scheme: HTTP
+            exec:
+              command:
+                - /bin/contour
+                - envoy
+                - shutdown
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This changes the preStop lifecycle hook to utilize a command instead of an http request. The /shutdown http endpoint now only returns when the pod is ready to be terminated, and no longer initiates the Envoy shutdown sequence.
    
The Envoy container will block on its preStop hook until the /shutdown endpoint returns. That endpoint, implemented in the shutdown-manager, will utilize a file messaging pattern to know when it is safe for Envoy to terminate by checking for the existence of a file in the filesystem.

Signed-off-by: Steve Sloka <slokas@vmware.com>