### PR TITLE
internal: rebuild endpoints based on the DAG services

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -205,9 +205,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Endpoints updates are handled directly by the EndpointsTranslator
 	// due to their high update rate and their orthogonal nature.
-	endpointHandler := &contour.EndpointsTranslator{
-		FieldLogger: log.WithField("context", "endpointstranslator"),
-	}
+	endpointHandler := contour.NewEndpointsTranslator(log.WithField("context", "endpointstranslator"))
 
 	resources := []contour.ResourceCache{
 		contour.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort),

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -14,6 +14,7 @@
 package contour
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 
@@ -26,30 +27,288 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
+	"github.com/projectcontour/contour/internal/xds"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 )
 
+type LocalityEndpoints = envoy_api_v2_endpoint.LocalityLbEndpoints
+type LoadBalancingEndpoint = envoy_api_v2_endpoint.LbEndpoint
+
+// RecalculateEndpoints generates a slice of LoadBalancingEndpoint
+// resources by matching the given service port to the given v1.Endpoints.
+// ep may be nil, in which case, the result is also nil.
+func RecalculateEndpoints(port v1.ServicePort, ep *v1.Endpoints) []*LoadBalancingEndpoint {
+	if ep == nil {
+		return nil
+	}
+
+	var lb []*LoadBalancingEndpoint
+	for _, s := range ep.Subsets {
+		// Skip subsets without ready addresses.
+		if len(s.Addresses) < 1 {
+			continue
+		}
+
+		for _, p := range s.Ports {
+			if port.Protocol != p.Protocol && p.Protocol != v1.ProtocolTCP {
+				// NOTE: we only support "TCP", which is the default.
+				continue
+			}
+
+			// If the port isn't named, it must be the
+			// only Service port, so it's a match by
+			// definition. Otherwise, only take endpoint
+			// ports that match the service port name.
+			if port.Name != "" && port.Name != p.Name {
+				continue
+			}
+
+			// If we matched this port, collect Envoy endpoints for all the ready addresses.
+			addresses := append([]v1.EndpointAddress{}, s.Addresses...) // Shallow copy.
+			sort.Slice(addresses, func(i, j int) bool { return addresses[i].IP < addresses[j].IP })
+
+			for _, a := range addresses {
+				addr := envoy.SocketAddress(a.IP, int(p.Port))
+				lb = append(lb, envoy.LBEndpoint(addr))
+			}
+		}
+	}
+
+	return lb
+}
+
+// EndpointsCache is a cache of Endpoint and ServiceCluster objects.
+type EndpointsCache struct {
+	mu sync.Mutex // Protects all fields.
+
+	// Slice of stale clusters. A stale cluster is one that
+	// needs to be recalculated. Clusters can be added to the stale
+	// slice due to changes in Endpoints or due to a DAG rebuild.
+	stale []*dag.ServiceCluster
+
+	// Index of ServiceClusters. ServiceClusters are indexed
+	// by the name of their Kubernetes Services. This makes it
+	// easy to determine which Endpoints affect which ServiceCluster.
+	services map[types.NamespacedName][]*dag.ServiceCluster
+
+	// Cache of endpoints, indexed by name.
+	endpoints map[types.NamespacedName]*v1.Endpoints
+}
+
+// Recalculate regenerates all the ClusterLoadAssignments from the
+// cached Endpoints and stale ServiceClusters. A ClusterLoadAssignment
+// will be generated for every stale ServerCluster, however, if there
+// are no endpoints for the Services in the ServiceCluster, the
+// ClusterLoadAssignment wil be empty.
+func (c *EndpointsCache) Recalculate() map[string]*v2.ClusterLoadAssignment {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	assignments := map[string]*v2.ClusterLoadAssignment{}
+	for _, cluster := range c.stale {
+		// Clusters can be in the stale list multiple times;
+		// skip to avoid duplicate recalculations.
+		if _, ok := assignments[cluster.ClusterName]; ok {
+			continue
+		}
+
+		cla := v2.ClusterLoadAssignment{
+			ClusterName: cluster.ClusterName,
+			Endpoints:   nil,
+			Policy:      nil,
+		}
+
+		// Look up each service, and if we have endpoints for that service,
+		// attach them as a new LocalityEndpoints resource.
+		for _, w := range cluster.Services {
+			n := types.NamespacedName{Namespace: w.ServiceNamespace, Name: w.ServiceName}
+			if lb := RecalculateEndpoints(w.ServicePort, c.endpoints[n]); lb != nil {
+				cla.Endpoints = append(
+					cla.Endpoints,
+					&LocalityEndpoints{
+						LbEndpoints:         lb,
+						LoadBalancingWeight: protobuf.UInt32(w.Weight),
+					},
+				)
+			}
+		}
+
+		assignments[cla.ClusterName] = &cla
+	}
+
+	c.stale = nil
+	return assignments
+}
+
+// SetClusters replaces the cache of ServiceCluster resources. All
+// the added clusters will be marked stale.
+func (c *EndpointsCache) SetClusters(clusters []*dag.ServiceCluster) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Keep a local index to start with so that errors don't cause
+	// partial failure.
+	serviceIndex := map[types.NamespacedName][]*dag.ServiceCluster{}
+
+	// Reindex the cluster so that we can find them by service name.
+	for _, cluster := range clusters {
+		if err := cluster.Validate(); err != nil {
+			return fmt.Errorf("invalid ServiceCluster %q: %w", cluster.ClusterName, err)
+		}
+
+		for _, s := range cluster.Services {
+			name := types.NamespacedName{
+				Namespace: s.ServiceNamespace,
+				Name:      s.ServiceName,
+			}
+
+			// Create the slice entry if we have not indexed this service yet.
+			entry := serviceIndex[name]
+			if entry == nil {
+				entry = []*dag.ServiceCluster{}
+			}
+
+			serviceIndex[name] = append(entry, cluster)
+		}
+	}
+
+	c.stale = clusters
+	c.services = serviceIndex
+
+	return nil
+}
+
+// UpdateEndpoint adds ep to the cache, or replaces it if it is
+// already cached. Any ServiceClusters that are backed by a Service
+// that ep belongs become stale.
+func (c *EndpointsCache) UpdateEndpoint(ep *v1.Endpoints) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	name := k8s.NamespacedNameOf(ep)
+	c.endpoints[name] = ep.DeepCopy()
+
+	// If any service clusters include this endpoint, mark them
+	// all as stale.
+	if affected := c.services[name]; len(affected) > 0 {
+		c.stale = append(c.stale, affected...)
+	}
+}
+
+// DeleteEndpoint deletes ep from the cache. Any ServiceClusters
+// that are backed by a Service that ep belongs become stale.
+func (c *EndpointsCache) DeleteEndpoint(ep *v1.Endpoints) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	name := k8s.NamespacedNameOf(ep)
+	delete(c.endpoints, name)
+
+	// If any service clusters include this endpoint, mark them
+	// all as stale.
+	if affected := c.services[name]; len(affected) > 0 {
+		c.stale = append(c.stale, affected...)
+	}
+}
+
+// EndpointsInterface exposes the interfaces supported by the endpoints translator.
+type EndpointsInterface interface {
+	cache.ResourceEventHandler
+	dag.Observer
+	xds.Resource
+}
+
+// NewEndpointsTranslator allocates a new endpoints translator.
+func NewEndpointsTranslator(log logrus.FieldLogger) EndpointsInterface {
+	return &EndpointsTranslator{
+		Cond:        Cond{},
+		FieldLogger: log,
+		entries:     map[string]*v2.ClusterLoadAssignment{},
+		cache: EndpointsCache{
+			stale:     nil,
+			services:  map[types.NamespacedName][]*dag.ServiceCluster{},
+			endpoints: map[types.NamespacedName]*v1.Endpoints{},
+		},
+	}
+}
+
 // A EndpointsTranslator translates Kubernetes Endpoints objects into Envoy
