### PR TITLE
internal: Add helpers to return []xds.Resource proto's for snapshots xDS Server

### DIFF
--- a/internal/contour/cluster.go
+++ b/internal/contour/cluster.go
@@ -17,9 +17,9 @@ import (
 	"sort"
 	"sync"
 
-	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_xds "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
@@ -43,8 +43,7 @@ func (c *ClusterCache) Update(v map[string]*v2.Cluster) {
 	c.Cond.Notify()
 }
 
-// Contents returns a copy of the cache's contents.
-func (c *ClusterCache) Contents() []proto.Message {
+func (c *ClusterCache) contents() []*v2.Cluster {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var values []*v2.Cluster
@@ -52,7 +51,19 @@ func (c *ClusterCache) Contents() []proto.Message {
 		values = append(values, v)
 	}
 	sort.Stable(sorter.For(values))
-	return protobuf.AsMessages(values)
+	return values
+}
+
+// Messages returns a copy of the cache's contents
+// as an array of proto.Message.
+func (c *ClusterCache) Messages() []proto.Message {
+	return protobuf.AsMessages(c.contents())
+}
+
+// Resources returns a copy of the cache's contents as
+// an array of xds.Resource.
+func (c *ClusterCache) Resources() []envoy_api_v2_xds.Resource {
+	return protobuf.AsResources(c.contents())
 }
 
 func (c *ClusterCache) Query(names []string) []proto.Message {

--- a/internal/contour/cluster_test.go
+++ b/internal/contour/cluster_test.go
@@ -69,7 +69,7 @@ func TestClusterCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var cc ClusterCache
 			cc.Update(tc.contents)
-			got := cc.Contents()
+			got := cc.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}

--- a/internal/contour/endpointstranslator.go
+++ b/internal/contour/endpointstranslator.go
@@ -20,6 +20,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	envoy_api_v2_xds "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
@@ -357,8 +358,7 @@ func (e *EndpointsTranslator) OnDelete(obj interface{}) {
 	}
 }
 
-// Contents returns a copy of the contents of the cache.
-func (e *EndpointsTranslator) Contents() []proto.Message {
+func (e *EndpointsTranslator) contents() []*v2.ClusterLoadAssignment {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -368,7 +368,17 @@ func (e *EndpointsTranslator) Contents() []proto.Message {
 	}
 
 	sort.Stable(sorter.For(values))
-	return protobuf.AsMessages(values)
+	return values
+}
+
+// Messages returns a copy of the contents of the cache.
+func (e *EndpointsTranslator) Messages() []proto.Message {
+	return protobuf.AsMessages(e.contents())
+}
+
+// Resources returns a copy of the contents of the cache.
+func (e *EndpointsTranslator) Resources() []envoy_api_v2_xds.Resource {
+	return protobuf.AsResources(e.contents())
 }
 
 func (e *EndpointsTranslator) Query(names []string) []proto.Message {

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -53,7 +53,7 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 			et.entries = tc.contents
-			got := et.Contents()
+			got := et.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
@@ -294,7 +294,7 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 			require.NoError(t, et.cache.SetClusters(clusters))
 			et.OnAdd(tc.ep)
-			got := et.Contents()
+			got := et.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
@@ -452,7 +452,7 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 			// only after that, verify that deletion gives
 			// the expected result.
 			et.OnDelete(tc.ep)
-			got := et.Contents()
+			got := et.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
@@ -550,7 +550,7 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 			et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 			require.NoError(t, et.cache.SetClusters([]*dag.ServiceCluster{&tc.cluster}))
 			et.OnAdd(tc.ep)
-			got := et.Contents()
+			got := et.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
@@ -588,7 +588,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 		},
 	}
 
-	protobuf.RequireEqual(t, want, et.Contents())
+	protobuf.RequireEqual(t, want, et.Messages())
 
 	// e2 is the same as e1, but without endpoint subsets
 	e2 := endpoints("default", "simple")
@@ -599,7 +599,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 		&v2.ClusterLoadAssignment{ClusterName: "default/simple"},
 	}
 
