### PR TITLE
internal/e2e: Move cluster tests to featuretests package

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -43,7 +43,6 @@ import (
 
 const (
 	endpointType = resource.EndpointType
-	clusterType  = resource.ClusterType
 	routeType    = resource.RouteType
 	listenerType = resource.ListenerType
 	secretType   = resource.SecretType

--- a/internal/e2e/rds_test.go
+++ b/internal/e2e/rds_test.go
@@ -1868,18 +1868,6 @@ func weightedclusters(clusters []weightedcluster) *envoy_api_v2_route.WeightedCl
 	return &wc
 }
 
-func service(ns, name string, ports ...v1.ServicePort) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: ports,
-		},
-	}
-}
-
 func TestHTTPProxyRouteWithAServiceWeight(t *testing.T) {
 	rh, cc, done := setup(t)
 	defer done()

--- a/internal/featuretests/cluster_test.go
+++ b/internal/featuretests/cluster_test.go
@@ -11,38 +11,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package featuretests
 
 import (
-	"context"
 	"testing"
-	"time"
+
+	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+
+	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
-	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
-	"github.com/projectcontour/contour/internal/envoy"
-	"github.com/projectcontour/contour/internal/featuretests"
-	"github.com/projectcontour/contour/internal/protobuf"
-	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// heptio/contour#186
+// projectcontour/contour#186
 // Cluster.ServiceName and ClusterLoadAssignment.ClusterName should not be truncated.
 func TestClusterLongServiceName(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
 			Name:      "kuard",
+			Namespace: "default",
 		},
 		Spec: v1beta1.IngressSpec{
 			Backend: &v1beta1.IngressBackend{
@@ -53,31 +49,32 @@ func TestClusterLongServiceName(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 
-	rh.OnAdd(service(
-		"default",
-		"kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r",
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       8080,
-			TargetPort: intstr.FromInt(8080),
+	rh.OnAdd(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r",
+			Namespace: "default",
 		},
-	))
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol: "TCP",
+				Port:     8080,
+			}},
+		},
+	})
 
 	// check that it's been translated correctly.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kbujbkuh-c83ceb/8080/da39a3ee5e", "default/kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r", "default_kbujbkuhdod66gjdmwmijz8xzgsx1nkfbrloezdjiulquzk4x3p0nnvpzi8r_8080"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "2",
-	}, streamCDS(t, cc))
+	})
 }
 
 // Test adding, updating, and removing a service
-// doesn't leave turds in the CDS cache.
+// doesn't leave objects in the CDS cache.
 func TestClusterAddUpdateDelete(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
@@ -119,103 +116,123 @@ func TestClusterAddUpdateDelete(t *testing.T) {
 	rh.OnAdd(i2)
 
 	// s1 is a simple tcp 80 -> 8080 service.
-	s1 := service("default", "kuard", v1.ServicePort{
-		Protocol:   "TCP",
-		Port:       80,
-		TargetPort: intstr.FromInt(8080),
-	})
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
 	rh.OnAdd(s1)
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "3",
-	}, streamCDS(t, cc))
+	})
 
 	// s2 is the same as s2, but the service port has a name
-	s2 := service("default", "kuard", v1.ServicePort{
-		Name:       "http",
-		Protocol:   "TCP",
-		Port:       80,
-		TargetPort: intstr.FromInt(8080),
-	})
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
 
 	// replace s1 with s2
 	rh.OnUpdate(s1, s2)
 
 	// check that we get two CDS records because the port is now named.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "4",
-	}, streamCDS(t, cc))
+	})
 
 	// s3 is like s2, but has a second named port. The k8s spec
 	// requires all ports to be named if there is more than one of them.
-	s3 := service("default", "kuard",
-		v1.ServicePort{
-			Name:       "http",
-			Protocol:   "TCP",
-			Port:       80,
-			TargetPort: intstr.FromInt(8080),
+	s3 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-		v1.ServicePort{
-			Name:       "https",
-			Protocol:   "TCP",
-			Port:       443,
-			TargetPort: intstr.FromInt(8443),
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}, {
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			}},
 		},
