### PR TITLE
internal/envoy: Set the dns lookup family on externalName type clusters

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -296,6 +296,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// register observer for endpoints updates.
 	endpointHandler.Observer = contour.ComposeObservers(snapshotHandler)
 
+	dnsLookupFamily, err := ParseDNSLookupFamily(ctx.DNSLookupFamily)
+	if err != nil {
+		return fmt.Errorf("failed to configure configuration file parameter cluster.dns-lookup-family: %w", err)
+	}
+
 	// Build the core Kubernetes event handler.
 	eventHandler := &contour.EventHandler{
 		HoldoffDelay:    100 * time.Millisecond,
@@ -317,6 +322,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 				&dag.HTTPProxyProcessor{
 					DisablePermitInsecure: ctx.DisablePermitInsecure,
 					FallbackCertificate:   fallbackCert,
+					DNSLookupFamily:       dnsLookupFamily,
 				},
 				&dag.ListenerProcessor{},
 			},

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -510,6 +511,49 @@ func TestParseHTTPVersions(t *testing.T) {
 
 			assert.Equal(t, testcase.parseError, err)
 			assert.Equal(t, testcase.parseVersions, vers)
+		})
+	}
+}
+
+func TestParseDNSLookupFamily(t *testing.T) {
+	cases := map[string]struct {
+		input         string
+		expectedError error
+		expected      string
+	}{
+		"empty": {
+			input:         "",
+			expectedError: nil,
+			expected:      "auto",
+		},
+		"auto": {
+			input:         "auto",
+			expectedError: nil,
+			expected:      "auto",
+		},
+		"v4": {
+			input:         "v4",
+			expectedError: nil,
+			expected:      "v4",
+		},
+		"v6": {
+			input:         "v6",
+			expectedError: nil,
+			expected:      "v6",
+		},
+		"invalid": {
+			input:         "abcdefg",
+			expectedError: fmt.Errorf("invalid dns lookup family \"abcdefg\" configured, defaulting to \"auto\""),
+			expected:      "auto",
+		},
+	}
+
+	for name, testcase := range cases {
+		testcase := testcase
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDNSLookupFamily(testcase.input)
+			assert.Equal(t, testcase.expectedError, err)
+			assert.Equal(t, testcase.expected, got)
 		})
 	}
 }

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -75,3 +75,9 @@ data:
     #   stream-idle-timeout: 5m
     #   max-connection-duration: infinity
     #   connection-shutdown-grace-period: 5s
+    #
+    # Envoy cluster settings.
+    # cluster:
+    #   configure the cluster dns lookup family
+    #   valid options are: auto (default), v4, v6
+    #   dns-lookup-family: auto

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -109,6 +109,12 @@ data:
     #   stream-idle-timeout: 5m
     #   max-connection-duration: infinity
     #   connection-shutdown-grace-period: 5s
