### PR TITLE
internal/dag: Change status mechanisms to be ready for Conditions

### DIFF
--- a/apis/projectcontour/v1/doc.go
+++ b/apis/projectcontour/v1/doc.go
@@ -13,7 +13,7 @@
 
 // +k8s:deepcopy-gen=package
 
-// This package holds the specification for the projectcontour.io Custom Resource Definitions (CRDs).
+// Package v1 holds the specification for the projectcontour.io Custom Resource Definitions (CRDs).
 //
 // In building this CRD, we've inadvertently overloaded the word "Condition", so we've tried to make
 // this spec clear as to which types of condition are which.

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -222,7 +222,7 @@ func (e *EventHandler) rebuildDAG() {
 }
 
 // setStatus updates the status of objects.
-func (e *EventHandler) setStatus(statuses map[types.NamespacedName]dag.Status) {
+func (e *EventHandler) setStatus(statuses map[types.NamespacedName]dag.ProxyStatusUpdate) {
 	for _, st := range statuses {
 		switch obj := st.Object.(type) {
 		case *projcontour.HTTPProxy:

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -87,7 +87,7 @@ func (m *RebuildMetricsObserver) OnChange(d *dag.DAG) {
 	}
 }
 
-func calculateRouteMetric(statuses map[types.NamespacedName]dag.Status) metrics.RouteMetric {
+func calculateRouteMetric(statuses map[types.NamespacedName]dag.ProxyStatusUpdate) metrics.RouteMetric {
 	proxyMetricTotal := make(map[metrics.Meta]int)
 	proxyMetricValid := make(map[metrics.Meta]int)
 	proxyMetricInvalid := make(map[metrics.Meta]int)
@@ -113,7 +113,7 @@ func calculateRouteMetric(statuses map[types.NamespacedName]dag.Status) metrics.
 	}
 }
 
-func calcMetrics(v dag.Status, metricValid map[metrics.Meta]int, metricInvalid map[metrics.Meta]int, metricOrphaned map[metrics.Meta]int, metricTotal map[metrics.Meta]int) {
+func calcMetrics(v dag.ProxyStatusUpdate, metricValid map[metrics.Meta]int, metricInvalid map[metrics.Meta]int, metricOrphaned map[metrics.Meta]int, metricTotal map[metrics.Meta]int) {
 	switch v.Status {
 	case k8s.StatusValid:
 		metricValid[metrics.Meta{VHost: v.Vhost, Namespace: v.Object.GetObjectMeta().GetNamespace()}]++

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -73,7 +73,7 @@ func (b *Builder) Build() *DAG {
 		dag.roots = append(dag.roots, b.listeners[i])
 	}
 
-	dag.statuses = b.statuses
+	dag.statuses = b.proxyStatuses
 	return &dag
 }
 
@@ -84,7 +84,7 @@ func (b *Builder) reset() {
 	b.securevirtualhosts = make(map[string]*SecureVirtualHost)
 	b.listeners = []*Listener{}
 
-	b.statuses = make(map[types.NamespacedName]Status, len(b.statuses))
+	b.proxyStatuses = make(map[types.NamespacedName]ProxyStatusUpdate, len(b.proxyStatuses))
 }
 
 // lookupService returns a Service that matches the Meta and Port of the Kubernetes' Service,

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -68,7 +68,7 @@ type DAG struct {
 	roots []Vertex
 
 	// status computed while building this dag.
-	statuses map[types.NamespacedName]Status
+	statuses map[types.NamespacedName]ProxyStatusUpdate
 }
 
 // Visit calls fn on each root of this DAG.
@@ -80,7 +80,7 @@ func (d *DAG) Visit(fn func(Vertex)) {
 
 // Statuses returns a slice of Status objects associated with
 // the computation of this DAG.
-func (d *DAG) Statuses() map[types.NamespacedName]Status {
+func (d *DAG) Statuses() map[types.NamespacedName]ProxyStatusUpdate {
 	return d.statuses
 }
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1692,11 +1692,11 @@ func TestDAGStatus(t *testing.T) {
 	tests := map[string]struct {
 		objs                []interface{}
 		fallbackCertificate *types.NamespacedName
-		want                map[types.NamespacedName]Status
+		want                map[types.NamespacedName]ProxyStatusUpdate
 	}{
 		"proxy has multiple includes, one is invalid": {
 			objs: []interface{}{proxyMultiIncludeOneInvalid, proxyChildValidFoo2, proxyChildInvalidBadPort, serviceFoo2, serviceFoo3InvalidPort},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyChildValidFoo2.Name, Namespace: proxyChildValidFoo2.Namespace}:                 {Object: proxyChildValidFoo2, Status: "valid", Description: "valid HTTPProxy"},
 				{Name: proxyChildInvalidBadPort.Name, Namespace: proxyChildInvalidBadPort.Namespace}:       {Object: proxyChildInvalidBadPort, Status: "invalid", Description: `service "foo3": port must be in the range 1-65535`},
 				{Name: proxyMultiIncludeOneInvalid.Name, Namespace: proxyMultiIncludeOneInvalid.Namespace}: {Object: proxyMultiIncludeOneInvalid, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
@@ -1704,7 +1704,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"multi-parent children is not orphaned when one of the parents is invalid": {
 			objs: []interface{}{proxyNoFQDN, proxyChildValidFoo2, proxyIncludeValidChild, serviceKuard, serviceFoo2},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyNoFQDN.Name, Namespace: proxyNoFQDN.Namespace}:                       {Object: proxyNoFQDN, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 				{Name: proxyChildValidFoo2.Name, Namespace: proxyChildValidFoo2.Namespace}:       {Object: proxyChildValidFoo2, Status: "valid", Description: "valid HTTPProxy"},
 				{Name: proxyIncludeValidChild.Name, Namespace: proxyIncludeValidChild.Namespace}: {Object: proxyIncludeValidChild, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
@@ -1715,7 +1715,7 @@ func TestDAGStatus(t *testing.T) {
 			objs: []interface{}{
 				secretRootsNS, serviceNginx, ingressSharedService, proxyTCPSharedService,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyTCPSharedService.Name, Namespace: proxyTCPSharedService.Namespace}: {
 					Object:      proxyTCPSharedService,
 					Status:      k8s.StatusValid,
@@ -1730,7 +1730,7 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxyDelegatedTCPTLS,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyDelegatedTCPTLS.Name, Namespace: proxyDelegatedTCPTLS.Namespace}: {
 					Object:      proxyDelegatedTCPTLS,
 					Status:      k8s.StatusInvalid,
@@ -1745,7 +1745,7 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxyDelegatedTLS,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyDelegatedTLS.Name, Namespace: proxyDelegatedTLS.Namespace}: {
 					Object:      proxyDelegatedTLS,
 					Status:      k8s.StatusInvalid,
@@ -1760,7 +1760,7 @@ func TestDAGStatus(t *testing.T) {
 				secretContourNS,
 				proxy19,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy19.Name, Namespace: proxy19.Namespace}: {
 					Object:      proxy19,
 					Status:      k8s.StatusInvalid,
@@ -1775,7 +1775,7 @@ func TestDAGStatus(t *testing.T) {
 				s10,
 				proxyPassthroughProxyNonSecure,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyPassthroughProxyNonSecure.Name, Namespace: proxyPassthroughProxyNonSecure.Namespace}: {
 					Object:      proxyPassthroughProxyNonSecure,
 					Status:      k8s.StatusValid,
@@ -1788,7 +1788,7 @@ func TestDAGStatus(t *testing.T) {
 			objs: []interface{}{
 				serviceKuard, proxyMultipleIncludersSite1, proxyMultipleIncludersSite2, proxyMultiIncludeChild,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyMultipleIncludersSite1.Name, Namespace: proxyMultipleIncludersSite1.Namespace}: {
 					Object:      proxyMultipleIncludersSite1,
 					Status:      "valid",
@@ -1810,31 +1810,31 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"valid proxy": {
 			objs: []interface{}{proxy1, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy1.Name, Namespace: proxy1.Namespace}: {Object: proxy1, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 			},
 		},
 		"proxy invalid port in service": {
 			objs: []interface{}{proxy2},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy2.Name, Namespace: proxy2.Namespace}: {Object: proxy2, Status: "invalid", Description: `service "home": port must be in the range 1-65535`, Vhost: "example.com"},
 			},
 		},
 		"root proxy outside of roots namespace": {
 			objs: []interface{}{proxy3},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy3.Name, Namespace: proxy3.Namespace}: {Object: proxy3, Status: "invalid", Description: "root HTTPProxy cannot be defined in this namespace"},
 			},
 		},
 		"root proxy does not specify FQDN": {
 			objs: []interface{}{proxyNoFQDN},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyNoFQDN.Name, Namespace: proxyNoFQDN.Namespace}: {Object: proxyNoFQDN, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 			},
 		},
 		"proxy self-edge produces a cycle": {
 			objs: []interface{}{proxy6, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy6.Name, Namespace: proxy6.Namespace}: {
 					Object:      proxy6,
 					Status:      "invalid",
@@ -1845,7 +1845,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy child delegates to parent, producing a cycle": {
 			objs: []interface{}{proxy7, proxy8},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy7.Name, Namespace: proxy7.Namespace}: {
 					Object:      proxy7,
 					Status:      "valid",
@@ -1861,26 +1861,26 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy orphaned route": {
 			objs: []interface{}{proxy8},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy8.Name, Namespace: proxy8.Namespace}: {Object: proxy8, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy"},
 			},
 		},
 		"proxy invalid parent orphans children": {
 			objs: []interface{}{proxy14, proxy11},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy14.Name, Namespace: proxy14.Namespace}: {Object: proxy14, Status: "invalid", Description: "Spec.VirtualHost.Fqdn must be specified"},
 				{Name: proxy11.Name, Namespace: proxy11.Namespace}: {Object: proxy11, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy"},
 			},
 		},
 		"proxy invalid FQDN contains wildcard": {
 			objs: []interface{}{proxy15},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy15.Name, Namespace: proxy15.Namespace}: {Object: proxy15, Status: "invalid", Description: `Spec.VirtualHost.Fqdn "example.*.com" cannot use wildcards`, Vhost: "example.*.com"},
 			},
 		},
 		"proxy missing service shows invalid status": {
 			objs: []interface{}{proxy16},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy16.Name, Namespace: proxy16.Namespace}: {
 					Object:      proxy16,
 					Status:      "invalid",
@@ -1891,7 +1891,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with service missing port shows invalid status": {
 			objs: []interface{}{proxy16a, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy16a.Name, Namespace: proxy16a.Namespace}: {
 					Object:      proxy16a,
 					Status:      "invalid",
@@ -1902,7 +1902,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"insert conflicting proxies due to fqdn reuse": {
 			objs: []interface{}{proxy17, proxy18},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy17.Name, Namespace: proxy17.Namespace}: {
 					Object:      proxy17,
 					Status:      k8s.StatusInvalid,
@@ -1919,7 +1919,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"root proxy including another root": {
 			objs: []interface{}{proxy20, proxy21},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy20.Name, Namespace: proxy20.Namespace}: {
 					Object:      proxy20,
 					Status:      k8s.StatusInvalid,
@@ -1936,7 +1936,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"root proxy including another root w/ different hostname": {
 			objs: []interface{}{proxy22, proxy23, serviceGreenMarketing},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy22.Name, Namespace: proxy22.Namespace}: {
 					Object:      proxy22,
 					Status:      k8s.StatusInvalid,
@@ -1953,7 +1953,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy includes another": {
 			objs: []interface{}{proxyBlogMarketing, proxy25, serviceKuard, serviceGreenMarketing},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxyBlogMarketing.Name, Namespace: proxyBlogMarketing.Namespace}: {
 					Object:      proxyBlogMarketing,
 					Status:      "valid",
@@ -1969,7 +1969,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with mirror": {
 			objs: []interface{}{proxy26, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy26.Name, Namespace: proxy26.Namespace}: {
 					Object:      proxy26,
 					Status:      "valid",
@@ -1980,7 +1980,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two mirrors": {
 			objs: []interface{}{proxy27, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy27.Name, Namespace: proxy27.Namespace}: {
 					Object:      proxy27,
 					Status:      "invalid",
@@ -1991,7 +1991,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two prefix conditions on route": {
 			objs: []interface{}{proxy32, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy32.Name, Namespace: proxy32.Namespace}: {
 					Object:      proxy32,
 					Status:      "invalid",
@@ -2002,7 +2002,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with two prefix conditions as an include": {
 			objs: []interface{}{proxy33, proxy34, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy33.Name, Namespace: proxy33.Namespace}: {
 					Object:      proxy33,
 					Status:      "invalid",
@@ -2017,7 +2017,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with prefix conditions on route that does not start with slash": {
 			objs: []interface{}{proxy35, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy35.Name, Namespace: proxy35.Namespace}: {
 					Object:      proxy35,
 					Status:      "invalid",
@@ -2028,7 +2028,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"proxy with include prefix that does not start with slash": {
 			objs: []interface{}{proxy36, proxy34, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy36.Name, Namespace: proxy36.Namespace}: {
 					Object:      proxy36,
 					Status:      "invalid",
@@ -2043,26 +2043,26 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate route condition headers": {
 			objs: []interface{}{proxy28, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy28.Name, Namespace: proxy28.Namespace}: {Object: proxy28, Status: "invalid", Description: "cannot specify duplicate header 'exact match' conditions in the same route", Vhost: "example.com"},
 			},
 		},
 		"duplicate valid route condition headers": {
 			objs: []interface{}{proxy31, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy31.Name, Namespace: proxy31.Namespace}: {Object: proxy31, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 			},
 		},
 		"duplicate include condition headers": {
 			objs: []interface{}{proxy29, proxy30, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy29.Name, Namespace: proxy29.Namespace}: {Object: proxy29, Status: "valid", Description: "valid HTTPProxy", Vhost: "example.com"},
 				{Name: proxy30.Name, Namespace: proxy30.Namespace}: {Object: proxy30, Status: "invalid", Description: "cannot specify duplicate header 'exact match' conditions in the same route", Vhost: ""},
 			},
 		},
 		"duplicate path conditions on an include": {
 			objs: []interface{}{proxy41, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy41.Name, Namespace: proxy41.Namespace}:   {Object: proxy41, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2070,7 +2070,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate header conditions on an include": {
 			objs: []interface{}{proxy42, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy42.Name, Namespace: proxy42.Namespace}:   {Object: proxy42, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2078,7 +2078,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"duplicate header+path conditions on an include": {
 			objs: []interface{}{proxy43, proxy41a, proxy41b, serviceHome, sericeKuardTeamA, serviceKuardTeamB},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy43.Name, Namespace: proxy43.Namespace}:   {Object: proxy43, Status: "invalid", Description: "duplicate conditions defined on an include", Vhost: "example.com"},
 				{Name: proxy41a.Name, Namespace: proxy41a.Namespace}: {Object: proxy41a, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
 				{Name: proxy41b.Name, Namespace: proxy41b.Namespace}: {Object: proxy41b, Status: "orphaned", Description: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy", Vhost: ""},
@@ -2086,7 +2086,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy with invalid tcpproxy": {
 			objs: []interface{}{proxy37, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy37.Name, Namespace: proxy37.Namespace}: {
 					Object:      proxy37,
 					Status:      "invalid",
@@ -2097,7 +2097,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy with empty tcpproxy": {
 			objs: []interface{}{proxy37a, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy37a.Name, Namespace: proxy37a.Namespace}: {
 					Object:      proxy37a,
 					Status:      "invalid",
@@ -2108,7 +2108,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ missing include": {
 			objs: []interface{}{proxy38, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "invalid",
@@ -2119,7 +2119,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ includes another root": {
 			objs: []interface{}{proxy38, proxy39, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "invalid",
@@ -2136,7 +2136,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ includes valid child": {
 			objs: []interface{}{proxy38, proxy40, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy38.Name, Namespace: proxy38.Namespace}: {
 					Object:      proxy38,
 					Status:      "valid",
@@ -2153,7 +2153,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ missing include": {
 			objs: []interface{}{proxy44, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy44.Name, Namespace: proxy44.Namespace}: {
 					Object:      proxy44,
 					Status:      "invalid",
@@ -2164,7 +2164,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ missing service": {
 			objs: []interface{}{proxy45},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy45.Name, Namespace: proxy45.Namespace}: {
 					Object:      proxy45,
 					Status:      "invalid",
@@ -2175,7 +2175,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy w/ service missing port": {
 			objs: []interface{}{proxy45a, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy45a.Name, Namespace: proxy45a.Namespace}: {
 					Object:      proxy45a,
 					Status:      "invalid",
@@ -2186,7 +2186,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing tls": {
 			objs: []interface{}{proxy46},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy46.Name, Namespace: proxy46.Namespace}: {
 					Object:      proxy46,
 					Status:      "invalid",
@@ -2197,7 +2197,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing service": {
 			objs: []interface{}{secretRootsNS, serviceKuard, proxy47},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy47.Name, Namespace: proxy47.Namespace}: {
 					Object:      proxy47,
 					Status:      "invalid",
@@ -2208,7 +2208,7 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"httpproxy w/ tcpproxy missing service port": {
 			objs: []interface{}{secretRootsNS, serviceKuard, proxy47a},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy47a.Name, Namespace: proxy47a.Namespace}: {
 					Object:      proxy47a,
 					Status:      "invalid",
@@ -2222,7 +2222,7 @@ func TestDAGStatus(t *testing.T) {
 				secretRootsNS,
 				tlsPassthroughAndSecretName,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: "invalid", Namespace: serviceKuard.Namespace}: {
 					Object:      tlsPassthroughAndSecretName,
 					Status:      "invalid",
@@ -2236,7 +2236,7 @@ func TestDAGStatus(t *testing.T) {
 				secretRootsNS,
 				tlsNoPassthroughOrSecretName,
 			},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: "invalid", Namespace: serviceKuard.Namespace}: {
 					Object:      tlsNoPassthroughOrSecretName,
 					Status:      "invalid",
@@ -2247,14 +2247,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 		"valid HTTPProxy.TCPProxy": {
 			objs: []interface{}{proxy48root, proxy48child, serviceKuard, secretRootsNS},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy48root.Name, Namespace: proxy48root.Namespace}:   {Object: proxy48root, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 				{Name: proxy48child.Name, Namespace: proxy48child.Namespace}: {Object: proxy48child, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 			},
 		},
 		"valid HTTPProxy.TCPProxy - plural": {
 			objs: []interface{}{proxy48rootplural, proxy48child, serviceKuard, secretRootsNS},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy48rootplural.Name, Namespace: proxy48rootplural.Namespace}: {Object: proxy48rootplural, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 				{Name: proxy48child.Name, Namespace: proxy48child.Namespace}:           {Object: proxy48child, Status: "valid", Description: "valid HTTPProxy", Vhost: "tcpproxy.example.com"},
 			},
@@ -2262,7 +2262,7 @@ func TestDAGStatus(t *testing.T) {
 		// issue 2309, each route must have at least one service
 		"invalid HTTPProxy due to empty route.service": {
 			objs: []interface{}{proxy49, serviceKuard},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: proxy49.Name, Namespace: proxy49.Namespace}: {
 					Object:      proxy49,
 					Status:      "invalid",
@@ -2277,25 +2277,25 @@ func TestDAGStatus(t *testing.T) {
 				Namespace: "invalid",
 			},
 			objs: []interface{}{fallbackCertificate, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS Secret \"invalid/invalid\" fallback certificate is invalid: Secret not found", Vhost: "example.com"},
 			},
 		},
 		"fallback certificate requested but cert not configured in contour": {
 			objs: []interface{}{fallbackCertificate, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: fallbackCertificate.Name, Namespace: fallbackCertificate.Namespace}: {Object: fallbackCertificate, Status: "invalid", Description: "Spec.Virtualhost.TLS enabled fallback but the fallback Certificate Secret is not configured in Contour configuration file", Vhost: "example.com"},
 			},
 		},
 		"fallback certificate requested and clientValidation also configured": {
 			objs: []interface{}{fallbackCertificateWithClientValidation, fallbackSecret, secretRootsNS, serviceHome},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: fallbackCertificateWithClientValidation.Name, Namespace: fallbackCertificateWithClientValidation.Namespace}: {Object: fallbackCertificateWithClientValidation, Status: "invalid", Description: "Spec.Virtualhost.TLS fallback & client validation are incompatible together", Vhost: "example.com"},
 			},
 		},
 		"proxy with no routes, includes, or tcpproxy is invalid": {
 			objs: []interface{}{emptyProxy},
-			want: map[types.NamespacedName]Status{
+			want: map[types.NamespacedName]ProxyStatusUpdate{
 				{Name: emptyProxy.Name, Namespace: emptyProxy.Namespace}: {
 					Object:      emptyProxy,
 					Status:      "invalid",


### PR DESCRIPTION
This commit updates a number of pieces in `status.go` to be ready for adding conditions.
In general, these are to make the names clearer and to keep space for us to add further
support for other objects later as well.

`StatusUpdate` is renamed to `ProxyStatusUpdate` as it's only used for HTTPProxy.
`ObjectStatusWriter` is renamed to `ProxyStatusWriter`, for the same reason.

`StatusWriter`'s status cache has been renamed to `proxyStatuses` from `statuses`, in
case we want to use it for storing other object updates later.

Short values have been updated to reflect the new struct names (`osw` changed to `psw`, etc.)

`SetInvalid` has been updated to `AddInvalidCondition`, with a new `conditionType`
argument, that is currently only used to add some extra text into the `description`
field of the HTTPProxy. This will mean that further PRs should not need to touch the
HTTPProxy Processor.

This is currently a WIP however, the tests have not been updated yet. Since we
moved to `assert.Equal` for errors, the errors messages must now match for
tests to pass.

Signed-off-by: Nick Young <ynick@vmware.com>