-// ClusterLoadAssignment objects.
+// ClusterLoadAssignment resources.
 type EndpointsTranslator struct {
 	Cond
 	logrus.FieldLogger
 
-	mu      sync.Mutex
+	cache EndpointsCache
+
+	mu      sync.Mutex // Protects entries.
 	entries map[string]*v2.ClusterLoadAssignment
 }
 
+// Merge combines the given entries with the existing entries in the
+// EndpointsTranslatore. If the same key exists in both maps, an existing entry
+// is replaced.
+func (e *EndpointsTranslator) Merge(entries map[string]*v2.ClusterLoadAssignment) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for k, v := range entries {
+		e.entries[k] = v
+	}
+}
+
+// OnChange observes DAG rebuild events.
 func (e *EndpointsTranslator) OnChange(d *dag.DAG) {
-	// TODO(jpeach) Update the internal model to map which
-	// services are targets of which cluster load assignments.
+	clusters := []*dag.ServiceCluster{}
+	names := map[string]bool{}
+
+	var visitor func(dag.Vertex)
+	visitor = func(vertex dag.Vertex) {
+		if svc, ok := vertex.(*dag.ServiceCluster); ok {
+			if err := svc.Validate(); err != nil {
+				e.WithError(err).Errorf("dropping invalid service cluster %q", svc.ClusterName)
+			} else if _, ok := names[svc.ClusterName]; ok {
+				e.Errorf("dropping service cluster with duplicate name %q", svc.ClusterName)
+			} else {
+
+				e.Debugf("added ServiceCluster %q from DAG", svc.ClusterName)
+				clusters = append(clusters, svc.DeepCopy())
+			}
+		}
+
+		vertex.Visit(visitor)
+	}
+
+	// Collect all the service clusters from the DAG.
+	d.Visit(visitor)
+
+	// Update the cache with the new clusters.
+	if err := e.cache.SetClusters(clusters); err != nil {
+		e.WithError(err).Error("failed to cache service clusters")
+	}
+
+	// After rebuilding the DAG, the service cluster could be
+	// completely different. Some could be added, and some could
+	// be removed. Since we reset the cluster cache above, all
+	// the load assignments will be recalculated and we can just
+	// set the entries rather than merging them.
+	entries := e.cache.Recalculate()
+
+	e.mu.Lock()
+	e.entries = entries
+	e.mu.Unlock()
+
+	e.Notify()
 }
 
 func (e *EndpointsTranslator) OnAdd(obj interface{}) {
 	switch obj := obj.(type) {
 	case *v1.Endpoints:
-		recomputeClusterLoadAssignment(e, nil, obj)
+		e.cache.UpdateEndpoint(obj)
+		e.Merge(e.cache.Recalculate())
+		e.Notify()
 	default:
 		e.Errorf("OnAdd unexpected type %T: %#v", obj, obj)
 	}
@@ -64,6 +323,12 @@ func (e *EndpointsTranslator) OnUpdate(oldObj, newObj interface{}) {
 			return
 		}
 
+		// Skip computation if either old and new services or
+		// endpoints are equal (thus also handling nil).
+		if oldObj == newObj {
+			return
+		}
+
 		// If there are no endpoints in this object, and the old
 		// object also had zero endpoints, ignore this update
 		// to avoid sending a noop notification to watchers.
@@ -71,8 +336,9 @@ func (e *EndpointsTranslator) OnUpdate(oldObj, newObj interface{}) {
 			return
 		}
 
-		recomputeClusterLoadAssignment(e, oldObj, newObj)
-
+		e.cache.UpdateEndpoint(newObj)
+		e.Merge(e.cache.Recalculate())
+		e.Notify()
 	default:
 		e.Errorf("OnUpdate unexpected type %T: %#v", newObj, newObj)
 	}
