### PR TITLE
testing: Migrate more things to testify

### DIFF
--- a/cmd/contour/certgen_test.go
+++ b/cmd/contour/certgen_test.go
@@ -20,9 +20,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/certgen"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetRequestTimeout(t *testing.T) {

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 )

--- a/cmd/contour/shutdownmanager_test.go
+++ b/cmd/contour/shutdownmanager_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShutdownManager_HealthzHandler(t *testing.T) {

--- a/internal/annotation/annotations_test.go
+++ b/internal/annotation/annotations_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/certgen/certgen_test.go
+++ b/internal/certgen/certgen_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
@@ -71,7 +70,7 @@ func TestClusterCacheContents(t *testing.T) {
 			var cc ClusterCache
 			cc.Update(tc.contents)
 			got := cc.Contents()
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -151,7 +150,7 @@ func TestClusterCacheQuery(t *testing.T) {
 			var cc ClusterCache
 			cc.Update(tc.contents)
 			got := cc.Query(tc.query)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -790,7 +789,7 @@ func TestClusterVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAG(t, tc.objs...)
 			got := visitClusters(root)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -18,9 +18,9 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/protobuf/proto"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -24,9 +24,9 @@ import (
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/golang/protobuf/proto"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -66,7 +66,7 @@ func TestListenerCacheContents(t *testing.T) {
 			var lc ListenerCache
 			lc.Update(tc.contents)
 			got := lc.Contents()
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -128,7 +128,7 @@ func TestListenerCacheQuery(t *testing.T) {
 			var lc ListenerCache
 			lc.Update(tc.contents)
 			got := lc.Query(tc.query)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -1998,7 +1998,7 @@ func TestListenerVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAGFallback(t, tc.fallbackCertificate, tc.objs...)
 			got := visitListeners(root, &tc.ListenerConfig)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/metrics"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -68,7 +67,7 @@ func TestRouteCacheContents(t *testing.T) {
 			var rc RouteCache
 			rc.Update(tc.contents)
 			got := rc.Contents()
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -128,7 +127,7 @@ func TestRouteCacheQuery(t *testing.T) {
 			var rc RouteCache
 			rc.Update(tc.contents)
 			got := rc.Query(tc.query)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -2756,7 +2755,7 @@ func TestRouteVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAGFallback(t, tc.fallbackCertificate, tc.objs...)
 			got := visitRoutes(root)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -2926,7 +2925,7 @@ func TestSortLongestRouteFirst(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := append([]*envoy_api_v2_route.Route{}, tc.routes...) // shallow copy
 			sortRoutes(got)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -20,9 +20,9 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ func TestSecretCacheContents(t *testing.T) {
 			var sc SecretCache
 			sc.Update(tc.contents)
 			got := sc.Contents()
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -98,7 +98,7 @@ func TestSecretCacheQuery(t *testing.T) {
 			var sc SecretCache
 			sc.Update(tc.contents)
 			got := sc.Query(tc.query)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -471,7 +471,7 @@ func TestSecretVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			root := buildDAG(t, tc.objs...)
 			got := visitSecrets(root)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/contour/visitor_test.go
+++ b/internal/contour/visitor_test.go
@@ -20,9 +20,9 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -75,7 +75,7 @@ func TestVisitClusters(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := visitClusters(tc.root)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -144,7 +144,7 @@ func TestVisitListeners(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := visitListeners(tc.root, new(ListenerConfig))
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -210,7 +210,7 @@ func TestVisitSecrets(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := visitSecrets(tc.root)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -20,9 +20,9 @@ import (
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -19,8 +19,8 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -743,7 +743,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				cache.Insert(p)
 			}
 			got := cache.Insert(tc.obj)
-			assert.Equal(t, tc.want, got)
+			assert.Equalf(t, tc.want, got, "Insert failed for object %v ", tc.obj)
 		})
 	}
 }
@@ -951,7 +951,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := tc.cache.Remove(tc.obj)
-			assert.Equal(t, tc.want, got)
+			assert.Equalf(t, tc.want, got, "Remove failed for object %v ", tc.obj)
 		})
 	}
 }

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPathMatchCondition(t *testing.T) {
@@ -494,11 +494,12 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gotErr := headerMatchConditionsValid(tc.matchconditions)
 
-			if !tc.wantErr && gotErr != nil {
-				t.Fatalf("Expected no error, got (%v)", gotErr)
+			if !tc.wantErr {
+				assert.NoError(t, gotErr)
 			}
-			if tc.wantErr && gotErr == nil {
-				t.Fatalf("Expected error, got none")
+
+			if tc.wantErr {
+				assert.Error(t, gotErr)
 			}
 		})
 	}

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -16,7 +16,7 @@ package dag
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -21,29 +21,27 @@ import (
 )
 
 func TestVirtualHostValid(t *testing.T) {
-	assert := Assert{t}
 
 	vh := VirtualHost{}
-	assert.False(vh.Valid())
+	assert.False(t, vh.Valid())
 
 	vh = VirtualHost{
 		routes: map[string]*Route{
 			"/": {},
 		},
 	}
-	assert.True(vh.Valid())
+	assert.True(t, vh.Valid())
 }
 
 func TestSecureVirtualHostValid(t *testing.T) {
-	assert := Assert{t}
 
 	vh := SecureVirtualHost{}
-	assert.False(vh.Valid())
+	assert.False(t, vh.Valid())
 
 	vh = SecureVirtualHost{
 		Secret: new(Secret),
 	}
-	assert.False(vh.Valid())
+	assert.False(t, vh.Valid())
 
 	vh = SecureVirtualHost{
 		VirtualHost: VirtualHost{
@@ -52,7 +50,7 @@ func TestSecureVirtualHostValid(t *testing.T) {
 			},
 		},
 	}
-	assert.False(vh.Valid())
+	assert.False(t, vh.Valid())
 
 	vh = SecureVirtualHost{
 		Secret: new(Secret),
@@ -62,18 +60,18 @@ func TestSecureVirtualHostValid(t *testing.T) {
 			},
 		},
 	}
-	assert.True(vh.Valid())
+	assert.True(t, vh.Valid())
 
 	vh = SecureVirtualHost{
 		TCPProxy: new(TCPProxy),
 	}
-	assert.True(vh.Valid())
+	assert.True(t, vh.Valid())
 
 	vh = SecureVirtualHost{
 		Secret:   new(Secret),
 		TCPProxy: new(TCPProxy),
 	}
-	assert.True(vh.Valid())
+	assert.True(t, vh.Valid())
 }
 
 func TestPeerValidationContext(t *testing.T) {
@@ -106,22 +104,4 @@ func TestObserverFunc(t *testing.T) {
 	result := false
 	ObserverFunc(func(*DAG) { result = true }).OnChange(nil)
 	assert.Equal(t, true, result)
-}
-
-type Assert struct {
-	*testing.T
-}
-
-func (a Assert) True(t bool) {
-	a.Helper()
-	if !t {
-		a.Error("expected true, got false")
-	}
-}
-
-func (a Assert) False(t bool) {
-	a.Helper()
-	if t {
-		a.Error("expected false, got true")
-	}
 }

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/timeout"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/envoy/accesslog_test.go
+++ b/internal/envoy/accesslog_test.go
@@ -20,7 +20,6 @@ import (
 	envoy_accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	_struct "github.com/golang/protobuf/ptypes/struct"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
@@ -44,7 +43,7 @@ func TestFileAccessLog(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := FileAccessLogEnvoy(tc.path)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -104,7 +103,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := FileAccessLogJSON(tc.path, tc.headers)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/auth_test.go
+++ b/internal/envoy/auth_test.go
@@ -19,8 +19,8 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -108,7 +108,7 @@ func TestUpstreamTLSContext(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := UpstreamTLSContext(tc.validation, tc.externalName, tc.alpnProtocols...)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -21,7 +21,8 @@ import (
 	envoy_api_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBootstrap(t *testing.T) {
@@ -1007,21 +1008,21 @@ func TestBootstrap(t *testing.T) {
 			if tc.wantedBootstrapConfig != "" {
 				want := new(envoy_api_bootstrap.Bootstrap)
 				unmarshal(t, tc.wantedBootstrapConfig, want)
-				assert.EqualProto(t, want, gotConfigs[tc.config.Path])
+				protobuf.ExpectEqual(t, want, gotConfigs[tc.config.Path])
 				delete(gotConfigs, tc.config.Path)
 			}
 
 			if tc.wantedTLSCertificateConfig != "" {
 				want := new(api.DiscoveryResponse)
 				unmarshal(t, tc.wantedTLSCertificateConfig, want)
-				assert.EqualProto(t, want, gotConfigs[sdsTLSCertificatePath])
+				protobuf.ExpectEqual(t, want, gotConfigs[sdsTLSCertificatePath])
 				delete(gotConfigs, sdsTLSCertificatePath)
 			}
 
 			if tc.wantedValidationContextConfig != "" {
 				want := new(api.DiscoveryResponse)
 				unmarshal(t, tc.wantedValidationContextConfig, want)
-				assert.EqualProto(t, want, gotConfigs[sdsValidationContextPath])
+				protobuf.ExpectEqual(t, want, gotConfigs[sdsValidationContextPath])
 				delete(gotConfigs, sdsValidationContextPath)
 			}
 

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -23,9 +23,9 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -395,7 +395,7 @@ func TestCluster(t *testing.T) {
 
 			proto.Merge(want, tc.want)
 
-			assert.Equal(t, want, got)
+			protobuf.ExpectEqual(t, want, got)
 		})
 	}
 }
@@ -546,9 +546,7 @@ func TestHashname(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := hashname(tc.l, append([]string{}, tc.s...)...)
-			if got != tc.want {
-				t.Fatalf("hashname(%d, %q): got %q, want %q", tc.l, tc.s, got, tc.want)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -574,9 +572,7 @@ func TestTruncate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := truncate(tc.l, tc.s, tc.suffix)
-			if got != tc.want {
-				t.Fatalf("hashname(%d, %q, %q): got %q, want %q", tc.l, tc.s, tc.suffix, got, tc.want)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/endpoint_test.go
+++ b/internal/envoy/endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 func TestLBEndpoint(t *testing.T) {
@@ -30,7 +30,7 @@ func TestLBEndpoint(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualProto(t, want, got)
+	protobuf.ExpectEqual(t, want, got)
 }
 
 func TestEndpoints(t *testing.T) {
@@ -53,7 +53,7 @@ func TestEndpoints(t *testing.T) {
 			},
 		}},
 	}}
-	assert.EqualProto(t, want, got)
+	protobuf.ExpectEqual(t, want, got)
 }
 
 func TestClusterLoadAssignment(t *testing.T) {
@@ -62,7 +62,7 @@ func TestClusterLoadAssignment(t *testing.T) {
 		ClusterName: "empty",
 	}
 
-	assert.EqualProto(t, want, got)
+	protobuf.RequireEqual(t, want, got)
 
 	got = ClusterLoadAssignment("one addr", SocketAddress("microsoft.com", 81))
 	want = &v2.ClusterLoadAssignment{
@@ -70,7 +70,7 @@ func TestClusterLoadAssignment(t *testing.T) {
 		Endpoints:   Endpoints(SocketAddress("microsoft.com", 81)),
 	}
 
-	assert.EqualProto(t, want, got)
+	protobuf.RequireEqual(t, want, got)
 
 	got = ClusterLoadAssignment("two addrs",
 		SocketAddress("microsoft.com", 81),
@@ -84,5 +84,5 @@ func TestClusterLoadAssignment(t *testing.T) {
 		),
 	}
 
-	assert.EqualProto(t, want, got)
+	protobuf.RequireEqual(t, want, got)
 }

--- a/internal/envoy/healthcheck_test.go
+++ b/internal/envoy/healthcheck_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
@@ -95,7 +94,7 @@ func TestHealthCheck(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := httpHealthCheck(tc.cluster)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 
 		})
 	}

--- a/internal/envoy/listener_test.go
+++ b/internal/envoy/listener_test.go
@@ -25,11 +25,11 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	envoy_config_v2_tcpproxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/google/go-cmp/cmp"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -120,7 +120,7 @@ func TestListener(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Listener(tc.name, tc.address, tc.port, tc.lf, tc.f...)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -143,9 +143,7 @@ func TestSocketAddress(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatal(diff)
-	}
+	require.Equal(t, want, got)
 
 	got = SocketAddress("::", port)
 	want = &envoy_api_v2_core.Address{
@@ -296,7 +294,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, tc.got)
+			protobuf.ExpectEqual(t, tc.want, tc.got)
 		})
 	}
 }
