### PR TITLE
internal/featuretests: add v1.Service fixture support

### DIFF
--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -23,28 +23,16 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestRouteRoute(t *testing.T) {
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "http",
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s1 := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
 	c1 := &dag.Cluster{
 		Upstream: &dag.Service{
 			Name:        s1.Name,

--- a/internal/featuretests/backendcavalidation_test.go
+++ b/internal/featuretests/backendcavalidation_test.go
@@ -20,6 +20,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,23 +40,9 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		},
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: secret.Namespace,
-			Annotations: map[string]string{
-				"contour.heptio.com/upstream-protocol.tls": "securebackend,443",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "securebackend",
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("default/kuard").
+		Annotate("contour.heptio.com/upstream-protocol.tls", "securebackend,443").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8080)})
 
 	p1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/downstreamvalidation_test.go
+++ b/internal/featuretests/downstreamvalidation_test.go
@@ -52,20 +52,8 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 	}
 	rh.OnAdd(clientCASecret)
 
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "http",
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	service := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(service)
 
 	proxy := fixture.NewProxy("example.com").

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -35,21 +35,15 @@ func TestExternalNameService(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
+	s1 := fixture.NewService("kuard").
+		WithSpec(v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
 				Port:       80,
 				TargetPort: intstr.FromInt(8080),
 			}},
 			ExternalName: "foo.io",
 			Type:         v1.ServiceTypeExternalName,
-		},
-	}
+		})
 
 	i1 := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/fallbackcert_test.go
+++ b/internal/featuretests/fallbackcert_test.go
@@ -58,19 +58,8 @@ func TestFallbackCertificate(t *testing.T) {
 
 	rh.OnAdd(fallbackSecret)
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: sec1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
+	s1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
 	// Valid HTTPProxy without FallbackCertificate enabled

--- a/internal/featuretests/headercondition_test.go
+++ b/internal/featuretests/headercondition_test.go
@@ -30,47 +30,18 @@ import (
 func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc1",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc2",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("svc1").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc3",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("svc2").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
+
+	rh.OnAdd(fixture.NewService("svc3").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
 
 	proxy1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -33,19 +33,9 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc1",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("svc1").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
 
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
 		projcontour.HTTPProxySpec{
@@ -153,24 +143,17 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "externalname",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/upstream-protocol.tls": "https,443",
-			},
-		},
-		Spec: v1.ServiceSpec{
+	rh.OnAdd(fixture.NewService("externalname").
+		Annotate("projectcontour.io/upstream-protocol.tls", "https,443").
+		WithSpec(v1.ServiceSpec{
 			ExternalName: "goodbye.planet",
+			Type:         v1.ServiceTypeExternalName,
 			Ports: []v1.ServicePort{{
-				Protocol: "TCP",
-				Port:     443,
-				Name:     "https",
+				Port: 443,
+				Name: "https",
 			}},
-			Type: v1.ServiceTypeExternalName,
-		},
-	})
+		}),
+	)
 
 	rh.OnAdd(&v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -16,13 +16,12 @@ package featuretests
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/internal/fixture"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -42,19 +41,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 	})
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
 	// Ingress
@@ -278,19 +266,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
 	// Ingress
@@ -527,16 +504,8 @@ func TestIngressClassUpdate(t *testing.T) {
 	})
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: fixture.ObjectMeta("default/kuard"),
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
 	vhost := &projcontour.HTTPProxy{

--- a/internal/featuretests/listeners_test.go
+++ b/internal/featuretests/listeners_test.go
@@ -16,15 +16,14 @@ package featuretests
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/internal/contour"
-
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,19 +59,8 @@ func TestNonTLSListener(t *testing.T) {
 		},
 	}
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add it and assert that we now have a ingress_http listener
 	rh.OnAdd(i1)
@@ -190,19 +178,8 @@ func TestTLSListener(t *testing.T) {
 		},
 	}
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add secret
 	rh.OnAdd(s1)
@@ -319,19 +296,8 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: secret1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
+	svc1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 
 	// p1 is a tls httpproxy
 	p1 := &projcontour.HTTPProxy{
@@ -525,19 +491,8 @@ func TestLDSFilter(t *testing.T) {
 		},
 	}
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add secret
 	rh.OnAdd(s1)
@@ -626,19 +581,9 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 			},
 		},
 	}
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add it and assert that we now have a ingress_http listener using
 	// the proxy protocol (the true param to filterchain)