@@ -81,8 +347,10 @@ func (e *EndpointsTranslator) OnUpdate(oldObj, newObj interface{}) {
 func (e *EndpointsTranslator) OnDelete(obj interface{}) {
 	switch obj := obj.(type) {
 	case *v1.Endpoints:
-		recomputeClusterLoadAssignment(e, obj, nil)
-	case k8scache.DeletedFinalStateUnknown:
+		e.cache.DeleteEndpoint(obj)
+		e.Merge(e.cache.Recalculate())
+		e.Notify()
+	case cache.DeletedFinalStateUnknown:
 		e.OnDelete(obj.Obj) // recurse into ourselves with the tombstoned value
 	default:
 		e.Errorf("OnDelete unexpected type %T: %#v", obj, obj)
@@ -111,6 +379,7 @@ func (e *EndpointsTranslator) Query(names []string) []proto.Message {
 	for _, n := range names {
 		v, ok := e.entries[n]
 		if !ok {
+			e.Debugf("no cache entry for %q", n)
 			v = &v2.ClusterLoadAssignment{
 				ClusterName: n,
 			}
@@ -123,95 +392,3 @@ func (e *EndpointsTranslator) Query(names []string) []proto.Message {
 }
 
 func (*EndpointsTranslator) TypeURL() string { return resource.EndpointType }
-
-// Add adds an entry to the cache. If a ClusterLoadAssignment with the same
-// name exists, it is replaced.
-func (e *EndpointsTranslator) Add(a *v2.ClusterLoadAssignment) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.entries == nil {
-		e.entries = make(map[string]*v2.ClusterLoadAssignment)
-	}
-	e.entries[a.ClusterName] = a
-	e.Notify(a.ClusterName)
-}
-
-// Remove removes the named entry from the cache. If the entry
-// is not present in the cache, the operation is a no-op.
-func (e *EndpointsTranslator) Remove(name string) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	delete(e.entries, name)
-	e.Notify(name)
-}
-
-// recomputeClusterLoadAssignment recomputes the EDS cache taking into account old and new endpoints.
-func recomputeClusterLoadAssignment(e *EndpointsTranslator, oldep, newep *v1.Endpoints) {
-	// Skip computation if either old and new services or
-	// endpoints are equal (thus also handling nil).
-	if oldep == newep {
-		return
-	}
-
-	if oldep == nil {
-		oldep = &v1.Endpoints{
-			ObjectMeta: newep.ObjectMeta,
-		}
-	}
-
-	if newep == nil {
-		newep = &v1.Endpoints{
-			ObjectMeta: oldep.ObjectMeta,
-		}
-	}
-
-	seen := make(map[string]bool)
-	// add or update endpoints
-	for _, s := range newep.Subsets {
-		if len(s.Addresses) < 1 {
-			// skip subset without ready addresses.
-			continue
-		}
-		for _, p := range s.Ports {
-			if p.Protocol != "TCP" {
-				// skip non TCP ports
-				continue
-			}
-
-			addresses := append([]v1.EndpointAddress{}, s.Addresses...) // shallow copy
-			sort.Slice(addresses, func(i, j int) bool { return addresses[i].IP < addresses[j].IP })
-
-			lbendpoints := make([]*envoy_api_v2_endpoint.LbEndpoint, 0, len(addresses))
-			for _, a := range addresses {
-				addr := envoy.SocketAddress(a.IP, int(p.Port))
-				lbendpoints = append(lbendpoints, envoy.LBEndpoint(addr))
-			}
-
-			cla := &v2.ClusterLoadAssignment{
-				ClusterName: envoy.ClusterLoadAssignmentName(k8s.NamespacedNameOf(newep), p.Name),
-				Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{{
-					LbEndpoints: lbendpoints,
-				}},
-			}
-			seen[cla.ClusterName] = true
-			e.Add(cla)
-		}
-	}
-
-	// iterate over the ports in the old spec, remove any were not seen.
-	for _, s := range oldep.Subsets {
-		if len(s.Addresses) == 0 {
-			continue
-		}
-		for _, p := range s.Ports {
-			name := envoy.ClusterLoadAssignmentName(k8s.NamespacedNameOf(newep), p.Name)
-			if _, ok := seen[name]; !ok {
-				// port is no longer present, remove it.
-				e.Remove(name)
-			}
-		}
-	}
-
-}

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -18,9 +18,11 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/stretchr/testify/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -49,10 +51,10 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var et EndpointsTranslator
+			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 			et.entries = tc.contents
 			got := et.Contents()
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -105,15 +107,51 @@ func TestEndpointCacheQuery(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var et EndpointsTranslator
+			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 			et.entries = tc.contents
 			got := et.Query(tc.query)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
 
 func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
+	clusters := []*dag.ServiceCluster{
+		&dag.ServiceCluster{
+			ClusterName: "default/httpbin-org/a",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "httpbin-org",
+					ServiceNamespace: "default",
+					ServicePort:      v1.ServicePort{Name: "a"},
+				},
+			},
+		},
+		&dag.ServiceCluster{
+			ClusterName: "default/httpbin-org/b",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "httpbin-org",
+					ServiceNamespace: "default",
+					ServicePort:      v1.ServicePort{Name: "b"},
+				},
+			},
+		},
+		&dag.ServiceCluster{
+			ClusterName: "default/simple",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "simple",
+					ServiceNamespace: "default",
+					ServicePort:      v1.ServicePort{},
+				},
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		ep   *v1.Endpoints
 		want []proto.Message
@@ -126,11 +164,16 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/simple", envoy.SocketAddress("192.168.183.24", 8080)),
+				&v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/a"},
+				&v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/b"},
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/simple",
+					Endpoints:   envoy.WeightedEndpoints(1, envoy.SocketAddress("192.168.183.24", 8080)),
+				},
 			},
 		},
 		"multiple addresses": {
-			ep: endpoints("default", "httpbin-org", v1.EndpointSubset{
+			ep: endpoints("default", "simple", v1.EndpointSubset{
 				Addresses: addresses(
 					"50.17.192.147",
 					"50.17.206.192",
@@ -142,12 +185,17 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/httpbin-org",
-					envoy.SocketAddress("23.23.247.89", 80), // addresses should be sorted
-					envoy.SocketAddress("50.17.192.147", 80),
-					envoy.SocketAddress("50.17.206.192", 80),
-					envoy.SocketAddress("50.19.99.160", 80),
-				),
+				&v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/a"},
+				&v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/b"},
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/simple",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("23.23.247.89", 80), // addresses should be sorted
+						envoy.SocketAddress("50.17.192.147", 80),
+						envoy.SocketAddress("50.17.206.192", 80),
+						envoy.SocketAddress("50.19.99.160", 80),
+					),
+				},
 			},
 		},
 		"multiple ports": {
@@ -161,12 +209,16 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/httpbin-org/a", // cluster names should be sorted
-					envoy.SocketAddress("10.10.1.1", 8675),
-				),
-				envoy.ClusterLoadAssignment("default/httpbin-org/b",
-					envoy.SocketAddress("10.10.1.1", 309),
-				),
+				// Results should be sorted by cluster name.
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/a",
+					Endpoints:   envoy.WeightedEndpoints(1, envoy.SocketAddress("10.10.1.1", 8675)),
+				},
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/b",
+					Endpoints:   envoy.WeightedEndpoints(1, envoy.SocketAddress("10.10.1.1", 309)),
+				},
+				&v2.ClusterLoadAssignment{ClusterName: "default/simple"},
 			},
 		},
 		"cartesian product": {
@@ -181,14 +233,21 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/httpbin-org/a",
-					envoy.SocketAddress("10.10.1.1", 8675), // addresses should be sorted
-					envoy.SocketAddress("10.10.2.2", 8675),
-				),
-				envoy.ClusterLoadAssignment("default/httpbin-org/b",
-					envoy.SocketAddress("10.10.1.1", 309),
-					envoy.SocketAddress("10.10.2.2", 309),
-				),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/a",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("10.10.1.1", 8675), // addresses should be sorted
+						envoy.SocketAddress("10.10.2.2", 8675),
+					),
+				},
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/b",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("10.10.1.1", 309),
+						envoy.SocketAddress("10.10.2.2", 309),
+					),
+				},
+				&v2.ClusterLoadAssignment{ClusterName: "default/simple"},
 			},
 		},
 		"not ready": {
@@ -212,30 +271,72 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/httpbin-org/a",
-					envoy.SocketAddress("10.10.1.1", 8675),
-				),
-				envoy.ClusterLoadAssignment("default/httpbin-org/b",
-					envoy.SocketAddress("10.10.1.1", 309),
-					envoy.SocketAddress("10.10.2.2", 309),
-				),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/a",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("10.10.1.1", 8675),
+					),
+				},
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org/b",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("10.10.1.1", 309),
+						envoy.SocketAddress("10.10.2.2", 309),
+					),
+				},
+				&v2.ClusterLoadAssignment{ClusterName: "default/simple"},
 			},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			et := &EndpointsTranslator{
-				FieldLogger: fixture.NewTestLogger(t),
-			}
+			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
+			require.NoError(t, et.cache.SetClusters(clusters))
 			et.OnAdd(tc.ep)
 			got := et.Contents()
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
 
 func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
