### PR TITLE
internal/timeout: return parse errors instead of defaulting to infinity

### DIFF
--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -64,6 +64,9 @@ func TestGetRequestTimeout(t *testing.T) {
 		log := logrus.New()
 		log.Out = ioutil.Discard
 
-		assert.Equal(t, tc.want, getRequestTimeout(log, tc.ctx))
+		got, gotErr := getRequestTimeout(log, tc.ctx)
+
+		assert.Equal(t, tc.want, got)
+		assert.NoError(t, gotErr)
 	}
 }

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -182,7 +182,7 @@ func NumRetries(i *v1beta1.Ingress) uint32 {
 }
 
 // PerTryTimeout returns the duration envoy will wait per retry cycle.
-func PerTryTimeout(i *v1beta1.Ingress) timeout.Setting {
+func PerTryTimeout(i *v1beta1.Ingress) (timeout.Setting, error) {
 	return timeout.Parse(CompatAnnotation(i, "per-try-timeout"))
 }
 

--- a/internal/contour/route_test.go
+++ b/internal/contour/route_test.go
@@ -701,7 +701,7 @@ func TestRouteVisit(t *testing.T) {
 					envoy.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
-							Action: routetimeout("default/kuard/8080/da39a3ee5e", 0),
+							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						},
 					),
 				),

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3715,9 +3715,6 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefix("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
-								ResponseTimeout: timeout.DisabledSetting(), // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
 						}),
 					),
 				},
@@ -3735,9 +3732,6 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefix("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
-								ResponseTimeout: timeout.DisabledSetting(), // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
 						}),
 					),
 				},
@@ -3749,20 +3743,7 @@ func TestDAGInsert(t *testing.T) {
 				proxyTimeoutPolicyInvalidResponse,
 				s1,
 			},
-			want: listeners(
-				&Listener{
-					Port: 80,
-					VirtualHosts: virtualhosts(
-						virtualhost("bar.com", &Route{
-							PathMatchCondition: prefix("/"),
-							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
-								ResponseTimeout: timeout.DisabledSetting(), // invalid timeout equals infinity ¯\_(ツ)_/¯.
-							},
-						}),
-					),
-				},
-			),
+			want: listeners(),
 		},
 		"insert ingress w/ valid legacy timeout annotation": {
 			objs: []interface{}{

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -59,6 +59,13 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 	cache *KubernetesCache,
 	ext *v1alpha1.ExtensionService,
 ) *ExtensionCluster {
+	tp, err := timeoutPolicy(ext.Spec.TimeoutPolicy)
+	if err != nil {
+		// TODO(jpeach): Add status condition, #2874.
+		p.WithError(err).Error("failed to parse timeout policy values")
+		return nil
+	}
+
 	extension := ExtensionCluster{
 		Name: extensionClusterName(k8s.NamespacedNameOf(ext)),
 		Upstream: ServiceCluster{
@@ -70,7 +77,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 		Protocol:           "h2",
 		UpstreamValidation: nil,
 		LoadBalancerPolicy: loadBalancerPolicy(ext.Spec.LoadBalancerPolicy),
-		TimeoutPolicy:      timeoutPolicy(ext.Spec.TimeoutPolicy),
+		TimeoutPolicy:      tp,
 		SNI:                "",
 	}
 

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -228,7 +228,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 
 				timeout, err := timeout.Parse(auth.ResponseTimeout)
 				if err != nil {
-					sw.SetInvalid("Spec.Virtualhost.Authorization.ResponseTimeout string %q cannot be parsed: %s", auth.ResponseTimeout, err)
+					sw.SetInvalid("Spec.Virtualhost.Authorization.ResponseTimeout is invalid: %s", err)
 					return
 				}
 				svhost.AuthorizationResponseTimeout = timeout

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1807,6 +1807,54 @@ func TestDAGStatus(t *testing.T) {
 			}},
 		})
 