@@ -716,19 +661,8 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add ingress and assert the existence of ingress_http and ingres_https and both
 	// are using proxy protocol
@@ -825,19 +759,8 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 		Nonce:   "0",
 	})
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add ingress and assert the existence of ingress_http and ingres_https and both
 	// are using proxy protocol
@@ -918,19 +841,8 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 		},
 	}
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// add secret
 	rh.OnAdd(s1)
@@ -1035,19 +947,8 @@ func TestHTTPProxyHTTPS(t *testing.T) {
 		},
 	}
 
-	svc1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     8080,
-			}},
-		},
-	}
+	svc1 := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Name: "http", Port: 8080})
 
 	// add secret
 	rh.OnAdd(s1)
@@ -1110,20 +1011,8 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 	}
 	rh.OnAdd(secret1)
 
-	svc1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
-	rh.OnAdd(svc1)
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// p1 is a tls httpproxy
 	p1 := &projcontour.HTTPProxy{
@@ -1259,20 +1148,8 @@ func TestLDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	svc1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "green",
-			Namespace: "marketing",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
-	rh.OnAdd(svc1)
+	rh.OnAdd(fixture.NewService("marketing/green").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	child := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1288,7 +1165,7 @@ func TestLDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 					Prefix: "/",
 				}},
 				Services: []projcontour.Service{{
-					Name: svc1.Name,
+					Name: "green",
 					Port: 80,
 				}},
 			}},

--- a/internal/featuretests/loadbalancerpolicy_test.go
+++ b/internal/featuretests/loadbalancerpolicy_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -31,23 +30,9 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "app",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}, {
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s1 := fixture.NewService("app").WithPorts(
+		v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+		v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
 	// simple single service

--- a/internal/featuretests/mirrorpolicy_test.go
+++ b/internal/featuretests/mirrorpolicy_test.go
@@ -21,6 +21,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,26 +31,10 @@ func TestMirrorPolicy(t *testing.T) {
 	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
 	defer done()
 
-	svc1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
-	svc2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mirror",
-			Namespace: svc1.Namespace,
-		},
-		Spec: svc1.Spec,
-	}
+	svc1 := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
+	svc2 := fixture.NewService("mirror").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc1)
 	rh.OnAdd(svc2)
 

