### PR TITLE
cmd/contour: Replace check function by log.Fatal()

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -441,12 +441,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			grpcServer = xds.RegisterServer(
 				xds.NewContourServer(log, contour.ResourcesOf(resources)...),
 				registry,
-				ctx.grpcOptions()...)
+				ctx.grpcOptions(log)...)
 		case "envoy":
 			grpcServer = xds.RegisterServer(
 				server.NewServer(context.Background(), snapshotCache, nil),
 				registry,
-				ctx.grpcOptions()...)
+				ctx.grpcOptions(log)...)
 		default:
 			log.Fatalf("invalid xdsServerType %q configured", ctx.XDSServerType)
 		}

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/fixture"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
@@ -338,7 +339,8 @@ func TestServeContextCertificateHandling(t *testing.T) {
 	checkFatalErr(t, err)
 
 	// Start a dummy server.
-	opts := ctx.grpcOptions()
+	log := fixture.NewTestLogger(t)
+	opts := ctx.grpcOptions(log)
 	g := grpc.NewServer(opts...)
 	if g == nil {
 		t.Error("failed to create server")


### PR DESCRIPTION
There are quite a few places in Contour that call a
local check helper that prints to standard error and exits.
This approach loses error context and makes it difficult for
aggregated log collectors to recognize that this is a fatal error message

Fixes #2811

Signed-off-by: Shailesh Suryawanshi <ss.shailesh28@gmail.com>