### PR TITLE
testing: Migrate as many tests as possible to internal/assert

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -26,6 +26,14 @@ var (
 	Equal         = tassert.Equal
 	Equalf        = tassert.Equalf
 	ElementsMatch = tassert.ElementsMatch
+	Error         = tassert.Error
+	Errorf        = tassert.Errorf
+	NoError       = tassert.NoError
+	NoErrorf      = tassert.NoErrorf
+	True          = tassert.True
+	Truef         = tassert.Truef
+	False         = tassert.False
+	Falsef        = tassert.Falsef
 )
 
 // EqualProto will test that want == got for protobufs, call t.Error if it does not,

--- a/internal/certgen/certgen_test.go
+++ b/internal/certgen/certgen_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGeneratedCertsValid(t *testing.T) {
@@ -29,17 +30,17 @@ func TestGeneratedCertsValid(t *testing.T) {
 	expiry := now.Add(24 * 365 * time.Hour)
 
 	cacert, cakey, err := NewCA("contour", expiry)
-	assert.NoErrorf(t, err, "Failed to generate CA cert")
+	require.NoErrorf(t, err, "Failed to generate CA cert")
 
 	contourcert, _, err := NewCert(cacert, cakey, expiry, "contour", "projectcontour")
-	assert.NoErrorf(t, err, "Failed to generate Contour cert")
+	require.NoErrorf(t, err, "Failed to generate Contour cert")
 
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM(cacert)
-	assert.Truef(t, ok, "Failed to set up CA cert for testing, maybe it's an invalid PEM")
+	require.Truef(t, ok, "Failed to set up CA cert for testing, maybe it's an invalid PEM")
 
 	envoycert, _, err := NewCert(cacert, cakey, expiry, "envoy", "projectcontour")
-	assert.NoErrorf(t, err, "Failed to generate Envoy cert")
+	require.NoErrorf(t, err, "Failed to generate Envoy cert")
 
 	tests := map[string]struct {
 		cert    []byte

--- a/internal/contour/server_test.go
+++ b/internal/contour/server_test.go
@@ -23,10 +23,10 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -64,7 +64,7 @@ func TestGRPC(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := sds.StreamClusters(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sendreq(t, stream, resource.ClusterType) // send initial notification
 			checkrecv(t, stream)                     // check we receive one notification
 			checktimeout(t, stream)                  // check that the second receive times out
@@ -91,7 +91,7 @@ func TestGRPC(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := eds.StreamEndpoints(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sendreq(t, stream, resource.EndpointType) // send initial notification
 			checkrecv(t, stream)                      // check we receive one notification
 			checktimeout(t, stream)                   // check that the second receive times out
@@ -124,7 +124,7 @@ func TestGRPC(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := lds.StreamListeners(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sendreq(t, stream, resource.ListenerType) // send initial notification
 			checkrecv(t, stream)                      // check we receive one notification
 			checktimeout(t, stream)                   // check that the second receive times out
@@ -156,7 +156,7 @@ func TestGRPC(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := rds.StreamRoutes(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sendreq(t, stream, resource.RouteType) // send initial notification
 			checkrecv(t, stream)                   // check we receive one notification
 			checktimeout(t, stream)                // check that the second receive times out
@@ -177,7 +177,7 @@ func TestGRPC(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := sds.StreamSecrets(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sendreq(t, stream, resource.SecretType) // send initial notification
 			checkrecv(t, stream)                    // check we receive one notification
 			checktimeout(t, stream)                 // check that the second receive times out
@@ -207,7 +207,7 @@ func TestGRPC(t *testing.T) {
 
 			srv := xds.RegisterServer(xds.NewContourServer(log, ResourcesOf(resources)...), nil)
 			l, err := net.Listen("tcp", "127.0.0.1:0")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			done := make(chan error, 1)
 			stop := make(chan struct{})
 			run := eh.Start()
@@ -221,7 +221,7 @@ func TestGRPC(t *testing.T) {
 				<-done
 			}()
 			cc, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer cc.Close()
 			fn(t, cc)
 		})
@@ -235,7 +235,7 @@ func sendreq(t *testing.T, stream interface {
 	err := stream.Send(&v2.DiscoveryRequest{
 		TypeUrl: typeurl,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func checkrecv(t *testing.T, stream interface {
@@ -243,7 +243,7 @@ func checkrecv(t *testing.T, stream interface {
 }) {
 	t.Helper()
 	_, err := stream.Recv()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func checktimeout(t *testing.T, stream interface {
@@ -251,9 +251,9 @@ func checktimeout(t *testing.T, stream interface {
 }) {
 	t.Helper()
 	_, err := stream.Recv()
-	assert.Errorf(t, err, "expected timeout")
+	require.Errorf(t, err, "expected timeout")
 	s, ok := status.FromError(err)
-	assert.True(t, ok, "Error wasn't what was expected: %T %v", err, err)
+	require.True(t, ok, "Error wasn't what was expected: %T %v", err, err)
 
 	// Work around grpc/grpc-go#1645 which sometimes seems to
 	// set the status code to Unknown, even when the message is derived from context.DeadlineExceeded.

--- a/internal/contour/server_test.go
+++ b/internal/contour/server_test.go
@@ -253,7 +253,7 @@ func checktimeout(t *testing.T, stream interface {
 	_, err := stream.Recv()
 	require.Errorf(t, err, "expected timeout")
 	s, ok := status.FromError(err)
-	require.True(t, ok, "Error wasn't what was expected: %T %v", err, err)
+	require.Truef(t, ok, "Error wasn't what was expected: %T %v", err, err)
 
 	// Work around grpc/grpc-go#1645 which sometimes seems to
 	// set the status code to Unknown, even when the message is derived from context.DeadlineExceeded.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
@@ -6026,13 +6026,7 @@ func TestDAGInsert(t *testing.T) {
 					want[l.Port] = l
 				}
 			}
-			opts := []cmp.Option{
-				cmp.AllowUnexported(VirtualHost{}),
-				cmp.AllowUnexported(timeout.Setting{}),
-			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 }
@@ -6130,14 +6124,8 @@ func TestBuilderLookupService(t *testing.T) {
 			b.reset()
 
 			got, gotErr := b.lookupService(tc.NamespacedName, tc.port)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-			if (tc.wantErr != nil) != (gotErr != nil) {
-				t.Errorf("got err = %v, wanted %v", gotErr, tc.wantErr)
-			} else if tc.wantErr != nil && gotErr != nil && tc.wantErr.Error() != gotErr.Error() {
-				t.Errorf("got err = %v, wanted %v", gotErr, tc.wantErr)
-			}
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantErr, gotErr)
 		})
 	}
 }
@@ -6425,9 +6413,7 @@ func TestHttpPaths(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := httppaths(tc.rule)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatalf(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -6504,9 +6490,7 @@ func TestDetermineSNI(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := determineSNI(tc.routeRequestHeaders, tc.clusterRequestHeaders, tc.service)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatalf(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -6542,9 +6526,7 @@ func TestEnforceRoute(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := routeEnforceTLS(tc.tlsEnabled, tc.permitInsecure)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatalf(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -6644,14 +6626,8 @@ func TestValidateHeaderAlteration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, gotErr := headersPolicy(test.in, false)
-			if !cmp.Equal(test.want, got) {
-				t.Errorf("set (-want, +got) = %s", cmp.Diff(test.want, got))
-			}
-			if (test.wantErr != nil) != (gotErr != nil) {
-				t.Errorf("err = %v, wanted %v", gotErr, test.wantErr)
-			} else if test.wantErr != nil && gotErr != nil && test.wantErr.Error() != gotErr.Error() {
-				t.Errorf("err = %v, wanted %v", gotErr, test.wantErr)
-			}
+			assert.Equal(t, test.want, got)
+			assert.Equal(t, test.wantErr, gotErr)
 		})
 	}
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -19,6 +19,7 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -742,9 +743,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				cache.Insert(p)
 			}
 			got := cache.Insert(tc.obj)
-			if tc.want != got {
-				t.Fatalf("Insert(%v): expected %v, got %v", tc.obj, tc.want, got)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -952,9 +951,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := tc.cache.Remove(tc.obj)
-			if tc.want != got {
-				t.Fatalf("Remove(%v): expected %v, got %v", tc.obj, tc.want, got)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/auth_test.go
+++ b/internal/envoy/auth_test.go
@@ -19,7 +19,7 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,9 +108,7 @@ func TestUpstreamTLSContext(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := UpstreamTLSContext(tc.validation, tc.externalName, tc.alpnProtocols...)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.EqualProto(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/endpoint_test.go
+++ b/internal/envoy/endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 )
 
 func TestLBEndpoint(t *testing.T) {
@@ -30,9 +30,7 @@ func TestLBEndpoint(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.EqualProto(t, want, got)
 }
 
 func TestEndpoints(t *testing.T) {
@@ -55,9 +53,7 @@ func TestEndpoints(t *testing.T) {
 			},
 		}},
 	}}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.EqualProto(t, want, got)
 }
 
 func TestClusterLoadAssignment(t *testing.T) {
@@ -66,9 +62,7 @@ func TestClusterLoadAssignment(t *testing.T) {
 		ClusterName: "empty",
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.EqualProto(t, want, got)
 
 	got = ClusterLoadAssignment("one addr", SocketAddress("microsoft.com", 81))
 	want = &v2.ClusterLoadAssignment{
@@ -76,9 +70,7 @@ func TestClusterLoadAssignment(t *testing.T) {
 		Endpoints:   Endpoints(SocketAddress("microsoft.com", 81)),
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.EqualProto(t, want, got)
 
 	got = ClusterLoadAssignment("two addrs",
 		SocketAddress("microsoft.com", 81),
@@ -92,7 +84,5 @@ func TestClusterLoadAssignment(t *testing.T) {
 		),
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	assert.EqualProto(t, want, got)
 }

--- a/internal/envoy/secret_test.go
+++ b/internal/envoy/secret_test.go
@@ -18,7 +18,7 @@ import (
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,9 +65,7 @@ func TestSecret(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Secret(tc.secret)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.EqualProto(t, tc.want, got)
 		})
 	}
 }
@@ -112,9 +110,7 @@ func TestSecretname(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Secretname(tc.secret)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -56,10 +56,7 @@ func TestVersionOf(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		kindOf := VersionOf(c.Obj)
-		if kindOf != c.Version {
-			t.Errorf("got %q for VersionOf(%T), wanted %q",
-				kindOf, c.Obj, c.Version)
-		}
+		versionOf := VersionOf(c.Obj)
+		assert.Equal(t, c.Version, versionOf)
 	}
 }

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,10 +32,7 @@ func TestKindOf(t *testing.T) {
 
 	for _, c := range cases {
 		kindOf := KindOf(c.Obj)
-		if kindOf != c.Kind {
-			t.Errorf("got %q for KindOf(%T), wanted %q",
-				kindOf, c.Obj, c.Kind)
-		}
+		assert.Equal(t, c.Kind, kindOf)
 	}
 }
 

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -31,8 +31,7 @@ func TestKindOf(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		kindOf := KindOf(c.Obj)
-		assert.Equal(t, c.Kind, kindOf)
+		assert.Equal(t, c.Kind, KindOf(c.Obj))
 	}
 }
 
@@ -56,7 +55,6 @@ func TestVersionOf(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		versionOf := VersionOf(c.Obj)
-		assert.Equal(t, c.Version, versionOf)
+		assert.Equal(t, c.Version, VersionOf(c.Obj))
 	}
 }

--- a/internal/k8s/objectmeta_test.go
+++ b/internal/k8s/objectmeta_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/projectcontour/contour/internal/assert"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -12,12 +12,7 @@ func TestNamespacedNameFrom(t *testing.T) {
 		t.Helper()
 		t.Run(testName, func(t *testing.T) {
 			t.Helper()
-			opts := []cmp.Option{
-				cmp.AllowUnexported(types.NamespacedName{}),
-			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
-				t.Fatal(diff)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -14,13 +14,12 @@
 package metrics
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
-	io_prometheus_client "github.com/prometheus/client_model/go"
-
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
 type testMetric struct {
@@ -71,9 +70,7 @@ func TestSetDAGLastRebuilt(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotTimestamp, tc.timestampMetric.want) {
-				t.Fatalf("write metric timestamp metric failed, want: %v got: %v", tc.timestampMetric.want, gotTimestamp)
-			}
+			assert.Equal(t, tc.timestampMetric.want, gotTimestamp)
 		})
 	}
 }
@@ -230,21 +227,12 @@ func TestWriteProxyMetric(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotTotal, tc.total.want) {
-				t.Fatalf("write metric total metric failed, want: %v got: %v", tc.total.want, gotTotal)
-			}
-			if !reflect.DeepEqual(gotValid, tc.valid.want) {
-				t.Fatalf("write metric valid metric failed, want: %v got: %v", tc.valid.want, gotValid)
-			}
-			if !reflect.DeepEqual(gotInvalid, tc.invalid.want) {
-				t.Fatalf("write metric invalid metric failed, want: %v got: %v", tc.invalid.want, gotInvalid)
-			}
-			if !reflect.DeepEqual(gotOrphaned, tc.orphaned.want) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", tc.orphaned.want, gotOrphaned)
-			}
-			if !reflect.DeepEqual(gotRoot, tc.root.want) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", tc.root.want, gotRoot)
-			}
+			assert.Equal(t, tc.total.want, gotTotal)
+			assert.Equal(t, tc.valid.want, gotValid)
+			assert.Equal(t, tc.invalid.want, gotInvalid)
+			assert.Equal(t, tc.orphaned.want, gotOrphaned)
+			assert.Equal(t, tc.root.want, gotRoot)
+
 		})
 	}
 }
@@ -655,21 +643,11 @@ func TestRemoveProxyMetric(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotTotal, total.want) {
-				t.Fatalf("write metric total metric failed, want: %v got: %v", total.want, gotTotal)
-			}
-			if !reflect.DeepEqual(gotValid, valid.want) {
-				t.Fatalf("write metric valid metric failed, want: %v got: %v", valid.want, gotValid)
-			}
-			if !reflect.DeepEqual(gotInvalid, invalid.want) {
-				t.Fatalf("write metric invalid metric failed, want: %v got: %v", invalid.want, gotInvalid)
-			}
-			if !reflect.DeepEqual(gotOrphaned, orphaned.want) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", orphaned.want, gotOrphaned)
-			}
-			if !reflect.DeepEqual(gotRoot, root.want) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", root.want, gotRoot)
-			}
+			assert.Equal(t, total.want, gotTotal)
+			assert.Equal(t, valid.want, gotValid)
+			assert.Equal(t, invalid.want, gotInvalid)
+			assert.Equal(t, orphaned.want, gotOrphaned)
+			assert.Equal(t, root.want, gotRoot)
 
 			m.SetHTTPProxyMetric(tc.irMetricsUpdated)
 
@@ -704,21 +682,11 @@ func TestRemoveProxyMetric(t *testing.T) {
 				}
 			}
 
-			if !reflect.DeepEqual(gotTotal, tc.totalWant) {
-				t.Fatalf("write metric total metric failed, want: %v got: %v", tc.totalWant, gotTotal)
-			}
-			if !reflect.DeepEqual(gotValid, tc.validWant) {
-				t.Fatalf("write metric valid metric failed, want: %v got: %v", tc.validWant, gotValid)
-			}
-			if !reflect.DeepEqual(gotInvalid, tc.invalidWant) {
-				t.Fatalf("write metric invalid metric failed, want: %v got: %v", tc.invalidWant, gotInvalid)
-			}
-			if !reflect.DeepEqual(gotOrphaned, tc.orphanedWant) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", tc.orphanedWant, gotOrphaned)
-			}
-			if !reflect.DeepEqual(gotRoot, tc.rootWant) {
-				t.Fatalf("write metric orphaned metric failed, want: %v got: %v", tc.rootWant, gotRoot)
-			}
+			assert.Equal(t, tc.totalWant, gotTotal)
+			assert.Equal(t, tc.validWant, gotValid)
+			assert.Equal(t, tc.invalidWant, gotInvalid)
+			assert.Equal(t, tc.orphanedWant, gotOrphaned)
+			assert.Equal(t, tc.rootWant, gotRoot)
 		})
 	}
 }

--- a/internal/xds/contour_test.go
+++ b/internal/xds/contour_test.go
@@ -194,13 +194,3 @@ func TestCounterNext(t *testing.T) {
 		assert.Equal(t, tc.want, got)
 	}
 }
-
-func equalError(a, b error) bool {
-	if a == nil {
-		return b == nil
-	}
-	if b == nil {
-		return a == nil
-	}
-	return a.Error() == b.Error()
-}

--- a/internal/xds/contour_test.go
+++ b/internal/xds/contour_test.go
@@ -22,6 +22,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/assert"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,24 +50,24 @@ func TestXDSHandlerStream(t *testing.T) {
 				context: context.Background,
 				recv: func() (*v2.DiscoveryRequest, error) {
 					return &v2.DiscoveryRequest{
-						TypeUrl: "com.heptio.potato",
+						TypeUrl: "io.projectcontour.potato",
 					}, nil
 				},
 			},
-			want: fmt.Errorf("no resource registered for typeURL %q", "com.heptio.potato"),
+			want: fmt.Errorf("no resource registered for typeURL %q", "io.projectcontour.potato"),
 		},
 		"failed to convert values to any": {
 			xh: contourServer{
 				FieldLogger: log,
 				resources: map[string]Resource{
-					"com.heptio.potato": &mockResource{
+					"io.projectcontour.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
 						},
 						contents: func() []proto.Message {
 							return []proto.Message{nil}
 						},
-						typeurl: func() string { return "com.heptio.potato" },
+						typeurl: func() string { return "io.projectcontour.potato" },
 					},
 				},
 			},
@@ -74,7 +75,7 @@ func TestXDSHandlerStream(t *testing.T) {
 				context: context.Background,
 				recv: func() (*v2.DiscoveryRequest, error) {
 					return &v2.DiscoveryRequest{
-						TypeUrl: "com.heptio.potato",
+						TypeUrl: "io.projectcontour.potato",
 					}, nil
 				},
 			},
@@ -84,14 +85,14 @@ func TestXDSHandlerStream(t *testing.T) {
 			xh: contourServer{
 				FieldLogger: log,
 				resources: map[string]Resource{
-					"com.heptio.potato": &mockResource{
+					"io.projectcontour.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							ch <- i + 1
 						},
 						contents: func() []proto.Message {
 							return []proto.Message{new(v2.ClusterLoadAssignment)}
 						},
-						typeurl: func() string { return "com.heptio.potato" },
+						typeurl: func() string { return "io.projectcontour.potato" },
 					},
 				},
 			},
@@ -99,7 +100,7 @@ func TestXDSHandlerStream(t *testing.T) {
 				context: context.Background,
 				recv: func() (*v2.DiscoveryRequest, error) {
 					return &v2.DiscoveryRequest{
-						TypeUrl: "com.heptio.potato",
+						TypeUrl: "io.projectcontour.potato",
 					}, nil
 				},
 				send: func(resp *v2.DiscoveryResponse) error {
@@ -112,11 +113,11 @@ func TestXDSHandlerStream(t *testing.T) {
 			xh: contourServer{
 				FieldLogger: log,
 				resources: map[string]Resource{
-					"com.heptio.potato": &mockResource{
+					"io.projectcontour.potato": &mockResource{
 						register: func(ch chan int, i int) {
 							// do nothing
 						},
-						typeurl: func() string { return "com.heptio.potato" },
+						typeurl: func() string { return "io.projectcontour.potato" },
 					},
 				},
 			},
@@ -129,7 +130,7 @@ func TestXDSHandlerStream(t *testing.T) {
 				},
 				recv: func() (*v2.DiscoveryRequest, error) {
 					return &v2.DiscoveryRequest{
-						TypeUrl: "com.heptio.potato",
+						TypeUrl: "io.projectcontour.potato",
 					}, nil
 				},
 				send: func(resp *v2.DiscoveryResponse) error {
@@ -143,9 +144,7 @@ func TestXDSHandlerStream(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := tc.xh.stream(tc.stream)
-			if !equalError(tc.want, got) {
-				t.Fatalf("expected: %v, got: %v", tc.want, got)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -192,9 +191,7 @@ func TestCounterNext(t *testing.T) {
 
 	for _, tc := range tests {
 		got := tc.fn()
-		if tc.want != got {
-			t.Fatalf("expected %d, got %d", tc.want, got)
-		}
+		assert.Equal(t, tc.want, got)
 	}
 }
 


### PR DESCRIPTION
Needed to update some aliases in internal/assert to cover all the cases.

Updates #2786.

Signed-off-by: Nick Young <ynick@vmware.com>