### PR TITLE
cmd/shutdownmanager: /shutdown handler fixes

### DIFF
--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -111,16 +111,16 @@ func (s *shutdownmanagerContext) shutdownReadyHandler(w http.ResponseWriter, r *
 	ctx := r.Context()
 	for {
 		_, err := os.Stat(s.shutdownReadyFile)
-		if err == nil {
+		if os.IsNotExist(err) {
+			l.Infof("file %s does not exist; checking again in %v", s.shutdownReadyFile,
+				s.shutdownReadyCheckInterval)
+		} else if err == nil {
 			l.Infof("detected file %s; sending HTTP response", s.shutdownReadyFile)
 			http.StatusText(http.StatusOK)
 			if _, err := w.Write([]byte("OK")); err != nil {
 				l.Error(err)
 			}
 			return
-		} else if os.IsNotExist(err) {
-			l.Infof("file %s does not yet exist; checking again in %v", s.shutdownReadyFile,
-				s.shutdownReadyCheckInterval)
 		} else {
 			l.Errorf("error checking for file: %v", err)
 		}

--- a/cmd/contour/shutdownmanager_test.go
+++ b/cmd/contour/shutdownmanager_test.go
@@ -110,7 +110,7 @@ func TestShutdownManager_ShutdownReadyHandler_ClientCancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mgr := shutdownmanagerContext{}
+	mgr := newShutdownManagerContext()
 	mgr.FieldLogger = fixture.NewTestLogger(t)
 
 	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.


### PR DESCRIPTION
Fixes #2896 , fixes #2897 

- shutdownReady filepath ("/ok") is configurable
- os.Stat() interval is configurable
- detect client disconnection and stop check loop
- don't use error logging level when os.Stat() tells us the file does not yet exist
- add test coverage for success and client disconnect cases
