### PR TITLE
makefile: Enable creating ExtensionService CRD yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,23 +195,13 @@ generate-deployment:
 
 .PHONY: generate-crd-yaml
 generate-crd-yaml:
-ifeq ($(ENABLE_EXTENSIONS_CRD),Y) # Remove in #2711.
-	@echo "Generating CRD YAML documents (including extensions) ..."
+	@echo "Generating CRD YAML documents..."
 	@./hack/generate-crd-yaml.sh
-else
-	@echo Generating CRD YAML documents ...
-	@./hack/generate-crd-yaml.sh ./apis/projectcontour/v1
-endif
 
 .PHONY: generate-api-docs
 generate-api-docs:
-ifeq ($(ENABLE_EXTENSIONS_CRD),Y) # Remove in #2711.
-	@echo "Generating API documentation (including extensions) ..."
+	@echo "Generating API documentation..."
 	@./hack/generate-api-docs.sh github.com/projectcontour/contour/apis/projectcontour
-else
-	@echo Generating API documentation ...
-	@./hack/generate-api-docs.sh
-endif
 
 .PHONY: generate-metrics-docs
 generate-metrics-docs:

--- a/apis/projectcontour/v1alpha1/register.go
+++ b/apis/projectcontour/v1alpha1/register.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var ExtensionServiceGVR = GroupVersion.WithResource("extensionservices")
+
 var (
 	// GroupVersion is group version used to register these objects
 	GroupVersion = schema.GroupVersion{Group: "projectcontour.io", Version: "v1alpha1"}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v2"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
@@ -300,13 +299,8 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// using the SyncList to keep track of what to sync later.
 	var informerSyncList k8s.InformerSyncList
 
+	// Inform on DefaultResources
 	informerSyncList.InformOnResources(clusterInformerFactory, dynamicHandler, k8s.DefaultResources()...)
-
-	// Inform on ExtensionService resources if they are installed
-	// in the cluster. TODO(jpeach) remove the resource check as part of #2711.
-	if gvr := projectcontourv1alpha1.GroupVersion.WithResource("extensionservices"); clients.ResourcesExist(gvr) {
-		informerSyncList.InformOnResources(clusterInformerFactory, dynamicHandler, gvr)
-	}
 
 	if ctx.UseExperimentalServiceAPITypes {
 		// Check if the resource exists in the API server before setting up the informer.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5,6 +5,241 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
+  name: extensionservices.projectcontour.io
+spec:
+  group: projectcontour.io
+  names:
+    kind: ExtensionService
+    listKind: ExtensionServiceList
+    plural: extensionservices
+    shortNames:
+    - extensionservice
+    - extensionservices
+    singular: extensionservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ExtensionService is the schema for the Contour extension services API. An ExtensionService resource binds a network service to the Contour API so that Contour API features can be implemented by collaborating components.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ExtensionServiceSpec defines the desired state of an ExtensionService resource.
+          properties:
+            loadBalancerPolicy:
+              description: The policy for load balancing GRPC service requests. Note that the `Cookie` load balancing strategy cannot be used here.
+              properties:
+                strategy:
+                  description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                  type: string
+              type: object
+            protocol:
+              description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+              enum:
+              - h2
+              - h2c
+              type: string
+            protocolVersion:
+              description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+              enum:
+              - v2
+              type: string
+            services:
+              description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.
+              items:
+                description: ExtensionServiceTarget defines an Kubernetes Service to target with extension service traffic.
+                properties:
+                  name:
+                    description: Name is the name of Kubernetes service that will accept service traffic.
+                    type: string
+                  port:
+                    description: Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+                    exclusiveMaximum: true
+                    maximum: 65536
+                    minimum: 1
+                    type: integer
+                  weight:
+                    description: Weight defines proportion of traffic to balance to the Kubernetes Service.
+                    format: int32
+                    type: integer
+                required:
+                - name
+                - port
+                type: object
+              minItems: 1
+              type: array
+            timeoutPolicy:
+              description: The timeout policy for requests to the services.
+              properties:
+                idle:
+                  description: Timeout after which, if there are no active requests for this route, the connection between Envoy and the backend or Envoy and the external client will be closed. If not specified, there is no per-route idle timeout, though a connection manager-wide stream_idle_timeout default of 5m still applies.
+                  type: string
+                response:
+                  description: Timeout for receiving a response from the server after processing a request from client. If not supplied, Envoy's default value of 15s applies.
+                  type: string
+              type: object
+            validation:
+              description: UpstreamValidation defines how to verify the backend service's certificate
+              properties:
+                caSecret:
+                  description: Name of the Kubernetes secret be used to validate the certificate presented by the backend
+                  type: string
+                subjectName:
+                  description: Key which is expected to be present in the 'subjectAltName' of the presented certificate
+                  type: string
+              required:
+              - caSecret
+              - subjectName
+              type: object
+          required:
+          - services
+          type: object
+        status:
+          description: ExtensionServiceStatus defines the observed state of an ExtensionService resource.
+          properties:
+            conditions:
+              description: "Conditions contains the current status of the ExtensionService resource. \n Contour will update a single condition, `Valid`, that is in normal-true polarity. \n Contour will not modify any other Conditions set in this block, in case some other controller wants to add a Condition."
+              items:
+                description: "DetailedCondition is an extension of the normal Kubernetes conditions, with two extra fields to hold sub-conditions, which provide more detailed reasons for the state (True or False) of the condition. \n `errors` holds information about sub-conditions which are fatal to that condition and render its state False. \n `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False. \n Remember that Conditions have a type, a status, and a reason. \n The type is the type of the condition, the most important one in this CRD set is `Valid`. \n In the case of `Valid`, `status: true` means that the object is has been ingested into Contour with no errors. `warnings` may still be present, and will be indicated in the Reason field. \n `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.  The details of the errors will be present under the `errors` field. \n There should never be subconditions under `errors` when `status` is `true`."
+                properties:
+                  errors:
+                    description: "Errors contains a slice of relevant error subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant. An empty slice here indicates no errors."
+                    items:
+                      description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                      properties:
+                        message:
+                          description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                          maxLength: 32768
+                          type: string
+                        reason:
+                          description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  lastTransitionTime:
+                    description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                    format: date-time
+                    type: string
+                  message:
+                    description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                  warnings:
+                    description: "Warnings contains a slice of relevant warning subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant. An empty slice here indicates no warnings."
+                    items:
+                      description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                      properties:
+                        message:
+                          description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                          maxLength: 32768
+                          type: string
+                        reason:
+                          description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
   additionalPrinterColumns:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -114,6 +114,241 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
+  name: extensionservices.projectcontour.io
+spec:
+  group: projectcontour.io
+  names:
+    kind: ExtensionService
+    listKind: ExtensionServiceList
+    plural: extensionservices
+    shortNames:
+    - extensionservice
+    - extensionservices
+    singular: extensionservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ExtensionService is the schema for the Contour extension services API. An ExtensionService resource binds a network service to the Contour API so that Contour API features can be implemented by collaborating components.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ExtensionServiceSpec defines the desired state of an ExtensionService resource.
+          properties:
+            loadBalancerPolicy:
+              description: The policy for load balancing GRPC service requests. Note that the `Cookie` load balancing strategy cannot be used here.
+              properties:
+                strategy:
+                  description: Strategy specifies the policy used to balance requests across the pool of backend pods. Valid policy names are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Random` and `Cookie`. If an unknown strategy name is specified or no policy is supplied, the default `RoundRobin` policy is used.
+                  type: string
+              type: object
+            protocol:
+              description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+              enum:
+              - h2
+              - h2c
+              type: string
+            protocolVersion:
+              description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+              enum:
+              - v2
+              type: string
+            services:
+              description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.
+              items:
+                description: ExtensionServiceTarget defines an Kubernetes Service to target with extension service traffic.
+                properties:
+                  name:
+                    description: Name is the name of Kubernetes service that will accept service traffic.
+                    type: string
+                  port:
+                    description: Port (defined as Integer) to proxy traffic to since a service can have multiple defined.
+                    exclusiveMaximum: true
+                    maximum: 65536
+                    minimum: 1
+                    type: integer
+                  weight:
+                    description: Weight defines proportion of traffic to balance to the Kubernetes Service.
+                    format: int32
+                    type: integer
+                required:
+                - name
+                - port
+                type: object
+              minItems: 1
+              type: array
+            timeoutPolicy:
+              description: The timeout policy for requests to the services.
+              properties:
+                idle:
+                  description: Timeout after which, if there are no active requests for this route, the connection between Envoy and the backend or Envoy and the external client will be closed. If not specified, there is no per-route idle timeout, though a connection manager-wide stream_idle_timeout default of 5m still applies.
+                  type: string
+                response:
+                  description: Timeout for receiving a response from the server after processing a request from client. If not supplied, Envoy's default value of 15s applies.
+                  type: string
+              type: object
+            validation:
+              description: UpstreamValidation defines how to verify the backend service's certificate
+              properties:
+                caSecret:
+                  description: Name of the Kubernetes secret be used to validate the certificate presented by the backend
+                  type: string
+                subjectName:
+                  description: Key which is expected to be present in the 'subjectAltName' of the presented certificate
+                  type: string
+              required:
+              - caSecret
+              - subjectName
+              type: object
+          required:
+          - services
+          type: object
+        status:
+          description: ExtensionServiceStatus defines the observed state of an ExtensionService resource.
+          properties:
+            conditions:
+              description: "Conditions contains the current status of the ExtensionService resource. \n Contour will update a single condition, `Valid`, that is in normal-true polarity. \n Contour will not modify any other Conditions set in this block, in case some other controller wants to add a Condition."
+              items:
+                description: "DetailedCondition is an extension of the normal Kubernetes conditions, with two extra fields to hold sub-conditions, which provide more detailed reasons for the state (True or False) of the condition. \n `errors` holds information about sub-conditions which are fatal to that condition and render its state False. \n `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False. \n Remember that Conditions have a type, a status, and a reason. \n The type is the type of the condition, the most important one in this CRD set is `Valid`. \n In the case of `Valid`, `status: true` means that the object is has been ingested into Contour with no errors. `warnings` may still be present, and will be indicated in the Reason field. \n `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.  The details of the errors will be present under the `errors` field. \n There should never be subconditions under `errors` when `status` is `true`."
+                properties:
+                  errors:
+                    description: "Errors contains a slice of relevant error subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a error), and disappear when not relevant. An empty slice here indicates no errors."
+                    items:
+                      description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                      properties:
+                        message:
+                          description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                          maxLength: 32768
+                          type: string
+                        reason:
+                          description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  lastTransitionTime:
+                    description: "lastTransitionTime is the last time the condition transitioned from one status to another. \n This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
+                    format: date-time
+                    type: string
+                  message:
+                    description: "message is a human readable message indicating details about the transition. \n This may be an empty string."
+                    maxLength: 32768
+                    type: string
+                  observedGeneration:
+                    description: "observedGeneration represents the .metadata.generation that the condition was set based upon. \n For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance."
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reason:
+                    description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. \n Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                    maxLength: 1024
+                    minLength: 1
+                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: "Type of condition in CamelCase or in foo.example.com/CamelCase. \n Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                    maxLength: 316
+                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    type: string
+                  warnings:
+                    description: "Warnings contains a slice of relevant warning subconditions for this object. \n Subconditions are expected to appear when relevant (when there is a warning), and disappear when not relevant. An empty slice here indicates no warnings."
+                    items:
+                      description: "SubCondition is a Condition-like type intended for use as a subcondition inside a DetailedCondition. \n It contains a subset of the Condition fields. \n It is intended for warnings and errors, so `type` names should use abnormal-true polarity, that is, they should be of the form \"ErrorPresent: true\". \n The expected lifecycle for these errors is that they should only be present when the error or warning is, and should be removed when they are not relevant."
+                      properties:
+                        message:
+                          description: "Message is a human readable message indicating details about the transition. \n This may be an empty string."
+                          maxLength: 32768
+                          type: string
+                        reason:
+                          description: "Reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. \n The value should be a CamelCase string. \n This field may not be empty."
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`. \n This must be in abnormal-true polarity, that is, `ErrorFound` or `controller.io/ErrorFound`. \n The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
   additionalPrinterColumns:

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -15,6 +15,7 @@ package k8s
 
 import (
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -35,6 +36,7 @@ func DefaultResources() []schema.GroupVersionResource {
 	return []schema.GroupVersionResource{
 		projectcontour.HTTPProxyGVR,
 		projectcontour.TLSCertificateDelegationGVR,
+		projectcontourv1alpha1.ExtensionServiceGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 		v1beta1.SchemeGroupVersion.WithResource("ingresses"),
 	}

--- a/site/docs/main/api-reference.html
+++ b/site/docs/main/api-reference.html
@@ -3,6 +3,9 @@
 <li>
 <a href="#projectcontour.io%2fv1">projectcontour.io/v1</a>
 </li>
+<li>
+<a href="#projectcontour.io%2fv1alpha1">projectcontour.io/v1alpha1</a>
+</li>
 </ul>
 <h2 id="projectcontour.io/v1">projectcontour.io/v1</h2>
 <p>
@@ -576,6 +579,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceStatus">ExtensionServiceStatus</a>, 
 <a href="#projectcontour.io/v1.HTTPProxyStatus">HTTPProxyStatus</a>, 
 <a href="#projectcontour.io/v1.TLSCertificateDelegationStatus">TLSCertificateDelegationStatus</a>)
 </p>
@@ -1274,6 +1278,7 @@ include invalid.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>, 
 <a href="#projectcontour.io/v1.Route">Route</a>, 
 <a href="#projectcontour.io/v1.TCPProxy">TCPProxy</a>)
 </p>
@@ -2353,6 +2358,7 @@ namespace your condition with a label, like <code>controller.domain.com\Conditio
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>, 
 <a href="#projectcontour.io/v1.Route">Route</a>)
 </p>
 <p>
@@ -2407,6 +2413,7 @@ stream_idle_timeout default of 5m still applies.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>, 
 <a href="#projectcontour.io/v1.Service">Service</a>)
 </p>
 <p>