+	invalidResponseTimeout := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceKuard.Namespace,
+			Name:      "invalid-timeouts",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Routes: []projcontour.Route{
+				{
+					Services: []projcontour.Service{
+						{
+							Name: serviceKuard.Name,
+						},
+					},
+					TimeoutPolicy: &projcontour.TimeoutPolicy{
+						Response: "invalid-val",
+					},
+				},
+			},
+		},
+	}
+
+	invalidIdleTimeout := &projcontour.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceKuard.Namespace,
+			Name:      "invalid-timeouts",
+		},
+		Spec: projcontour.HTTPProxySpec{
+			VirtualHost: &projcontour.VirtualHost{
+				Fqdn: "example.com",
+			},
+			Routes: []projcontour.Route{
+				{
+					Services: []projcontour.Service{
+						{
+							Name: serviceKuard.Name,
+						},
+					},
+					TimeoutPolicy: &projcontour.TimeoutPolicy{
+						Idle: "invalid-val",
+					},
+				},
+			},
+		},
+	}
+
 	tests := map[string]struct {
 		objs                []interface{}
 		fallbackCertificate *types.NamespacedName
@@ -2474,6 +2522,34 @@ func TestDAGStatus(t *testing.T) {
 					Status:      "invalid",
 					Description: "rewriting \"Host\" header is not supported on response headers",
 					Vhost:       invalidResponseHeadersPolicyRoute.Spec.VirtualHost.Fqdn,
+				},
+			},
+		},
+		"proxy with invalid response timeout value is invalid": {
+			objs: []interface{}{invalidResponseTimeout, serviceKuard},
+			want: map[types.NamespacedName]Status{
+				{
+					Name:      invalidResponseTimeout.Name,
+					Namespace: invalidResponseTimeout.Namespace,
+				}: {
+					Object:      invalidResponseTimeout,
+					Status:      "invalid",
+					Description: "route.timeoutPolicy failed to parse: error parsing response timeout: unable to parse timeout string \"invalid-val\": time: invalid duration \"invalid-val\"",
+					Vhost:       invalidResponseTimeout.Spec.VirtualHost.Fqdn,
+				},
+			},
+		},
+		"proxy with invalid idle timeout value is invalid": {
+			objs: []interface{}{invalidIdleTimeout, serviceKuard},
+			want: map[types.NamespacedName]Status{
+				{
+					Name:      invalidIdleTimeout.Name,
+					Namespace: invalidIdleTimeout.Namespace,
+				}: {
+					Object:      invalidIdleTimeout,
+					Status:      "invalid",
+					Description: "route.timeoutPolicy failed to parse: error parsing idle timeout: unable to parse timeout string \"invalid-val\": time: invalid duration \"invalid-val\"",
+					Vhost:       invalidIdleTimeout.Spec.VirtualHost.Fqdn,
 				},
 			},
 		},

--- a/internal/featuretests/extensionservice_test.go
+++ b/internal/featuretests/extensionservice_test.go
@@ -207,6 +207,25 @@ func extMissingService(_ *testing.T, rh cache.ResourceEventHandler, c *Contour) 
 	})
 }
 