+	clusters := []*dag.ServiceCluster{
+		&dag.ServiceCluster{
+			ClusterName: "default/simple",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "simple",
+					ServiceNamespace: "default",
+					ServicePort:      v1.ServicePort{},
+				},
+			},
+		},
+		&dag.ServiceCluster{
+			ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "what-a-descriptive-service-name-you-must-be-so-proud",
+					ServiceNamespace: "super-long-namespace-name-oh-boy",
+					ServicePort:      v1.ServicePort{Name: "http"},
+				},
+			},
+		},
+		&dag.ServiceCluster{
+			ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https",
+			Services: []dag.WeightedService{
+				dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "what-a-descriptive-service-name-you-must-be-so-proud",
+					ServiceNamespace: "super-long-namespace-name-oh-boy",
+					ServicePort:      v1.ServicePort{Name: "https"},
+				},
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		setup func(*EndpointsTranslator)
 		ep    *v1.Endpoints
@@ -256,7 +357,11 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
-			want: nil,
+			want: []proto.Message{
+				envoy.ClusterLoadAssignment("default/simple"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+			},
 		},
 		"remove different": {
 			setup: func(et *EndpointsTranslator) {
@@ -274,7 +379,12 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/simple", envoy.SocketAddress("192.168.183.24", 8080)),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/simple",
+					Endpoints:   envoy.WeightedEndpoints(1, envoy.SocketAddress("192.168.183.24", 8080)),
+				},
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 			},
 		},
 		"remove non existent": {
@@ -285,7 +395,11 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					port("", 8080),
 				),
 			}),
-			want: nil,
+			want: []proto.Message{
+				envoy.ClusterLoadAssignment("default/simple"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+			},
 		},
 		"remove long name": {
 			setup: func(et *EndpointsTranslator) {
@@ -319,41 +433,70 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 					),
 				},
 			),
