### PR TITLE
internal/workgroup: add cancellation support

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -446,7 +447,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	})
 
 	// GO!
-	return g.Run()
+	return g.Run(context.Background())
 }
 
 func contains(namespaces []string, ns string) bool {

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -138,15 +138,11 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 		EndpointsTranslator: et,
 	}
 
-	stop := make(chan struct{})
-	g.Add(func(_ <-chan struct{}) error {
-		<-stop
-		return nil
-	})
+	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error)
 	go func() {
-		done <- g.Run()
+		done <- g.Run(ctx)
 	}()
 
 	return rh, cc, func() {
@@ -154,7 +150,7 @@ func setup(t *testing.T, opts ...func(*contour.EventHandler)) (cache.ResourceEve
 		cc.Close()
 
 		// stop server
-		close(stop)
+		cancel()
 
 		<-done
 	}

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -147,15 +147,11 @@ func setupWithFallbackCert(t *testing.T, fallbackCertName, fallbackCertNamespace
 		statusCache:         statusCache,
 	}
 
-	stop := make(chan struct{})
-	g.Add(func(_ <-chan struct{}) error {
-		<-stop
-		return nil
-	})
+	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error)
 	go func() {
-		done <- g.Run()
+		done <- g.Run(ctx)
 	}()
 
 	return rh, &Contour{
@@ -167,7 +163,7 @@ func setupWithFallbackCert(t *testing.T, fallbackCertName, fallbackCertNamespace
 			cc.Close()
 
 			// stop server
-			close(stop)
+			cancel()
 
 			<-done
 		}

--- a/internal/workgroup/example_test.go
+++ b/internal/workgroup/example_test.go
@@ -14,6 +14,7 @@
 package workgroup_test
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -39,7 +40,7 @@ func ExampleGroup_Run() {
 	}
 	g.Add(b)
 
-	err := g.Run()
+	err := g.Run(context.Background())
 	fmt.Println(err)
 
 	// Output:
@@ -66,7 +67,7 @@ func ExampleGroup_Run_withShutdown() {
 		shutdown <- <-time.After(100 * time.Millisecond)
 	}()
 
-	err := g.Run()
+	err := g.Run(context.Background())
 	fmt.Println(err)
 
 	// Output:
@@ -109,5 +110,5 @@ func ExampleGroup_Run_multipleListeners() {
 		return http.Serve(l, mux)
 	})
 
-	g.Run() // nolint:errcheck
+	g.Run(context.Background()) // nolint:errcheck
 }

--- a/internal/workgroup/group_test.go
+++ b/internal/workgroup/group_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGroupRunWithNoRegisteredFunctions(t *testing.T) {
 	var g Group
-	got := g.Run()
+	got := g.Run(context.TODO())
 	assert(t, nil, got)
 }
 
@@ -41,7 +41,7 @@ func TestGroupFirstReturnValueIsReturnedToRunsCaller(t *testing.T) {
 
 	result := make(chan error)
 	go func() {
-		result <- g.Run()
+		result <- g.Run(context.TODO())
 	}()
 	close(wait)
 	assert(t, io.EOF, <-result)
@@ -61,7 +61,7 @@ func TestGroupAddContext(t *testing.T) {
 
 	result := make(chan error)
 	go func() {
-		result <- g.Run()
+		result <- g.Run(context.TODO())
 	}()
 	close(wait)
 	assert(t, io.EOF, <-result)


### PR DESCRIPTION
Replace the weird hack that feature tests use to cancel running
a workgroup with structured context cancellation.

Signed-off-by: James Peach <jpeach@vmware.com>