### PR TITLE
Fix a nlb doc typo

### DIFF
--- a/site/_guides/deploy-aws-nlb.md
+++ b/site/_guides/deploy-aws-nlb.md
@@ -20,7 +20,7 @@ This configuration has several advantages:
 ## Deploying Contour
 
 1. [Clone the Contour repository][4] and cd into the repo 
-2. Edit the Envoy service (`03-service-envoy.yaml`) in the `examples/contour` directory:
+2. Edit the Envoy service (`02-service-envoy.yaml`) in the `examples/contour` directory:
     - Remove the existing annotation: `service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp`
     - Add the following annotation: `service.beta.kubernetes.io/aws-load-balancer-type: nlb`
 3. Run `kubectl apply -f examples/contour`


### PR DESCRIPTION
On deploy-aws-nlb guide, it refers to a wrong service envoy file.
Fix the file name to point to correct file.

Change-Id: Ia2186796c9babb84d199c72bbbdc3da2fd9262ae
Signed-off-by: Tong Liu <tongl@vmware.com>