### PR TITLE
Parse yaml

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -76,6 +76,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 		}
 		defer f.Close()
 		dec := yaml.NewDecoder(f)
+		dec.SetStrict(true)
 		parsed = true
 		return dec.Decode(&ctx)
 	}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -78,7 +78,10 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 		dec := yaml.NewDecoder(f)
 		dec.SetStrict(true)
 		parsed = true
-		return dec.Decode(&ctx)
+		if err := dec.Decode(&ctx); err != nil {
+			return fmt.Errorf("failed to parse contour configuration: %w", err)
+		}
+		return nil
 	}
 
 	serve.Flag("config-path", "Path to base configuration.").Short('c').Action(parseConfig).ExistingFileVar(&configFile)


### PR DESCRIPTION
Enables strict configuration YAML parsing.

Fixes #2623

Signed-off-by: Tim Gretler "gretler.tim@gmail.com"