-	)
+	}
 
 	// replace s2 with s3
 	rh.OnUpdate(s2, s3)
 
 	// check that we get four CDS records. Order is important
 	// because the CDS cache is sorted.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "5",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443"),
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "5",
-	}, streamCDS(t, cc))
+	})
 
 	// s4 is s3 with the http port removed.
-	s4 := service("default", "kuard",
-		v1.ServicePort{
-			Name:       "https",
-			Protocol:   "TCP",
-			Port:       443,
-			TargetPort: intstr.FromInt(8443),
+	s4 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-	)
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			}},
+		},
+	}
 
 	// replace s3 with s4
 	rh.OnUpdate(s3, s4)
 
 	// check that we get two CDS records only, and that the 80 and http
 	// records have been removed even though the service object remains.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "6",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "6",
-	}, streamCDS(t, cc))
+	})
 }
 
 // pathological hard case, one service is removed, the other is moved to a different port, and its name removed.
 func TestClusterRenameUpdateDelete(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
@@ -247,76 +264,83 @@ func TestClusterRenameUpdateDelete(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 
-	s1 := service("default", "kuard",
-		v1.ServicePort{
-			Name:       "http",
-			Protocol:   "TCP",
-			Port:       80,
-			TargetPort: intstr.FromInt(8080),
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-		v1.ServicePort{
-			Name:       "https",
-			Protocol:   "TCP",
-			Port:       443,
-			TargetPort: intstr.FromInt(8443),
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}, {
+				Name:       "https",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8443),
+			}},
 		},
-	)
+	}
 
 	rh.OnAdd(s1)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443"),
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "2",
-	}, streamCDS(t, cc))
+	})
 
 	// s2 removes the name on port 80, moves it to port 443 and deletes the https port
-	s2 := service("default", "kuard",
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       443,
-			TargetPort: intstr.FromInt(8000),
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-	)
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
 
 	rh.OnUpdate(s1, s2)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/443/da39a3ee5e", "default/kuard", "default_kuard_443"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "3",
-	}, streamCDS(t, cc))
+	})
 
 	// now replace s2 with s1 to check it works in the other direction.
 	rh.OnUpdate(s2, s1)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "4",
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/443/da39a3ee5e", "default/kuard/https", "default_kuard_443"),
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard/http", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "4",
-	}, streamCDS(t, cc))
+	})
 
 	// cleanup and check
 	rh.OnDelete(s1)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "5",
-		Resources:   resources(t),
-		TypeUrl:     clusterType,
-		Nonce:       "5",
-	}, streamCDS(t, cc))
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
+		Resources: nil,
+		TypeUrl:   clusterType,
+	})
 }
 
 // issue#243. A single unnamed service with a different numeric target port
 func TestIssue243(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	t.Run("single unnamed service with a different numeric target port", func(t *testing.T) {
@@ -334,28 +358,33 @@ func TestIssue243(t *testing.T) {
 			},
 		}
 		rh.OnAdd(i1)
-		s1 := service("default", "kuard",
-			v1.ServicePort{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
+		s1 := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kuard",
+				Namespace: "default",
 			},
-		)
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{{
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				}},
+			},
+		}
+
 		rh.OnAdd(s1)
-		assert.Equal(t, &v2.DiscoveryResponse{
-			VersionInfo: "2",
+		c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 			Resources: resources(t,
 				cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 			),
 			TypeUrl: clusterType,
-			Nonce:   "2",
-		}, streamCDS(t, cc))
+		})
 	})
 }
 
 // issue 247, a single unnamed service with a named target port
 func TestIssue247(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
@@ -377,25 +406,31 @@ func TestIssue247(t *testing.T) {
 	//   - port: 80
 	//     protocol: TCP
 	//     targetPort: kuard
-	s1 := service("default", "kuard",
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       80,
-			TargetPort: intstr.FromString("kuard"),
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-	)
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromString("kuard"),
+			}},
+		},
+	}
+
 	rh.OnAdd(s1)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "2",
-	}, streamCDS(t, cc))
+	})
 }
+
 func TestCDSResourceFiltering(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
@@ -428,53 +463,60 @@ func TestCDSResourceFiltering(t *testing.T) {
 	rh.OnAdd(i1)
 
 	// add two services, check that they are there
-	s1 := service("default", "kuard",
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       80,
-			TargetPort: intstr.FromString("kuard"),
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
 		},
-	)
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.FromString("kuard"),
+			}},
+		},
+	}
 	rh.OnAdd(s1)
