### PR TITLE
internal/dag: Refactor some logic from builder into KubernetesCache

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,6 +14,7 @@
 package dag
 
 import (
+	"fmt"
 	"sync"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -404,4 +405,23 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 	}
 
 	return false
+}
+
+// LookupSecret returns a Secret if present or nil if the underlying kubernetes
+// secret fails validation or is missing.
+func (kc *KubernetesCache) LookupSecret(name types.NamespacedName, validate func(*v1.Secret) error) (*Secret, error) {
+	sec, ok := kc.secrets[name]
+	if !ok {
+		return nil, fmt.Errorf("Secret not found")
+	}
+
+	if err := validate(sec); err != nil {
+		return nil, err
+	}
+
+	s := &Secret{
+		Object: sec,
+	}
+
+	return s, nil
 }


### PR DESCRIPTION
Moves some common components from the builder into the KubernetesCache
so that it can be reused from other components. This is the first of a few PRs in refactoring
the builder out. 

Updates #2226

Signed-off-by: Steve Sloka <slokas@vmware.com>