### PR TITLE
internal/dag: Update how headers are processed for special 'Host' header

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -282,10 +282,11 @@ type Route struct {
 	//
 	// +optional
 	PathRewritePolicy *PathRewritePolicy `json:"pathRewritePolicy,omitempty"`
-	// The policy for managing request headers during proxying
+	// The policy for managing request headers during proxying.
 	// +optional
 	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
-	// The policy for managing response headers during proxying
+	// The policy for managing response headers during proxying.
+	// Rewriting the 'Host' header is not supported.
 	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }
@@ -348,10 +349,12 @@ type Service struct {
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
 	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
 	Mirror bool `json:"mirror,omitempty"`
-	// The policy for managing request headers during proxying
+	// The policy for managing request headers during proxying.
+	// Rewriting the 'Host' header is not supported.
 	// +optional
 	RequestHeadersPolicy *HeadersPolicy `json:"requestHeadersPolicy,omitempty"`
-	// The policy for managing response headers during proxying
+	// The policy for managing response headers during proxying.
+	// Rewriting the 'Host' header is not supported.
 	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeadersPolicy,omitempty"`
 }

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -216,7 +216,7 @@ spec:
                     description: Allow this path to respond to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
                     type: boolean
                   requestHeadersPolicy:
-                    description: The policy for managing request headers during proxying
+                    description: The policy for managing request headers during proxying.
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names to remove.
@@ -243,7 +243,7 @@ spec:
                         type: array
                     type: object
                   responseHeadersPolicy:
-                    description: The policy for managing response headers during proxying
+                    description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names to remove.
@@ -332,7 +332,7 @@ spec:
                           - tls
                           type: string
                         requestHeadersPolicy:
-                          description: The policy for managing request headers during proxying
+                          description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header names to remove.
@@ -359,7 +359,7 @@ spec:
                               type: array
                           type: object
                         responseHeadersPolicy:
-                          description: The policy for managing response headers during proxying
+                          description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header names to remove.
@@ -502,7 +502,7 @@ spec:
                         - tls
                         type: string
                       requestHeadersPolicy:
-                        description: The policy for managing request headers during proxying
+                        description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names to remove.
@@ -529,7 +529,7 @@ spec:
                             type: array
                         type: object
                       responseHeadersPolicy:
-                        description: The policy for managing response headers during proxying
+                        description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names to remove.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -325,7 +325,7 @@ spec:
                     description: Allow this path to respond to insecure requests over HTTP which are normally not permitted when a `virtualhost.tls` block is present.
                     type: boolean
                   requestHeadersPolicy:
-                    description: The policy for managing request headers during proxying
+                    description: The policy for managing request headers during proxying.
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names to remove.
@@ -352,7 +352,7 @@ spec:
                         type: array
                     type: object
                   responseHeadersPolicy:
-                    description: The policy for managing response headers during proxying
+                    description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                     properties:
                       remove:
                         description: Remove specifies a list of HTTP header names to remove.
@@ -441,7 +441,7 @@ spec:
                           - tls
                           type: string
                         requestHeadersPolicy:
-                          description: The policy for managing request headers during proxying
+                          description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header names to remove.
@@ -468,7 +468,7 @@ spec:
                               type: array
                           type: object
                         responseHeadersPolicy:
-                          description: The policy for managing response headers during proxying
+                          description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                           properties:
                             remove:
                               description: Remove specifies a list of HTTP header names to remove.
@@ -611,7 +611,7 @@ spec:
                         - tls
                         type: string
                       requestHeadersPolicy:
-                        description: The policy for managing request headers during proxying
+                        description: The policy for managing request headers during proxying. Rewriting the 'Host' header is not supported.
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names to remove.
@@ -638,7 +638,7 @@ spec:
                             type: array
                         type: object
                       responseHeadersPolicy:
