### PR TITLE
internal: Wire up new snapshots to DAG rebuilds

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -17,9 +17,8 @@ import (
 	"sort"
 	"sync"
 
-	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"

--- a/internal/contour/snapshot.go
+++ b/internal/contour/snapshot.go
@@ -1,0 +1,46 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contour
+
+import (
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/sirupsen/logrus"
+)
+
+// SnapshotHandler implements the xDS snapshot cache
+type SnapshotHandler struct {
+	// resources holds the cache of xDS contents.
+	resources []ResourceCache
+
+	// snapshotCache is a snapshot-based cache that maintains a single versioned
+	// snapshot of responses for xDS resources that Contour manages
+	snapshotCache cache.SnapshotCache
+
+	logrus.FieldLogger
+}
+
+// NewSnapshotHandler returns an instance of SnapShotHandler
+func NewSnapshotHandler(c cache.SnapshotCache, resources []ResourceCache, logger logrus.FieldLogger) *SnapshotHandler {
+	return &SnapshotHandler{
+		snapshotCache: c,
+		resources:     resources,
+		FieldLogger:   logger,
+	}
+}
+
+// OnChange is called when the DAG is rebuilt
+// and a new snapshot is needed.
+func (s *SnapshotHandler) OnChange(root *dag.DAG) {
+}

--- a/internal/xds/hash.go
+++ b/internal/xds/hash.go
@@ -1,0 +1,36 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+)
+
+// ConstantHash is a specialized node ID hasher used to allow
+// any instance of Envoy to connect to Contour regardless of the
+// service-node flag configured on Envoy.
+type ConstantHash string
+
+func (c ConstantHash) ID(*envoy_api_v2_core.Node) string {
+	return string(c)
+}
+
+func (c ConstantHash) String() string {
+	return string(c)
+}
+
+var _ cache.NodeHash = ConstantHash("")
+
+var DefaultHash = ConstantHash("contour")

--- a/internal/xds/server.go
+++ b/internal/xds/server.go
@@ -14,11 +14,7 @@
 package xds
 
 import (
-	clusterservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	endpointservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	listenerservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	routeservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,12 +23,12 @@ import (
 
 // Server is a collection of handlers for streaming discovery requests.
 type Server interface {
-	clusterservice.ClusterDiscoveryServiceServer
+	api.ClusterDiscoveryServiceServer
+	api.EndpointDiscoveryServiceServer
+	api.ListenerDiscoveryServiceServer
+	api.RouteDiscoveryServiceServer
 	discovery.AggregatedDiscoveryServiceServer
 	discovery.SecretDiscoveryServiceServer
-	endpointservice.EndpointDiscoveryServiceServer
-	listenerservice.ListenerDiscoveryServiceServer
-	routeservice.RouteDiscoveryServiceServer
 }
 
 // RegisterServer registers the given xDS protocol Server with the gRPC
@@ -41,7 +37,7 @@ type Server interface {
 func RegisterServer(srv Server, registry *prometheus.Registry, opts ...grpc.ServerOption) *grpc.Server {
 	var metrics *grpc_prometheus.ServerMetrics
 
-	// TODO(jpeach) Figure out how to decouple this.
+	// TODO: Decouple registry from this.
 	if registry != nil {
 		metrics = grpc_prometheus.NewServerMetrics()
 		registry.MustRegister(metrics)
@@ -57,10 +53,10 @@ func RegisterServer(srv Server, registry *prometheus.Registry, opts ...grpc.Serv
 
 	discovery.RegisterAggregatedDiscoveryServiceServer(g, srv)
 	discovery.RegisterSecretDiscoveryServiceServer(g, srv)
-	v2.RegisterClusterDiscoveryServiceServer(g, srv)
-	v2.RegisterEndpointDiscoveryServiceServer(g, srv)
-	v2.RegisterListenerDiscoveryServiceServer(g, srv)
-	v2.RegisterRouteDiscoveryServiceServer(g, srv)
+	api.RegisterClusterDiscoveryServiceServer(g, srv)
+	api.RegisterEndpointDiscoveryServiceServer(g, srv)
+	api.RegisterListenerDiscoveryServiceServer(g, srv)
+	api.RegisterRouteDiscoveryServiceServer(g, srv)
 
 	if metrics != nil {
 		metrics.InitializeMetrics(g)


### PR DESCRIPTION
Adds the snapshotHandler to react to DAG rebuilds so that new
snapshots can be created.

Follows #2845 
Updates #2134 

Signed-off-by: Steve Sloka <slokas@vmware.com>