### PR TITLE
site: add `area/operational` label

### DIFF
--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -122,6 +122,11 @@ default:
       name: area/tls
       target: both
       addedBy: label
+    - color: 0052cc
+      description: Issues or PRs about making Contour easier to operate as a production service.
+      name: area/operational
+      target: both
+      addedBy: label
 
 # Blocked.
     - color: "FF7B7B"


### PR DESCRIPTION
Add a label to capture issues that are related to operating Contour in a
production environment. This includes troubleshooting and observability,
as well as behaviors that improve the operational experience (e.g. rate
limiting failures, improving error visibility, and so on).

Signed-off-by: James Peach <jpeach@vmware.com>