### PR TITLE
[release-1.8] internal/k8s: Change StatusUpdaterHandler channel to buffered

### DIFF
--- a/internal/k8s/statusupdater.go
+++ b/internal/k8s/statusupdater.go
@@ -141,7 +141,7 @@ func (suh *StatusUpdateHandler) Start(stop <-chan struct{}) error {
 func (suh *StatusUpdateHandler) Writer() StatusUpdater {
 
 	if suh.UpdateChannel == nil {
-		suh.UpdateChannel = make(chan StatusUpdate)
+		suh.UpdateChannel = make(chan StatusUpdate, 100)
 	}
 
 	return &StatusUpdateWriter{


### PR DESCRIPTION
Updates #2857.

This should ensure that the DAG has some headroom before
status updates start blocking the DAG rebuilds, even in
reasonably busy clusters.

Signed-off-by: Nick Young <ynick@vmware.com>