-	s2 := service("default", "httpbin",
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       8080,
-			TargetPort: intstr.FromString("httpbin"),
+
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "httpbin",
+			Namespace: "default",
 		},
-	)
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromString("httpbin"),
+			}},
+		},
+	}
+
 	rh.OnAdd(s2)
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			// note, resources are sorted by Cluster.Name
 			cluster("default/httpbin/8080/da39a3ee5e", "default/httpbin", "default_httpbin_8080"),
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "3",
-	}, streamCDS(t, cc))
+	})
 
 	// assert we can filter on one resource
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+	c.Request(clusterType, "default/kuard/80/da39a3ee5e").Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
-		),
+			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80")),
 		TypeUrl: clusterType,
-		Nonce:   "3",
-	}, streamCDS(t, cc, "default/kuard/80/da39a3ee5e"))
+	})
 
 	// assert a non matching filter returns a response with no entries.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
-		TypeUrl:     clusterType,
-		Nonce:       "3",
-	}, streamCDS(t, cc, "default/httpbin/9000"))
+	c.Request(clusterType, "default/httpbin/9000").Equals(&v2.DiscoveryResponse{
+		TypeUrl: clusterType,
+	})
 }
 
 func TestClusterCircuitbreakerAnnotations(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	i1 := &v1beta1.Ingress{
@@ -491,28 +533,32 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 
-	s1 := serviceWithAnnotations(
-		"default",
-		"kuard",
-		map[string]string{
-			"projectcontour.io/max-connections":      "9000",
-			"projectcontour.io/max-pending-requests": "4096",
-			"projectcontour.io/max-requests":         "404",
-			"projectcontour.io/max-retries":          "7",
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"projectcontour.io/max-connections":      "9000",
+				"projectcontour.io/max-pending-requests": "4096",
+				"projectcontour.io/max-requests":         "404",
+				"projectcontour.io/max-retries":          "7",
+			},
 		},
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       8080,
-			TargetPort: intstr.FromInt(8080),
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromString("8080"),
+			}},
 		},
-	)
+	}
+
 	rh.OnAdd(s1)
 
 	// check that it's been translated correctly.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "2",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			featuretests.DefaultCluster(&v2.Cluster{
+			DefaultCluster(&v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
 				AltStatName:          "default_kuard_8080",
 				ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
@@ -531,31 +577,33 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			}),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "2",
-	}, streamCDS(t, cc))
+	})
 
 	// update s1 with slightly weird values
-	s2 := serviceWithAnnotations(
-		"default",
-		"kuard",
-		map[string]string{
-			"projectcontour.io/max-pending-requests": "9999",
-			"projectcontour.io/max-requests":         "1e6",
-			"projectcontour.io/max-retries":          "0",
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"projectcontour.io/max-pending-requests": "9999",
+				"projectcontour.io/max-requests":         "1e6",
+				"projectcontour.io/max-retries":          "0",
+			},
 		},
-		v1.ServicePort{
-			Protocol:   "TCP",
-			Port:       8080,
-			TargetPort: intstr.FromInt(8080),
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromString("8080"),
+			}},
 		},