-			want: nil,
+			want: []proto.Message{
+				envoy.ClusterLoadAssignment("default/simple"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+			},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			et := &EndpointsTranslator{
-				FieldLogger: fixture.NewTestLogger(t),
-			}
+			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
+			require.NoError(t, et.cache.SetClusters(clusters))
 			tc.setup(et)
+			// TODO(jpeach): this doesn't actually test
+			// that deleting endpoints works. We ought to
+			// ensure the cache is populated first and
+			// only after that, verify that deletion gives
+			// the expected result.
 			et.OnDelete(tc.ep)
 			got := et.Contents()
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
 
 func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 	tests := map[string]struct {
-		oldep, newep *v1.Endpoints
-		want         []proto.Message
+		cluster dag.ServiceCluster
+		ep      *v1.Endpoints
+		want    []proto.Message
 	}{
 		"simple": {
-			newep: endpoints("default", "simple", v1.EndpointSubset{
+			cluster: dag.ServiceCluster{
+				ClusterName: "default/simple",
+				Services: []dag.WeightedService{{
+					Weight:           1,
+					ServiceName:      "simple",
+					ServiceNamespace: "default",
+				}},
+			},
+			ep: endpoints("default", "simple", v1.EndpointSubset{
 				Addresses: addresses("192.168.183.24"),
 				Ports: ports(
 					port("", 8080),
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/simple", envoy.SocketAddress("192.168.183.24", 8080)),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/simple",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("192.168.183.24", 8080)),
+				},
 			},
 		},
 		"multiple addresses": {
-			newep: endpoints("default", "httpbin-org", v1.EndpointSubset{
+			cluster: dag.ServiceCluster{
+				ClusterName: "default/httpbin-org",
+				Services: []dag.WeightedService{{
+					Weight:           1,
+					ServiceName:      "httpbin-org",
+					ServiceNamespace: "default",
+				}},
+			},
+			ep: endpoints("default", "httpbin-org", v1.EndpointSubset{
 				Addresses: addresses(
 					"50.17.192.147",
 					"23.23.247.89",
@@ -365,49 +508,70 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/httpbin-org",
-					envoy.SocketAddress("23.23.247.89", 80),
-					envoy.SocketAddress("50.17.192.147", 80),
-					envoy.SocketAddress("50.17.206.192", 80),
-					envoy.SocketAddress("50.19.99.160", 80),
-				),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/httpbin-org",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("23.23.247.89", 80),
+						envoy.SocketAddress("50.17.192.147", 80),
+						envoy.SocketAddress("50.17.206.192", 80),
+						envoy.SocketAddress("50.19.99.160", 80),
+					),
+				},
 			},
 		},
 		"named container port": {
-			newep: endpoints("default", "secure", v1.EndpointSubset{
+			cluster: dag.ServiceCluster{
+				ClusterName: "default/secure/https",
+				Services: []dag.WeightedService{{
+					Weight:           1,
+					ServiceName:      "secure",
+					ServiceNamespace: "default",
+					ServicePort:      v1.ServicePort{Name: "https"},
+				}},
+			},
+			ep: endpoints("default", "secure", v1.EndpointSubset{
 				Addresses: addresses("192.168.183.24"),
 				Ports: ports(
 					port("https", 8443),
 				),
 			}),
 			want: []proto.Message{
-				envoy.ClusterLoadAssignment("default/secure/https", envoy.SocketAddress("192.168.183.24", 8443)),
+				&v2.ClusterLoadAssignment{
+					ClusterName: "default/secure/https",
+					Endpoints: envoy.WeightedEndpoints(1,
+						envoy.SocketAddress("192.168.183.24", 8443)),
+				},
 			},
-		},
-		"remove existing": {
-			oldep: endpoints("default", "simple", v1.EndpointSubset{
-				Addresses: addresses("192.168.183.24"),
-				Ports: ports(
-					port("", 8080),
-				),
-			}),
-			want: nil,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var et EndpointsTranslator
-			recomputeClusterLoadAssignment(&et, tc.oldep, tc.newep)
+			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
+			require.NoError(t, et.cache.SetClusters([]*dag.ServiceCluster{&tc.cluster}))
+			et.OnAdd(tc.ep)
 			got := et.Contents()
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
 
 // See #602
 func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
-	var et EndpointsTranslator
+	et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
+
+	require.NoError(t, et.cache.SetClusters([]*dag.ServiceCluster{
+		&dag.ServiceCluster{
+			ClusterName: "default/simple",
+			Services: []dag.WeightedService{{
+				Weight:           1,
+				ServiceName:      "simple",
+				ServiceNamespace: "default",
+				ServicePort:      v1.ServicePort{},
+			}},
+		},
+	}))
+
 	e1 := endpoints("default", "simple", v1.EndpointSubset{
 		Addresses: addresses("192.168.183.24"),
 		Ports: ports(
@@ -418,21 +582,24 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 
 	// Assert endpoint was added
 	want := []proto.Message{
-		envoy.ClusterLoadAssignment("default/simple", envoy.SocketAddress("192.168.183.24", 8080)),
+		&v2.ClusterLoadAssignment{
+			ClusterName: "default/simple",
+			Endpoints:   envoy.WeightedEndpoints(1, envoy.SocketAddress("192.168.183.24", 8080)),
+		},
 	}
-	got := et.Contents()
 
-	assert.Equal(t, want, got)
+	protobuf.RequireEqual(t, want, et.Contents())
 
 	// e2 is the same as e1, but without endpoint subsets
 	e2 := endpoints("default", "simple")
 	et.OnUpdate(e1, e2)
 
 	// Assert endpoints are removed
-	want = nil
-	got = et.Contents()
+	want = []proto.Message{
+		&v2.ClusterLoadAssignment{ClusterName: "default/simple"},
+	}
 
-	assert.Equal(t, want, got)
+	protobuf.RequireEqual(t, want, et.Contents())
 }
 
 func ports(eps ...v1.EndpointPort) []v1.EndpointPort {

--- a/internal/contour/server_test.go
+++ b/internal/contour/server_test.go
@@ -24,6 +24,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ import (
 
 func TestGRPC(t *testing.T) {
 	// tr and et is recreated before the start of each test.
-	var et *EndpointsTranslator
+	var et EndpointsInterface
 	var eh *EventHandler
 
 	tests := map[string]func(*testing.T, *grpc.ClientConn){
@@ -188,9 +189,7 @@ func TestGRPC(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
-			et = &EndpointsTranslator{
-				FieldLogger: log,
-			}
+			et = NewEndpointsTranslator(fixture.NewTestLogger(t))
 
 			resources := []ResourceCache{
 				NewListenerCache(ListenerConfig{}, "", 0),

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -44,12 +44,15 @@ func TestVisitClusters(t *testing.T) {
 						TCPProxy: &dag.TCPProxy{
 							Clusters: []*dag.Cluster{{
 								Upstream: &dag.Service{
-									Name:      "example",
-									Namespace: "default",
-									ServicePort: v1.ServicePort{
-										Protocol:   "TCP",
-										Port:       443,
-										TargetPort: intstr.FromInt(8443),
+									Weighted: dag.WeightedService{
+										Weight:           1,
+										ServiceName:      "example",
+										ServiceNamespace: "default",
+										ServicePort: v1.ServicePort{
+											Protocol:   "TCP",
+											Port:       443,
+											TargetPort: intstr.FromInt(8443),
+										},
 									},
 								},
 							}},
@@ -84,12 +87,15 @@ func TestVisitListeners(t *testing.T) {
 	p1 := &dag.TCPProxy{
 		Clusters: []*dag.Cluster{{
 			Upstream: &dag.Service{
-				Name:      "example",
-				Namespace: "default",
-				ServicePort: v1.ServicePort{
-					Protocol:   "TCP",
-					Port:       443,
-					TargetPort: intstr.FromInt(8443),
+				Weighted: dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "example",
+					ServiceNamespace: "default",
+					ServicePort: v1.ServicePort{
+						Protocol:   "TCP",
+						Port:       443,
+						TargetPort: intstr.FromInt(8443),
+					},
 				},
 			},
 		}},
@@ -165,12 +171,15 @@ func TestVisitSecrets(t *testing.T) {
 						TCPProxy: &dag.TCPProxy{
 							Clusters: []*dag.Cluster{{
 								Upstream: &dag.Service{
-									Name:      "example",
-									Namespace: "default",
-									ServicePort: v1.ServicePort{
-										Protocol:   "TCP",
-										Port:       443,
-										TargetPort: intstr.FromInt(8443),
+									Weighted: dag.WeightedService{
+										Weight:           1,
+										ServiceName:      "example",
+										ServiceNamespace: "default",
+										ServicePort: v1.ServicePort{
+											Protocol:   "TCP",
+											Port:       443,
+											TargetPort: intstr.FromInt(8443),
+										},
 									},
 								},
 							}},

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4091,10 +4091,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3d.Name,
-								Namespace:   s3d.Namespace,
-								ServicePort: s3d.Spec.Ports[0],
-								Protocol:    "h2c",
+								Protocol: "h2c",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3d.Name,
+									ServiceNamespace: s3d.Namespace,
+									ServicePort:      s3d.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4111,10 +4114,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3e.Name,
-								Namespace:   s3e.Namespace,
-								ServicePort: s3e.Spec.Ports[0],
-								Protocol:    "h2",
+								Protocol: "h2",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3e.Name,
+									ServiceNamespace: s3e.Namespace,
+									ServicePort:      s3e.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4131,10 +4137,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3f.Name,
-								Namespace:   s3f.Namespace,
-								ServicePort: s3f.Spec.Ports[0],
-								Protocol:    "tls",
+								Protocol: "tls",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3f.Name,
+									ServiceNamespace: s3f.Namespace,
+									ServicePort:      s3f.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4152,10 +4161,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3a.Name,
-								Namespace:   s3a.Namespace,
-								ServicePort: s3a.Spec.Ports[0],
-								Protocol:    "h2c",
+								Protocol: "h2c",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3a.Name,
+									ServiceNamespace: s3a.Namespace,
+									ServicePort:      s3a.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4172,10 +4184,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3b.Name,
-								Namespace:   s3b.Namespace,
-								ServicePort: s3b.Spec.Ports[0],
-								Protocol:    "h2",
+								Protocol: "h2",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3b.Name,
+									ServiceNamespace: s3b.Namespace,
+									ServicePort:      s3b.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4192,10 +4207,13 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:        s3c.Name,
-								Namespace:   s3c.Namespace,
-								ServicePort: s3c.Spec.Ports[0],
-								Protocol:    "tls",
+								Protocol: "tls",
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s3c.Name,
+									ServiceNamespace: s3c.Namespace,
+									ServicePort:      s3c.Spec.Ports[0],
+								},
 							}),
 						),
 					),
@@ -4213,9 +4231,12 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
 							prefixroute("/", &Service{
-								Name:               s1b.Name,
-								Namespace:          s1b.Namespace,
-								ServicePort:        s1b.Spec.Ports[0],
+								Weighted: WeightedService{
+									Weight:           1,
+									ServiceName:      s1b.Name,
+									ServiceNamespace: s1b.Namespace,
+									ServicePort:      s1b.Spec.Ports[0],
+								},
 								MaxConnections:     9000,
 								MaxPendingRequests: 4096,
 								MaxRequests:        404,
@@ -4237,17 +4258,23 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("example.com",
 							routeCluster("/a", &Cluster{
 								Upstream: &Service{
-									Name:        s1.Name,
-									Namespace:   s1.Namespace,
-									ServicePort: s1.Spec.Ports[0],
+									Weighted: WeightedService{
+										Weight:           1,
+										ServiceName:      s1.Name,
+										ServiceNamespace: s1.Namespace,
+										ServicePort:      s1.Spec.Ports[0],
+									},
 								},
 								Weight: 90,
 							}),
 							routeCluster("/b", &Cluster{
 								Upstream: &Service{
-									Name:        s1.Name,
-									Namespace:   s1.Namespace,
-									ServicePort: s1.Spec.Ports[0],
+									Weighted: WeightedService{
+										Weight:           1,
+										ServiceName:      s1.Name,
+										ServiceNamespace: s1.Namespace,
+										ServicePort:      s1.Spec.Ports[0],
+									},
 								},
 								Weight: 60,
 							}),
@@ -4268,16 +4295,22 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/a",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 									Weight: 90,
 								}, &Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 									Weight: 60,
 								},
@@ -4551,10 +4584,13 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: s1a.Spec.Ports[0],
-										Protocol:    "tls",
+										Protocol: "tls",
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1a.Name,
+											ServiceNamespace: s1a.Namespace,
+											ServicePort:      s1a.Spec.Ports[0],
+										},
 									},
 									Protocol: "tls",
 									UpstreamValidation: &PeerValidationContext{
@@ -4580,9 +4616,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1a.Name,
-										Namespace:   s1a.Namespace,
-										ServicePort: s1a.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1a.Name,
+											ServiceNamespace: s1a.Namespace,
+											ServicePort:      s1a.Spec.Ports[0],
+										},
 									},
 									Protocol: "h2",
 									UpstreamValidation: &PeerValidationContext{
@@ -4788,18 +4827,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/blog",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: s4.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s4.Name,
+											ServiceNamespace: s4.Namespace,
+											ServicePort:      s4.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4820,9 +4865,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4830,11 +4878,15 @@ func TestDAGInsert(t *testing.T) {
 								PathMatchCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: s4.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s4.Name,
+											ServiceNamespace: s4.Namespace,
+											ServicePort:      s4.Spec.Ports[0],
+										},
 									},
-								}},
+								},
+								},
 							},
 						),
 					),
@@ -4853,9 +4905,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4863,18 +4918,24 @@ func TestDAGInsert(t *testing.T) {
 								PathMatchCondition: prefix("/blog/infotech"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: s4.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s4.Name,
+											ServiceNamespace: s4.Namespace,
+											ServicePort:      s4.Spec.Ports[0],
+										},
 									},
 								}},
 							},
 							routeCluster("/blog",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s4.Name,
-										Namespace:   s4.Namespace,
-										ServicePort: s4.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s4.Name,
+											ServiceNamespace: s4.Namespace,
+											ServicePort:      s4.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4882,9 +4943,12 @@ func TestDAGInsert(t *testing.T) {
 								PathMatchCondition: prefix("/blog/it/foo"),
 								Clusters: []*Cluster{{
 									Upstream: &Service{
-										Name:        s11.Name,
-										Namespace:   s11.Namespace,
-										ServicePort: s11.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s11.Name,
+											ServiceNamespace: s11.Namespace,
+											ServicePort:      s11.Spec.Ports[0],
+										},
 									},
 								}},
 							},
@@ -4905,18 +4969,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/kuarder",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: s2.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s2.Name,
+											ServiceNamespace: s2.Namespace,
+											ServicePort:      s2.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4937,18 +5007,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/kuarder",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: s2.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s2.Name,
+											ServiceNamespace: s2.Namespace,
+											ServicePort:      s2.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -4969,18 +5045,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/kuarder/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: s2.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s2.Name,
+											ServiceNamespace: s2.Namespace,
+											ServicePort:      s2.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -5001,18 +5083,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/kuarder/withavengeance",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: s2.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s2.Name,
+											ServiceNamespace: s2.Namespace,
+											ServicePort:      s2.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -5033,18 +5121,24 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s1.Name,
-										Namespace:   s1.Namespace,
-										ServicePort: s1.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s1.Name,
+											ServiceNamespace: s1.Namespace,
+											ServicePort:      s1.Spec.Ports[0],
+										},
 									},
 								},
 							),
 							routeCluster("/kuarder/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s2.Name,
-										Namespace:   s2.Namespace,
-										ServicePort: s2.Spec.Ports[0],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s2.Name,
+											ServiceNamespace: s2.Namespace,
+											ServicePort:      s2.Spec.Ports[0],
+										},
 									},
 								},
 							),
