### PR TITLE
internal: remove copies of testLogger

### DIFF
--- a/internal/contour/contour_test.go
+++ b/internal/contour/contour_test.go
@@ -14,27 +14,9 @@
 package contour
 
 import (
-	"testing"
-
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func testLogger(t *testing.T) logrus.FieldLogger {
-	log := logrus.New()
-	log.Out = &testWriter{t}
-	return log
-}
-
-type testWriter struct {
-	*testing.T
-}
-
-func (t *testWriter) Write(buf []byte) (int, error) {
-	t.Logf("%s", buf)
-	return len(buf), nil
-}
 
 func endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {
 	return &v1.Endpoints{

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -222,11 +223,10 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 		},
 	}
 
-	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			et := &EndpointsTranslator{
-				FieldLogger: log,
+				FieldLogger: fixture.NewTestLogger(t),
 			}
 			et.OnAdd(tc.ep)
 			got := et.Contents()
@@ -323,11 +323,10 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 		},
 	}
 
-	log := testLogger(t)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			et := &EndpointsTranslator{
-				FieldLogger: log,
+				FieldLogger: fixture.NewTestLogger(t),
 			}
 			tc.setup(et)
 			et.OnDelete(tc.ep)

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -19,6 +19,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/metrics"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ func TestHTTPProxyMetrics(t *testing.T) {
 			builder := dag.Builder{
 				Source: dag.KubernetesCache{
 					RootNamespaces: tc.rootNamespaces,
-					FieldLogger:    testLogger(t),
+					FieldLogger:    fixture.NewTestLogger(t),
 				},
 			}
 

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -22,6 +22,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -479,7 +480,7 @@ func TestSecretVisit(t *testing.T) {
 func buildDAG(t *testing.T, objs ...interface{}) *dag.DAG {
 	builder := dag.Builder{
 		Source: dag.KubernetesCache{
-			FieldLogger: testLogger(t),
+			FieldLogger: fixture.NewTestLogger(t),
 		},
 	}
 
@@ -493,7 +494,7 @@ func buildDAG(t *testing.T, objs ...interface{}) *dag.DAG {
 func buildDAGFallback(t *testing.T, fallbackCertificate *types.NamespacedName, objs ...interface{}) *dag.DAG {
 	builder := dag.Builder{
 		Source: dag.KubernetesCache{
-			FieldLogger: testLogger(t),
+			FieldLogger: fixture.NewTestLogger(t),
 		},
 		FallbackCertificate: fallbackCertificate,
 	}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -21,6 +21,7 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -6007,7 +6008,7 @@ func TestDAGInsert(t *testing.T) {
 					Namespace: tc.fallbackCertificateNamespace,
 				},
 				Source: KubernetesCache{
-					FieldLogger: testLogger(t),
+					FieldLogger: fixture.NewTestLogger(t),
 				},
 			}
 			for _, o := range tc.objs {
@@ -6122,7 +6123,7 @@ func TestBuilderLookupService(t *testing.T) {
 			b := Builder{
 				Source: KubernetesCache{
 					services:    services,
-					FieldLogger: testLogger(t),
+					FieldLogger: fixture.NewTestLogger(t),
 				},
 			}
 			b.reset()
@@ -6256,7 +6257,7 @@ func TestDAGRootNamespaces(t *testing.T) {
 			builder := Builder{
 				Source: KubernetesCache{
 					RootNamespaces: tc.rootNamespaces,
-					FieldLogger:    testLogger(t),
+					FieldLogger:    fixture.NewTestLogger(t),
 				},
 			}
 

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -20,7 +20,6 @@ import (
 	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -737,7 +736,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cache := KubernetesCache{
-				FieldLogger: testLogger(t),
+				FieldLogger: fixture.NewTestLogger(t),
 			}
 			for _, p := range tc.pre {
 				cache.Insert(p)
@@ -753,7 +752,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 func TestKubernetesCacheRemove(t *testing.T) {
 	cache := func(objs ...interface{}) *KubernetesCache {
 		cache := KubernetesCache{
-			FieldLogger: testLogger(t),
+			FieldLogger: fixture.NewTestLogger(t),
 		}
 		for _, o := range objs {
 			cache.Insert(o)
@@ -958,21 +957,4 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			}
 		})
 	}
-}
-
-func testLogger(t *testing.T) logrus.FieldLogger {
-	t.Helper()
-	log := logrus.New()
-	log.Out = &testWriter{t}
-	return log
-}
-
-type testWriter struct {
-	*testing.T
-}
-
-func (t *testWriter) Write(buf []byte) (int, error) {
-	t.Helper()
-	t.Logf("%s", buf)
-	return len(buf), nil
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -19,6 +19,7 @@ import (
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -2286,7 +2287,7 @@ func TestDAGStatus(t *testing.T) {
 				FallbackCertificate: tc.fallbackCertificate,
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
-					FieldLogger:    testLogger(t),
+					FieldLogger:    fixture.NewTestLogger(t),
 				},
 			}
 			for _, o := range tc.objs {

--- a/internal/fixture/meta.go
+++ b/internal/fixture/meta.go
@@ -14,7 +14,8 @@
 package fixture
 
 import (
-	"github.com/projectcontour/contour/internal/k8s"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -22,10 +23,22 @@ import (
 // "namespace/name" into a metav1.ObjectMeta struct. If the namespace
 // portion is omitted, then the default namespace is filled in.
 func ObjectMeta(nameStr string) metav1.ObjectMeta {
-	name := k8s.NamespacedNameFrom(nameStr)
-	return metav1.ObjectMeta{
-		Name:        name.Name,
-		Namespace:   name.Namespace,
-		Annotations: map[string]string{},
+	// NOTE: We don't use k8s.NamespacedNameFrom here, because that
+	// would generate an import cycle.
+	v := strings.SplitN(nameStr, "/", 2)
+	switch len(v) {
+	case 1:
+		// No '/' separator.
+		return metav1.ObjectMeta{
+			Name:        v[0],
+			Namespace:   metav1.NamespaceDefault,
+			Annotations: map[string]string{},
+		}
+	default:
+		return metav1.ObjectMeta{
+			Name:        v[1],
+			Namespace:   v[0],
+			Annotations: map[string]string{},
+		}
 	}
 }

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -26,27 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func testLogger(t *testing.T) logrus.FieldLogger {
-	log := logrus.New()
-	log.Out = &testWriter{t}
-	return log
-}
-
-type testWriter struct {
-	*testing.T
-}
-
-func (t *testWriter) Write(buf []byte) (int, error) {
-	t.Logf("%s", buf)
-	return len(buf), nil
-}
-
 func TestServiceStatusLoadBalancerWatcherOnAdd(t *testing.T) {
 	lbstatus := make(chan v1.LoadBalancerStatus, 1)
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
-		Log:         testLogger(t),
+		Log:         fixture.NewTestLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {
@@ -94,7 +80,7 @@ func TestServiceStatusLoadBalancerWatcherOnUpdate(t *testing.T) {
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
-		Log:         testLogger(t),
+		Log:         fixture.NewTestLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {
@@ -144,7 +130,7 @@ func TestServiceStatusLoadBalancerWatcherOnDelete(t *testing.T) {
 	sw := ServiceStatusLoadBalancerWatcher{
 		ServiceName: "envoy",
 		LBStatus:    lbstatus,
-		Log:         testLogger(t),
+		Log:         fixture.NewTestLogger(t),
 	}
 
 	recv := func() (v1.LoadBalancerStatus, bool) {


### PR DESCRIPTION
Remove copies of testLogger and replace them with
fixture.NewTestLogger.

Signed-off-by: James Peach <jpeach@vmware.com>