### PR TITLE
internal/dag: move validation struct lookups

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -14,6 +14,7 @@
 package dag
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -438,6 +439,43 @@ func (kc *KubernetesCache) LookupSecret(name types.NamespacedName, validate func
 	return s, nil
 }
 
+func (kc *KubernetesCache) LookupUpstreamValidation(uv *projectcontour.UpstreamValidation, namespace string) (*PeerValidationContext, error) {
+	if uv == nil {
+		// no upstream validation requested, nothing to do
+		return nil, nil
+	}
+
+	secretName := types.NamespacedName{Name: uv.CACertificate, Namespace: namespace}
+	cacert, err := kc.LookupSecret(secretName, validCA)
+	if err != nil {
+		// UpstreamValidation is requested, but cert is missing or not configured
+		return nil, fmt.Errorf("invalid CA Secret %q: %s", secretName, err)
+	}
+
+	if uv.SubjectName == "" {
+		// UpstreamValidation is requested, but SAN is not provided
+		return nil, errors.New("missing subject alternative name")
+	}
+
+	return &PeerValidationContext{
+		CACertificate: cacert,
+		SubjectName:   uv.SubjectName,
+	}, nil
+}
+
+func (kc *KubernetesCache) LookupDownstreamValidation(vc *projectcontour.DownstreamValidation, namespace string) (*PeerValidationContext, error) {
+	secretName := types.NamespacedName{Name: vc.CACertificate, Namespace: namespace}
+	cacert, err := kc.LookupSecret(secretName, validCA)
+	if err != nil {
+		// PeerValidationContext is requested, but cert is missing or not configured.
+		return nil, fmt.Errorf("invalid CA Secret %q: %s", secretName, err)
+	}
+
+	return &PeerValidationContext{
+		CACertificate: cacert,
+	}, nil
+}
+
 // DelegationPermitted returns true if the referenced secret has been delegated
 // to the namespace where the ingress object is located.
 func (kc *KubernetesCache) DelegationPermitted(secret types.NamespacedName, targetNamespace string) bool {
@@ -471,4 +509,12 @@ func (kc *KubernetesCache) DelegationPermitted(secret types.NamespacedName, targ
 		}
 	}
 	return false
+}
+
+func validCA(s *v1.Secret) error {
+	if len(s.Data[CACertificateKey]) == 0 {
+		return fmt.Errorf("empty %q key", CACertificateKey)
+	}
+
+	return nil
 }

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -14,7 +14,6 @@
 package dag
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -161,7 +159,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 
 			// Fill in DownstreamValidation when external client validation is enabled.
 			if tls.ClientValidation != nil {
-				dv, err := p.lookupDownstreamValidation(tls.ClientValidation, proxy.Namespace)
+				dv, err := p.builder.Source.LookupDownstreamValidation(tls.ClientValidation, proxy.Namespace)
 				if err != nil {
 					sw.SetInvalid("Spec.VirtualHost.TLS client validation is invalid: %s", err)
 					return
@@ -361,7 +359,7 @@ func (p *HTTPProxyProcessor) computeRoutes(sw *ObjectStatusWriter, proxy *projco
 			var uv *PeerValidationContext
 			if protocol == "tls" || protocol == "h2" {
 				// we can only validate TLS connections to services that talk TLS
-				uv, err = p.lookupUpstreamValidation(service.UpstreamValidation, proxy.Namespace)
+				uv, err = p.builder.Source.LookupUpstreamValidation(service.UpstreamValidation, proxy.Namespace)
 				if err != nil {
 					sw.SetInvalid("Service [%s:%d] TLS upstream validation policy error: %s",
 						service.Name, service.Port, err)
@@ -556,51 +554,6 @@ func (p *HTTPProxyProcessor) rootAllowed(namespace string) bool {
 		}
 	}
 	return false
-}
-
-func (p *HTTPProxyProcessor) lookupUpstreamValidation(uv *projcontour.UpstreamValidation, namespace string) (*PeerValidationContext, error) {
-	if uv == nil {
-		// no upstream validation requested, nothing to do
-		return nil, nil
-	}
-
-	secretName := types.NamespacedName{Name: uv.CACertificate, Namespace: namespace}
-	cacert, err := p.builder.Source.LookupSecret(secretName, validCA)
-	if err != nil {
-		// UpstreamValidation is requested, but cert is missing or not configured
-		return nil, fmt.Errorf("invalid CA Secret %q: %s", secretName, err)
-	}
-
-	if uv.SubjectName == "" {
-		// UpstreamValidation is requested, but SAN is not provided
-		return nil, errors.New("missing subject alternative name")
-	}
-
-	return &PeerValidationContext{
-		CACertificate: cacert,
-		SubjectName:   uv.SubjectName,
-	}, nil
-}
-
-func (p *HTTPProxyProcessor) lookupDownstreamValidation(vc *projcontour.DownstreamValidation, namespace string) (*PeerValidationContext, error) {
-	secretName := types.NamespacedName{Name: vc.CACertificate, Namespace: namespace}
-	cacert, err := p.builder.Source.LookupSecret(secretName, validCA)
-	if err != nil {
-		// PeerValidationContext is requested, but cert is missing or not configured.
-		return nil, fmt.Errorf("invalid CA Secret %q: %s", secretName, err)
-	}
-
-	return &PeerValidationContext{
-		CACertificate: cacert,
-	}, nil
-}
-
-func validCA(s *v1.Secret) error {
-	if len(s.Data[CACertificateKey]) == 0 {
-		return fmt.Errorf("empty %q key", CACertificateKey)
-	}
-
-	return nil
 }
 
 // setOrphaned records an HTTPProxy resource as orphaned.


### PR DESCRIPTION
Build processors for both the ExtensionService and HTTPProxy types
have to deal with `UpstreamValidation`. Move the helpers that look up
`UpstreamValidation` and `DownstreamValidation` types to the Kubernetes
cache so that they are accessible to all the build processors.

This updates #2713.

Signed-off-by: James Peach <jpeach@vmware.com>