### PR TITLE
docs: guides/cert-manager

### DIFF
--- a/site/_guides/cert-manager.md
+++ b/site/_guides/cert-manager.md
@@ -542,7 +542,7 @@ spec:
   virtualhost:
     fqdn: httpbinproxy.davecheney.com
     tls:
-      secretName: httpbin
+      secretName: httpbinproxy
   routes:
   - services:
     - name: httpbin
@@ -561,7 +561,6 @@ metadata:
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
   name: httpbinproxy
-  namespace: default
 spec:
   rules:
   - host: httpbinproxy.davecheney.com
@@ -573,7 +572,7 @@ spec:
   tls:
   - hosts:
     - httpbinproxy.davecheney.com
-    secretName: httpbin
+    secretName: httpbinproxy
 ```
 
 Once cert-manager has done its thing, you will have a `httpbinproxy` secret, that will contain the keypair.


### PR DESCRIPTION
Set correct `secretName` for resources related to `httpbinproxy`.
Also set correct namespace for the dummy ingress object.

Fixes #2800

Signed-off-by: Rajat Goyal <404rajat@gmail.com>