### PR TITLE
internal/dag: stop embedding ServicePort in dag.Service

### DIFF
--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -46,7 +46,7 @@ func TestVisitClusters(t *testing.T) {
 								Upstream: &dag.Service{
 									Name:      "example",
 									Namespace: "default",
-									ServicePort: &v1.ServicePort{
+									ServicePort: v1.ServicePort{
 										Protocol:   "TCP",
 										Port:       443,
 										TargetPort: intstr.FromInt(8443),
@@ -86,7 +86,7 @@ func TestVisitListeners(t *testing.T) {
 			Upstream: &dag.Service{
 				Name:      "example",
 				Namespace: "default",
-				ServicePort: &v1.ServicePort{
+				ServicePort: v1.ServicePort{
 					Protocol:   "TCP",
 					Port:       443,
 					TargetPort: intstr.FromInt(8443),
@@ -167,7 +167,7 @@ func TestVisitSecrets(t *testing.T) {
 								Upstream: &dag.Service{
 									Name:      "example",
 									Namespace: "default",
-									ServicePort: &v1.ServicePort{
+									ServicePort: v1.ServicePort{
 										Protocol:   "TCP",
 										Port:       443,
 										TargetPort: intstr.FromInt(8443),

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -108,7 +108,7 @@ func (b *Builder) lookupService(m types.NamespacedName, port intstr.IntOrString)
 		return nil, fmt.Errorf("service %q not found", m)
 	}
 	for i := range svc.Spec.Ports {
-		p := &svc.Spec.Ports[i]
+		p := svc.Spec.Ports[i]
 		switch {
 		case int(p.Port) == port.IntValue():
 			return b.addService(svc, p), nil
@@ -119,7 +119,7 @@ func (b *Builder) lookupService(m types.NamespacedName, port intstr.IntOrString)
 	return nil, fmt.Errorf("port %q on service %q not matched", port.String(), m)
 }
 
-func (b *Builder) addService(svc *v1.Service, port *v1.ServicePort) *Service {
+func (b *Builder) addService(svc *v1.Service, port v1.ServicePort) *Service {
 	s := &Service{
 		Name:        svc.Name,
 		Namespace:   svc.Namespace,
@@ -136,7 +136,7 @@ func (b *Builder) addService(svc *v1.Service, port *v1.ServicePort) *Service {
 	return s
 }
 
-func upstreamProtocol(svc *v1.Service, port *v1.ServicePort) string {
+func upstreamProtocol(svc *v1.Service, port v1.ServicePort) string {
 	up := annotation.ParseUpstreamProtocols(svc.Annotations)
 	protocol := up[port.Name]
 	if protocol == "" {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4066,7 +4066,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3d.Name,
 								Namespace:   s3d.Namespace,
-								ServicePort: &s3d.Spec.Ports[0],
+								ServicePort: s3d.Spec.Ports[0],
 								Protocol:    "h2c",
 							}),
 						),
@@ -4086,7 +4086,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3e.Name,
 								Namespace:   s3e.Namespace,
-								ServicePort: &s3e.Spec.Ports[0],
+								ServicePort: s3e.Spec.Ports[0],
 								Protocol:    "h2",
 							}),
 						),
@@ -4106,7 +4106,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3f.Name,
 								Namespace:   s3f.Namespace,
-								ServicePort: &s3f.Spec.Ports[0],
+								ServicePort: s3f.Spec.Ports[0],
 								Protocol:    "tls",
 							}),
 						),
@@ -4127,7 +4127,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3a.Name,
 								Namespace:   s3a.Namespace,
-								ServicePort: &s3a.Spec.Ports[0],
+								ServicePort: s3a.Spec.Ports[0],
 								Protocol:    "h2c",
 							}),
 						),
@@ -4147,7 +4147,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3b.Name,
 								Namespace:   s3b.Namespace,
-								ServicePort: &s3b.Spec.Ports[0],
+								ServicePort: s3b.Spec.Ports[0],
 								Protocol:    "h2",
 							}),
 						),
@@ -4167,7 +4167,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:        s3c.Name,
 								Namespace:   s3c.Namespace,
-								ServicePort: &s3c.Spec.Ports[0],
+								ServicePort: s3c.Spec.Ports[0],
 								Protocol:    "tls",
 							}),
 						),
