### PR TITLE
Update linter configuration.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,9 @@ run:
 linters:
   enable:
   - bodyclose
+  - gofmt
   - goimports
+  - golint
   - gosec
   - misspell
   - unconvert
@@ -40,4 +42,15 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: package github.com/golang/protobuf"
-
+  - linters:
+    - golint
+    text: "var `ingress_https` should be `ingressHTTPS`"
+  - linters:
+    - golint
+    text: "var `ingress_http` should be `ingressHTTP`"
+  - linters:
+    - golint
+    text: "returns unexported type"
+  - linters:
+    - golint
+    text: "don't use ALL_CAPS in Go names; use CamelCase"

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -99,15 +99,15 @@ func (s *shutdownmanagerContext) healthzHandler(w http.ResponseWriter, r *http.R
 // the kubelet calls the shutdown command is different than the HTTP request from Envoy to /shutdown
 func (s *shutdownmanagerContext) shutdownReadyHandler(w http.ResponseWriter, r *http.Request) {
 	for {
-		if _, err := os.Stat(shutdownReadyFile); err == nil {
+		_, err := os.Stat(shutdownReadyFile)
+		if err != nil {
 			http.StatusText(http.StatusOK)
 			if _, err := w.Write([]byte("OK")); err != nil {
 				s.WithField("context", "shutdownReadyHandler").Error(err)
 			}
 			return
-		} else {
-			s.WithField("context", "shutdownReadyHandler").Errorf("error checking for file: %v", err)
 		}
+		s.WithField("context", "shutdownReadyHandler").Errorf("error checking for file: %v", err)
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -18,6 +18,7 @@ import (
 )
 
 // BuildInfo is a struct for build information.
+// nolint:golint
 type BuildInfo struct {
 	Branch  string `yaml:"branch,omitempty"`
 	Sha     string `yaml:"sha,omitempty"`

--- a/internal/contour/endpointstranslator_test.go
+++ b/internal/contour/endpointstranslator_test.go
@@ -118,10 +118,10 @@ func TestEndpointCacheQuery(t *testing.T) {
 
 func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 	clusters := []*dag.ServiceCluster{
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/httpbin-org/a",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "httpbin-org",
 					ServiceNamespace: "default",
@@ -129,10 +129,10 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				},
 			},
 		},
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/httpbin-org/b",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "httpbin-org",
 					ServiceNamespace: "default",
@@ -140,10 +140,10 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				},
 			},
 		},
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/simple",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "simple",
 					ServiceNamespace: "default",
@@ -303,10 +303,10 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 
 func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 	clusters := []*dag.ServiceCluster{
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/simple",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "simple",
 					ServiceNamespace: "default",
@@ -314,10 +314,10 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				},
 			},
 		},
-		&dag.ServiceCluster{
+		{
 			ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "what-a-descriptive-service-name-you-must-be-so-proud",
 					ServiceNamespace: "super-long-namespace-name-oh-boy",
@@ -325,10 +325,10 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				},
 			},
 		},
