### PR TITLE
internal/dag: improve status errors for invalid TLS

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -115,17 +115,19 @@ type VirtualHost struct {
 }
 
 // TLS describes tls properties. The SNI names that will be matched on
-// are described in fqdn, the tls.secretName secret must contain a
-// matching certificate unless tls.passthrough is set to true.
+// are described in the HTTPProxy's Spec.VirtualHost.Fqdn field.
 type TLS struct {
-	// required, the name of a secret in the current namespace
+	// SecretName is the name of a TLS secret in the current namespace.
+	// Either SecretName or Passthrough must be specified, but not both.
+	// If specified, the named secret must contain a matching certificate
+	// for the virtual host's FQDN.
 	SecretName string `json:"secretName,omitempty"`
 	// Minimum TLS version this vhost should negotiate
 	// +optional
 	MinimumProtocolVersion string `json:"minimumProtocolVersion,omitempty"`
-	// If Passthrough is set to true, the SecretName will be ignored
-	// and the encrypted handshake will be passed through to the
-	// backing cluster.
+	// Passthrough defines whether the encrypted TLS handshake will be
+	// passed through to the backing cluster. Either Passthrough or
+	// SecretName must be specified, but not both.
 	// +optional
 	Passthrough bool `json:"passthrough,omitempty"`
 	// ClientValidation defines how to verify the client certificate

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -765,12 +765,15 @@ spec:
                       description: Minimum TLS version this vhost should negotiate
                       type: string
                     passthrough:
-                      description: If Passthrough is set to true, the SecretName will
-                        be ignored and the encrypted handshake will be passed through
-                        to the backing cluster.
+                      description: Passthrough defines whether the encrypted TLS handshake
+                        will be passed through to the backing cluster. Either Passthrough
+                        or SecretName must be specified, but not both.
                       type: boolean
                     secretName:
-                      description: required, the name of a secret in the current namespace
+                      description: SecretName is the name of a TLS secret in the current
+                        namespace. Either SecretName or Passthrough must be specified,
+                        but not both. If specified, the named secret must contain
+                        a matching certificate for the virtual host's FQDN.
                       type: string
                   type: object
               required:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -872,12 +872,15 @@ spec:
                       description: Minimum TLS version this vhost should negotiate
                       type: string
                     passthrough:
-                      description: If Passthrough is set to true, the SecretName will
-                        be ignored and the encrypted handshake will be passed through
-                        to the backing cluster.
+                      description: Passthrough defines whether the encrypted TLS handshake
+                        will be passed through to the backing cluster. Either Passthrough
+                        or SecretName must be specified, but not both.
                       type: boolean
                     secretName:
-                      description: required, the name of a secret in the current namespace
+                      description: SecretName is the name of a TLS secret in the current
+                        namespace. Either SecretName or Passthrough must be specified,
+                        but not both. If specified, the named secret must contain
+                        a matching certificate for the virtual host's FQDN.
                       type: string
                   type: object
               required:

--- a/site/docs/master/api-reference.html
+++ b/site/docs/master/api-reference.html
@@ -1965,8 +1965,7 @@ string
 </p>
 <p>
 <p>TLS describes tls properties. The SNI names that will be matched on
-are described in fqdn, the tls.secretName secret must contain a
-matching certificate unless tls.passthrough is set to true.</p>
+are described in the HTTPProxy&rsquo;s Spec.VirtualHost.Fqdn field.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">
 <thead class="border-bottom">
@@ -1985,7 +1984,10 @@ string
 </em>
 </td>
 <td>
-<p>required, the name of a secret in the current namespace</p>
+<p>SecretName is the name of a TLS secret in the current namespace.
+Either SecretName or Passthrough must be specified, but not both.
+If specified, the named secret must contain a matching certificate
+for the virtual host&rsquo;s FQDN.</p>
 </td>
 </tr>
 <tr>
@@ -2011,9 +2013,9 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>If Passthrough is set to true, the SecretName will be ignored
-and the encrypted handshake will be passed through to the
-backing cluster.</p>
+<p>Passthrough defines whether the encrypted TLS handshake will be
+passed through to the backing cluster. Either Passthrough or
+SecretName must be specified, but not both.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
When validating an HTTPProxy's TLS configuration, separately check
for cases where both secretName and passthrough are specified, and
for cases where neither secretName nor passthrough are specified.
Sets a corresponding HTTPProxy status message for both cases. Also
improves the status message for when TCPProxy is enabled, but TLS
is not enabled.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes #2501 
Fixes #2273 