### PR TITLE
cmd/contour: add a Kubernetes debug logging flag

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -128,6 +128,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("disable-leader-election", "Disable leader election mechanism.").BoolVar(&ctx.DisableLeaderElection)
 
 	serve.Flag("debug", "Enable debug logging.").Short('d').BoolVar(&ctx.Debug)
+	serve.Flag("kubernetes-debug", "Enable Kubernetes client debug logging.").UintVar(&ctx.KubernetesDebug)
 	serve.Flag("experimental-service-apis", "Subscribe to the new service-apis types.").BoolVar(&ctx.UseExperimentalServiceAPITypes)
 	return serve, ctx
 }

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -40,6 +40,9 @@ type serveContext struct {
 	// Enable debug logging
 	Debug bool
 
+	// Enable Kubernetes client-go debugging.
+	KubernetesDebug uint
+
 	// contour's kubernetes client parameters
 	InCluster  bool   `yaml:"incluster,omitempty"`
 	Kubeconfig string `yaml:"kubeconfig,omitempty"`

--- a/internal/k8s/log.go
+++ b/internal/k8s/log.go
@@ -1,0 +1,126 @@
+package k8s
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/klog"
+)
+
+type klogParams struct {
+	flags *flag.FlagSet
+	log   *logrus.Entry
+}
+
+type LogOption func(*klogParams)
+
+// LogLevelOption creates an option to set the Kubernetes verbose
+// log level (1 - 10 is the standard range).
+func LogLevelOption(level int) LogOption {
+	return LogOption(func(p *klogParams) {
+		if err := p.flags.Set("v", strconv.Itoa(level)); err != nil {
+			panic(fmt.Sprintf("failed to set flag: %s", err))
+		}
+	})
+}
+
+// LogWriterOption creates an option to set the Kubernetes logging output.
+func LogWriterOption(log *logrus.Entry) LogOption {
+	return LogOption(func(p *klogParams) {
+		p.log = log
+	})
+}
+
+// InitLogging initializes the Kubernetes client-go logging subsystem.
+func InitLogging(options ...LogOption) {
+	must := func(err error) {
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+
+	p := klogParams{
+		flags: flag.NewFlagSet(os.Args[0], flag.ExitOnError),
+	}
+
+	// First, init the flags so that we can set specific values.
+	klog.InitFlags(p.flags)
+
+	for _, o := range options {
+		o(&p)
+	}
+
+	switch p.log {
+	case nil:
+	default:
+		// Force klog to a file output so that it uses the PipeWriter.
+		must(p.flags.Set("logtostderr", "false"))
+		must(p.flags.Set("alsologtostderr", "false"))
+
+		klog.SetOutput(makeWriter(p.log))
+	}
+}
+
+// makeWriter is based on (*Entry).Writer() from logrus, but has a
+// couple of improvements. We avoid the fixed buffer size of using
+// bufio.Scanner, and we take advantage of out knowledge of the fixed
+// klog output format to improve the final logging output.
+func makeWriter(entry *logrus.Entry) io.Writer {
+	closer := func(writer *io.PipeWriter) {
+		writer.Close()
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	runtime.SetFinalizer(pipeWriter, closer)
+
+	go func() {
+		defer pipeReader.Close()
+
+		reader := bufio.NewReader(pipeReader)
+
+		for {
+			line, err := reader.ReadString('\n')
+			switch err {
+			case nil:
+			case io.EOF:
+				// Most likely, when the pipe closes, klog is being reinitialized.
+				return
+			default:
+				entry.Errorf("error reading from log pipe: %s", err)
+				return
+			}
+
+			// klog logs have the following format: Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+			fields := strings.SplitN(line, "] ", 2)
+
+			// Split out the file location. I could not
+			// find a reasonable way to make this work
+			// with (*Logger).SetReportCaller(), so we
+			// preserve it in the "location" field.
+			location := fields[0][strings.LastIndexByte(fields[0], ' ')+1:]
+
+			e := entry.WithField("location", location)
+
+			// The first character of the first header field is the log level.
+			switch fields[0][0] {
+			case 'I':
+				e.Info(fields[1])
+			case 'W':
+				e.Warn(fields[1])
+			case 'E':
+				e.Error(fields[1])
+			case 'F':
+				e.Fatal(fields[1])
+			}
+		}
+	}()
+
+	return pipeWriter
+}

--- a/site/docs/main/troubleshooting.md
+++ b/site/docs/main/troubleshooting.md
@@ -84,6 +84,13 @@ Replace `contour cli lds` with `contour cli rds` for RDS, `contour cli cds` for 
 
 See [the deployment documentation][5] for some tips on using these two deployment options successfully.
 
+## Enabling Contour debug logging
+
+The `contour serve` subcommand has two command-line flags that can be helpful for debugging.
+The `--debug` flag enabled general Contour debug logging, which logs more information about how Contour is processing API resources.
+The `--kubernetes-debug` flag enables verbose logging in the Kubernetes client API, which can help debug interactions between Contour and the Kubernetes API server.
+This flag accepts an integer log level argument, where higher number indicates more detailed logging.
+
 [1]: https://golang.org/pkg/net/http/pprof
 [2]: https://en.wikipedia.org/wiki/DOT
 [3]: https://graphviz.gitlab.io/


### PR DESCRIPTION
Add a `--kubernetes-debug` flag that enables verbose client-go logging
in the `klog` package. The logs are piped through `logrus` so that the
output format is consistent.

Signed-off-by: James Peach <jpeach@vmware.com>