### PR TITLE
internal/dag: fix adding a ServiceCluster entry

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -541,7 +541,7 @@ func (s *ServiceCluster) AddService(name types.NamespacedName, port v1.ServicePo
 func (s *ServiceCluster) AddWeightedService(weight uint32, name types.NamespacedName, port v1.ServicePort) {
 	w := WeightedService{
 		Weight:           weight,
-		ServiceName:      name.Namespace,
+		ServiceName:      name.Name,
 		ServiceNamespace: name.Namespace,
 		ServicePort:      port,
 	}


### PR DESCRIPTION
`(*ServiceCluster).AddWeightedService` didn't copy the service name
properly, leading to a failure to match the service endpoints. Copy
the correct fields and add tests for `ServiceCluster` type.

This updates #2713.

Signed-off-by: James Peach <jpeach@vmware.com>