+func extInvalidTimeout(_ *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	rh.OnAdd(&v1alpha1.ExtensionService{
+		ObjectMeta: fixture.ObjectMeta("ns/ext"),
+		Spec: v1alpha1.ExtensionServiceSpec{
+			Services: []v1alpha1.ExtensionServiceTarget{
+				{Name: "svc1", Port: 8081},
+				{Name: "svc2", Port: 8082},
+			},
+			TimeoutPolicy: &projcontour.TimeoutPolicy{
+				Response: "invalid",
+			},
+		},
+	})
+
+	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
+		TypeUrl: clusterType,
+	})
+}
+
 func extInconsistentProto(_ *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 	rh.OnAdd(&v1alpha1.ExtensionService{
 		ObjectMeta: fixture.ObjectMeta("ns/ext"),
@@ -236,6 +255,7 @@ func TestExtensionService(t *testing.T) {
 		"ExternalName":       extExternalName,
 		"MissingService":     extMissingService,
 		"InconsistentProto":  extInconsistentProto,
+		"InvalidTimeout":     extInvalidTimeout,
 	}
 
 	for n, f := range subtests {

--- a/internal/featuretests/timeoutpolicy_test.go
+++ b/internal/featuretests/timeoutpolicy_test.go
@@ -105,14 +105,14 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(i2, i3)
 
-	// check annotation with malformed timeout is propogated as infinity
+	// check annotation with malformed timeout is not propagated
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoy.RouteConfiguration("ingress_http",
 				envoy.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
-						Action: withResponseTimeout(routeCluster("default/kuard/8080/da39a3ee5e"), 0), // zero means infinity
+						Action: routeCluster("default/kuard/8080/da39a3ee5e"),
 					},
 				),
 			),
@@ -170,17 +170,10 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnAdd(p1)
 
-	// check timeout policy with malformed response timeout is propogated as infinity
+	// check timeout policy with malformed response timeout is not propogated
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoy.RouteConfiguration("ingress_http",
-				envoy.VirtualHost("test2.test.com",
-					&envoy_api_v2_route.Route{
-						Match:  routePrefix("/"),
-						Action: withResponseTimeout(routeCluster("default/kuard/8080/da39a3ee5e"), 0), // zero means infinity
-					},
-				),
-			),
+			envoy.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 	})
@@ -225,7 +218,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 			Routes: []projcontour.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
 				TimeoutPolicy: &projcontour.TimeoutPolicy{
-					Response: "infinty",
+					Response: "infinity",
 				},
 				Services: []projcontour.Service{{
 					Name: svc.Name,
@@ -281,17 +274,10 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 	}
 	rh.OnAdd(p1)
 
-	// check timeout policy with malformed response timeout is propogated as infinity
+	// check timeout policy with malformed response timeout is not propogated
 	c.Request(routeType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoy.RouteConfiguration("ingress_http",
-				envoy.VirtualHost("test2.test.com",
-					&envoy_api_v2_route.Route{
-						Match:  routePrefix("/"),
-						Action: withIdleTimeout(routeCluster("default/kuard/8080/da39a3ee5e"), 0), // zero means infinity
-					},
-				),
-			),
+			envoy.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 	})
@@ -336,7 +322,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 			Routes: []projcontour.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
 				TimeoutPolicy: &projcontour.TimeoutPolicy{
-					Idle: "infinty",
+					Idle: "infinity",
 				},
 				Services: []projcontour.Service{{
 					Name: svc.Name,

--- a/internal/timeout/timeout_test.go
+++ b/internal/timeout/timeout_test.go
@@ -23,6 +23,7 @@ func TestParse(t *testing.T) {
 	tests := map[string]struct {
 		duration string
 		want     Setting
+		wantErr  bool
 	}{
 		"empty": {
 			duration: "",
@@ -40,19 +41,30 @@ func TestParse(t *testing.T) {
 			duration: "infinity",
 			want:     DisabledSetting(),
 		},
+		"infinite": {
+			duration: "infinite",
+			want:     DisabledSetting(),
+		},
 		"10 seconds": {
 			duration: "10s",
 			want:     DurationSetting(10 * time.Second),
 		},
 		"invalid": {
 			duration: "10", // 10 what?
-			want:     DisabledSetting(),
+			want:     DefaultSetting(),
+			wantErr:  true,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, Parse(tc.duration))
+			got, gotErr := Parse(tc.duration)
+			assert.Equal(t, tc.want, got)
+			if tc.wantErr {
+				assert.Error(t, gotErr)
+			} else {
+				assert.NoError(t, gotErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Returns errors when parsing timeout strings so they can be reported to
the user, either as invalid HTTPProxies, or in Contour logs. Previously,
such errors were swallowed and the timeout in question was disabled/set
to infinity.

Updates #2728

Signed-off-by: Steve Kriss <krisss@vmware.com>