### PR TITLE
internal/dag: move logger from builder to processors

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -233,14 +233,15 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		HoldoffMaxDelay: 500 * time.Millisecond,
 		Observer:        dag.ComposeObservers(append(contour.ObserversOf(resources), snapshotHandler)...),
 		Builder: dag.Builder{
-			FieldLogger: log.WithField("context", "builder"),
 			Source: dag.KubernetesCache{
 				RootNamespaces: ctx.proxyRootNamespaces(),
 				IngressClass:   ctx.ingressClass,
 				FieldLogger:    log.WithField("context", "KubernetesCache"),
 			},
 			Processors: []dag.Processor{
-				&dag.IngressProcessor{},
+				&dag.IngressProcessor{
+					FieldLogger: log.WithField("context", "IngressProcessor"),
+				},
 				&dag.HTTPProxyProcessor{
 					DisablePermitInsecure: ctx.DisablePermitInsecure,
 					FallbackCertificate:   fallbackCert,

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -40,13 +40,14 @@ func TestHTTPProxyMetrics(t *testing.T) {
 			t.Helper()
 
 			builder := dag.Builder{
-				FieldLogger: fixture.NewTestLogger(t),
 				Source: dag.KubernetesCache{
 					RootNamespaces: tc.rootNamespaces,
 					FieldLogger:    fixture.NewTestLogger(t),
 				},
 				Processors: []dag.Processor{
-					&dag.IngressProcessor{},
+					&dag.IngressProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
 					&dag.HTTPProxyProcessor{},
 					&dag.ListenerProcessor{},
 				},

--- a/internal/contour/secret_test.go
+++ b/internal/contour/secret_test.go
@@ -479,12 +479,13 @@ func TestSecretVisit(t *testing.T) {
 // buildDAG produces a dag.DAG from the supplied objects.
 func buildDAG(t *testing.T, objs ...interface{}) *dag.DAG {
 	builder := dag.Builder{
-		FieldLogger: fixture.NewTestLogger(t),
 		Source: dag.KubernetesCache{
 			FieldLogger: fixture.NewTestLogger(t),
 		},
 		Processors: []dag.Processor{
-			&dag.IngressProcessor{},
+			&dag.IngressProcessor{
+				FieldLogger: fixture.NewTestLogger(t),
+			},
 			&dag.HTTPProxyProcessor{},
 			&dag.ListenerProcessor{},
 		},
@@ -499,12 +500,13 @@ func buildDAG(t *testing.T, objs ...interface{}) *dag.DAG {
 // buildDAGFallback produces a dag.DAG from the supplied objects with a fallback cert configured.
 func buildDAGFallback(t *testing.T, fallbackCertificate *types.NamespacedName, objs ...interface{}) *dag.DAG {
 	builder := dag.Builder{
-		FieldLogger: fixture.NewTestLogger(t),
 		Source: dag.KubernetesCache{
 			FieldLogger: fixture.NewTestLogger(t),
 		},
 		Processors: []dag.Processor{
-			&dag.IngressProcessor{},
+			&dag.IngressProcessor{
+				FieldLogger: fixture.NewTestLogger(t),
+			},
 			&dag.HTTPProxyProcessor{
 				FallbackCertificate: fallbackCertificate,
 			},

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
-	"github.com/sirupsen/logrus"
 )
 
 type RouteServiceName struct {
@@ -55,7 +54,6 @@ type Builder struct {
 	listeners          []*Listener
 
 	StatusWriter
-	logrus.FieldLogger
 }
 
 // Build builds and returns a new DAG by running the

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -6162,12 +6162,13 @@ func TestDAGInsert(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			builder := Builder{
-				FieldLogger: fixture.NewTestLogger(t),
 				Source: KubernetesCache{
 					FieldLogger: fixture.NewTestLogger(t),
 				},
 				Processors: []Processor{
-					&IngressProcessor{},
+					&IngressProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
 					&HTTPProxyProcessor{
 						DisablePermitInsecure: tc.disablePermitInsecure,
 						FallbackCertificate: &types.NamespacedName{
@@ -6411,13 +6412,14 @@ func TestDAGRootNamespaces(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			builder := Builder{
-				FieldLogger: fixture.NewTestLogger(t),
 				Source: KubernetesCache{
 					RootNamespaces: tc.rootNamespaces,
 					FieldLogger:    fixture.NewTestLogger(t),
 				},
 				Processors: []Processor{
-					&IngressProcessor{},
+					&IngressProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
 					&HTTPProxyProcessor{},
 					&ListenerProcessor{},
 				},

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -25,6 +26,8 @@ import (
 // IngressProcessor translates Ingresses into DAG
 // objects and adds them to the DAG builder.
 type IngressProcessor struct {
+	logrus.FieldLogger
+
 	builder *Builder
 }
 
@@ -53,7 +56,7 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(ing.GetNamespace()))
 			sec, err := p.builder.Source.LookupSecret(secretName, validSecret)
 			if err != nil {
-				p.builder.WithError(err).
+				p.WithError(err).
 					WithField("name", ing.GetName()).
 					WithField("namespace", ing.GetNamespace()).
 					WithField("secret", secretName).
@@ -62,7 +65,7 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 			}
 
 			if !p.builder.Source.DelegationPermitted(secretName, ing.GetNamespace()) {
-				p.builder.WithError(err).
+				p.WithError(err).
 					WithField("name", ing.GetName()).
 					WithField("namespace", ing.GetNamespace()).
 					WithField("secret", secretName).

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2309,13 +2309,14 @@ func TestDAGStatus(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			builder := Builder{
-				FieldLogger: fixture.NewTestLogger(t),
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
 				},
 				Processors: []Processor{
-					&IngressProcessor{},
+					&IngressProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
 					&HTTPProxyProcessor{
 						FallbackCertificate: tc.fallbackCertificate,
 					},

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -97,7 +97,6 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 			NextObserver: dag.ComposeObservers(contour.ObserversOf(resources)...),
 		},
 		Builder: dag.Builder{
-			FieldLogger: fixture.NewTestLogger(t),
 			Source: dag.KubernetesCache{
 				FieldLogger: log,
 			},
@@ -105,7 +104,9 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	}
 
 	eh.Builder.Processors = []dag.Processor{
-		&dag.IngressProcessor{},
+		&dag.IngressProcessor{
+			FieldLogger: fixture.NewTestLogger(t),
+		},
 		&dag.HTTPProxyProcessor{},
 		&dag.ListenerProcessor{},
 	}


### PR DESCRIPTION
Removes the logrus.FieldLogger from the DAG builder and adds
it directly to the IngressProcessor where it's used.

Updates #2226

Signed-off-by: Steve Kriss <krisss@vmware.com>