### PR TITLE
testsuite: fix httproxies count

### DIFF
--- a/_integration/testsuite/httpproxy/002-header-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/002-header-condition-match.yaml
@@ -162,7 +162,7 @@ spec:
 
 default http_proxy_count = 0
 http_proxy_count = n {
-  n := count(data.resources.httpproxies[_])
+  n := count(data.resources.httpproxies)
 }
 
 error[msg] {


### PR DESCRIPTION
The Rego expression `count(data.resources.httpproxies[_])` generates a
map of the length of each proxy resource name. What we actually want is
`count(data.resources.httpproxies)` which is the number of elements in
the proxies map.

Signed-off-by: James Peach <jpeach@vmware.com>