@@ -683,7 +681,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 				DefaultFilters().
 				Get()
 
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -771,7 +769,7 @@ func TestTCPProxy(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := TCPProxy(statPrefix, tc.proxy, FileAccessLogEnvoy(accessLogPath))
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/regex_test.go
+++ b/internal/envoy/regex_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
@@ -63,7 +62,7 @@ func TestSafeRegexMatch(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := SafeRegexMatch(tc.regex)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/route_test.go
+++ b/internal/envoy/route_test.go
@@ -21,11 +21,11 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -482,7 +482,7 @@ func TestRouteRoute(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteRoute(tc.route)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -599,7 +599,7 @@ func TestWeightedClusters(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := weightedClusters(tc.clusters)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -648,7 +648,7 @@ func TestRouteConfiguration(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteConfiguration(tc.name, tc.virtualhosts...)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -679,7 +679,7 @@ func TestVirtualHost(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := VirtualHost(tc.hostname)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -791,7 +791,7 @@ func TestRouteMatch(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := RouteMatch(tc.route)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/secret_test.go
+++ b/internal/envoy/secret_test.go
@@ -18,8 +18,9 @@ import (
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -65,7 +66,7 @@ func TestSecret(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := Secret(tc.secret)
-			assert.EqualProto(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/socket_test.go
+++ b/internal/envoy/socket_test.go
@@ -18,7 +18,6 @@ import (
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ func TestUpstreamTLSTransportSocket(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := UpstreamTLSTransportSocket(tc.ctxt)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }
@@ -80,7 +79,7 @@ func TestDownstreamTLSTransportSocket(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := DownstreamTLSTransportSocket(tc.ctxt)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/envoy/stats_test.go
+++ b/internal/envoy/stats_test.go
@@ -21,7 +21,6 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
 
@@ -94,7 +93,7 @@ func TestStatsListener(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := StatsListener(tc.address, tc.port)
-			assert.Equal(t, tc.want, got)
+			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
 }

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -28,7 +28,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -39,6 +38,7 @@ import (
 	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -379,9 +379,7 @@ type Response struct {
 func (r *Response) Equals(want *v2.DiscoveryResponse) *Contour {
 	r.Helper()
 
-	if !assert.EqualProto(r.T, want.Resources, r.DiscoveryResponse.Resources) {
-		r.Fatal("feature test failure")
-	}
+	protobuf.RequireEqual(r.T, want.Resources, r.DiscoveryResponse.Resources)
 
 	return r.Contour
 }

--- a/internal/k8s/clients_test.go
+++ b/internal/k8s/clients_test.go
@@ -18,7 +18,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResourceKindExists(t *testing.T) {

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -19,7 +19,7 @@ import (
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/internal/k8s/objectmeta_test.go
+++ b/internal/k8s/objectmeta_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -17,9 +17,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 )
 
 type testMetric struct {

--- a/internal/protobuf/testhelpers.go
+++ b/internal/protobuf/testhelpers.go
@@ -11,35 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package assert provides assertion helpers
-package assert
+// Package protobuf provides helpers for working with golang/protobuf types.
+
+package protobuf
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-var (
-	Equal         = tassert.Equal
-	Equalf        = tassert.Equalf
-	ElementsMatch = tassert.ElementsMatch
-	Error         = tassert.Error
-	Errorf        = tassert.Errorf
-	NoError       = tassert.NoError
-	NoErrorf      = tassert.NoErrorf
-	True          = tassert.True
-	Truef         = tassert.Truef
-	False         = tassert.False
-	Falsef        = tassert.Falsef
-)
-
-// EqualProto will test that want == got for protobufs, call t.Error if it does not,
+// ExpectEqual will test that want == got for protobufs, call t.Error if it does not,
 // and return a bool to indicate the result. This mimics the behavior of the testify `assert`
 // functions.
-func EqualProto(t *testing.T, want, got interface{}) bool {
+func ExpectEqual(t *testing.T, want, got interface{}) bool {
 	t.Helper()
 
 	diff := cmp.Diff(want, got, protocmp.Transform())
@@ -49,4 +35,16 @@ func EqualProto(t *testing.T, want, got interface{}) bool {
 	}
 
 	return true
+}
+
+// RequireEqual will test that want == got for protobufs, call t.fatal if it does not,
+// This mimics the behavior of the testify `require` functions.
+func RequireEqual(t *testing.T, want, got interface{}) {
+	t.Helper()
+
+	diff := cmp.Diff(want, got, protocmp.Transform())
+	if diff != "" {
+		t.Fatal(diff)
+	}
+
 }

--- a/internal/protobuf/testhelpers.go
+++ b/internal/protobuf/testhelpers.go
@@ -46,5 +46,4 @@ func RequireEqual(t *testing.T, want, got interface{}) {
 	if diff != "" {
 		t.Fatal(diff)
 	}
-
 }

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -23,8 +23,8 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInvalidSorter(t *testing.T) {

--- a/internal/timeout/timeout_test.go
+++ b/internal/timeout/timeout_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/internal/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/xds/contour_test.go
+++ b/internal/xds/contour_test.go
@@ -22,8 +22,8 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/protobuf/proto"
-	"github.com/projectcontour/contour/internal/assert"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestXDSHandlerStream(t *testing.T) {


### PR DESCRIPTION
So, in this commit, I have four goals:
- Remove the `internal/assert` package.
- Move `assert.EqualProto` into the `internal/protobuf` package.
- Make `protobuf.ExpectEqual` and `protobuf.RequireEqual` work similarly
to testify `assert` and `require` respectively.
- Replace any remaining `cmp.Diff` calls in tests with `assert.Equal`
- Check all the tests in `internal/envoy` for protobufs and migrate any
remaining to `protobuf.ExpectEqual`.

Sorry, it's a big PR, but there's a lot of cleanup here.

Updates #2786

Signed-off-by: Nick Young <ynick@vmware.com>