### PR TITLE
internal: make ServiceCluster weights consistent

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -549,6 +549,24 @@ func (s *ServiceCluster) AddWeightedService(weight uint32, name types.Namespaced
 	s.Services = append(s.Services, w)
 }
 
+// Rebalance rewrites the weights for the service cluster so that
+// if no weights are specifies, the traffic is evenly distributed.
+// This matches the behavior of weighted routes. Note that this is
+// a destructive operation.
+func (s *ServiceCluster) Rebalance() {
+	var sum uint32
+
+	for _, w := range s.Services {
+		sum += w.Weight
+	}
+
+	if sum == 0 {
+		for i := range s.Services {
+			s.Services[i].Weight = 1
+		}
+	}
+}
+
 // Secret represents a K8s Secret for TLS usage as a DAG Vertex. A Secret is
 // a leaf in the DAG.
 type Secret struct {

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -25,7 +25,6 @@ import (
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/xds"
@@ -69,10 +68,10 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 	if anyPositive(service.MaxConnections, service.MaxPendingRequests, service.MaxRequests, service.MaxRetries) {
 		cluster.CircuitBreakers = &envoy_cluster.CircuitBreakers{
 			Thresholds: []*envoy_cluster.CircuitBreakers_Thresholds{{
-				MaxConnections:     u32nil(service.MaxConnections),
-				MaxPendingRequests: u32nil(service.MaxPendingRequests),
-				MaxRequests:        u32nil(service.MaxRequests),
-				MaxRetries:         u32nil(service.MaxRetries),
+				MaxConnections:     protobuf.UInt32OrNil(service.MaxConnections),
+				MaxPendingRequests: protobuf.UInt32OrNil(service.MaxPendingRequests),
+				MaxRequests:        protobuf.UInt32OrNil(service.MaxRequests),
+				MaxRetries:         protobuf.UInt32OrNil(service.MaxRetries),
 			}},
 		}
 	}
@@ -250,17 +249,6 @@ func anyPositive(first uint32, rest ...uint32) bool {
 		}
 	}
 	return false
-}
-
-// u32nil creates a *types.UInt32Value containing v.
-// u33nil returns nil if v is zero.
-func u32nil(val uint32) *wrappers.UInt32Value {
-	switch val {
-	case 0:
-		return nil
-	default:
-		return protobuf.UInt32(val)
-	}
 }
 
 // ClusterCommonLBConfig creates a *v2.Cluster_CommonLbConfig with HealthyPanicThreshold disabled.

