### PR TITLE
internal/k8s: add ExtensionService to Kind helpers

### DIFF
--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -15,6 +15,7 @@ package k8s
 
 import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -43,6 +44,8 @@ func KindOf(obj interface{}) string {
 			return "HTTPProxy"
 		case *projectcontour.TLSCertificateDelegation:
 			return "TLSCertificateDelegation"
+		case *v1alpha1.ExtensionService:
+			return "ExtensionService"
 		case *unstructured.Unstructured:
 			return obj.GetKind()
 		default:
@@ -68,6 +71,8 @@ func VersionOf(obj interface{}) string {
 			return v1beta1.SchemeGroupVersion.String()
 		case *projectcontour.HTTPProxy, *projectcontour.TLSCertificateDelegation:
 			return projectcontour.GroupVersion.String()
+		case *v1alpha1.ExtensionService:
+			return v1alpha1.GroupVersion.String()
 		case *unstructured.Unstructured:
 			return obj.GetAPIVersion()
 		default:

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -22,6 +23,7 @@ func TestKindOf(t *testing.T) {
 		{"Ingress", &v1beta1.Ingress{}},
 		{"HTTPProxy", &projectcontour.HTTPProxy{}},
 		{"TLSCertificateDelegation", &projectcontour.TLSCertificateDelegation{}},
+		{"ExtensionService", &v1alpha1.ExtensionService{}},
 		{"Foo", &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "test.projectcontour.io/v1",
@@ -46,6 +48,7 @@ func TestVersionOf(t *testing.T) {
 		{"networking.k8s.io/v1beta1", &v1beta1.Ingress{}},
 		{"projectcontour.io/v1", &projectcontour.HTTPProxy{}},
 		{"projectcontour.io/v1", &projectcontour.TLSCertificateDelegation{}},
+		{"projectcontour.io/v1alpha1", &v1alpha1.ExtensionService{}},
 		{"test.projectcontour.io/v1", &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "test.projectcontour.io/v1",


### PR DESCRIPTION
Add ExtensionService to the builtin Kubernetes type helpers for accessing
the resource kind and version.

This updates #2713.

Signed-off-by: James Peach <jpeach@vmware.com>