@@ -4188,7 +4188,7 @@ func TestDAGInsert(t *testing.T) {
 							prefixroute("/", &Service{
 								Name:               s1b.Name,
 								Namespace:          s1b.Namespace,
-								ServicePort:        &s1b.Spec.Ports[0],
+								ServicePort:        s1b.Spec.Ports[0],
 								MaxConnections:     9000,
 								MaxPendingRequests: 4096,
 								MaxRequests:        404,
@@ -4212,7 +4212,7 @@ func TestDAGInsert(t *testing.T) {
 								Upstream: &Service{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
-									ServicePort: &s1.Spec.Ports[0],
+									ServicePort: s1.Spec.Ports[0],
 								},
 								Weight: 90,
 							}),
@@ -4220,7 +4220,7 @@ func TestDAGInsert(t *testing.T) {
 								Upstream: &Service{
 									Name:        s1.Name,
 									Namespace:   s1.Namespace,
-									ServicePort: &s1.Spec.Ports[0],
+									ServicePort: s1.Spec.Ports[0],
 								},
 								Weight: 60,
 							}),
@@ -4243,14 +4243,14 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 									Weight: 90,
 								}, &Cluster{
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 									Weight: 60,
 								},
@@ -4526,7 +4526,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1a.Name,
 										Namespace:   s1a.Namespace,
-										ServicePort: &s1a.Spec.Ports[0],
+										ServicePort: s1a.Spec.Ports[0],
 										Protocol:    "tls",
 									},
 									Protocol: "tls",
@@ -4735,7 +4735,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4744,7 +4744,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s4.Name,
 										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										ServicePort: s4.Spec.Ports[0],
 									},
 								},
 							),
@@ -4767,7 +4767,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4777,7 +4777,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s4.Name,
 										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										ServicePort: s4.Spec.Ports[0],
 									},
 								}},
 							},
@@ -4800,7 +4800,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4810,7 +4810,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s4.Name,
 										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										ServicePort: s4.Spec.Ports[0],
 									},
 								}},
 							},
@@ -4819,7 +4819,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s4.Name,
 										Namespace:   s4.Namespace,
-										ServicePort: &s4.Spec.Ports[0],
+										ServicePort: s4.Spec.Ports[0],
 									},
 								},
 							),
@@ -4829,7 +4829,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s11.Name,
 										Namespace:   s11.Namespace,
-										ServicePort: &s11.Spec.Ports[0],
+										ServicePort: s11.Spec.Ports[0],
 									},
 								}},
 							},
@@ -4852,7 +4852,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4861,7 +4861,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s2.Name,
 										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										ServicePort: s2.Spec.Ports[0],
 									},
 								},
 							),
@@ -4884,7 +4884,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4893,7 +4893,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s2.Name,
 										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										ServicePort: s2.Spec.Ports[0],
 									},
 								},
 							),
@@ -4916,7 +4916,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4925,7 +4925,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s2.Name,
 										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										ServicePort: s2.Spec.Ports[0],
 									},
 								},
 							),
@@ -4948,7 +4948,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4957,7 +4957,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s2.Name,
 										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										ServicePort: s2.Spec.Ports[0],
 									},
 								},
 							),
@@ -4980,7 +4980,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s1.Name,
 										Namespace:   s1.Namespace,
-										ServicePort: &s1.Spec.Ports[0],
+										ServicePort: s1.Spec.Ports[0],
 									},
 								},
 							),
@@ -4989,7 +4989,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s2.Name,
 										Namespace:   s2.Namespace,
-										ServicePort: &s2.Spec.Ports[0],
+										ServicePort: s2.Spec.Ports[0],
 									},
 								},
 							),
@@ -5083,7 +5083,7 @@ func TestDAGInsert(t *testing.T) {
 									Upstream: &Service{
 										Name:        s10.Name,
 										Namespace:   s10.Namespace,
-										ServicePort: &s10.Spec.Ports[1],
+										ServicePort: s10.Spec.Ports[1],
 									},
 								},
 							),
