### PR TITLE
cmd/contour: add xds-server-type arg to config file

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -45,8 +45,11 @@ type serveContext struct {
 	Kubeconfig string `yaml:"kubeconfig,omitempty"`
 
 	// contour's xds service parameters
-	xdsAddr                         string
-	xdsPort                         int
+	xdsAddr string
+	xdsPort int
+	// Defines the XDSServer to use for `contour serve`
+	// Defaults to "contour"
+	XDSServerType                   string `yaml:"xds-server-type,omitempty"`
 	caFile, contourCert, contourKey string
 
 	// contour's debug handler parameters
@@ -155,6 +158,7 @@ func newServeContext() *serveContext {
 		Kubeconfig:            filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		xdsAddr:               "127.0.0.1",
 		xdsPort:               8001,
+		XDSServerType:         "contour",
 		statsAddr:             "0.0.0.0",
 		statsPort:             8002,
 		debugAddr:             "127.0.0.1",

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
+    # determine which XDS Server implementation to utilize in Contour.
+    # xds-server-type: contour
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -40,6 +40,8 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
+    # determine which XDS Server implementation to utilize in Contour.
+    # xds-server-type: contour
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #


### PR DESCRIPTION
Adds a config file option to define the XDS server to use when serving Envoy's gRPC XDS.

Signed-off-by: Steve Sloka <slokas@vmware.com>