### PR TITLE
config file: Move xds-server-type into a ServerConfig struct

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -48,13 +48,7 @@ type serveContext struct {
 	InCluster  bool   `yaml:"incluster,omitempty"`
 	Kubeconfig string `yaml:"kubeconfig,omitempty"`
 
-	// contour's xds service parameters
-	xdsAddr string
-	xdsPort int
-	// Defines the XDSServer to use for `contour serve`
-	// Defaults to "contour"
-	XDSServerType                   string `yaml:"xds-server-type,omitempty"`
-	caFile, contourCert, contourKey string
+	ServerConfig `yaml:"server,omitempty"`
 
 	// contour's debug handler parameters
 	debugAddr string
@@ -160,9 +154,6 @@ func newServeContext() *serveContext {
 	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
 	return &serveContext{
 		Kubeconfig:            filepath.Join(os.Getenv("HOME"), ".kube", "config"),
-		xdsAddr:               "127.0.0.1",
-		xdsPort:               8001,
-		XDSServerType:         "contour",
 		statsAddr:             "0.0.0.0",
 		statsPort:             8002,
 		debugAddr:             "127.0.0.1",
@@ -196,6 +187,11 @@ func newServeContext() *serveContext {
 			// without stopping slow connections from being terminated too quickly.
 			ConnectionIdleTimeout: "60s",
 		},
+		ServerConfig: ServerConfig{
+			xdsAddr:       "127.0.0.1",
+			xdsPort:       8001,
+			XDSServerType: "contour",
+		},
 	}
 }
 
@@ -206,6 +202,17 @@ type TLSConfig struct {
 	// FallbackCertificate defines the namespace/name of the Kubernetes secret to
 	// use as fallback when a non-SNI request is received.
 	FallbackCertificate FallbackCertificate `yaml:"fallback-certificate,omitempty"`
+}
+
+type ServerConfig struct {
+	// contour's xds service parameters
+	xdsAddr                         string
+	xdsPort                         int
+	caFile, contourCert, contourKey string
+
+	// Defines the XDSServer to use for `contour serve`
+	// Defaults to "contour"
+	XDSServerType string `yaml:"xds-server-type,omitempty"`
 }
 
 // FallbackCertificate defines the namespace/name of the Kubernetes secret to

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -91,16 +91,20 @@ func TestServeContextTLSParams(t *testing.T) {
 	}{
 		"tls supplied correctly": {
 			ctx: serveContext{
-				caFile:      "cacert.pem",
-				contourCert: "contourcert.pem",
-				contourKey:  "contourkey.pem",
+				ServerConfig: ServerConfig{
+					caFile:      "cacert.pem",
+					contourCert: "contourcert.pem",
+					contourKey:  "contourkey.pem",
+				},
 			},
 			expecterror: false,
 		},
 		"tls partially supplied": {
 			ctx: serveContext{
-				contourCert: "contourcert.pem",
-				contourKey:  "contourkey.pem",
+				ServerConfig: ServerConfig{
+					contourCert: "contourcert.pem",
+					contourKey:  "contourkey.pem",
+				},
 			},
 			expecterror: true,
 		},
@@ -213,7 +217,7 @@ default-http-versions:
 			checkFatalErr(t, err)
 			want := tc.want()
 
-			if diff := cmp.Diff(*want, *got, cmp.AllowUnexported(serveContext{})); diff != "" {
+			if diff := cmp.Diff(*want, *got, cmp.AllowUnexported(serveContext{}, ServerConfig{})); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -328,9 +332,11 @@ func TestServeContextCertificateHandling(t *testing.T) {
 	defer os.RemoveAll(configDir)
 
 	ctx := serveContext{
-		caFile:      filepath.Join(configDir, "CAcert.pem"),
-		contourCert: filepath.Join(configDir, "contourcert.pem"),
-		contourKey:  filepath.Join(configDir, "contourkey.pem"),
+		ServerConfig: ServerConfig{
+			caFile:      filepath.Join(configDir, "CAcert.pem"),
+			contourCert: filepath.Join(configDir, "contourcert.pem"),
+			contourKey:  filepath.Join(configDir, "contourkey.pem"),
+		},
 	}
 
 	// Initial set of credentials must be linked into temp directory before

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -6,8 +6,11 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
-    # determine which XDS Server implementation to utilize in Contour.
-    # xds-server-type: contour
+    #
+    # server:
+    #   determine which XDS Server implementation to utilize in Contour.
+    #   xds-server-type: contour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -40,8 +40,11 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
-    # determine which XDS Server implementation to utilize in Contour.
-    # xds-server-type: contour
+    #
+    # server:
+    #   determine which XDS Server implementation to utilize in Contour.
+    #   xds-server-type: contour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -28,6 +28,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | request-timeout | [duration][4] | `0s` | **Deprecated and will be removed in a future release. Use [timeouts.request-timeout](#timeout-configuration) instead.**<br /><br /> This field specifies the default request timeout as a Go duration string. Zero means there is no timeout. |
 | tls | TLS | | The default [TLS configuration](#tls-configuration). |
 | timeouts | TimeoutConfig | | The [timeout configuration](#timeout-configuration). |
+| server | ServerConfig |  | The [server configuration](#server-configuration) for `contour serve` command. |
 {: class="table thead-dark table-bordered"}
 <br>
 
@@ -81,8 +82,17 @@ The timeout configuration block can be used to configure various timeouts for th
 | connection-shutdown-grace-period | string | `5s`* | This field defines how long the proxy will wait between sending an initial GOAWAY frame and a second, final GOAWAY frame when terminating an HTTP/2 connection. During this grace period, the proxy will continue to respond to new streams. After the final GOAWAY frame has been sent, the proxy will refuse new streams. Must be a [valid Go duration string][4]. See [the Envoy documentation][11] for more information. |
 {: class="table thead-dark table-bordered"}
 <br>
-
 _* This is Envoy's default setting value and is not explicitly configured by Contour._
+
+### Server Configuration
+
+The server configuration block can be used to configure various settings for the `contour serve` command.
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| xds-server-type | string | contour | This field specifies the xDS Server to use. Options are `contour` or `envoy`.  |
+{: class="table thead-dark table-bordered"}
+<br>
 
 ### Configuration Example
 
@@ -96,6 +106,10 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
+    # server:
+    #   determine which XDS Server implementation to utilize in Contour.
+    #   xds-server-type: contour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #


### PR DESCRIPTION
Moves the xds-server-type field into a ServerConfig struct to allow
for other future server parameters to be added to the config file
under the same section.

Updates: #2134
Fixes: #2923


Signed-off-by: Steve Sloka <slokas@vmware.com>