-	)
+	}
 	rh.OnUpdate(s1, s2)
 
 	// check that it's been translated correctly.
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "3",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			featuretests.DefaultCluster(&v2.Cluster{
+			DefaultCluster(&v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
 				AltStatName:          "default_kuard_8080",
 				ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
@@ -571,14 +619,13 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			}),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "3",
-	}, streamCDS(t, cc))
+	})
 }
 
 // issue 581, different service parameters should generate
 // a single CDS entry if they differ only in weight.
 func TestClusterPerServiceParameters(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	rh.OnAdd(&v1.Service{
@@ -624,20 +671,19 @@ func TestClusterPerServiceParameters(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
+			// note, resources are sorted by Cluster.Name
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "1",
-	}, streamCDS(t, cc))
+	})
 }
 
 // issue 581, different load balancer parameters should
 // generate multiple cds entries.
 func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	rh.OnAdd(&v1.Service{
@@ -687,10 +733,9 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			featuretests.DefaultCluster(&v2.Cluster{
+			DefaultCluster(&v2.Cluster{
 				Name:                 "default/kuard/80/58d888c08a",
 				AltStatName:          "default_kuard_80",
 				ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
@@ -700,7 +745,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				},
 				LbPolicy: v2.Cluster_RANDOM,
 			}),
-			featuretests.DefaultCluster(&v2.Cluster{
+			DefaultCluster(&v2.Cluster{
 				Name:                 "default/kuard/80/8bf87fefba",
 				AltStatName:          "default_kuard_80",
 				ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
@@ -712,12 +757,11 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 			}),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "1",
-	}, streamCDS(t, cc))
+	})
 }
 
 func TestClusterWithHealthChecks(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	rh.OnAdd(&v1.Service{
@@ -757,19 +801,17 @@ func TestClusterWithHealthChecks(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			clusterWithHealthCheck("default/kuard/80/bc862a33ca", "default/kuard", "default_kuard_80", "/healthz", true),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "1",
-	}, streamCDS(t, cc))
+	})
 }
 
 // Test processing a service that exists but is not referenced
 func TestUnreferencedService(t *testing.T) {
-	rh, cc, done := setup(t)
+	rh, c, done := setup(t)
 	defer done()
 
 	rh.OnAdd(&v1.Service{
@@ -815,14 +857,12 @@ func TestUnreferencedService(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "1",
-	}, streamCDS(t, cc))
+	})
 
 	// This service which is added should not cause a DAG rebuild
 	rh.OnAdd(&v1.Service{
@@ -839,66 +879,10 @@ func TestUnreferencedService(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, &v2.DiscoveryResponse{
-		VersionInfo: "1",
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			cluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80"),
 		),
 		TypeUrl: clusterType,
-		Nonce:   "1",
-	}, streamCDS(t, cc))
-}
-
-func serviceWithAnnotations(ns, name string, annotations map[string]string, ports ...v1.ServicePort) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
-			Annotations: annotations,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: ports,
-		},
-	}
-}
-
-func streamCDS(t *testing.T, cc *grpc.ClientConn, rn ...string) *v2.DiscoveryResponse {
-	t.Helper()
-	rds := v2.NewClusterDiscoveryServiceClient(cc)
-	st, err := rds.StreamClusters(context.TODO())
-	check(t, err)
-	return stream(t, st, &v2.DiscoveryRequest{
-		TypeUrl:       clusterType,
-		ResourceNames: rn,
 	})
-}
-
-func cluster(name, servicename, statName string) *v2.Cluster {
-	return featuretests.DefaultCluster(&v2.Cluster{
-		Name:                 name,
-		ClusterDiscoveryType: envoy.ClusterDiscoveryType(v2.Cluster_EDS),
-		AltStatName:          statName,
-		EdsClusterConfig: &v2.Cluster_EdsClusterConfig{
-			EdsConfig:   envoy.ConfigSource("contour"),
-			ServiceName: servicename,
-		},
-	})
-}
-
-func clusterWithHealthCheck(name, servicename, statName, healthCheckPath string, drainConnOnHostRemoval bool) *v2.Cluster {
-	c := cluster(name, servicename, statName)
-	c.HealthChecks = []*envoy_api_v2_core.HealthCheck{{
-		Timeout:            protobuf.Duration(2 * time.Second),
-		Interval:           protobuf.Duration(10 * time.Second),
-		UnhealthyThreshold: protobuf.UInt32(3),
-		HealthyThreshold:   protobuf.UInt32(2),
-		HealthChecker: &envoy_api_v2_core.HealthCheck_HttpHealthCheck_{
-			HttpHealthCheck: &envoy_api_v2_core.HealthCheck_HttpHealthCheck{
-				Host: "contour-envoy-healthcheck",
-				Path: healthCheckPath,
-			},
-		},
-	}}
-	c.DrainConnectionsOnHostRemoval = drainConnOnHostRemoval
-	return c
 }


### PR DESCRIPTION
Moves the CDS tests from the e2e package to the featuretests package.

Updates #2549

Signed-off-by: Steve Sloka <slokas@vmware.com>