### PR TITLE
[WIP] move builder caches into DAG

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -6721,25 +6721,17 @@ func TestBuilderRunsProcessorsInOrder(t *testing.T) {
 
 	b := Builder{
 		Processors: []Processor{
-			&pluggableProcessor{runFunc: func(_ *Builder) { got = append(got, "foo") }},
-			&pluggableProcessor{runFunc: func(_ *Builder) { got = append(got, "bar") }},
-			&pluggableProcessor{runFunc: func(_ *Builder) { got = append(got, "baz") }},
-			&pluggableProcessor{runFunc: func(_ *Builder) { got = append(got, "abc") }},
-			&pluggableProcessor{runFunc: func(_ *Builder) { got = append(got, "def") }},
+			ProcessorFunc(func(*DAG, *Builder) { got = append(got, "foo") }),
+			ProcessorFunc(func(*DAG, *Builder) { got = append(got, "bar") }),
+			ProcessorFunc(func(*DAG, *Builder) { got = append(got, "baz") }),
+			ProcessorFunc(func(*DAG, *Builder) { got = append(got, "abc") }),
+			ProcessorFunc(func(*DAG, *Builder) { got = append(got, "def") }),
 		},
 	}
 
 	b.Build()
 
 	assert.Equal(t, []string{"foo", "bar", "baz", "abc", "def"}, got)
-}
-
-type pluggableProcessor struct {
-	runFunc func(builder *Builder)
-}
-
-func (p *pluggableProcessor) Run(builder *Builder) {
-	p.runFunc(builder)
 }
 
 func routes(routes ...*Route) map[string]*Route {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -69,6 +69,9 @@ type DAG struct {
 
 	// status computed while building this dag.
 	statuses map[types.NamespacedName]Status
+
+	virtualhosts       map[string]*VirtualHost
+	securevirtualhosts map[string]*SecureVirtualHost
 }
 
 // Visit calls fn on each root of this DAG.
@@ -76,6 +79,56 @@ func (d *DAG) Visit(fn func(Vertex)) {
 	for _, r := range d.roots {
 		fn(r)
 	}
+}
+
+func (d *DAG) GetOrAddVirtualHost(name string) *VirtualHost {
+	vh, ok := d.virtualhosts[name]
+	if !ok {
+		vh := &VirtualHost{
+			Name: name,
+		}
+		d.virtualhosts[vh.Name] = vh
+		return vh
+	}
+	return vh
+}
+
+func (d *DAG) GetVirtualHost(name string) *VirtualHost {
+	return d.virtualhosts[name]
+}
+
+func (d *DAG) ListVirtualHosts() []*VirtualHost {
+	res := make([]*VirtualHost, 0, len(d.virtualhosts))
+	for _, vh := range d.virtualhosts {
+		res = append(res, vh)
+	}
+	return res
+}
+
+func (d *DAG) GetOrAddSecureVirtualHost(name string) *SecureVirtualHost {
+	svh, ok := d.securevirtualhosts[name]
+	if !ok {
+		svh := &SecureVirtualHost{
+			VirtualHost: VirtualHost{
+				Name: name,
+			},
+		}
+		d.securevirtualhosts[svh.VirtualHost.Name] = svh
+		return svh
+	}
+	return svh
+}
+
+func (d *DAG) GetSecureVirtualHost(name string) *SecureVirtualHost {
+	return d.securevirtualhosts[name]
+}
+
+func (d *DAG) ListSecureVirtualHosts() []*SecureVirtualHost {
+	res := make([]*SecureVirtualHost, 0, len(d.securevirtualhosts))
+	for _, svh := range d.securevirtualhosts {
+		res = append(res, svh)
+	}
+	return res
 }
 
 // Statuses returns a slice of Status objects associated with

--- a/internal/dag/listener_processor.go
+++ b/internal/dag/listener_processor.go
@@ -19,17 +19,20 @@ import "sort"
 // the DAG builder if there are virtual hosts and secure
 // virtual hosts already defined in the builder.
 type ListenerProcessor struct {
+	dag     *DAG
 	builder *Builder
 }
 
 // Run adds HTTP and HTTPS listeners to the DAG builder
 // if there are virtual hosts and secure virtual hosts already
 // defined in the builder.
-func (p *ListenerProcessor) Run(builder *Builder) {
+func (p *ListenerProcessor) Run(dag *DAG, builder *Builder) {
+	p.dag = dag
 	p.builder = builder
 
 	// reset the processor when we're done
 	defer func() {
+		p.dag = nil
 		p.builder = nil
 	}()
 
@@ -48,9 +51,9 @@ func (p *ListenerProcessor) Run(builder *Builder) {
 // The list of virtual hosts will attached to the listener will be sorted
 // by hostname.
 func (p *ListenerProcessor) buildHTTPListener() *Listener {
-	var virtualhosts = make([]Vertex, 0, len(p.builder.virtualhosts))
+	var virtualhosts []Vertex
 
-	for _, vh := range p.builder.virtualhosts {
+	for _, vh := range p.dag.ListVirtualHosts() {
 		if vh.Valid() {
 			virtualhosts = append(virtualhosts, vh)
 		}
@@ -68,8 +71,9 @@ func (p *ListenerProcessor) buildHTTPListener() *Listener {
 // The list of virtual hosts will attached to the listener will be sorted
 // by hostname.
 func (p *ListenerProcessor) buildHTTPSListener() *Listener {
-	var virtualhosts = make([]Vertex, 0, len(p.builder.securevirtualhosts))
-	for _, svh := range p.builder.securevirtualhosts {
+	var virtualhosts []Vertex
+
+	for _, svh := range p.dag.ListSecureVirtualHosts() {
 		if svh.Valid() {
 			virtualhosts = append(virtualhosts, svh)
 		}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Updates #2226 

This is a WIP for moving the DAG builder caches into the `DAG` struct directly. So far, I've only moved two of them, just to illustrate what I was thinking.

If this looks reasonable, then I can move `services` and `listeners` over too (`services` is a little tricky since there are related `Builder` methods that access both the `KubernetesCache` and the `services` map, but I'll sort it out).

This could get us to something like the following, where the `Builder` is just orchestrating calls to the `Processors` and the `Processors` no longer depend on the `Builder`:

```go
// Processor constructs part of a DAG.
type Processor interface {
	// Run executes the processor with the given DAG.
	Run(dag *DAG)
}

// Build builds and returns a new DAG by running the
// configured DAG processors, in order.
func (b *Builder) Build() *DAG {
	dag := &DAG{
		virtualhosts:       make(map[string]*VirtualHost),
		securevirtualhosts: make(map[string]*SecureVirtualHost),
                ...
	}

	for _, p := range b.Processors {
		p.Run(dag)
	}
        
        return dag
}
```

The `Processors` would probably be instantiated with a `KubernetesCache`, a `StatusWriter` (if needed), and a `logrus.FieldLogger` so those wouldn't have to come from the `Builder`.

Let me know what you think!