### PR TITLE
internal: test reliability improvements

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -434,7 +434,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 		go func() {
 			<-stop
-			s.Stop()
+			s.GracefulStop()
 		}()
 
 		return s.Serve(l)

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -352,7 +352,7 @@ func TestServeContextCertificateHandling(t *testing.T) {
 		err := g.Serve(l)
 		checkFatalErr(t, err)
 	}()
-	defer g.Stop()
+	defer g.GracefulStop()
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/contour/server_test.go
+++ b/internal/contour/server_test.go
@@ -216,7 +216,7 @@ func TestGRPC(t *testing.T) {
 				done <- srv.Serve(l)
 			}()
 			defer func() {
-				srv.Stop()
+				srv.GracefulStop()
 				close(stop)
 				<-done
 			}()

--- a/internal/fixture/log.go
+++ b/internal/fixture/log.go
@@ -1,0 +1,36 @@
+package fixture
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+type testWriter struct {
+	*testing.T
+}
+
+func (t *testWriter) Write(buf []byte) (int, error) {
+	t.Logf("%s", buf)
+	return len(buf), nil
+}
+
+// NewTestLogger returns logrus.Logger that writes messages using (*testing.T)Logf.
+func NewTestLogger(t *testing.T) *logrus.Logger {
+	log := logrus.New()
+	log.Out = &testWriter{t}
+	return log
+}
+
+type discardWriter struct{}
+
+func (d *discardWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+// NewDiscardLogger returns logrus.Logger that discards log messages.
+func NewDiscardLogger() *logrus.Logger {
+	log := logrus.New()
+	log.Out = &discardWriter{}
+	return log
+}


### PR DESCRIPTION
* Switch from shutting down gRPC server with `Stop()` to `GracefulStop()`.
  which waits for current requests to drain before returning. This
  means that tests which log to the test runner won't ever attempt to
  log after the test has completed.

* Hoist test loggers into the fixtures package and use them from there.

* Add a workgroup context cancellation test.

This updates #2775.

Signed-off-by: James Peach <jpeach@vmware.com>