-                        description: The policy for managing response headers during proxying
+                        description: The policy for managing response headers during proxying. Rewriting the 'Host' header is not supported.
                         properties:
                           remove:
                             description: Remove specifies a list of HTTP header names to remove.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -5563,54 +5563,14 @@ func TestDAGInsert(t *testing.T) {
 				proxyReplaceHostHeaderService,
 				s9,
 			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", &Route{
-							PathMatchCondition: prefix("/"),
-							Clusters: []*Cluster{{
-								Upstream: service(s9),
-								RequestHeadersPolicy: &HeadersPolicy{
-									HostRewrite: "bar.com",
-								},
-								SNI: "bar.com",
-							}},
-						}),
-					),
-				},
-			),
+			want: listeners(),
 		},
 		"insert proxy with replace header policy - service - host header - externalName": {
 			objs: []interface{}{
 				proxyReplaceHostHeaderService,
 				s14,
 			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("example.com", &Route{
-							PathMatchCondition: prefix("/"),
-							Clusters: []*Cluster{{
-								Upstream: &Service{
-									ExternalName: "externalservice.io",
-									Weighted: WeightedService{
-										Weight:           1,
-										ServiceName:      s14.Name,
-										ServiceNamespace: s14.Namespace,
-										ServicePort:      s14.Spec.Ports[0],
-									},
-								},
-								RequestHeadersPolicy: &HeadersPolicy{
-									HostRewrite: "bar.com",
-								},
-								SNI: "bar.com",
-							}},
-						}),
-					),
-				},
-			),
+			want: listeners(),
 		},
 		"insert proxy with response header policy - route - host header": {
 			objs: []interface{}{
@@ -6711,7 +6671,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := headersPolicy(test.in, false)
+			got, gotErr := headersPolicyService(test.in)
 			assert.Equal(t, test.want, got)
 			assert.Equal(t, test.wantErr, gotErr)
 		})

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -338,15 +338,15 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			return nil
 		}
 
-		reqHP, err := headersPolicy(route.RequestHeadersPolicy, true /* allow Host */)
+		reqHP, err := headersPolicyRoute(route.RequestHeadersPolicy, true /* allow Host */)
 		if err != nil {
 			sw.SetInvalid(err.Error())
 			return nil
 		}
 
-		respHP, err := headersPolicy(route.ResponseHeadersPolicy, false /* disallow Host */)
+		respHP, err := headersPolicyRoute(route.ResponseHeadersPolicy, false /* disallow Host */)
 		if err != nil {
-			sw.SetInvalid(err.Error())
+			sw.SetInvalid("%s on response headers", err)
 			return nil
 		}
 
@@ -455,15 +455,15 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				}
 			}
 
-			reqHP, err := headersPolicy(service.RequestHeadersPolicy, true /* allow Host */)
+			reqHP, err := headersPolicyService(service.RequestHeadersPolicy)
 			if err != nil {
-				sw.SetInvalid(err.Error())
+				sw.SetInvalid("%s on a service", err)
 				return nil
 			}
 
-			respHP, err := headersPolicy(service.ResponseHeadersPolicy, false /* disallow Host */)
+			respHP, err := headersPolicyService(service.ResponseHeadersPolicy)
 			if err != nil {
-				sw.SetInvalid(err.Error())
+				sw.SetInvalid("%s on response headers", err)
 				return nil
 			}
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -64,7 +64,12 @@ func retryPolicy(rp *projcontour.RetryPolicy) *RetryPolicy {
 	}
 }
 
-func headersPolicy(policy *projcontour.HeadersPolicy, allowHostRewrite bool) (*HeadersPolicy, error) {
+func headersPolicyService(policy *projcontour.HeadersPolicy) (*HeadersPolicy, error) {
+	return headersPolicyRoute(policy, false)
+
+}
+
+func headersPolicyRoute(policy *projcontour.HeadersPolicy, allowHostRewrite bool) (*HeadersPolicy, error) {
 	if policy == nil {
 		return nil, nil
 	}

--- a/site/docs/main/api-reference.html
+++ b/site/docs/main/api-reference.html
@@ -1732,7 +1732,7 @@ HeadersPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>The policy for managing request headers during proxying</p>
+<p>The policy for managing request headers during proxying.</p>
 </td>
 </tr>
 <tr>
@@ -1747,7 +1747,8 @@ HeadersPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>The policy for managing response headers during proxying</p>
+<p>The policy for managing response headers during proxying.
+Rewriting the &lsquo;Host&rsquo; header is not supported.</p>
 </td>
 </tr>
 </tbody>
@@ -1861,7 +1862,8 @@ HeadersPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>The policy for managing request headers during proxying</p>
+<p>The policy for managing request headers during proxying.
+Rewriting the &lsquo;Host&rsquo; header is not supported.</p>
 </td>
 </tr>
 <tr>
@@ -1876,7 +1878,8 @@ HeadersPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>The policy for managing response headers during proxying</p>
+<p>The policy for managing response headers during proxying.
+Rewriting the &lsquo;Host&rsquo; header is not supported.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
The 'Host" header value is special when applied to a
requestHeadersPolicy. When this is set it configures
the hostRewrite field in envoy to match the value of the
requestHeadersPolicy value field.

However, setting this value is only valid when applied to
a route in Envoy, it cannot be applied to a cluster, so
any user setting the "host" header field on a requestHeadersPolicy
on a Spec.Route.Service is invalid.

Fixes #2872

Signed-off-by: Steve Sloka <slokas@vmware.com>