+    #
+    # Envoy cluster settings.
+    # cluster:
+    #   configure the cluster dns lookup family
+    #   valid options are: auto (default), v4, v6
+    #   dns-lookup-family: auto
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -503,6 +503,16 @@ type Cluster struct {
 	// is used if the route is configured to proxy to an externalService type.
 	// If the value is not set, then SNI is not changed.
 	SNI string
+
+	// DNSLookupFamily defines how external names are looked up
+	// When configured as V4, the DNS resolver will only perform a lookup
+	// for addresses in the IPv4 family. If V6 is configured, the DNS resolver
+	// will only perform a lookup for addresses in the IPv6 family.
+	// If AUTO is configured, the DNS resolver will first perform a lookup
+	// for addresses in the IPv6 family and fallback to a lookup for addresses
+	// in the IPv4 family.
+	// Note: This only applies to externalName clusters.
+	DNSLookupFamily string
 }
 
 func (c Cluster) Visit(f func(Vertex)) {

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -53,6 +53,16 @@ type HTTPProxyProcessor struct {
 	// TLS secret to use by default when SNI is not set on a
 	// request.
 	FallbackCertificate *types.NamespacedName
+
+	// DNSLookupFamily defines how external names are looked up
+	// When configured as V4, the DNS resolver will only perform a lookup
+	// for addresses in the IPv4 family. If V6 is configured, the DNS resolver
+	// will only perform a lookup for addresses in the IPv6 family.
+	// If AUTO is configured, the DNS resolver will first perform a lookup
+	// for addresses in the IPv6 family and fallback to a lookup for addresses
+	// in the IPv4 family.
+	// Note: This only applies to externalName clusters.
+	DNSLookupFamily string
 }
 
 // Run translates HTTPProxies into DAG objects and
@@ -488,6 +498,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				ResponseHeadersPolicy: respHP,
 				Protocol:              protocol,
 				SNI:                   determineSNI(r.RequestHeadersPolicy, reqHP, s),
+				DNSLookupFamily:       p.DNSLookupFamily,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				sw.SetInvalid("only one service per route may be nominated as mirror")

--- a/internal/envoy/v2/cluster.go
+++ b/internal/envoy/v2/cluster.go
@@ -45,6 +45,7 @@ func Cluster(c *dag.Cluster) *v2.Cluster {
 	cluster.AltStatName = envoy.AltStatName(service)
 	cluster.LbPolicy = lbPolicy(c.LoadBalancerPolicy)
 	cluster.HealthChecks = edshealthcheck(c)
+	cluster.DnsLookupFamily = parseDNSLookupFamily(c.DNSLookupFamily)
 
 	switch len(service.ExternalName) {
 	case 0:
@@ -222,4 +223,16 @@ func ConfigSource(cluster string) *envoy_api_v2_core.ConfigSource {
 // ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
 func ClusterDiscoveryType(t v2.Cluster_DiscoveryType) *v2.Cluster_Type {
 	return &v2.Cluster_Type{Type: t}
+}
+
+// parseDNSLookupFamily parses the dnsLookupFamily string into a v2.Cluster_DnsLookupFamily
+func parseDNSLookupFamily(value string) v2.Cluster_DnsLookupFamily {
+
+	switch value {
+	case "v4":
+		return v2.Cluster_V4_ONLY
+	case "v6":
+		return v2.Cluster_V6_ONLY
+	}
+	return v2.Cluster_AUTO
 }

--- a/internal/envoy/v2/cluster_test.go
+++ b/internal/envoy/v2/cluster_test.go
@@ -157,6 +157,58 @@ func TestCluster(t *testing.T) {
 				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
 			},
 		},
+		"externalName service - dns-lookup-family v4": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "v4",
+			},
+			want: &v2.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(v2.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      v2.Cluster_V4_ONLY,
+			},
+		},
+		"externalName service - dns-lookup-family v6": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "v6",
+			},
+			want: &v2.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(v2.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      v2.Cluster_V6_ONLY,
+			},
+		},
+		"externalName service - dns-lookup-family auto": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "auto",
+			},
+			want: &v2.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(v2.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      v2.Cluster_AUTO,
+			},
+		},
+		"externalName service - dns-lookup-family not defined": {
+			cluster: &dag.Cluster{
+				Upstream: service(s2),
+				//DNSLookupFamily: "auto",
+			},
+			want: &v2.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(v2.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      v2.Cluster_AUTO,
+			},
+		},
 		"tls upstream": {
 			cluster: &dag.Cluster{
 				Upstream: service(s1, "tls"),

--- a/site/docs/main/api-reference.html
+++ b/site/docs/main/api-reference.html
@@ -1,12 +1,425 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#projectcontour.io%2fv1">projectcontour.io/v1</a>
-</li>
-<li>
 <a href="#projectcontour.io%2fv1alpha1">projectcontour.io/v1alpha1</a>
 </li>
+<li>
+<a href="#projectcontour.io%2fv1">projectcontour.io/v1</a>
+</li>
 </ul>
+<h2 id="projectcontour.io/v1alpha1">projectcontour.io/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the projectcontour.io v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>
+</li></ul>
+<h3 id="projectcontour.io/v1alpha1.ExtensionService">ExtensionService
+</h3>
+<p>
+<p>ExtensionService is the schema for the Contour extension services API.
+An ExtensionService resource binds a network service to the Contour
+API so that Contour API features can be implemented by collaborating
+components.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td>
+<code>apiVersion</code>
+<br>
+string</td>
+<td>
+<code>
+projectcontour.io/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code>
+<br>
+string
+</td>
+<td><code>ExtensionService</code></td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>metadata</code>
+<br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>spec</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">
+ExtensionServiceSpec
+</a>
+</em>
+</td>
+<td>
+<br>
+<br>
+<table style="border:none">
+<tr>
+<td style="white-space:nowrap">
+<code>services</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
+[]ExtensionServiceTarget
+</a>
+</em>
+</td>
+<td>
+<p>Services specifies the set of Kubernetes Service resources that
+receive GRPC extension API requests.
+If no weights are specified for any of the entries in
+this array, traffic will be spread evenly across all the
+services.
+Otherwise, traffic is balanced proportionally to the
+Weight field in each entry.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>validation</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.UpstreamValidation">
+UpstreamValidation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocol</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>loadBalancerPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.LoadBalancerPolicy">
+LoadBalancerPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The policy for load balancing GRPC service requests. Note
+that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>timeoutPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.TimeoutPolicy">
+TimeoutPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The timeout policy for requests to the services.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocolVersion</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
+ExtensionProtocolVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This field sets the version of the GRPC protocol that Envoy uses to
+send requests to the extension service. Since Contour always uses the
+v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+protocol options will be available in future.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>status</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceStatus">
+ExtensionServiceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionProtocolVersion">ExtensionProtocolVersion
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
+</p>
+<p>
+<p>ExtensionProtocolVersion is the version of the GRPC protocol used
+to access extension services. The only version currently supported
+is &ldquo;v2&rdquo;.</p>
+</p>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
+</p>
+<p>
+<p>ExtensionServiceSpec defines the desired state of an ExtensionService resource.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>services</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
+[]ExtensionServiceTarget
+</a>
+</em>
+</td>
+<td>
+<p>Services specifies the set of Kubernetes Service resources that
+receive GRPC extension API requests.
+If no weights are specified for any of the entries in
+this array, traffic will be spread evenly across all the
+services.
+Otherwise, traffic is balanced proportionally to the
+Weight field in each entry.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>validation</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.UpstreamValidation">
+UpstreamValidation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocol</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>loadBalancerPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.LoadBalancerPolicy">
+LoadBalancerPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The policy for load balancing GRPC service requests. Note
+that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>timeoutPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.TimeoutPolicy">
+TimeoutPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The timeout policy for requests to the services.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocolVersion</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
+ExtensionProtocolVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This field sets the version of the GRPC protocol that Envoy uses to
+send requests to the extension service. Since Contour always uses the
+v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+protocol options will be available in future.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceStatus">ExtensionServiceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
+</p>
+<p>
+<p>ExtensionServiceStatus defines the observed state of an
+ExtensionService resource.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>conditions</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.DetailedCondition">
+[]DetailedCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions contains the current status of the ExtensionService resource.</p>
+<p>Contour will update a single condition, <code>Valid</code>, that is in normal-true polarity.</p>
+<p>Contour will not modify any other Conditions set in this block,
+in case some other controller wants to add a Condition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceTarget">ExtensionServiceTarget
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
+</p>
+<p>
+<p>ExtensionServiceTarget defines an Kubernetes Service to target with
+extension service traffic.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>name</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of Kubernetes service that will accept service
+traffic.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>port</code>
+<br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Port (defined as Integer) to proxy traffic to since a service can have multiple defined.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>weight</code>
+<br>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Weight defines proportion of traffic to balance to the Kubernetes Service.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="projectcontour.io/v1">projectcontour.io/v1</h2>
 <p>
 <p>This package holds the specification for the projectcontour.io Custom Resource Definitions (CRDs).</p>
@@ -2521,419 +2934,6 @@ only be configured on virtual hosts that have TLS enabled.
 If the TLS configuration requires client certificate
 /validation, the client certificate is always included in the
 authentication check request.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="projectcontour.io/v1alpha1">projectcontour.io/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the projectcontour.io v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>
-</li></ul>
-<h3 id="projectcontour.io/v1alpha1.ExtensionService">ExtensionService
-</h3>
-<p>
-<p>ExtensionService is the schema for the Contour extension services API.
-An ExtensionService resource binds a network service to the Contour
-API so that Contour API features can be implemented by collaborating
-components.</p>
-</p>
-<table class="table table-striped table-borderless" style="border:none">
-<thead class="border-bottom">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody class="border-top">
-<tr>
-<td>
-<code>apiVersion</code>
-<br>
-string</td>
-<td>
-<code>
-projectcontour.io/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code>
-<br>
-string
-</td>
-<td><code>ExtensionService</code></td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>metadata</code>
-<br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>spec</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">
-ExtensionServiceSpec
-</a>
-</em>
-</td>
-<td>
-<br>
-<br>
-<table style="border:none">
-<tr>
-<td style="white-space:nowrap">
-<code>services</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
-[]ExtensionServiceTarget
-</a>
-</em>
-</td>
-<td>
-<p>Services specifies the set of Kubernetes Service resources that
-receive GRPC extension API requests.
-If no weights are specified for any of the entries in
-this array, traffic will be spread evenly across all the
-services.
-Otherwise, traffic is balanced proportionally to the
-Weight field in each entry.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>validation</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.UpstreamValidation">
-UpstreamValidation
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>protocol</code>
-<br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>loadBalancerPolicy</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.LoadBalancerPolicy">
-LoadBalancerPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The policy for load balancing GRPC service requests. Note
-that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>timeoutPolicy</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.TimeoutPolicy">
-TimeoutPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The timeout policy for requests to the services.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>protocolVersion</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
-ExtensionProtocolVersion
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This field sets the version of the GRPC protocol that Envoy uses to
-send requests to the extension service. Since Contour always uses the
-v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
-protocol options will be available in future.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>status</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceStatus">
-ExtensionServiceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="projectcontour.io/v1alpha1.ExtensionProtocolVersion">ExtensionProtocolVersion
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
-</p>
-<p>
-<p>ExtensionProtocolVersion is the version of the GRPC protocol used
-to access extension services. The only version currently supported
-is &ldquo;v2&rdquo;.</p>
-</p>
-<h3 id="projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
-</p>
-<p>
-<p>ExtensionServiceSpec defines the desired state of an ExtensionService resource.</p>
-</p>
-<table class="table table-striped table-borderless" style="border:none">
-<thead class="border-bottom">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody class="border-top">
-<tr>
-<td style="white-space:nowrap">
-<code>services</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
-[]ExtensionServiceTarget
-</a>
-</em>
-</td>
-<td>
-<p>Services specifies the set of Kubernetes Service resources that
-receive GRPC extension API requests.
-If no weights are specified for any of the entries in
-this array, traffic will be spread evenly across all the
-services.
-Otherwise, traffic is balanced proportionally to the
-Weight field in each entry.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>validation</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.UpstreamValidation">
-UpstreamValidation
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>protocol</code>
-<br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>loadBalancerPolicy</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.LoadBalancerPolicy">
-LoadBalancerPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The policy for load balancing GRPC service requests. Note
-that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>timeoutPolicy</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.TimeoutPolicy">
-TimeoutPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The timeout policy for requests to the services.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>protocolVersion</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
-ExtensionProtocolVersion
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>This field sets the version of the GRPC protocol that Envoy uses to
-send requests to the extension service. Since Contour always uses the
-v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
-protocol options will be available in future.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="projectcontour.io/v1alpha1.ExtensionServiceStatus">ExtensionServiceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
-</p>
-<p>
-<p>ExtensionServiceStatus defines the observed state of an
-ExtensionService resource.</p>
-</p>
-<table class="table table-striped table-borderless" style="border:none">
-<thead class="border-bottom">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody class="border-top">
-<tr>
-<td style="white-space:nowrap">
-<code>conditions</code>
-<br>
-<em>
-<a href="#projectcontour.io/v1.DetailedCondition">
-[]DetailedCondition
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Conditions contains the current status of the ExtensionService resource.</p>
-<p>Contour will update a single condition, <code>Valid</code>, that is in normal-true polarity.</p>
-<p>Contour will not modify any other Conditions set in this block,
-in case some other controller wants to add a Condition.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="projectcontour.io/v1alpha1.ExtensionServiceTarget">ExtensionServiceTarget
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
-</p>
-<p>
-<p>ExtensionServiceTarget defines an Kubernetes Service to target with
-extension service traffic.</p>
-</p>
-<table class="table table-striped table-borderless" style="border:none">
-<thead class="border-bottom">
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody class="border-top">
-<tr>
-<td style="white-space:nowrap">
-<code>name</code>
-<br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is the name of Kubernetes service that will accept service
-traffic.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>port</code>
-<br>
-<em>
-int
-</em>
-</td>
-<td>
-<p>Port (defined as Integer) to proxy traffic to since a service can have multiple defined.</p>
-</td>
-</tr>
-<tr>
-<td style="white-space:nowrap">
-<code>weight</code>
-<br>
-<em>
-uint32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Weight defines proportion of traffic to balance to the Kubernetes Service.</p>
 </td>
 </tr>
 </tbody>

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -28,6 +28,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | request-timeout | [duration][4] | `0s` | **Deprecated and will be removed in a future release. Use [timeouts.request-timeout](#timeout-configuration) instead.**<br /><br /> This field specifies the default request timeout as a Go duration string. Zero means there is no timeout. |
 | tls | TLS | | The default [TLS configuration](#tls-configuration). |
 | timeouts | TimeoutConfig | | The [timeout configuration](#timeout-configuration). |
+| cluster | ClusterConfig | | The [cluster configuration](#cluster-configuration). |
 | server | ServerConfig |  | The [server configuration](#server-configuration) for `contour serve` command. |
 {: class="table thead-dark table-bordered"}
 <br>
@@ -84,6 +85,16 @@ The timeout configuration block can be used to configure various timeouts for th
 <br>
 _* This is Envoy's default setting value and is not explicitly configured by Contour._
 
+### Cluster Configuration
+
+The cluster configuration block can be used to configure various parameters for Envoy clusters.
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| dns-lookup-family | string | auto | This field specifies the dns-lookup-family to use for upstream requests to externalName type Kubernetes services from an HTTPProxy route. Values are: `auto`, `v4, `v6` |
+{: class="table thead-dark table-bordered"}
+<br>
+
 ### Server Configuration
 
 The server configuration block can be used to configure various settings for the `contour serve` command.
@@ -139,6 +150,12 @@ data:
     #  stream-idle-timeout: 5m
     #  max-connection-duration: infinity
     #  connection-shutdown-grace-period: 5s
+    #
+    # Envoy cluster settings.
+    # cluster:
+    #   configure the cluster dns lookup family
+    #   valid options are: auto (default), v4, v6
+    #   dns-lookup-family: auto
 ```
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.


### PR DESCRIPTION
Adds a config file option `Cluster.DnsLookupFamily` which allows users to define what dns lookup family is used for any
externalName type cluster. This ensures that lookups to external resources are resolved correctly.

Fixes #2873

Signed-off-by: Steve Sloka <slokas@vmware.com>