### PR TITLE
cmd/contour: forcibly terminate the xDS server on shutdown

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -437,7 +437,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 		go func() {
 			<-stop
-			rpcServer.GracefulStop()
+
+			// We don't use GracefulStop here because envoy
+			// has long-lived hanging xDS requests. There's no
+			// mechanism to make those pending requests fail,
+			// so we forcibly terminate the TCP sessions.
+			rpcServer.Stop()
 		}()
 
 		return rpcServer.Serve(l)


### PR DESCRIPTION
Fix a regression from #2780, where the Contour xDS server would fail
to stop because it is waiting for xDS connections to drain (they won't
drain).

This updates #2780.

Signed-off-by: James Peach <jpeach@vmware.com>