--- a/internal/featuretests/replaceprefix_test.go
+++ b/internal/featuretests/replaceprefix_test.go
@@ -16,16 +16,15 @@ package featuretests
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/internal/fixture"
-	"k8s.io/client-go/tools/cache"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Update helper to modify a proxy and call rh.OnUpdate. Returns the modified object.
@@ -42,16 +41,8 @@ func basic(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: fixture.ObjectMeta("default/kuard"),
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)}))
 
 	vhost := fixture.NewProxy("kuard").WithSpec(
 		projcontour.HTTPProxySpec{
@@ -226,16 +217,8 @@ func multiInclude(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: fixture.ObjectMeta("default/kuard"),
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)}))
 
 	vhost1 := fixture.NewProxy("host1").WithSpec(
 		projcontour.HTTPProxySpec{
@@ -355,16 +338,8 @@ func replaceWithSlash(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: fixture.ObjectMeta("default/kuard"),
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)}))
 
 	vhost1 := fixture.NewProxy("host1").WithSpec(
 		projcontour.HTTPProxySpec{
@@ -494,16 +469,8 @@ func artifactoryDocker(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: fixture.ObjectMeta("artifactory/service"),
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	})
+	rh.OnAdd(fixture.NewService("artifactory/service").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)}))
 
 	rh.OnAdd(fixture.NewProxy("artifactory/routes").WithSpec(
 		projcontour.HTTPProxySpec{

--- a/internal/featuretests/retrypolicy_test.go
+++ b/internal/featuretests/retrypolicy_test.go
@@ -21,6 +21,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,19 +32,8 @@ func TestRetryPolicy(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{

--- a/internal/featuretests/secrets_test.go
+++ b/internal/featuretests/secrets_test.go
@@ -20,6 +20,7 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,20 +135,8 @@ func TestSDSShouldNotIncrementVersionNumberForUnrelatedSecret(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 
-	rh.OnAdd(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	})
-
+	rh.OnAdd(fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 	c.Request(secretType).Equals(&v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources:   resources(t, secret(s1)),

--- a/internal/featuretests/tcpproxy_test.go
+++ b/internal/featuretests/tcpproxy_test.go
@@ -21,6 +21,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,19 +40,8 @@ func TestTCPProxy(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "correct-backend",
-			Namespace: s1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("correct-backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	rh.OnAdd(s1)
 	rh.OnAdd(svc)
@@ -125,19 +115,9 @@ func TestTCPProxyDelegation(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "app",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("app/backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
+
 	rh.OnAdd(s1)
 	rh.OnAdd(svc)
 
@@ -213,19 +193,8 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "correct-backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("correct-backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	rh.OnAdd(svc)
 
@@ -306,23 +275,9 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubernetes",
-			Namespace: s1.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/upstream-protocol.tls": "https,443",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "https",
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(6443),
-			}},
-		},
-	}
+	svc := fixture.NewService("kubernetes").
+		Annotate("projectcontour.io/upstream-protocol.tls", "https,443").
+		WithPorts(v1.ServicePort{Name: "https", Port: 443, TargetPort: intstr.FromInt(6443)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -402,19 +357,8 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: s1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -508,19 +452,8 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: s1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -610,19 +543,8 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -713,19 +635,8 @@ func TestTCPProxyTLSPassthroughAndHTTPServicePermitInsecure(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -830,19 +741,8 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	}
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: s1.Name,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 
 	hp1 := &projcontour.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/timeoutpolicy_test.go
+++ b/internal/featuretests/timeoutpolicy_test.go
@@ -22,6 +22,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,19 +33,8 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
 	i1 := &v1beta1.Ingress{
@@ -266,19 +256,8 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
 	defer done()
 
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       8080,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	svc := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
 	p1 := &projcontour.HTTPProxy{

--- a/internal/featuretests/timeouts_test.go
+++ b/internal/featuretests/timeouts_test.go
@@ -21,6 +21,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,19 +32,8 @@ func TestTimeoutsNotSpecified(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
+	s1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
 	hp1 := &projcontour.HTTPProxy{
@@ -95,19 +85,8 @@ func TestNonZeroTimeoutsSpecified(t *testing.T) {
 	rh, c, done := setup(t, withTimeouts)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
+	s1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
 	hp1 := &projcontour.HTTPProxy{

--- a/internal/featuretests/tlscertificatedelegation_test.go
+++ b/internal/featuretests/tlscertificatedelegation_test.go
@@ -19,6 +19,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,19 +48,8 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	// add a secret object secret/wildcard.
 	rh.OnAdd(sec1)
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     8080,
-			}},
-		},
-	}
+	s1 := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080})
 	rh.OnAdd(s1)
 
 	// add an httpproxy in a different namespace mentioning secret/wildcard.

--- a/internal/featuretests/tlsprotocolversion_test.go
+++ b/internal/featuretests/tlsprotocolversion_test.go
@@ -22,6 +22,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,19 +42,8 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 	}
 	rh.OnAdd(sec1)
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend",
-			Namespace: sec1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:     "http",
-				Protocol: "TCP",
-				Port:     80,
-			}},
-		},
-	}
+	s1 := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{

--- a/internal/featuretests/upstreamprotocol_test.go
+++ b/internal/featuretests/upstreamprotocol_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,23 +30,9 @@ func TestUpstreamProtocolTLS(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"contour.heptio.com/upstream-protocol.tls": "securebackend",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "securebackend",
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8888),
-			}},
-		},
-	}
+	s1 := fixture.NewService("kuard").
+		Annotate("contour.heptio.com/upstream-protocol.tls", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{
@@ -69,16 +56,9 @@ func TestUpstreamProtocolTLS(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	s2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/upstream-protocol.tls": "securebackend",
-			},
-		},
-		Spec: s1.Spec,
-	}
+	s2 := fixture.NewService("kuard").
+		Annotate("projectcontour.io/upstream-protocol.tls", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnUpdate(s1, s2)
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
@@ -95,23 +75,9 @@ func TestUpstreamProtocolH2C(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"contour.heptio.com/upstream-protocol.h2c": "securebackend",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "securebackend",
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8888),
-			}},
-		},
-	}
+	s1 := fixture.NewService("kuard").
+		Annotate("contour.heptio.com/upstream-protocol.h2c", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{
@@ -135,16 +101,9 @@ func TestUpstreamProtocolH2C(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	s2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/upstream-protocol.h2c": "securebackend",
-			},
-		},
-		Spec: s1.Spec,
-	}
+	s2 := fixture.NewService("kuard").
+		Annotate("projectcontour.io/upstream-protocol.h2c", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnUpdate(s1, s2)
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
@@ -161,23 +120,9 @@ func TestUpstreamProtocolH2(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"contour.heptio.com/upstream-protocol.h2": "securebackend",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Name:       "securebackend",
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8888),
-			}},
-		},
-	}
+	s1 := fixture.NewService("kuard").
+		Annotate("contour.heptio.com/upstream-protocol.h2", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{
@@ -201,16 +146,9 @@ func TestUpstreamProtocolH2(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	s2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/upstream-protocol.h2": "securebackend",
-			},
-		},
-		Spec: s1.Spec,
-	}
+	s2 := fixture.NewService("kuard").
+		Annotate("projectcontour.io/upstream-protocol.h2", "securebackend").
+		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnUpdate(s1, s2)
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{

--- a/internal/featuretests/websockets_test.go
+++ b/internal/featuretests/websockets_test.go
@@ -20,6 +20,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,19 +31,8 @@ func TestWebsocketsIngress(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ws",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s1 := fixture.NewService("ws").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
 	i1 := &v1beta1.Ingress{
@@ -134,34 +124,12 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 
-	s1 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ws",
-			Namespace: "default",
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s1 := fixture.NewService("ws").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
-	s2 := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ws2",
-			Namespace: s1.Namespace,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{{
-				Protocol:   "TCP",
-				Port:       80,
-				TargetPort: intstr.FromInt(8080),
-			}},
-		},
-	}
+	s2 := fixture.NewService("ws2").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s2)
 
 	hp1 := &projcontour.HTTPProxy{

--- a/internal/fixture/httpproxy.go
+++ b/internal/fixture/httpproxy.go
@@ -32,7 +32,7 @@ func NewProxy(name string) *ProxyBuilder {
 	return b
 }
 
-// Label adds the given values as metadata annotations.
+// Annotate adds the given values as metadata annotations.
 func (b *ProxyBuilder) Annotate(k string, v string) *ProxyBuilder {
 	b.ObjectMeta.Annotations[k] = v
 	return b

--- a/internal/fixture/meta.go
+++ b/internal/fixture/meta.go
@@ -24,7 +24,8 @@ import (
 func ObjectMeta(nameStr string) metav1.ObjectMeta {
 	name := k8s.NamespacedNameFrom(nameStr)
 	return metav1.ObjectMeta{
-		Name:      name.Name,
-		Namespace: name.Namespace,
+		Name:        name.Name,
+		Namespace:   name.Namespace,
+		Annotations: map[string]string{},
 	}
 }

--- a/internal/fixture/service.go
+++ b/internal/fixture/service.go
@@ -1,0 +1,51 @@
+package fixture
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+type ServiceBuilder v1.Service
+
+// NewService creates a new ServiceBuilder with the given resource name.
+func NewService(name string) *ServiceBuilder {
+	s := &ServiceBuilder{
+		ObjectMeta: ObjectMeta(name),
+		Spec:       v1.ServiceSpec{},
+	}
+
+	return s
+}
+
+// Annotate adds the given values as metadata annotations.
+func (s *ServiceBuilder) Annotate(k string, v string) *ServiceBuilder {
+	s.ObjectMeta.Annotations[k] = v
+	return s
+}
+
+// WithPorts specifies the ports for the .Spec.Ports field.
+func (s *ServiceBuilder) WithPorts(ports ...v1.ServicePort) *v1.Service {
+	s.Spec.Ports = make([]v1.ServicePort, len(ports))
+
+	copy(s.Spec.Ports, ports)
+
+	for _, p := range s.Spec.Ports {
+		if p.Protocol == "" {
+			p.Protocol = "TCP"
+		}
+	}
+
+	return (*v1.Service)(s)
+}
+
+// WithSpec specifies the .Spec field.
+func (s *ServiceBuilder) WithSpec(spec v1.ServiceSpec) *v1.Service {
+	s.Spec = spec
+
+	for _, p := range s.Spec.Ports {
+		if p.Protocol == "" {
+			p.Protocol = "TCP"
+		}
+	}
+
+	return (*v1.Service)(s)
+}


### PR DESCRIPTION
Add fixture support for generating `v1.Service` resources with a reduced
amount of boilerplate.

Signed-off-by: James Peach <jpeach@vmware.com>