### PR TITLE
makefile: Update checkall task to vendor go modules before running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ export GO111MODULE=on
 check: install check-test check-test-race ## Install and run tests
 
 .PHONY: checkall
-checkall: check lint check-generate
+checkall: vendor check lint check-generate
 
 install: ## Build and install the contour binary
 	go install -mod=readonly -v -ldflags="$(GO_LDFLAGS)" $(GO_TAGS) $(MODULE)/cmd/contour
@@ -83,6 +83,10 @@ race:
 
 download: ## Download Go modules
 	go mod download
+
+## Vendor Go modules
+vendor:
+	go mod vendor
 
 container: ## Build the Contour container image
 	docker build \


### PR DESCRIPTION
The `lint` task fails when a previous vendor directory is out of date resulting in having to run `go mod vendor` manually, then run the `checkall` task again. This has the vendor step happen automatically to solve that problem. 

Signed-off-by: Steve Sloka <slokas@vmware.com>