### PR TITLE
internal/dag: Refactor out DelegationPermitted into the KubernetesCache

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -425,3 +425,38 @@ func (kc *KubernetesCache) LookupSecret(name types.NamespacedName, validate func
 
 	return s, nil
 }
+
+// DelegationPermitted returns true if the referenced secret has been delegated
+// to the namespace where the ingress object is located.
+func (kc *KubernetesCache) DelegationPermitted(secret types.NamespacedName, targetNamespace string) bool {
+	contains := func(haystack []string, needle string) bool {
+		if len(haystack) == 1 && haystack[0] == "*" {
+			return true
+		}
+		for _, h := range haystack {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	if secret.Namespace == targetNamespace {
+		// secret is in the same namespace as target
+		return true
+	}
+
+	for _, d := range kc.httpproxydelegations {
+		if d.Namespace != secret.Namespace {
+			continue
+		}
+		for _, d := range d.Spec.Delegations {
+			if contains(d.TargetNamespaces, targetNamespace) {
+				if secret.Name == d.SecretName {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Moves some common components from the builder into the KubernetesCache
so that it can be reused from other components. This is the first of a few PRs in refactoring
the builder out.

Updates #2226