### PR TITLE
Second attempt at fixing knative-sandbox/net-contour#226

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -365,10 +365,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	}
 
 	sh := k8s.StatusUpdateHandler{
-		Log:           log.WithField("context", "StatusUpdateWriter"),
-		Clients:       clients,
-		LeaderElected: eventHandler.IsLeader,
-		Converter:     converter,
+		Log:             log.WithField("context", "StatusUpdateWriter"),
+		Clients:         clients,
+		LeaderElected:   eventHandler.IsLeader,
+		Converter:       converter,
+		InformerFactory: clusterInformerFactory,
 	}
 	g.Add(sh.Start)
 

--- a/internal/k8s/statusupdater.go
+++ b/internal/k8s/statusupdater.go
@@ -50,12 +50,13 @@ func (m StatusMutatorFunc) Mutate(old interface{}) interface{} {
 
 // StatusUpdateHandler holds the details required to actually write an Update back to the referenced object.
 type StatusUpdateHandler struct {
-	Log           logrus.FieldLogger
-	Clients       *Clients
-	UpdateChannel chan StatusUpdate
-	LeaderElected chan struct{}
-	IsLeader      bool
-	Converter     *UnstructuredConverter
+	Log             logrus.FieldLogger
+	Clients         *Clients
+	UpdateChannel   chan StatusUpdate
+	LeaderElected   chan struct{}
+	IsLeader        bool
+	Converter       *UnstructuredConverter
+	InformerFactory InformerFactory
 }
 
 // Start runs the goroutine to perform status writes.
@@ -82,9 +83,10 @@ func (suh *StatusUpdateHandler) Start(stop <-chan struct{}) error {
 			suh.Log.WithField("name", upd.NamespacedName.Name).
 				WithField("namespace", upd.NamespacedName.Namespace).
 				Debug("received a status update")
-			uObj, err := suh.Clients.DynamicClient().
-				Resource(upd.Resource).
-				Namespace(upd.NamespacedName.Namespace).Get(context.TODO(), upd.NamespacedName.Name, metav1.GetOptions{})
+
+			// Fetch the lister cache for the informer associated with this resource.
+			lister := suh.InformerFactory.ForResource(upd.Resource).Lister()
+			uObj, err := lister.ByNamespace(upd.NamespacedName.Namespace).Get(upd.NamespacedName.Name)
 			if err != nil {
 				suh.Log.WithError(err).
 					WithField("name", upd.NamespacedName.Name).
@@ -129,7 +131,6 @@ func (suh *StatusUpdateHandler) Start(stop <-chan struct{}) error {
 					Error("unable to update status")
 				continue
 			}
-
 		}
 
 	}


### PR DESCRIPTION
Replace the dynamic client Get (uncached) with a read from
the informer's lister cache.  This code path is evaluated
for every HTTP Proxy on each DAG rebuild, and the call to
the API Server on each results in a thundering herd that
triggers the built-in rate limiting in k8s.io/client-go.

With this change, the only API Server calls on DAG rebuilds
happen only when our cached copy of the HTTP Proxy shows
that we need to perform a status update.

Updates #2857