### PR TITLE
internal: improve Ingress class matching log messages

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -83,7 +83,8 @@ func (kc *KubernetesCache) matchesIngressClass(obj k8s.Object) bool {
 		kc.WithField("name", om.GetName()).
 			WithField("namespace", om.GetNamespace()).
 			WithField("kind", kind).
-			WithField("ingress.class", annotation.IngressClass(obj)).
+			WithField("ingress-class", annotation.IngressClass(obj)).
+			WithField("target-ingress-class", kc.IngressClass).
 			Debug("ignoring object with unmatched ingress class")
 		return false
 	}

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -71,7 +71,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 			WithField("name", typed.GetObjectMeta().GetName()).
 			WithField("namespace", typed.GetObjectMeta().GetNamespace()).
 			WithField("ingress-class", annotation.IngressClass(typed)).
-			WithField("defined-ingress-class", s.IngressClass).
+			WithField("target-ingress-class", s.IngressClass).
 			WithField("kind", kind).
 			Debug("unmatched ingress class, skipping status address update")
 		return


### PR DESCRIPTION
Make the two debug log messages for Ingress class matching emit
the same field.

Signed-off-by: James Peach <jpeach@vmware.com>