@@ -5339,7 +5339,7 @@ func TestDAGInsert(t *testing.T) {
 								Upstream: &Service{
 									Name:         s14.Name,
 									Namespace:    s14.Namespace,
-									ServicePort:  &s14.Spec.Ports[0],
+									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
 								},
 								SNI: "externalservice.io",
@@ -5387,7 +5387,7 @@ func TestDAGInsert(t *testing.T) {
 								Upstream: &Service{
 									Name:         s14.Name,
 									Namespace:    s14.Namespace,
-									ServicePort:  &s14.Spec.Ports[0],
+									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
 								},
 								SNI: "bar.com",
@@ -5438,7 +5438,7 @@ func TestDAGInsert(t *testing.T) {
 								Upstream: &Service{
 									Name:         s14.Name,
 									Namespace:    s14.Namespace,
-									ServicePort:  &s14.Spec.Ports[0],
+									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
 								},
 								RequestHeadersPolicy: &HeadersPolicy{
@@ -6731,7 +6731,7 @@ func service(s *v1.Service) *Service {
 	return &Service{
 		Name:        s.Name,
 		Namespace:   s.Namespace,
-		ServicePort: &s.Spec.Ports[0],
+		ServicePort: s.Spec.Ports[0],
 	}
 }
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -371,9 +371,10 @@ func (t *TCPProxy) Visit(f func(Vertex)) {
 
 // Service represents a single Kubernetes' Service's Port.
 type Service struct {
-	Name, Namespace string
+	Name      string
+	Namespace string
 
-	*v1.ServicePort
+	ServicePort v1.ServicePort
 
 	// Protocol is the layer 7 protocol of this service
 	// One of "", "h2", "h2c", or "tls".
@@ -411,7 +412,7 @@ func (s *Service) ToFullName() servicemeta {
 	return servicemeta{
 		name:      s.Name,
 		namespace: s.Namespace,
-		port:      s.Port,
+		port:      s.ServicePort.Port,
 	}
 }
 
@@ -419,10 +420,9 @@ func (s *Service) Visit(func(Vertex)) {
 	// Services are leaves in the DAG.
 }
 
-// Cluster holds the connetion specific parameters that apply to
+// Cluster holds the connection specific parameters that apply to
 // traffic routed to an upstream service.
 type Cluster struct {
-
 	// Upstream is the backend Kubernetes service traffic arriving
 	// at this Cluster will be forwarded too.
 	Upstream *Service

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -48,7 +48,7 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.Secret:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{secret|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
 	case *dag.Service:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace, v.Name, v.Port)
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace, v.Name, v.ServicePort.Port)
 	case *dag.VirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{http://%s}"]`+"\n", v, v.Name)
 	case *dag.SecureVirtualHost:

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -200,13 +200,13 @@ func Clustername(cluster *dag.Cluster) string {
 
 	ns := service.Namespace
 	name := service.Name
-	return hashname(60, ns, name, strconv.Itoa(int(service.Port)), fmt.Sprintf("%x", hash[:5]))
+	return hashname(60, ns, name, strconv.Itoa(int(service.ServicePort.Port)), fmt.Sprintf("%x", hash[:5]))
 }
 
 // altStatName generates an alternative stat name for the service
 // using format ns_name_port
 func altStatName(service *dag.Service) string {
-	return strings.Join([]string{service.Namespace, service.Name, strconv.Itoa(int(service.Port))}, "_")
+	return strings.Join([]string{service.Namespace, service.Name, strconv.Itoa(int(service.ServicePort.Port))}, "_")
 }
 
 // hashname takes a lenth l and a varargs of strings s and returns a string whose length

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -221,7 +221,7 @@ func TestCluster(t *testing.T) {
 			cluster: &dag.Cluster{
 				Upstream: &dag.Service{
 					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort:    &s1.Spec.Ports[0],
+					ServicePort:    s1.Spec.Ports[0],
 					MaxConnections: 9000,
 				},
 			},
@@ -244,7 +244,7 @@ func TestCluster(t *testing.T) {
 			cluster: &dag.Cluster{
 				Upstream: &dag.Service{
 					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort:        &s1.Spec.Ports[0],
+					ServicePort:        s1.Spec.Ports[0],
 					MaxPendingRequests: 4096,
 				},
 			},
@@ -267,7 +267,7 @@ func TestCluster(t *testing.T) {
 			cluster: &dag.Cluster{
 				Upstream: &dag.Service{
 					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
+					ServicePort: s1.Spec.Ports[0],
 					MaxRequests: 404,
 				},
 			},
@@ -290,7 +290,7 @@ func TestCluster(t *testing.T) {
 			cluster: &dag.Cluster{
 				Upstream: &dag.Service{
 					Name: s1.Name, Namespace: s1.Namespace,
-					ServicePort: &s1.Spec.Ports[0],
+					ServicePort: s1.Spec.Ports[0],
 					MaxRetries:  7,
 				},
 			},
@@ -416,7 +416,7 @@ func TestClustername(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "backend",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
 						Port:       80,
@@ -431,7 +431,7 @@ func TestClustername(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "must-be-in-want-of-a-wife",
 					Namespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
 						Port:       9999,
@@ -446,7 +446,7 @@ func TestClustername(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "backend",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
 						Port:       80,
@@ -469,7 +469,7 @@ func TestClustername(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "backend",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Name:       "http",
 						Protocol:   "TCP",
 						Port:       80,
@@ -612,7 +612,7 @@ func service(s *v1.Service, protocols ...string) *dag.Service {
 	return &dag.Service{
 		Name:         s.Name,
 		Namespace:    s.Namespace,
-		ServicePort:  &s.Spec.Ports[0],
+		ServicePort:  s.Spec.Ports[0],
 		ExternalName: s.Spec.ExternalName,
 		Protocol:     protocol,
 	}

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -698,7 +698,7 @@ func TestTCPProxy(t *testing.T) {
 		Upstream: &dag.Service{
 			Name:      "example",
 			Namespace: "default",
-			ServicePort: &v1.ServicePort{
+			ServicePort: v1.ServicePort{
 				Protocol:   "TCP",
 				Port:       443,
 				TargetPort: intstr.FromInt(8443),
@@ -709,7 +709,7 @@ func TestTCPProxy(t *testing.T) {
 		Upstream: &dag.Service{
 			Name:      "example2",
 			Namespace: "default",
-			ServicePort: &v1.ServicePort{
+			ServicePort: v1.ServicePort{
 				Protocol:   "TCP",
 				Port:       443,
 				TargetPort: intstr.FromInt(8443),

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -49,14 +49,14 @@ func TestRouteRoute(t *testing.T) {
 		Upstream: &dag.Service{
 			Name:        s1.Name,
 			Namespace:   s1.Namespace,
-			ServicePort: &s1.Spec.Ports[0],
+			ServicePort: s1.Spec.Ports[0],
 		},
 	}
 	c2 := &dag.Cluster{
 		Upstream: &dag.Service{
 			Name:        s1.Name,
 			Namespace:   s1.Namespace,
-			ServicePort: &s1.Spec.Ports[0],
+			ServicePort: s1.Spec.Ports[0],
 		},
 		LoadBalancerPolicy: "Cookie",
 	}
@@ -99,14 +99,14 @@ func TestRouteRoute(t *testing.T) {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace,
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 					Weight: 90,
 				}, {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 				}},
 			},
@@ -134,14 +134,14 @@ func TestRouteRoute(t *testing.T) {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace,
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 					Weight: 90,
 				}, {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 				}},
 			},
@@ -172,7 +172,7 @@ func TestRouteRoute(t *testing.T) {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace,
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 
 					RequestHeadersPolicy: &dag.HeadersPolicy{
@@ -464,7 +464,7 @@ func TestRouteRoute(t *testing.T) {
 					Upstream: &dag.Service{
 						Name:        s1.Name,
 						Namespace:   s1.Namespace,
-						ServicePort: &s1.Spec.Ports[0],
+						ServicePort: s1.Spec.Ports[0],
 					},
 					Weight: 90,
 				}},
@@ -473,7 +473,7 @@ func TestRouteRoute(t *testing.T) {
 						Upstream: &dag.Service{
 							Name:        s1.Name,
 							Namespace:   s1.Namespace,
-							ServicePort: &s1.Spec.Ports[0],
+							ServicePort: s1.Spec.Ports[0],
 						},
 					},
 				},
@@ -509,7 +509,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "kuard",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -517,7 +517,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "nginx",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -538,7 +538,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "kuard",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -547,7 +547,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "nginx",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -569,7 +569,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "kuard",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -578,7 +578,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "nginx",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},
@@ -587,7 +587,7 @@ func TestWeightedClusters(t *testing.T) {
 				Upstream: &dag.Service{
 					Name:      "notraffic",
 					Namespace: "default",
-					ServicePort: &v1.ServicePort{
+					ServicePort: v1.ServicePort{
 						Port: 8080,
 					},
 				},


### PR DESCRIPTION
The Kubernetes `v1.ServicePort` is embedded in `dag.Service` as a pointer
field. There's no need to have a pointer here, since it is always assumed
to be non-nil, and using the type as an explicit field makes is easier to
see where it is used, and clarifies overlapping field (i.e. `Protocol`).

This updates #2769.

Signed-off-by: James Peach <jpeach@vmware.com>