### PR TITLE
site: Add clickable anchor links to the website

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -48,6 +48,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
     crossorigin="anonymous"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.2/anchor.min.js" integrity="sha512-I7w3ZdSFzw5j3jU3ZkNikBNeIrl3i+hEuEdwNmqUJvwNcaBUNcijnP2gd9DtGlgVYDplfjGoD8vTNsID+lCjqg=="
+    crossorigin="anonymous"></script>
 
 <script src="/js/jquery.matchHeight.js?{{site.time | date: '%s%N'}}"></script>
 <script src="/js/scripts.js?{{site.time | date: '%s%N'}}"></script>
@@ -62,4 +64,9 @@ $(document).ready(function() {
         listType: 'ul',
     });
 });
+</script>
+
+<!-- https://github.com/bryanbraun/anchorjs -->
+<script>
+    anchors.add();
 </script>

--- a/site/_resources/faq.md
+++ b/site/_resources/faq.md
@@ -3,7 +3,7 @@ title: Frequently Asked Questions
 layout: page
 ---
 
-# Q: What's the relationship between Contour and Istio? 
+## Q: What's the relationship between Contour and Istio? 
 
 Both projects use Envoy under the covers as a "data plane".
 They can both be thought of as ways to configure Envoy, but they approach configuration differently, and address different use cases.
@@ -15,7 +15,7 @@ Contour focuses on north-south traffic only -- on making Envoy available to Kube
 We continue to work with contributors to Istio and Envoy to find common ground; we're also part of Kubernetes SIG-networking.
 As Contour continues to develop -- who knows what the future holds?
 
-# Q: What are the differences between Ingress and HTTPProxy?
+## Q: What are the differences between Ingress and HTTPProxy?
 
 Contour supports both the Kubernetes Ingress API and the HTTPProxy API, a custom resource that enables a richer and more robust experience for configuring ingress into your Kubernetes cluster.
 
@@ -27,7 +27,7 @@ The HTTPProxy custom resource is an attempt to solve these issues with an API th
 More importantly, the HTTPProxy CRD is designed with inclusion in mind, a feature that enables administrators to configure top-level ingress settings (for example, which virtual hosts are available to each team), while delegating the lower-level configuration (for example, the mapping between paths and backend services) to each development team.
 More information about the HTTPProxy API can be found [in the HTTPProxy documentation][1].
 
