### PR TITLE
internal/dag: set HTTPProxy with no routes/includes/tcpproxy invalid

### DIFF
--- a/examples/gatekeeper/validations/01-template-non-empty.yml
+++ b/examples/gatekeeper/validations/01-template-non-empty.yml
@@ -1,0 +1,32 @@
+# httpproxynonempty is a ConstraintTemplate that requires
+# an HTTPProxy to have at least one route, include, or a
+# tcp proxy defined.
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: httpproxynonempty
+  labels:
+    app: contour
+spec:
+  crd:
+    spec:
+      names:
+        kind: HTTPProxyNonEmpty
+        listKind: HTTPProxyNonEmptyList
+        plural: HTTPProxyNonEmptys
+        singular: HTTPProxyNonEmpty
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package httpproxy.nonempty
+
+        violation[{"msg": msg}] {
+          # only check root HTTPProxies
+          input.review.object.spec.virtualhost
+          
+          not input.review.object.spec.routes
+          not input.review.object.spec.includes
+          not input.review.object.spec.tcpproxy
+
+          msg := "proxy must define at least one route, include, or a tcp proxy"
+        }

--- a/examples/gatekeeper/validations/02-constraint-non-empty.yml
+++ b/examples/gatekeeper/validations/02-constraint-non-empty.yml
@@ -1,0 +1,13 @@
+# httpproxy-non-empty instantiates an HTTPProxyNonEmpty
+# ConstraintTemplate.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: HTTPProxyNonEmpty
+metadata:
+  name: httpproxy-non-empty
+  labels:
+    app: contour
+spec:
+  match:
+    kinds:
+      - apiGroups: ["projectcontour.io"]
+        kinds: ["HTTPProxy"]

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -102,6 +102,11 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 		return
 	}
 
+	if len(proxy.Spec.Routes) == 0 && len(proxy.Spec.Includes) == 0 && proxy.Spec.TCPProxy == nil {
+		sw.SetInvalid("HTTPProxy.Spec must have at least one Route, Include, or a TCPProxy")
+		return
+	}
+
 	var tlsEnabled bool
 	if tls := proxy.Spec.VirtualHost.TLS; tls != nil {
 		if !isBlank(tls.SecretName) && tls.Passthrough {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1675,6 +1675,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
+	// a proxy without any routes, includes, or a tcp proxy
+	// is invalid.
+	emptyProxy := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "empty",
+			Namespace: "roots",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		objs                []interface{}
 		fallbackCertificate *types.NamespacedName
@@ -2277,6 +2291,17 @@ func TestDAGStatus(t *testing.T) {
 			objs: []interface{}{fallbackCertificateWithClientValidation, fallbackSecret, secretRootsNS, serviceHome},
 			want: map[types.NamespacedName]Status{
 				{Name: fallbackCertificateWithClientValidation.Name, Namespace: fallbackCertificateWithClientValidation.Namespace}: {Object: fallbackCertificateWithClientValidation, Status: "invalid", Description: "Spec.Virtualhost.TLS fallback & client validation are incompatible together", Vhost: "example.com"},
+			},
+		},
+		"proxy with no routes, includes, or tcpproxy is invalid": {
+			objs: []interface{}{emptyProxy},
+			want: map[types.NamespacedName]Status{
+				{Name: emptyProxy.Name, Namespace: emptyProxy.Namespace}: {
+					Object:      emptyProxy,
+					Status:      "invalid",
+					Description: "HTTPProxy.Spec must have at least one Route, Include, or a TCPProxy",
+					Vhost:       emptyProxy.Spec.VirtualHost.Fqdn,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #2835 

Signed-off-by: Steve Kriss <krisss@vmware.com>

This was what I had in mind for #2835. It does not attempt to solve the whole issue around inclusion described in #2141. It simply ensures that one of `spec.routes`, `spec.includes`, or `spec.tcpproxy` is defined/non-empty for each proxy.

I think this has value separate from addressing #2141, since it is a useful validation for folks who aren't using inclusion, and it shouldn't have any impact on inclusion chains, but let me know if I'm missing something.

Will likely rebase this on #2847.