### PR TITLE
internal/e2e: Move listener tests to featuretests package

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -44,7 +44,6 @@ import (
 const (
 	endpointType = resource.EndpointType
 	routeType    = resource.RouteType
-	listenerType = resource.ListenerType
 	secretType   = resource.SecretType
 	statsAddress = "0.0.0.0"
 	statsPort    = 8002

--- a/internal/e2e/sds_test.go
+++ b/internal/e2e/sds_test.go
@@ -72,7 +72,10 @@ func TestSDSVisibility(t *testing.T) {
 				IngressRuleValue: v1beta1.IngressRuleValue{
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *backend("backend", intstr.FromInt(80)),
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "backend",
+								ServicePort: intstr.FromInt(80),
+							},
 						}},
 					},
 				},
@@ -127,7 +130,10 @@ func TestSDSShouldNotIncrementVersionNumberForUnrelatedSecret(t *testing.T) {
 				IngressRuleValue: v1beta1.IngressRuleValue{
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *backend("backend", intstr.FromInt(80)),
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "backend",
+								ServicePort: intstr.FromInt(80),
+							},
 						}},
 					},
 				},
@@ -227,7 +233,10 @@ func TestSDSshouldNotPublishInvalidSecret(t *testing.T) {
 				IngressRuleValue: v1beta1.IngressRuleValue{
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *backend("backend", intstr.FromInt(80)),
+							Backend: v1beta1.IngressBackend{
+								ServiceName: "backend",
+								ServicePort: intstr.FromInt(80),
+							},
 						}},
 					},
 				},


### PR DESCRIPTION
Moves the LDS tests from the e2e package to the featuretests package.

Updates #2549

Signed-off-by: Steve Sloka <slokas@vmware.com>