-# Q: When I load my site in Safari, it shows me an empty page. Developer tools show that the HTTP response was 421. Why does this happen?
+## Q: When I load my site in Safari, it shows me an empty page. Developer tools show that the HTTP response was 421. Why does this happen?
 
 The HTTP/2 specification allows user agents (browsers) to re-use TLS sessions to different hostnames as long as they share an IP address and a TLS server certificate (see [RFC 7540](https://tools.ietf.org/html/rfc7540#section-9.1.1)).
 Sharing a TLS certificate typically uses a wildcard certificate, or a certificate containing multiple alternate names.

--- a/site/_resources/philosophy.md
+++ b/site/_resources/philosophy.md
@@ -1,8 +1,6 @@
 ---
 title: Contour Philosophy
 layout: page
-# NOTE(jpeach): we have to use 'h1,h2' here, because the TOC is not generated at all if we just use 'h1'.
-toc: h1,h2
 ---
 
 <!-- NOTE: this document should be formatted with one sentence per line to made reviewing easier. -->

--- a/site/_resources/upgrading.md
+++ b/site/_resources/upgrading.md
@@ -1,8 +1,6 @@
 ---
 title: Upgrading Contour
 layout: page
-# NOTE(jpeach): we have to use 'h1,h2' here, because the TOC is not generated at all if we just use 'h1'.
-toc: h1,h2
 ---
 
 <!-- NOTE: this document should be formatted with one sentence per line to made reviewing easier. -->
@@ -31,17 +29,17 @@ Use of these annotations will be logged as warnings.
 
 <br>
 
-# Upgrading Contour 1.7.0 to 1.8.0
+## Upgrading Contour 1.7.0 to 1.8.0
 
 Contour 1.8.0 is the current stable release.
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.15.0`.
 
 Please see the [Envoy Release Notes][23] for information about issues fixed in Envoy 1.15.0.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -60,7 +58,7 @@ This will remove the Envoy and Contour pods from your cluster and recreate them 
 If you're using a `LoadBalancer` Service, (which most of the examples do) deleting and recreating may change the public IP assigned by your cloud provider.
 You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.7.0 to 1.8.0 changes manually.
 The YAML files referenced in this section can be found by cloning the Contour repository and checking out the `v1.8.0` tag.
@@ -78,7 +76,7 @@ Users of the example deployment should first reapply the certgen Job YAML which 
 $ kubectl apply -f examples/contour/02-job-certgen.yaml
 ```
 
-## Removing the IngressRoute CRDs
+### Removing the IngressRoute CRDs
 
 As a reminder, support for `IngressRoute` was officially dropped in v1.6.
 If you haven't already migrated to `HTTPProxy`, see [the IngressRoute to HTTPProxy migration guide][24] for instructions on how to do so.
@@ -89,15 +87,15 @@ $ kubectl delete crd ingressroutes.contour.heptio.com
 $ kubectl delete crd tlscertificatedelegations.contour.heptio.com
 ```
 
-# Upgrading Contour 1.6.1 to 1.7.0
+## Upgrading Contour 1.6.1 to 1.7.0
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.15.0`.
 
 Please see the [Envoy Release Notes][23] for information about issues fixed in Envoy 1.15.0.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -116,7 +114,7 @@ This will remove the Envoy and Contour pods from your cluster and recreate them 
 If you're using a `LoadBalancer` Service, (which most of the examples do) deleting and recreating may change the public IP assigned by your cloud provider.
 You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.6.1 to 1.7.0 changes manually.
 The YAML files referenced in this section can be found by cloning the Contour repository and checking out the `v1.7.0` tag.
@@ -143,7 +141,7 @@ $ kubectl apply -f examples/contour/03-contour.yaml
 $ kubectl apply -f examples/contour/03-envoy.yaml
 ```
 
-## Removing the IngressRoute CRDs
+### Removing the IngressRoute CRDs
 
 As a reminder, support for `IngressRoute` was officially dropped in v1.6.
 If you haven't already migrated to `HTTPProxy`, see [the IngressRoute to HTTPProxy migration guide][24] for instructions on how to do so.
@@ -154,17 +152,17 @@ $ kubectl delete crd ingressroutes.contour.heptio.com
 $ kubectl delete crd tlscertificatedelegations.contour.heptio.com
 ```
 
-# Upgrading Contour 1.5.1 to 1.6.1
+## Upgrading Contour 1.5.1 to 1.6.1
 
 Contour 1.6.1 is the current stable release.
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.14.3`.
 
 Please see the [Envoy Release Notes][22] for information about issues fixed in Envoy 1.14.3.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -185,7 +183,7 @@ This will remove the IngressRoute CRD, and both the Envoy and Contour pods from 
 If you're using a `LoadBalancer` Service, (which most of the examples do) deleting and recreating may change the public IP assigned by your cloud provider.
 You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.5.1 to 1.6.1 changes manually.
 The YAML files referenced in this section can be found by cloning the Contour repository and checking out the `v1.6.1` tag.
@@ -222,15 +220,15 @@ If you are upgrading from Contour 1.6.0, the only required change is to upgrade 
 The Contour image can optionally be upgraded to `v1.6.1`.
 
 
-# Upgrading Contour 1.4.0 to 1.5.1
+## Upgrading Contour 1.4.0 to 1.5.1
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.14.2`.
 
 Please see the [Envoy Release Notes][21] for information about issues fixed in Envoy 1.14.2.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -249,7 +247,7 @@ This will remove both the Envoy and Contour pods from your cluster and recreate 
 If you're using a `LoadBalancer` Service, (which most of the examples do) deleting and recreating may change the public IP assigned by your cloud provider.
 You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.4.0 to 1.5.1 changes manually.
 The YAML files referenced in this section can be found by cloning the Contour repository and checking out the `v1.5.1` tag.
@@ -281,15 +279,15 @@ $ kubectl apply -f examples/contour/03-envoy.yaml
 Users who secure the gRPC session with their own certificate may need to modify the Envoy Daemonset and the Contour Deployment to ensure that their Secrets are correctly mounted within the corresponding Pod containers.
 When making these changes, be sure to retain the `--resources-dir` flag to the `contour bootstrap` command so that Envoy will be configured with reloadable TLS certificate support.
 
-# Upgrading Contour 1.3.0 to 1.4.0
+## Upgrading Contour 1.3.0 to 1.4.0
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.14.1`.
 
 Please see the [Envoy Release Notes][20] for information about issues fixed in Envoy 1.14.1.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -311,11 +309,11 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than `projectcontour` with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `projectcontour` and replace it with your preferred name space and apply the updated manifest.
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.3.0 to 1.4.0 changes manually.
 
-### Upgrade to Contour 1.4.0
+#### Upgrade to Contour 1.4.0
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.4.0`
 
@@ -338,17 +336,17 @@ kubectl apply -f examples/contour/03-envoy.yaml
 Otherwise, you should add the new `envoy` `serviceAccount` to your Envoy deployment.
 This will be used in the future to add further container-level security via PodSecurityPolicies.
 
-# Upgrading Contour 1.2.1 to 1.3.0
+## Upgrading Contour 1.2.1 to 1.3.0
 
 Contour 1.3.0 is the current stable release.
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.13.1`.
 
 Please see the [Envoy Release Notes][17] for information about issues fixed in Envoy 1.13.1.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -370,23 +368,23 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than `projectcontour` with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `projectcontour` and replace it with your preferred name space and apply the updated manifest.
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.2.1 to 1.3.0 changes manually.
 
-### Upgrade to Contour 1.3.0
+#### Upgrade to Contour 1.3.0
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.3.0`
 
-# Upgrading Contour 1.2.0 to 1.2.1
+## Upgrading Contour 1.2.0 to 1.2.1
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.13.1`.
 
 Please see the [Envoy Release Notes][17] for information about issues fixed in Envoy 1.13.1.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -409,30 +407,30 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than `projectcontour` with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `projectcontour` and replace it with your preferred name space and apply the updated manifest.
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.2.0 to 1.2.1 changes manually.
 
-### Upgrade to Contour 1.2.1
+#### Upgrade to Contour 1.2.1
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.2.1`.
 
-### Upgrade to Envoy 1.13.1
+#### Upgrade to Envoy 1.13.1
 
 Contour 1.2.1 requires Envoy 1.13.1.
 Change the Envoy image version to `docker.io/envoyproxy/envoy:v1.13.1`.
 
 _Note: Envoy 1.13.1 includes fixes to a number of [CVEs][19]_
 
-# Upgrading Contour 1.1.0 to 1.2.1
+## Upgrading Contour 1.1.0 to 1.2.1
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.13.1`.
 
 Please see the [Envoy Release Notes][17] for information about issues fixed in Envoy 1.13.1.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -455,33 +453,33 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than `projectcontour` with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `projectcontour` and replace it with your preferred name space and apply the updated manifest.
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.1.0 to 1.2.1 changes manually.
 
-### Upgrade to Contour 1.2.1
+#### Upgrade to Contour 1.2.1
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.2.1`.
 
-### Upgrade to Envoy 1.13.1
+#### Upgrade to Envoy 1.13.1
 
 Contour 1.2.1 requires Envoy 1.13.1.
 Change the Envoy image version to `docker.io/envoyproxy/envoy:v1.13.0`.
 
-### Envoy shutdown manager
+#### Envoy shutdown manager
 
 Contour 1.2.1 introduces a new sidecar to aid graceful shutdown of the Envoy pod.
 Consult [shutdown manager]({% link docs/v1.2.1/redeploy-envoy.md %}) documentation for installation instructions.
 
-# Upgrading Contour 1.0.1 to 1.1.0
+## Upgrading Contour 1.0.1 to 1.1.0
 
-## Required Envoy version
+### Required Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.12.2`.
 
 Please see the [Envoy Release Notes][15] for information about issues fixed in Envoy 1.12.2.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -512,23 +510,23 @@ $ kubectl get crd  | awk '/projectcontour.io|contour.heptio.com/{print $1}' | xa
 $ kubectl apply -f examples/<your-desired-deployment>
 ```
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 1.0.1 to 1.1.0 changes manually.
 
-### Upgrade to Contour 1.1.0
+#### Upgrade to Contour 1.1.0
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.1.0`.
 
-### Upgrade to Envoy 1.12.2
+#### Upgrade to Envoy 1.12.2
 
 Contour 1.1.0 requires Envoy 1.12.2. Change the Envoy image version to `docker.io/envoyproxy/envoy:v1.12.2`.
 
-# Upgrading Contour 1.0.0 to 1.0.1
+## Upgrading Contour 1.0.0 to 1.0.1
 
 Contour 1.0.1 is the current stable release.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If you are running Contour 1.0.0, the easy way to upgrade to Contour 1.0.1 is to reapply the [quickstart yaml][16].
 
@@ -536,28 +534,28 @@ If you are running Contour 1.0.0, the easy way to upgrade to Contour 1.0.1 is to
 $ kubectl apply -f {{site.url}}/quickstart/v1.0.1/contour.yaml
 ```
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to manually upgrade from Contour 1.0.0 to Contour 1.0.1.
 
-### Contour version
+#### Contour version
 
 Ensure the Contour image version is `docker.io/projectcontour/contour:v1.0.1`.
 
-### Envoy version
+#### Envoy version
 
 Ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.12.2`.
 
 Please see the [Envoy Release Notes][15] for information about issues fixed in Envoy 1.12.2.
 
-# Upgrading Contour 0.15.3 to 1.0.0
+## Upgrading Contour 0.15.3 to 1.0.0
 
-## Required Envoy version
+### Required Envoy version
 
 The required version of Envoy remains unchanged.
 Ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.11.2`.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -577,17 +575,17 @@ This will remove both the Envoy and Contour pods from your cluster and recreate 
 If you're using a `LoadBalancer` Service, deleting and recreating may change the public IP assigned by your cloud provider.
 You'll need to re-check where your DNS names are pointing as well, using [Get your hostname or IP address][12].
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to manually upgrade from Contour 0.15.3 to Contour 1.0.0.
 
-### Upgrade to Contour 1.0.0
+#### Upgrade to Contour 1.0.0
 
 Change the Contour image version to `docker.io/projectcontour/contour:v1.0.0`.
 
 Note that as part of sunsetting the Heptio brand, Contour Docker images have moved from `gcr.io/heptio-images` to `docker.io/projectcontour`.
 
-### Reapply HTTPProxy and IngressRoute CRD definitions
+#### Reapply HTTPProxy and IngressRoute CRD definitions
 
 Contour 1.0.0 ships with updated OpenAPIv3 validation schemas.
 
@@ -599,20 +597,20 @@ See the [HTTPProxy documentation][3] for more information.
 $ kubectl apply -f examples/contour/01-crds.yaml
 ```
 
-### Update deprecated `contour.heptio.com` annotations
+#### Update deprecated `contour.heptio.com` annotations
 
 All the annotations with the prefix `contour.heptio.com` have been migrated to their respective `projectcontour.io` counterparts.
 The deprecated `contour.heptio.com` annotations will be recognized through the Contour 1.0 release, but are scheduled to be removed after Contour 1.0.
 
 See the [annotation documentation][4] for more information.
 
-### Update old `projectcontour.io/v1alpha1` group versions
+#### Update old `projectcontour.io/v1alpha1` group versions
 
 If you are upgrading a cluster that you previously installed a 1.0.0 release candidate, note that Contour 1.0.0 moves the HTTPProxy CRD from `projectcontour.io/v1alpha1` to `projectcontour.io/v1` and will no longer recognize the former group version.
 
 Please edit your HTTPProxy documents to update their group version to `projectcontour.io/v1`.
 
-### Check for HTTPProxy v1 schema changes
+#### Check for HTTPProxy v1 schema changes
 
 As part of finalizing the HTTPProxy v1 schema, three breaking changes have been introduced.
 If you are upgrading a cluster that you previously installed a Contour 1.0.0 release candidate, you may need to edit HTTPProxy object to conform to the upgraded schema.
@@ -694,7 +692,7 @@ spec:
 </tr>
 </table>
 
-#### Check for Contour namespace change
+##### Check for Contour namespace change
 
 As part of sunsetting the Heptio brand the `heptio-contour` namespace has been renamed to `projectcontour`.
 Contour assumes it will be deployed into the `projectcontour` namespace.
@@ -702,14 +700,14 @@ Contour assumes it will be deployed into the `projectcontour` namespace.
 If you deploy Contour into a different namespace you will need to pass `contour bootstrap --namespace=<namespace>` and update the leader election parameters in the [`contour.yaml` configuration][6]
 as appropriate.
 
-### Split deployment/daemonset now the default
+#### Split deployment/daemonset now the default
 
 We have changed the example installation to use a separate pod installation, where Contour is in a Deployment and Envoy is in a Daemonset.
 Separated pod installations separate the lifecycle of Contour and Envoy, increasing operability.
 Because of this, we are marking the single pod install type as officially deprecated.
 If you are still running a single pod install type, please review the [`contour` example][7] and either adapt it or use it directly.
 
-### Verify leader election
+#### Verify leader election
 
 Contour 1.0.0 enables leader election by default.
 No specific configuration is required if you are using the [example deployment][7].
@@ -724,7 +722,7 @@ Leader election controls writing status back to Contour CRDs (like HTTPProxy and
 
 Should you wish to disable leader election, pass `contour serve --disable-leader-election`.
 
-### Envoy pod readiness checks
+#### Envoy pod readiness checks
 
 Update the readiness checks on your Envoy pod's spec to reflect Envoy 1.11.1's `/ready` endpoint
 ```yaml
@@ -734,31 +732,31 @@ readinessProbe:
     port: 8002
 ```
 
-### Root namespace restriction
+#### Root namespace restriction
 
 The `contour serve --ingressroute-root-namespaces` flag has been renamed to `--root-namespaces`.
 If you use this feature please update your deployments.
 
-# Upgrading Contour 0.14.x to 0.15.3
+## Upgrading Contour 0.14.x to 0.15.3
 
 Contour 0.15.3 requires changes to your deployment manifests to explicitly opt in, or opt out of, secure communication between Contour and Envoy.
 
 Contour 0.15.3 also adds experimental support for leader election which may be useful for installations which have split their Contour and Envoy containers into separate pods.
 A configuration we call _split deployment_.
 
-## Breaking change
+### Breaking change
 
 Contour's `contour serve` now requires that either TLS certificates be available, or you supply the `--insecure` parameter.
 
 **If you do not supply TLS details or `--insecure`, `contour serve` will not start.**
 
-## Recommended Envoy version
+### Recommended Envoy version
 
 All users should ensure the Envoy image version is `docker.io/envoyproxy/envoy:v1.11.2`.
 
 Please see the [Envoy Release Notes][10] for information about issues fixed in Envoy 1.11.2.
 
-## The easy way to upgrade
+### The easy way to upgrade
 
 If the following are true for you:
 
@@ -780,17 +778,17 @@ You'll need to re-check where your DNS names are pointing as well, using [Get yo
 **Note:** If you deployed Contour into a different namespace than heptio-contour with a standard example, please delete that namespace.
 Then in your editor of choice do a search and replace for `heptio-contour` and replace it with your preferred name space and apply the updated manifest.
 
-## The less easy way
+### The less easy way
 
 This section contains information for administrators who wish to apply the Contour 0.14.x to 0.15.3 changes manually.
 
-### Upgrade to Contour 0.15.3
+#### Upgrade to Contour 0.15.3
 
 Due to the sun setting on the Heptio brand, from v0.15.0 onwards our images are now served from the docker hub repository [`docker.io/projectcontour/contour`][13]
 
 Change the Contour image version to `docker.io/projectcontour/contour:v0.15.3`.
 
-### Enabling TLS for gRPC
+#### Enabling TLS for gRPC
 
 You *must* either enable TLS for gRPC serving, or put `--insecure` into your `contour serve` startup line.
 If you are running with both Contour and Envoy in a single pod, the existing deployment examples have already been updated with this change.
@@ -801,11 +799,11 @@ There is a Job in the `ds-hostnet-split` directory that will use the new `contou
 
 If you would like more detail, see [grpc-tls-howto.md][14], which explains your options.
 
-### Upgrade to Envoy 1.11.2
+#### Upgrade to Envoy 1.11.2
 
 Contour 0.15.3 requires Envoy 1.11.2. Change the Envoy image version to `docker.io/envoyproxy/envoy:v1.11.2`.
 
-### Enabling Leader Election
+#### Enabling Leader Election
 
 Contour 0.15.3 adds experimental support for leader election.
 Enabling leader election will mean that only one of the Contour pods will actually serve gRPC traffic.

--- a/site/_scss/_styles.scss
+++ b/site/_scss/_styles.scss
@@ -24,6 +24,7 @@
 @import "./site/objects/post";
 @import "./site/objects/toc";
 @import "./site/objects/deprecated";
+@import "./site/objects/anchor";
 
 // Utilities
 @import "./site/utilities/image";

--- a/site/_scss/site/common/_core.scss
+++ b/site/_scss/site/common/_core.scss
@@ -2,7 +2,6 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-
 a {
   &.dark {
     color: $body-color !important;
@@ -12,8 +11,7 @@ a {
   }
 }
 
-.center-image
-{
-    margin: 0 auto;
-    display: block;
+.center-image {
+  margin: 0 auto;
+  display: block;
 }

--- a/site/_scss/site/objects/_anchor.scss
+++ b/site/_scss/site/objects/_anchor.scss
@@ -1,0 +1,3 @@
+a.anchorjs-link {
+  text-decoration: none;
+}

--- a/site/_scss/site/objects/_button.scss
+++ b/site/_scss/site/objects/_button.scss
@@ -4,7 +4,7 @@
     bottom: 9px;
   }
   font-size: 0.75rem;
-  border-radius: 5px;  
+  border-radius: 5px;
   text-transform: uppercase;
   font-weight: $font-weight-bold;
   &.btn-no-border {
@@ -31,7 +31,7 @@
   }
 }
 
-.btn-secondary {  
+.btn-secondary {
   color: $button-secondary-foreground;
   background-color: $button-secondary-background;
   border-color: $button-secondary-border;
@@ -52,6 +52,7 @@
     background: $button-primary-foreground;
   }
 }
+
 .btn-outline-light {
   &:hover {
     color: $button-primary-foreground;

--- a/site/_scss/site/objects/_deprecated.scss
+++ b/site/_scss/site/objects/_deprecated.scss
@@ -1,9 +1,9 @@
 .alert-deprecation {
-    @extend .alert-warning;
-    border-radius: 5px;
-    padding-left: 10px;
-    padding-right: 10px;
-    display: inline-block;
+  @extend .alert-warning;
+  border-radius: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  display: inline-block;
 }
 
 /*
@@ -11,8 +11,8 @@
  * warning.
  */
 .alert-deprecation::before {
-    font-size: 175%;
-    font-weight: bold;
-    vertical-align: middle;
-    content: "⚠"
+  font-size: 175%;
+  font-weight: bold;
+  vertical-align: middle;
+  content: "⚠"
 }

--- a/site/_scss/site/objects/_footer.scss
+++ b/site/_scss/site/objects/_footer.scss
@@ -1,34 +1,34 @@
 .site-footer {
   padding: 24px 0 34px 0;
   .social-links {
-      color: $footer-foreground;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      a {        
-          font-size: 0.75rem; 
-          color: $footer-link-color;
-          &:hover {
-              color: $footer-link-color;
-              text-decoration: underline;
-          }
+    color: $footer-foreground;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    a {
+      font-size: 0.75rem;
+      color: $footer-link-color;
+      &:hover {
+        color: $footer-link-color;
+        text-decoration: underline;
       }
-      li {
-          display: inline-block;
-          padding: 5px;          
-          &:hover {
-            color: $footer-link-color;
-            a {
-              text-decoration: underline;
-            }
-          }
+    }
+    li {
+      display: inline-block;
+      padding: 5px;
+      &:hover {
+        color: $footer-link-color;
+        a {
+          text-decoration: underline;
+        }
       }
+    }
   }
   .copyright {
-    font-size: 0.75rem; 
+    font-size: 0.75rem;
     font-weight: $font-weight-light;
     color: $footer-copyright;
-  }  
+  }
   .logo {
     max-width: 146px;
     height: auto;

--- a/site/_scss/site/objects/_header.scss
+++ b/site/_scss/site/objects/_header.scss
@@ -11,7 +11,7 @@
       padding: {
         left: $grid-gutter-width / 2 + $section-padding-x;
         right: $grid-gutter-width / 2 + $section-padding-x;
-      }  
+      }
     }
   }
 

--- a/site/_scss/site/objects/_home-hero.scss
+++ b/site/_scss/site/objects/_home-hero.scss
@@ -5,7 +5,7 @@
     background-image: none !important;
   }
   @include media-breakpoint-up(md) {
-    min-height: 500px;  
+    min-height: 500px;
   }
   color: $white;
   h1,
@@ -17,24 +17,24 @@
   .section-content {
     margin-top: 15px;
     .hero-content,
-    .hero-cta {       
+    .hero-cta {
       @include media-breakpoint-up(md) {
         @include make-col-ready();
         @include make-col(8);
-      }  
+      }
     }
   }
 
   .hero-cta {
     display: block;
     margin-bottom: 70px;
-    @include media-breakpoint-up(md) { 
+    @include media-breakpoint-up(md) {
       display: flex;
       flex-direction: row;
       justify-content: left;
     }
     .btn {
-      @include media-breakpoint-up(md) { 
+      @include media-breakpoint-up(md) {
         min-width: 250px;
       }
       padding: {
@@ -44,7 +44,7 @@
       margin: 0 32px 0 0;
     }
   }
-  
+
   .section-card {
     margin-top: 68px;
     .section-content {

--- a/site/_scss/site/objects/_post.scss
+++ b/site/_scss/site/objects/_post.scss
@@ -1,5 +1,5 @@
 .post-thumbnail {
-  width: 100%;  
+  width: 100%;
   margin: 0 auto 1.875rem auto;
   height: 137px;
   position: relative;

--- a/site/_scss/site/objects/_toc.scss
+++ b/site/_scss/site/objects/_toc.scss
@@ -1,6 +1,6 @@
 div#toc {
-    padding: 10px;
-    margin: 10px;
-    float: right;
-    border: 1px solid;
+  padding: 10px;
+  margin: 10px;
+  float: right;
+  border: 1px solid;
 }

--- a/site/_scss/site/settings/_variables.scss
+++ b/site/_scss/site/settings/_variables.scss
@@ -7,7 +7,7 @@ $path-images: "img";
 $black: #000;
 $white: #FFFFFF;
 $light: $white;
-$pink:    #A41458;
+$pink: #A41458;
 $darkest-blue: #1D428A;
 
 // Bootstrap overrides
@@ -89,7 +89,7 @@ $field-backgrounds: (
     h1,
     h2,
     p {
-      color: $white !important;      
+      color: $white !important;
     }
   }
   .bg-color-#{$name} {


### PR DESCRIPTION
Use [anchor.js](https://github.com/bryanbraun/anchorjs) to put an anchored element by the webpage headers, which can be used to obtain a link. It currently uses the default style (displayed on hover) and adds anchors to `h2`, `h3`, `h4`, `h5`, `h6` elements, which looks good to me, though there are other [options](https://www.bryanbraun.com/anchorjs/#options).

Fixes #2469.

A preview with `make site-devel`:
<img width="1246" alt="anchor-preview" src="https://user-images.githubusercontent.com/32248945/91670112-61106c80-eae8-11ea-8382-4bbc39a74b32.png">

Signed-off-by: Zian Ke <zian.ke@zian.ke>