### PR TITLE
#2589 - add groupversion for logging

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -113,7 +113,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 				kc.WithField("name", om.GetName()).
 					WithField("namespace", om.GetNamespace()).
 					WithField("kind", kind).
-					WithField("version", "v1").
+					WithField("version", k8s.VersionOf(obj)).
 					WithField("annotation", key).
 					Error("ignoring invalid or unsupported annotation")
 			}
@@ -129,7 +129,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 				kc.WithField("name", om.GetName()).
 					WithField("namespace", om.GetNamespace()).
 					WithField("kind", "Secret").
-					WithField("version", "v1").
+					WithField("version", k8s.VersionOf(obj)).
 					Error(err)
 			}
 			return false

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -18,6 +18,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // KindOf returns the kind string for the given Kubernetes object.
@@ -26,22 +28,54 @@ import (
 // objects, so we have to use a type assertion to detect kinds that
 // we care about.
 func KindOf(obj interface{}) string {
-	switch obj := obj.(type) {
-	case *v1.Secret:
-		return "Secret"
-	case *v1.Service:
-		return "Service"
-	case *v1.Endpoints:
-		return "Endpoints"
-	case *v1beta1.Ingress:
-		return "Ingress"
-	case *projectcontour.HTTPProxy:
-		return "HTTPProxy"
-	case *projectcontour.TLSCertificateDelegation:
-		return "TLSCertificateDelegation"
-	case *unstructured.Unstructured:
-		return obj.GetKind()
-	default:
-		return ""
+	gvk, _, err := scheme.Scheme.ObjectKinds(obj.(runtime.Object))
+	if err != nil {
+		switch obj := obj.(type) {
+		case *v1.Secret:
+			return "Secret"
+		case *v1.Service:
+			return "Service"
+		case *v1.Endpoints:
+			return "Endpoints"
+		case *v1beta1.Ingress:
+			return "Ingress"
+		case *projectcontour.HTTPProxy:
+			return "HTTPProxy"
+		case *projectcontour.TLSCertificateDelegation:
+			return "TLSCertificateDelegation"
+		case *unstructured.Unstructured:
+			return obj.GetKind()
+		default:
+			return ""
+		}
 	}
+	for _, gv := range gvk {
+		return gv.GroupKind().Kind
+	}
+	return ""
+}
+
+// VersionOf returns the GroupVersion string for the given Kubernetes object.
+//
+func VersionOf(obj interface{}) string {
+	//If err is not nil we have the GVK and we can use it. Otherwise we're going to use switch case method as failover
+	gvk, _, err := scheme.Scheme.ObjectKinds(obj.(runtime.Object))
+	if err != nil {
+		switch obj := obj.(type) {
+		case *v1.Secret, *v1.Service, *v1.Endpoints:
+			return v1.SchemeGroupVersion.String()
+		case *v1beta1.Ingress:
+			return v1beta1.SchemeGroupVersion.String()
+		case *projectcontour.HTTPProxy, *projectcontour.TLSCertificateDelegation:
+			return projectcontour.GroupVersion.String()
+		case *unstructured.Unstructured:
+			return obj.GetAPIVersion()
+		default:
+			return ""
+		}
+	}
+	for _, gv := range gvk {
+		return gv.GroupVersion().String()
+	}
+	return ""
 }

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -17,7 +17,7 @@ func TestKindOf(t *testing.T) {
 		{"Secret", &v1.Secret{}},
 		{"Service", &v1.Service{}},
 		{"Endpoints", &v1.Endpoints{}},
-		{"", &v1.Pod{}},
+		{"Pod", &v1.Pod{}},
 		{"Ingress", &v1beta1.Ingress{}},
 		{"HTTPProxy", &projectcontour.HTTPProxy{}},
 		{"TLSCertificateDelegation", &projectcontour.TLSCertificateDelegation{}},
@@ -34,6 +34,34 @@ func TestKindOf(t *testing.T) {
 		if kindOf != c.Kind {
 			t.Errorf("got %q for KindOf(%T), wanted %q",
 				kindOf, c.Obj, c.Kind)
+		}
+	}
+}
+
+func TestVersionOf(t *testing.T) {
+	cases := []struct {
+		Version string
+		Obj     interface{}
+	}{
+		{"v1", &v1.Secret{}},
+		{"v1", &v1.Service{}},
+		{"v1", &v1.Endpoints{}},
+		{"networking.k8s.io/v1beta1", &v1beta1.Ingress{}},
+		{"projectcontour.io/v1", &projectcontour.HTTPProxy{}},
+		{"projectcontour.io/v1", &projectcontour.TLSCertificateDelegation{}},
+		{"test.projectcontour.io/v1", &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.projectcontour.io/v1",
+				"kind":       "Foo",
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		kindOf := VersionOf(c.Obj)
+		if kindOf != c.Version {
+			t.Errorf("got %q for VersionOf(%T), wanted %q",
+				kindOf, c.Obj, c.Version)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Fahri Yardımcı 

Tested on minikube v1.12.3  - Kubernetes v1.17.11 on Docker 19.03.8

logs:
``` 
time="2020-08-18T20:50:34Z" level=info msg="started HTTP server" address="127.0.0.1:6060" context=debugsvc
time="2020-08-18T20:50:34Z" level=error msg="ignoring invalid or unsupported annotation" annotation=projectcontour.io/wololo context=KubernetesCache kind=Ingress name=kuard namespace=default version=networking.k8s.io/v1beta1
time="2020-08-18T20:50:34Z" level=error msg="ignoring invalid or unsupported annotation" annotation=projectcontour.io/wololo context=KubernetesCache kind=HTTPProxy name=basic namespace=default version=projectcontour.io/v1
```