-	protobuf.RequireEqual(t, want, et.Contents())
+	protobuf.RequireEqual(t, want, et.Messages())
 }
 
 func ports(eps ...v1.EndpointPort) []v1.EndpointPort {

--- a/internal/contour/listener_test.go
+++ b/internal/contour/listener_test.go
@@ -65,7 +65,7 @@ func TestListenerCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var lc ListenerCache
 			lc.Update(tc.contents)
-			got := lc.Contents()
+			got := lc.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -66,7 +66,7 @@ func TestRouteCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var rc RouteCache
 			rc.Update(tc.contents)
-			got := rc.Contents()
+			got := rc.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -53,7 +53,7 @@ func TestSecretCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var sc SecretCache
 			sc.Update(tc.contents)
-			got := sc.Contents()
+			got := sc.Messages()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"time"
 
+	envoy_api_v2_xds "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -60,6 +61,24 @@ func AsMessages(messages interface{}) []proto.Message {
 
 	for i := range protos {
 		protos[i] = v.Index(i).Interface().(proto.Message)
+	}
+
+	return protos
+}
+
+// AsResources casts the given slice of values (that implement the xds.Resource
+// interface) to a slice of xds.Resource. If the length of the slice is 0, it
+// returns nil.
+func AsResources(messages interface{}) []envoy_api_v2_xds.Resource {
+	v := reflect.ValueOf(messages)
+	if v.Len() == 0 {
+		return nil
+	}
+
+	protos := make([]envoy_api_v2_xds.Resource, v.Len())
+
+	for i := range protos {
+		protos[i] = v.Index(i).Interface().(envoy_api_v2_xds.Resource)
 	}
 
 	return protos

--- a/internal/xds/contour.go
+++ b/internal/xds/contour.go
@@ -21,6 +21,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	envoy_api_v2_xds "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -30,8 +31,11 @@ import (
 // Resource represents a source of proto.Messages that can be registered
 // for interest.
 type Resource interface {
-	// Contents returns the contents of this resource.
-	Contents() []proto.Message
+	// Messages returns the contents of this resource as []proto.Message.
+	Messages() []proto.Message
+
+	// Resources returns the contents of this resource as []xds.Resource.
+	Resources() []envoy_api_v2_xds.Resource
 
 	// Query returns an entry for each resource name supplied.
 	Query(names []string) []proto.Message
@@ -158,7 +162,7 @@ func (s *contourServer) stream(st grpcStream) error {
 			case 0:
 				// no resource hints supplied, return the full
 				// contents of the resource
-				resources = r.Contents()
+				resources = r.Messages()
 			default:
 				// resource hints supplied, return exactly those
 				resources = r.Query(req.ResourceNames)

--- a/internal/xds/contour_test.go
+++ b/internal/xds/contour_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_xds "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +65,7 @@ func TestXDSHandlerStream(t *testing.T) {
 						register: func(ch chan int, i int) {
 							ch <- i + 1
 						},
-						contents: func() []proto.Message {
+						messages: func() []proto.Message {
 							return []proto.Message{nil}
 						},
 						typeurl: func() string { return "io.projectcontour.potato" },
@@ -89,7 +90,7 @@ func TestXDSHandlerStream(t *testing.T) {
 						register: func(ch chan int, i int) {
 							ch <- i + 1
 						},
-						contents: func() []proto.Message {
+						messages: func() []proto.Message {
 							return []proto.Message{new(v2.ClusterLoadAssignment)}
 						},
 						typeurl: func() string { return "io.projectcontour.potato" },
@@ -160,13 +161,15 @@ func (m *mockStream) Send(resp *v2.DiscoveryResponse) error { return m.send(resp
 func (m *mockStream) Recv() (*v2.DiscoveryRequest, error)   { return m.recv() }
 
 type mockResource struct {
-	contents func() []proto.Message
-	query    func([]string) []proto.Message
-	register func(chan int, int)
-	typeurl  func() string
+	messages  func() []proto.Message
+	resources func() []envoy_api_v2_xds.Resource
+	query     func([]string) []proto.Message
+	register  func(chan int, int)
+	typeurl   func() string
 }
 
-func (m *mockResource) Contents() []proto.Message                       { return m.contents() }
+func (m *mockResource) Messages() []proto.Message                       { return m.messages() }
+func (m *mockResource) Resources() []envoy_api_v2_xds.Resource          { return m.resources() }
 func (m *mockResource) Query(names []string) []proto.Message            { return m.query(names) }
 func (m *mockResource) Register(ch chan int, last int, hints ...string) { m.register(ch, last) }
 func (m *mockResource) TypeURL() string                                 { return m.typeurl() }


### PR DESCRIPTION
This preps the local Contour caches for returning arrays of type xds.Resource
so they can be called when creating new snapshots for the go-control-plane
xDS implementation.

Updates #2134

Signed-off-by: Steve Sloka <slokas@vmware.com>