### PR TITLE
testsuite: add a fallback certificate test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,7 @@ site-check: ## Test the site's links
 
 integration: ## Run integration tests against a real k8s cluster
 	./_integration/testsuite/make-kind-cluster.sh
+	./_integration/testsuite/install-fallback-certificate.sh
 	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml
 	./_integration/testsuite/cleanup.sh
 

--- a/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
+++ b/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
@@ -1,0 +1,135 @@
+# This check depends on the `--watch=configmaps` argument being given
+# to integration-tester.
+
+import data.contour.resources
+import data.contour.resources.configmap
+
+Namespace := "projectcontour"
+Config := sprintf("%s/contour",[Namespace])
+
+# Skip if the configmap isn't present.
+skip[msg] {
+  not resources.is_present("configmaps", Config)
+  msg := sprintf("Contour is not installed in the %q namespace", [Namespace])
+}
+
+skip[msg] {
+  conf := configmap.get_data(Config)
+  contour := yaml.unmarshal(object.get(conf, "contour.yaml", "{}"))
+  tls := object.get(contour, "tls", {})
+  fallback := object.get(tls, "fallback-certificate", {})
+
+  name := object.get(fallback, "name", "")
+
+  # Skip if there's no fallback certificate name.
+  name == ""
+  msg := "Contour fallback certificate is not configured"
+}
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo-cert
+spec:
+  dnsNames:
+  - echo.projectcontour.io
+  secretName: echo
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: echo.projectcontour.io
+    tls:
+      secretName: echo
+      enableFallbackCertificate: true
+  routes:
+  - services:
+    - name: echo
+      port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.request
+import data.contour.http.response
+
+Response := client.Get({
+  "url": url.https(sprintf("/fallback/%d", [time.now_ns()])),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("fallback-certificate"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_200_response [msg] {
+  not response.status_is(Response, 200)
+  msg := sprintf("SNI request got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_wrong_routing [msg] {
+  wanted := "echo"
+  testid := response.testid(Response)
+  testid != wanted
+  msg := sprintf("SNI request got test ID %q, wanted %q", [testid, wanted])
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.request
+import data.contour.http.response
+
+Response := client.Get({
+  "url": url.https(sprintf("/fallback/%d", [time.now_ns()])),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("fallback-certificate"),
+  },
+  "tls_insecure_skip_verify": true,
+  "tls_server_name": client.target_addr,
+})
+
+error_non_200_response [msg] {
+  not response.status_is(Response, 200)
+  msg := sprintf("fallback request got status %d, wanted %d", [Response.status_code, 200])
+}
+
+error_wrong_routing [msg] {
+  wanted := "echo"
+  testid := response.testid(Response)
+  testid != wanted
+  msg := sprintf("fallback request got test ID %q, wanted %q", [testid, wanted])
+}

--- a/_integration/testsuite/install-fallback-certificate.sh
+++ b/_integration/testsuite/install-fallback-certificate.sh
@@ -1,0 +1,102 @@
+#! /usr/bin/env bash
+
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# install-fallback-certificate.sh: Install a fallback certificate
+# configuration for Contour.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+readonly KIND=${KIND:-kind}
+readonly KUBECTL=${KUBECTL:-kubectl}
+
+readonly CLUSTERNAME=${CLUSTER:-contour-integration}
+readonly WAITTIME=${WAITTIME:-5m}
+
+readonly HERE=$(cd $(dirname $0) && pwd)
+readonly REPO=$(cd ${HERE}/../.. && pwd)
+
+kind::cluster::exists() {
+    ${KIND} get clusters | grep -q "$1"
+}
+
+if ! kind::cluster::exists "$CLUSTERNAME" ; then
+    echo "cluster $CLUSTERNAME does not exist"
+    exit 2
+fi
+
+${KUBECTL} apply -f - <<EOF
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+EOF
+
+${KUBECTL} apply -f - <<EOF
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: fallback-cert
+  namespace: projectcontour
+spec:
+  dnsNames:
+  - fallback.projectcontour.io
+  secretName: fallback-cert
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+EOF
+
+${KUBECTL} apply -f - <<EOF
+apiVersion: projectcontour.io/v1
+kind: TLSCertificateDelegation
+metadata:
+  name: fallback-cert
+  namespace: projectcontour
+spec:
+  delegations:
+  - secretName: fallback-cert
+    targetNamespaces:
+    - "*"
+EOF
+
+${KUBECTL} apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: projectcontour
+data:
+  contour.yaml: |
+    tls:
+      fallback-certificate:
+        name: fallback-cert
+        namespace: projectcontour
+    accesslog-format: envoy
+    disablePermitInsecure: false
+EOF
+
+# Wait for the fallback certificate to issue.
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour certificates/fallback-cert --for=condition=Ready
+
+# Restart to pick up the new config map.
+${KUBECTL} rollout restart deployment -n projectcontour contour
+
+# Wait for contour to restart.
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=contour deployments --for=condition=Available

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -93,3 +93,4 @@ ${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=envoy pods --fo
 # Install cert-manager.
 ${KUBECTL} apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.1/cert-manager.yaml
 ${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=cert-manager deployments --for=condition=Available
+${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=webhook deployments --for=condition=Available

--- a/_integration/testsuite/policies/contour-configmap.rego
+++ b/_integration/testsuite/policies/contour-configmap.rego
@@ -1,0 +1,34 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+package contour.resources.configmap
+
+import  data.contour.resources
+
+# get_data returns the .data field of the named ConfigMap resource. If
+# the resource is not present or does not have a .data field, and empty
+# object is returned.
+#
+# Examples:
+#   configmap.data("foo")
+#   configmap.data("namespace-name/foo")
+get_data(name) = obj {
+  # Get the named configmap resource.
+  config := resources.get("configmaps", name)
+
+  # Get the .data field.
+  obj := object.get(config, "data", {})
+} else = obj {
+  obj := {}
+}


### PR DESCRIPTION
Add a simple integration test to ensure that using the fallback
certificate works as expected. This requires that Contour is deployed
with a valid fallback certificate. For integration testing, we can use
cert-manager to pre-configure that, but this approach won't work well
for large numbers of configuration permutations, so we should revisit
it relatively soon.

Signed-off-by: James Peach <jpeach@vmware.com>