### PR TITLE
internal/e2e: Move endpoint tests to featuretests package

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	endpointType = resource.EndpointType
 	routeType    = resource.RouteType
 	listenerType = resource.ListenerType
 	secretType   = resource.SecretType

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -355,6 +355,11 @@ func (c *Contour) Request(typeurl string, names ...string) *Response {
 		stl, err := lds.StreamListeners(ctx)
 		c.check(err)
 		st = stl
+	case endpointType:
+		eds := v2.NewEndpointDiscoveryServiceClient(c.ClientConn)
+		ste, err := eds.StreamEndpoints(ctx)
+		c.check(err)
+		st = ste
 	default:
 		c.Fatal("unknown typeURL:", typeurl)
 	}

--- a/internal/featuretests/kubernetes.go
+++ b/internal/featuretests/kubernetes.go
@@ -18,6 +18,7 @@ package featuretests
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -84,4 +85,34 @@ func secretdata(cert, key string) map[string][]byte {
 		v1.TLSCertKey:       []byte(cert),
 		v1.TLSPrivateKeyKey: []byte(key),
 	}
+}
+
+func endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {
+	return &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Subsets: subsets,
+	}
+}
+
+func ports(eps ...v1.EndpointPort) []v1.EndpointPort {
+	return eps
+}
+
+func port(name string, port int32) v1.EndpointPort {
+	return v1.EndpointPort{
+		Name:     name,
+		Port:     port,
+		Protocol: "TCP",
+	}
+}
+
+func addresses(ips ...string) []v1.EndpointAddress {
+	var addrs []v1.EndpointAddress
+	for _, ip := range ips {
+		addrs = append(addrs, v1.EndpointAddress{IP: ip})
+	}
+	return addrs
 }


### PR DESCRIPTION
Moves the EDS tests from the e2e package to the featuretests package.

Updates #2549

Signed-off-by: Steve Sloka <slokas@vmware.com>