-		&dag.ServiceCluster{
+		{
 			ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "what-a-descriptive-service-name-you-must-be-so-proud",
 					ServiceNamespace: "super-long-namespace-name-oh-boy",
@@ -562,7 +562,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 	et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 
 	require.NoError(t, et.cache.SetClusters([]*dag.ServiceCluster{
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/simple",
 			Services: []dag.WeightedService{{
 				Weight:           1,
@@ -607,22 +607,22 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 func TestEndpointsTranslatorWeightedService(t *testing.T) {
 	et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 	clusters := []*dag.ServiceCluster{
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/weighted",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					Weight:           0,
 					ServiceName:      "weight0",
 					ServiceNamespace: "default",
 					ServicePort:      v1.ServicePort{},
 				},
-				dag.WeightedService{
+				{
 					Weight:           1,
 					ServiceName:      "weight1",
 					ServiceNamespace: "default",
 					ServicePort:      v1.ServicePort{},
 				},
-				dag.WeightedService{
+				{
 					Weight:           2,
 					ServiceName:      "weight2",
 					ServiceNamespace: "default",
@@ -668,20 +668,20 @@ func TestEndpointsTranslatorWeightedService(t *testing.T) {
 func TestEndpointsTranslatorDefaultWeightedService(t *testing.T) {
 	et := NewEndpointsTranslator(fixture.NewTestLogger(t)).(*EndpointsTranslator)
 	clusters := []*dag.ServiceCluster{
-		&dag.ServiceCluster{
+		{
 			ClusterName: "default/weighted",
 			Services: []dag.WeightedService{
-				dag.WeightedService{
+				{
 					ServiceName:      "weight0",
 					ServiceNamespace: "default",
 					ServicePort:      v1.ServicePort{},
 				},
-				dag.WeightedService{
+				{
 					ServiceName:      "weight1",
 					ServiceNamespace: "default",
 					ServicePort:      v1.ServicePort{},
 				},
-				dag.WeightedService{
+				{
 					ServiceName:      "weight2",
 					ServiceNamespace: "default",
 					ServicePort:      v1.ServicePort{},

--- a/internal/contour/listener.go
+++ b/internal/contour/listener.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcontour/contour/internal/timeout"
 )
 
+// nolint:golint
 const (
 	ENVOY_HTTP_LISTENER            = "ingress_http"
 	ENVOY_FALLBACK_ROUTECONFIG     = "ingress_fallbackcert"
@@ -284,9 +285,9 @@ func (c *ListenerCache) Query(names []string) []proto.Message {
 
 func (*ListenerCache) TypeURL() string { return resource.ListenerType }
 
-func (l *ListenerCache) OnChange(root *dag.DAG) {
-	listeners := visitListeners(root, &l.Config)
-	l.Update(listeners)
+func (c *ListenerCache) OnChange(root *dag.DAG) {
+	listeners := visitListeners(root, &c.Config)
+	c.Update(listeners)
 }
 
 type listenerVisitor struct {

--- a/internal/contour/route.go
+++ b/internal/contour/route.go
@@ -87,9 +87,9 @@ func (c *RouteCache) Query(names []string) []proto.Message {
 // TypeURL returns the string type of RouteCache Resource.
 func (*RouteCache) TypeURL() string { return resource.RouteType }
 
-func (r *RouteCache) OnChange(root *dag.DAG) {
+func (c *RouteCache) OnChange(root *dag.DAG) {
 	routes := visitRoutes(root)
-	r.Update(routes)
+	c.Update(routes)
 }
 
 type routeVisitor struct {

--- a/internal/contour/secret.go
+++ b/internal/contour/secret.go
@@ -72,9 +72,9 @@ func (c *SecretCache) Query(names []string) []proto.Message {
 
 func (*SecretCache) TypeURL() string { return resource.SecretType }
 
-func (s *SecretCache) OnChange(root *dag.DAG) {
+func (c *SecretCache) OnChange(root *dag.DAG) {
 	secrets := visitSecrets(root)
-	s.Update(secrets)
+	c.Update(secrets)
 }
 
 type secretVisitor struct {

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -144,10 +144,10 @@ func edshealthcheck(c *dag.Cluster) []*envoy_api_v2_core.HealthCheck {
 		return []*envoy_api_v2_core.HealthCheck{
 			httpHealthCheck(c),
 		}
-	} else {
-		return []*envoy_api_v2_core.HealthCheck{
-			tcpHealthCheck(c),
-		}
+	}
+
+	return []*envoy_api_v2_core.HealthCheck{
+		tcpHealthCheck(c),
 	}
 }
 

--- a/internal/featuretests/route_test.go
+++ b/internal/featuretests/route_test.go
@@ -1509,14 +1509,14 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 	})
 }
 
-func assertRDS(t *testing.T, c *Contour, versioninfo string, ingress_http, ingress_https []*envoy_api_v2_route.VirtualHost) {
+func assertRDS(t *testing.T, c *Contour, versioninfo string, ingressHTTP, ingressHTTPS []*envoy_api_v2_route.VirtualHost) {
 	t.Helper()
 
 	routes := []*v2.RouteConfiguration{
-		envoy.RouteConfiguration("ingress_http", ingress_http...),
+		envoy.RouteConfiguration("ingress_http", ingressHTTP...),
 	}
 
-	for _, vh := range ingress_https {
+	for _, vh := range ingressHTTPS {
 		routes = append(routes,
 			envoy.RouteConfiguration(path.Join("https", vh.Name), vh))
 	}

--- a/internal/k8s/clients_test.go
+++ b/internal/k8s/clients_test.go
@@ -30,7 +30,7 @@ func TestResourceKindExists(t *testing.T) {
 		Group: metav1.APIGroup{
 			Name: "networking.k8s.io",
 			Versions: []metav1.GroupVersionForDiscovery{
-				metav1.GroupVersionForDiscovery{
+				{
 					GroupVersion: "networking.k8s.io/v1beta1",
 					Version:      "v1beta1",
 				},
@@ -41,15 +41,15 @@ func TestResourceKindExists(t *testing.T) {
 			},
 		},
 		VersionedResources: map[string][]metav1.APIResource{
-			"v1beta1": []metav1.APIResource{
-				metav1.APIResource{
+			"v1beta1": {
+				{
 					Name:               "ingressclasses",
 					Namespaced:         false,
 					Kind:               "IngressClass",
 					Verbs:              metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 					StorageVersionHash: "6upRfBq0FOI=",
 				},
-				metav1.APIResource{
+				{
 					Name:               "ingresses",
 					Namespaced:         true,
 					Kind:               "Ingress",
@@ -57,7 +57,7 @@ func TestResourceKindExists(t *testing.T) {
 					ShortNames:         []string{"ing"},
 					StorageVersionHash: "ZOAfGflaKd0=",
 				},
-				metav1.APIResource{
+				{
 					Name:       "ingresses/status",
 					Namespaced: true,
 					Kind:       "Ingress",

--- a/internal/protobuf/testhelpers.go
+++ b/internal/protobuf/testhelpers.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 // Package protobuf provides helpers for working with golang/protobuf types.
-
 package protobuf
 
 import (

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -33,11 +33,11 @@ func TestInvalidSorter(t *testing.T) {
 
 func TestSortRouteConfiguration(t *testing.T) {
 	want := []*v2.RouteConfiguration{
-		&v2.RouteConfiguration{Name: "bar"},
-		&v2.RouteConfiguration{Name: "baz"},
-		&v2.RouteConfiguration{Name: "foo"},
-		&v2.RouteConfiguration{Name: "same", InternalOnlyHeaders: []string{"z", "y"}},
-		&v2.RouteConfiguration{Name: "same", InternalOnlyHeaders: []string{"a", "b"}},
+		{Name: "bar"},
+		{Name: "baz"},
+		{Name: "foo"},
+		{Name: "same", InternalOnlyHeaders: []string{"z", "y"}},
+		{Name: "same", InternalOnlyHeaders: []string{"a", "b"}},
 	}
 
 	have := []*v2.RouteConfiguration{
@@ -54,11 +54,11 @@ func TestSortRouteConfiguration(t *testing.T) {
 
 func TestSortVirtualHosts(t *testing.T) {
 	want := []*envoy_api_v2_route.VirtualHost{
-		&envoy_api_v2_route.VirtualHost{Name: "bar"},
-		&envoy_api_v2_route.VirtualHost{Name: "baz"},
-		&envoy_api_v2_route.VirtualHost{Name: "foo"},
-		&envoy_api_v2_route.VirtualHost{Name: "same", Domains: []string{"z", "y"}},
-		&envoy_api_v2_route.VirtualHost{Name: "same", Domains: []string{"a", "b"}},
+		{Name: "bar"},
+		{Name: "baz"},
+		{Name: "foo"},
+		{Name: "same", Domains: []string{"z", "y"}},
+		{Name: "same", Domains: []string{"a", "b"}},
 	}
 
 	have := []*envoy_api_v2_route.VirtualHost{
@@ -107,23 +107,23 @@ func presentHeader(name string) *envoy_api_v2_route.HeaderMatcher {
 
 func TestSortRoutesLongestPath(t *testing.T) {
 	want := []*envoy_api_v2_route.Route{
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchRegex("/this/is/the/longest"),
 			}},
 
 		// Note that regex matches sort before prefix matches.
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchRegex("."),
 			}},
 
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchPrefix("/path/prefix2"),
 			}},
 
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchPrefix("/path/prefix"),
 			}},
@@ -145,21 +145,21 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 		// Although the header names are the same, this value
 		// should sort before the next one because it is
 		// textually longer.
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchPrefix("/path"),
 				Headers: []*envoy_api_v2_route.HeaderMatcher{
 					exactHeader("header-name", "header-value"),
 				},
 			}},
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchPrefix("/path"),
 				Headers: []*envoy_api_v2_route.HeaderMatcher{
 					presentHeader("header-name"),
 				},
 			}},
-		&envoy_api_v2_route.Route{
+		{
 			Match: &envoy_api_v2_route.RouteMatch{
 				PathSpecifier: matchPrefix("/path"),
 				Headers: []*envoy_api_v2_route.HeaderMatcher{
@@ -180,8 +180,8 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 
 func TestSortSecrets(t *testing.T) {
 	want := []*envoy_api_v2_auth.Secret{
-		&envoy_api_v2_auth.Secret{Name: "first"},
-		&envoy_api_v2_auth.Secret{Name: "second"},
+		{Name: "first"},
+		{Name: "second"},
 	}
 
 	have := []*envoy_api_v2_auth.Secret{
@@ -215,8 +215,8 @@ func TestSortHeaderMatchers(t *testing.T) {
 
 func TestSortClusters(t *testing.T) {
 	want := []*v2.Cluster{
-		&v2.Cluster{Name: "first"},
-		&v2.Cluster{Name: "second"},
+		{Name: "first"},
+		{Name: "second"},
 	}
 
 	have := []*v2.Cluster{
@@ -230,8 +230,8 @@ func TestSortClusters(t *testing.T) {
 
 func TestSortClusterLoadAssignments(t *testing.T) {
 	want := []*v2.ClusterLoadAssignment{
-		&v2.ClusterLoadAssignment{ClusterName: "first"},
-		&v2.ClusterLoadAssignment{ClusterName: "second"},
+		{ClusterName: "first"},
+		{ClusterName: "second"},
 	}
 
 	have := []*v2.ClusterLoadAssignment{
@@ -245,15 +245,15 @@ func TestSortClusterLoadAssignments(t *testing.T) {
 
 func TestSortHTTPWeightedClusters(t *testing.T) {
 	want := []*envoy_api_v2_route.WeightedCluster_ClusterWeight{
-		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+		{
 			Name:   "first",
 			Weight: protobuf.UInt32(10),
 		},
-		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+		{
 			Name:   "second",
 			Weight: protobuf.UInt32(10),
 		},
-		&envoy_api_v2_route.WeightedCluster_ClusterWeight{
+		{
 			Name:   "second",
 			Weight: protobuf.UInt32(20),
 		},
@@ -271,15 +271,15 @@ func TestSortHTTPWeightedClusters(t *testing.T) {
 
 func TestSortTCPWeightedClusters(t *testing.T) {
 	want := []*tcp.TcpProxy_WeightedCluster_ClusterWeight{
-		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+		{
 			Name:   "first",
 			Weight: 10,
 		},
-		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+		{
 			Name:   "second",
 			Weight: 10,
 		},
-		&tcp.TcpProxy_WeightedCluster_ClusterWeight{
+		{
 			Name:   "second",
 			Weight: 20,
 		},
@@ -297,8 +297,8 @@ func TestSortTCPWeightedClusters(t *testing.T) {
 
 func TestSortListeners(t *testing.T) {
 	want := []*v2.Listener{
-		&v2.Listener{Name: "first"},
-		&v2.Listener{Name: "second"},
+		{Name: "first"},
+		{Name: "second"},
 	}
 
 	have := []*v2.Listener{


### PR DESCRIPTION
Ensure that `golint` and `gofmt -s` are run as part of the lint
configuration.

Signed-off-by: James Peach <jpeach@vmware.com>