@@ -2513,6 +2520,419 @@ only be configured on virtual hosts that have TLS enabled.
 If the TLS configuration requires client certificate
 /validation, the client certificate is always included in the
 authentication check request.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="projectcontour.io/v1alpha1">projectcontour.io/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the projectcontour.io v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>
+</li></ul>
+<h3 id="projectcontour.io/v1alpha1.ExtensionService">ExtensionService
+</h3>
+<p>
+<p>ExtensionService is the schema for the Contour extension services API.
+An ExtensionService resource binds a network service to the Contour
+API so that Contour API features can be implemented by collaborating
+components.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td>
+<code>apiVersion</code>
+<br>
+string</td>
+<td>
+<code>
+projectcontour.io/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code>
+<br>
+string
+</td>
+<td><code>ExtensionService</code></td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>metadata</code>
+<br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>spec</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">
+ExtensionServiceSpec
+</a>
+</em>
+</td>
+<td>
+<br>
+<br>
+<table style="border:none">
+<tr>
+<td style="white-space:nowrap">
+<code>services</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
+[]ExtensionServiceTarget
+</a>
+</em>
+</td>
+<td>
+<p>Services specifies the set of Kubernetes Service resources that
+receive GRPC extension API requests.
+If no weights are specified for any of the entries in
+this array, traffic will be spread evenly across all the
+services.
+Otherwise, traffic is balanced proportionally to the
+Weight field in each entry.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>validation</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.UpstreamValidation">
+UpstreamValidation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocol</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>loadBalancerPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.LoadBalancerPolicy">
+LoadBalancerPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The policy for load balancing GRPC service requests. Note
+that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>timeoutPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.TimeoutPolicy">
+TimeoutPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The timeout policy for requests to the services.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocolVersion</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
+ExtensionProtocolVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This field sets the version of the GRPC protocol that Envoy uses to
+send requests to the extension service. Since Contour always uses the
+v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+protocol options will be available in future.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>status</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceStatus">
+ExtensionServiceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionProtocolVersion">ExtensionProtocolVersion
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
+</p>
+<p>
+<p>ExtensionProtocolVersion is the version of the GRPC protocol used
+to access extension services. The only version currently supported
+is &ldquo;v2&rdquo;.</p>
+</p>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
+</p>
+<p>
+<p>ExtensionServiceSpec defines the desired state of an ExtensionService resource.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>services</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceTarget">
+[]ExtensionServiceTarget
+</a>
+</em>
+</td>
+<td>
+<p>Services specifies the set of Kubernetes Service resources that
+receive GRPC extension API requests.
+If no weights are specified for any of the entries in
+this array, traffic will be spread evenly across all the
+services.
+Otherwise, traffic is balanced proportionally to the
+Weight field in each entry.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>validation</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.UpstreamValidation">
+UpstreamValidation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UpstreamValidation defines how to verify the backend service&rsquo;s certificate</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocol</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Protocol may be used to specify (or override) the protocol used to reach this Service.
+Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>loadBalancerPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.LoadBalancerPolicy">
+LoadBalancerPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The policy for load balancing GRPC service requests. Note
+that the <code>Cookie</code> load balancing strategy cannot be used here.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>timeoutPolicy</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.TimeoutPolicy">
+TimeoutPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The timeout policy for requests to the services.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>protocolVersion</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1alpha1.ExtensionProtocolVersion">
+ExtensionProtocolVersion
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This field sets the version of the GRPC protocol that Envoy uses to
+send requests to the extension service. Since Contour always uses the
+v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+protocol options will be available in future.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceStatus">ExtensionServiceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionService">ExtensionService</a>)
+</p>
+<p>
+<p>ExtensionServiceStatus defines the observed state of an
+ExtensionService resource.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>conditions</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.DetailedCondition">
+[]DetailedCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions contains the current status of the ExtensionService resource.</p>
+<p>Contour will update a single condition, <code>Valid</code>, that is in normal-true polarity.</p>
+<p>Contour will not modify any other Conditions set in this block,
+in case some other controller wants to add a Condition.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="projectcontour.io/v1alpha1.ExtensionServiceTarget">ExtensionServiceTarget
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec</a>)
+</p>
+<p>
+<p>ExtensionServiceTarget defines an Kubernetes Service to target with
+extension service traffic.</p>
+</p>
+<table class="table table-striped table-borderless" style="border:none">
+<thead class="border-bottom">
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody class="border-top">
+<tr>
+<td style="white-space:nowrap">
+<code>name</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of Kubernetes service that will accept service
+traffic.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>port</code>
+<br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Port (defined as Integer) to proxy traffic to since a service can have multiple defined.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>weight</code>
+<br>
+<em>
+uint32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Weight defines proportion of traffic to balance to the Kubernetes Service.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Enables the creation of the ExtensionService CRD when running `make generate`.

Fixes #2711

Signed-off-by: Steve Sloka <slokas@vmware.com>