@@ -5136,9 +5230,12 @@ func TestDAGInsert(t *testing.T) {
 							routeCluster("/",
 								&Cluster{
 									Upstream: &Service{
-										Name:        s10.Name,
-										Namespace:   s10.Namespace,
-										ServicePort: s10.Spec.Ports[1],
+										Weighted: WeightedService{
+											Weight:           1,
+											ServiceName:      s10.Name,
+											ServiceNamespace: s10.Namespace,
+											ServicePort:      s10.Spec.Ports[1],
+										},
 									},
 								},
 							),
@@ -5392,10 +5489,13 @@ func TestDAGInsert(t *testing.T) {
 							PathMatchCondition: prefix("/"),
 							Clusters: []*Cluster{{
 								Upstream: &Service{
-									Name:         s14.Name,
-									Namespace:    s14.Namespace,
-									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
+									Weighted: WeightedService{
+										Weight:           1,
+										ServiceName:      s14.Name,
+										ServiceNamespace: s14.Namespace,
+										ServicePort:      s14.Spec.Ports[0],
+									},
 								},
 								SNI: "externalservice.io",
 							}},
@@ -5440,10 +5540,13 @@ func TestDAGInsert(t *testing.T) {
 							PathMatchCondition: prefix("/"),
 							Clusters: []*Cluster{{
 								Upstream: &Service{
-									Name:         s14.Name,
-									Namespace:    s14.Namespace,
-									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
+									Weighted: WeightedService{
+										Weight:           1,
+										ServiceName:      s14.Name,
+										ServiceNamespace: s14.Namespace,
+										ServicePort:      s14.Spec.Ports[0],
+									},
 								},
 								SNI: "bar.com",
 							}},
@@ -5491,10 +5594,13 @@ func TestDAGInsert(t *testing.T) {
 							PathMatchCondition: prefix("/"),
 							Clusters: []*Cluster{{
 								Upstream: &Service{
-									Name:         s14.Name,
-									Namespace:    s14.Namespace,
-									ServicePort:  s14.Spec.Ports[0],
 									ExternalName: "externalservice.io",
+									Weighted: WeightedService{
+										Weight:           1,
+										ServiceName:      s14.Name,
+										ServiceNamespace: s14.Namespace,
+										ServicePort:      s14.Spec.Ports[0],
+									},
 								},
 								RequestHeadersPolicy: &HeadersPolicy{
 									HostRewrite: "bar.com",
@@ -6762,9 +6868,12 @@ func clusters(services ...*Service) (c []*Cluster) {
 
 func service(s *v1.Service) *Service {
 	return &Service{
-		Name:        s.Name,
-		Namespace:   s.Namespace,
-		ServicePort: s.Spec.Ports[0],
+		Weighted: WeightedService{
+			Weight:           1,
+			ServiceName:      s.Name,
+			ServiceNamespace: s.Namespace,
+			ServicePort:      s.Spec.Ports[0],
+		},
 	}
 }
 

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -48,7 +48,8 @@ func (c *ctx) writeVertex(v dag.Vertex) {
 	case *dag.Secret:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{secret|%s/%s}"]`+"\n", v, v.Namespace(), v.Name())
 	case *dag.Service:
-		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n", v, v.Namespace, v.Name, v.ServicePort.Port)
+		fmt.Fprintf(c.w, `"%p" [shape=record, label="{service|%s/%s:%d}"]`+"\n",
+			v, v.Weighted.ServiceNamespace, v.Weighted.ServiceName, v.Weighted.ServicePort.Port)
 	case *dag.VirtualHost:
 		fmt.Fprintf(c.w, `"%p" [shape=record, label="{http://%s}"]`+"\n", v, v.Name)
 	case *dag.SecureVirtualHost:

--- a/internal/envoy/endpoint.go
+++ b/internal/envoy/endpoint.go
@@ -17,6 +17,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 // LBEndpoint creates a new LbEndpoint.
@@ -36,17 +37,17 @@ func LBEndpoint(addr *envoy_api_v2_core.Address) *envoy_api_v2_endpoint.LbEndpoi
 func Endpoints(addrs ...*envoy_api_v2_core.Address) []*envoy_api_v2_endpoint.LocalityLbEndpoints {
 	lbendpoints := make([]*envoy_api_v2_endpoint.LbEndpoint, 0, len(addrs))
 	for _, addr := range addrs {
-		lbendpoints = append(lbendpoints, &envoy_api_v2_endpoint.LbEndpoint{
-			HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
-				Endpoint: &envoy_api_v2_endpoint.Endpoint{
-					Address: addr,
-				},
-			},
-		})
+		lbendpoints = append(lbendpoints, LBEndpoint(addr))
 	}
 	return []*envoy_api_v2_endpoint.LocalityLbEndpoints{{
 		LbEndpoints: lbendpoints,
 	}}
+}
+
+func WeightedEndpoints(weight uint32, addrs ...*envoy_api_v2_core.Address) []*envoy_api_v2_endpoint.LocalityLbEndpoints {
+	lbendpoints := Endpoints(addrs...)
+	lbendpoints[0].LoadBalancingWeight = protobuf.UInt32(weight)
+	return lbendpoints
 }
 
 // ClusterLoadAssignment returns a *v2.ClusterLoadAssignment with a single

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -694,23 +694,28 @@ func TestTCPProxy(t *testing.T) {
 
 	c1 := &dag.Cluster{
 		Upstream: &dag.Service{
-			Name:      "example",
-			Namespace: "default",
-			ServicePort: v1.ServicePort{
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8443),
+			Weighted: dag.WeightedService{
+				Weight:           1,
+				ServiceName:      "example",
+				ServiceNamespace: "default",
+				ServicePort: v1.ServicePort{
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
 			},
 		},
 	}
 	c2 := &dag.Cluster{
 		Upstream: &dag.Service{
-			Name:      "example2",
-			Namespace: "default",
-			ServicePort: v1.ServicePort{
-				Protocol:   "TCP",
-				Port:       443,
-				TargetPort: intstr.FromInt(8443),
+			Weighted: dag.WeightedService{
+				ServiceName:      "example2",
+				ServiceNamespace: "default",
+				ServicePort: v1.ServicePort{
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
 			},
 		},
 		Weight: 20,

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -35,16 +35,22 @@ func TestRouteRoute(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
 	c1 := &dag.Cluster{
 		Upstream: &dag.Service{
-			Name:        s1.Name,
-			Namespace:   s1.Namespace,
-			ServicePort: s1.Spec.Ports[0],
+			Weighted: dag.WeightedService{
+				Weight:           1,
+				ServiceName:      s1.Name,
+				ServiceNamespace: s1.Namespace,
+				ServicePort:      s1.Spec.Ports[0],
+			},
 		},
 	}
 	c2 := &dag.Cluster{
 		Upstream: &dag.Service{
-			Name:        s1.Name,
-			Namespace:   s1.Namespace,
-			ServicePort: s1.Spec.Ports[0],
+			Weighted: dag.WeightedService{
+				Weight:           1,
+				ServiceName:      s1.Name,
+				ServiceNamespace: s1.Namespace,
+				ServicePort:      s1.Spec.Ports[0],
+			},
 		},
 		LoadBalancerPolicy: "Cookie",
 	}
@@ -85,16 +91,22 @@ func TestRouteRoute(t *testing.T) {
 			route: &dag.Route{
 				Clusters: []*dag.Cluster{{
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace,
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
 					Weight: 90,
 				}, {
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace, // it's valid to mention the same service several times per route.
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
 				}},
 			},
@@ -119,17 +131,25 @@ func TestRouteRoute(t *testing.T) {
 			route: &dag.Route{
 				Websocket: true,
 				Clusters: []*dag.Cluster{{
+
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace,
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
+
 					Weight: 90,
 				}, {
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace, // it's valid to mention the same service several times per route.
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
 				}},
 			},
@@ -158,9 +178,12 @@ func TestRouteRoute(t *testing.T) {
 				Websocket: true,
 				Clusters: []*dag.Cluster{{
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace,
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
 
 					RequestHeadersPolicy: &dag.HeadersPolicy{
@@ -450,18 +473,24 @@ func TestRouteRoute(t *testing.T) {
 			route: &dag.Route{
 				Clusters: []*dag.Cluster{{
 					Upstream: &dag.Service{
-						Name:        s1.Name,
-						Namespace:   s1.Namespace,
-						ServicePort: s1.Spec.Ports[0],
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
 					},
 					Weight: 90,
 				}},
 				MirrorPolicy: &dag.MirrorPolicy{
 					Cluster: &dag.Cluster{
 						Upstream: &dag.Service{
-							Name:        s1.Name,
-							Namespace:   s1.Namespace,
-							ServicePort: s1.Spec.Ports[0],
+							Weighted: dag.WeightedService{
+								Weight:           1,
+								ServiceName:      s1.Name,
+								ServiceNamespace: s1.Namespace,
+								ServicePort:      s1.Spec.Ports[0],
+							},
 						},
 					},
 				},
@@ -495,18 +524,24 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple services w/o weights": {
 			clusters: []*dag.Cluster{{
 				Upstream: &dag.Service{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "kuard",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 			}, {
 				Upstream: &dag.Service{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "nginx",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 			}},
@@ -524,19 +559,25 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple weighted services": {
 			clusters: []*dag.Cluster{{
 				Upstream: &dag.Service{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "kuard",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 				Weight: 80,
 			}, {
 				Upstream: &dag.Service{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "nginx",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 				Weight: 20,
@@ -555,28 +596,37 @@ func TestWeightedClusters(t *testing.T) {
 		"multiple weighted services and one with no weight specified": {
 			clusters: []*dag.Cluster{{
 				Upstream: &dag.Service{
-					Name:      "kuard",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "kuard",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 				Weight: 80,
 			}, {
 				Upstream: &dag.Service{
-					Name:      "nginx",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "nginx",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 				Weight: 20,
 			}, {
 				Upstream: &dag.Service{
-					Name:      "notraffic",
-					Namespace: "default",
-					ServicePort: v1.ServicePort{
-						Port: 8080,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "notraffic",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Port: 8080,
+						},
 					},
 				},
 			}},

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -59,10 +60,9 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	t.Parallel()
 
 	log := fixture.NewTestLogger(t)
+	log.SetLevel(logrus.DebugLevel)
 
-	et := &contour.EndpointsTranslator{
-		FieldLogger: log,
-	}
+	et := contour.NewEndpointsTranslator(log)
 
 	conf := contour.ListenerConfig{}
 	for _, opt := range opts {

--- a/internal/xds/util.go
+++ b/internal/xds/util.go
@@ -1,0 +1,40 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ClusterLoadAssignmentName generates the name used for an EDS
+// ClusterLoadAssignment, given a fully qualified Service name and
+// port. This name is a contract between the producer of a cluster
+// (i.e. the EDS service) and the consumer of a cluster (most likely
+// a HTTP Route Action).
+func ClusterLoadAssignmentName(service types.NamespacedName, portName string) string {
+	name := []string{
+		service.Namespace,
+		service.Name,
+		portName,
+	}
+
+	// If the port is empty, omit it.
+	if portName == "" {
+		return strings.Join(name[:2], "/")
+	}
+
+	return strings.Join(name, "/")
+}


### PR DESCRIPTION
The EndpointsTranslator generates Envoy ClusterLoadAssignment resources
in a fixed configuration. Each service/port pair generates a separate
ClusterLoadAssignment, that is associated with an Envoy Cluster solely
by its matching name.

This change introduces a new ServiceCluster concept that represents a
single set of endpoints, weighted across multiple Kubernetes Services.
This allows the upcoming ext_auth support to weight traffic, even though
(by definition), it still uses a single Envoy Cluster. The weighted
balancing is done within the cluster.

The DAG Service object is updated to use a ServiceCluster rather than
referencing a Service directly. This is exposed to the EndpointsTranslator,
which is now a DAG observer. The EndpointsTranslator rebuilds the
ClusterLoadAssigments globally on a DAG rebuild, and incrementally
on an Endpoints update.

The only semantic change here is that Contour will no longer generate
Envoy ClusterLoadAssignment resources for all Kubernetes Services. They
will only be generated for Services that are referenced by an Ingress
or HTTPProxy resource.

This updates #2769.

Signed-off-by: James Peach <jpeach@vmware.com>