### PR TITLE
CI: run apt-get update at start of siteproof job

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -73,5 +73,6 @@ jobs:
       - name: run site proof
         if: ${{ success() }}
         run: |
+          sudo apt-get update
           sudo apt-get -yqq install libcurl4-openssl-dev
           ./hack/site-proofing/cibuild


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

This should fix the persistent error we've been getting with the siteproof CI job.