### PR TITLE
Switch from cmp.Equal to equality.Semantic.DeepEqual

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -22,10 +22,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -798,7 +798,7 @@ func includeMatchConditionsIdentical(includes []projcontour.Include) bool {
 		// Now compare each include's set of conditions
 		for _, cA := range includes[i].Conditions {
 			for _, cB := range includes[j].Conditions {
-				if (cA.Prefix == cB.Prefix) && cmp.Equal(cA.Header, cB.Header) {
+				if (cA.Prefix == cB.Prefix) && equality.Semantic.DeepEqual(cA.Header, cB.Header) {
 					return true
 				}
 			}

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -14,9 +14,9 @@
 package k8s
 
 import (
-	"github.com/google/go-cmp/cmp"
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // IsStatusEqual checks that two objects of supported Kubernetes types
@@ -29,16 +29,12 @@ func IsStatusEqual(objA, objB interface{}) bool {
 	case *v1beta1.Ingress:
 		switch b := objB.(type) {
 		case *v1beta1.Ingress:
-			if cmp.Equal(a.Status, b.Status) {
-				return true
-			}
+			return equality.Semantic.DeepEqual(a.Status, b.Status)
 		}
 	case *projcontour.HTTPProxy:
 		switch b := objB.(type) {
 		case *projcontour.HTTPProxy:
-			if cmp.Equal(a.Status, b.Status) {
-				return true
-			}
+			return equality.Semantic.DeepEqual(a.Status, b.Status)
 		}
 	}
 


### PR DESCRIPTION
Google's `cmp` library is great, but it's intended for test code, so it can panic as a failure mode.  Also, the K8s equality package seems purpose built for the use case here.

Fixes: https://github.com/projectcontour/contour/issues/2851