--- a/internal/envoy/cluster_test.go
+++ b/internal/envoy/cluster_test.go
@@ -22,7 +22,6 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/xds"
@@ -395,8 +394,8 @@ func TestCluster(t *testing.T) {
 				HealthChecks: []*envoy_api_v2_core.HealthCheck{{
 					Timeout:            durationOrDefault(2, hcTimeout),
 					Interval:           durationOrDefault(10, hcInterval),
-					UnhealthyThreshold: countOrDefault(3, hcUnhealthyThreshold),
-					HealthyThreshold:   countOrDefault(2, hcHealthyThreshold),
+					UnhealthyThreshold: protobuf.UInt32OrDefault(3, hcUnhealthyThreshold),
+					HealthyThreshold:   protobuf.UInt32OrDefault(2, hcHealthyThreshold),
 					HealthChecker: &envoy_api_v2_core.HealthCheck_TcpHealthCheck_{
 						TcpHealthCheck: &envoy_api_v2_core.HealthCheck_TcpHealthCheck{},
 					},
@@ -612,11 +611,6 @@ func TestAnyPositive(t *testing.T) {
 	assert.Equal(t, false, anyPositive(0, 0))
 	assert.Equal(t, true, anyPositive(1, 0))
 	assert.Equal(t, true, anyPositive(0, 1))
-}
-
-func TestU32nil(t *testing.T) {
-	assert.Equal(t, (*wrappers.UInt32Value)(nil), u32nil(0))
-	assert.Equal(t, protobuf.UInt32(1), u32nil(1))
 }
 
 func TestClusterCommonLBConfig(t *testing.T) {

--- a/internal/envoy/healthcheck.go
+++ b/internal/envoy/healthcheck.go
@@ -18,7 +18,6 @@ import (
 
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/protobuf"
 )
@@ -45,8 +44,8 @@ func httpHealthCheck(cluster *dag.Cluster) *envoy_api_v2_core.HealthCheck {
 	return &envoy_api_v2_core.HealthCheck{
 		Timeout:            durationOrDefault(hc.Timeout, hcTimeout),
 		Interval:           durationOrDefault(hc.Interval, hcInterval),
-		UnhealthyThreshold: countOrDefault(hc.UnhealthyThreshold, hcUnhealthyThreshold),
-		HealthyThreshold:   countOrDefault(hc.HealthyThreshold, hcHealthyThreshold),
+		UnhealthyThreshold: protobuf.UInt32OrDefault(hc.UnhealthyThreshold, hcUnhealthyThreshold),
+		HealthyThreshold:   protobuf.UInt32OrDefault(hc.HealthyThreshold, hcHealthyThreshold),
 		HealthChecker: &envoy_api_v2_core.HealthCheck_HttpHealthCheck_{
 			HttpHealthCheck: &envoy_api_v2_core.HealthCheck_HttpHealthCheck{
 				Path: hc.Path,
@@ -63,8 +62,8 @@ func tcpHealthCheck(cluster *dag.Cluster) *envoy_api_v2_core.HealthCheck {
 	return &envoy_api_v2_core.HealthCheck{
 		Timeout:            durationOrDefault(hc.Timeout, hcTimeout),
 		Interval:           durationOrDefault(hc.Interval, hcInterval),
-		UnhealthyThreshold: countOrDefault(hc.UnhealthyThreshold, hcUnhealthyThreshold),
-		HealthyThreshold:   countOrDefault(hc.HealthyThreshold, hcHealthyThreshold),
+		UnhealthyThreshold: protobuf.UInt32OrDefault(hc.UnhealthyThreshold, hcUnhealthyThreshold),
+		HealthyThreshold:   protobuf.UInt32OrDefault(hc.HealthyThreshold, hcHealthyThreshold),
 		HealthChecker: &envoy_api_v2_core.HealthCheck_TcpHealthCheck_{
 			TcpHealthCheck: &envoy_api_v2_core.HealthCheck_TcpHealthCheck{},
 		},
@@ -76,13 +75,4 @@ func durationOrDefault(d, def time.Duration) *duration.Duration {
 		return protobuf.Duration(d)
 	}
 	return protobuf.Duration(def)
-}
-
-func countOrDefault(count uint32, def uint32) *wrappers.UInt32Value {
-	switch count {
-	case 0:
-		return protobuf.UInt32(def)
-	default:
-		return protobuf.UInt32(count)
-	}
 }

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -40,6 +40,26 @@ func UInt32(val uint32) *wrappers.UInt32Value {
 	}
 }
 
+// UInt32OrDefault returns a wrapped UInt32Value. If val is 0, def is wrapped and returned.
+func UInt32OrDefault(val uint32, def uint32) *wrappers.UInt32Value {
+	switch val {
+	case 0:
+		return UInt32(def)
+	default:
+		return UInt32(val)
+	}
+}
+
+// UInt32OrNil returns a wrapped UInt32Value. If val is 0, nil is returned
+func UInt32OrNil(val uint32) *wrappers.UInt32Value {
+	switch val {
+	case 0:
+		return nil
+	default:
+		return UInt32(val)
+	}
+}
+
 // Bool converts a bool to a pointer to a wrappers.BoolValue.
 func Bool(val bool) *wrappers.BoolValue {
 	return &wrappers.BoolValue{

--- a/internal/protobuf/helpers_test.go
+++ b/internal/protobuf/helpers_test.go
@@ -1,0 +1,18 @@
+package protobuf
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestU32Nil(t *testing.T) {
+	assert.Equal(t, (*wrappers.UInt32Value)(nil), UInt32OrNil(0))
+	assert.Equal(t, UInt32(1), UInt32OrNil(1))
+}
+
+func TestU32Default(t *testing.T) {
+	assert.Equal(t, UInt32(99), UInt32OrDefault(0, 99))
+	assert.Equal(t, UInt32(1), UInt32OrDefault(1, 99))
+}


### PR DESCRIPTION
Make ServiceCluster weights consistent with HTTPProxy Route weights. If
no weights are specified, distribute the load equally, otherwise take
the weights as specified by the users. In the latter case, 0 is a valid
weight and removes all traffic from that destination.

Hoist the 2 helpers for marshaling protobuf uint32 wrappers into the
`protobuf` package since they are part of an API family we now use one
of them in the endpoints handler.

This updates #2713.

Signed-off-by: James Peach <jpeach@vmware.com>