### PR TITLE
internal/featuretests: Refactor featuretests into v2 package

### DIFF
--- a/internal/featuretests/kubernetes.go
+++ b/internal/featuretests/kubernetes.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func backend(svc *v1.Service) *v1beta1.IngressBackend {
+func Backend(svc *v1.Service) *v1beta1.IngressBackend {
 	return &v1beta1.IngressBackend{
 		ServiceName: svc.Name,
 		ServicePort: intstr.FromInt(int(svc.Spec.Ports[0].Port)),
@@ -80,14 +80,14 @@ dk98FvYdyAjjgNsxXCyx7vIgYU3OgVNgvFsFubX/Uk66fcfCpPBMLg==
 -----END RSA PRIVATE KEY-----`
 )
 
-func secretdata(cert, key string) map[string][]byte {
+func Secretdata(cert, key string) map[string][]byte {
 	return map[string][]byte{
 		v1.TLSCertKey:       []byte(cert),
 		v1.TLSPrivateKeyKey: []byte(key),
 	}
 }
 
-func endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {
+func Endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {
 	return &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -97,11 +97,11 @@ func endpoints(ns, name string, subsets ...v1.EndpointSubset) *v1.Endpoints {
 	}
 }
 
-func ports(eps ...v1.EndpointPort) []v1.EndpointPort {
+func Ports(eps ...v1.EndpointPort) []v1.EndpointPort {
 	return eps
 }
 
-func port(name string, port int32) v1.EndpointPort {
+func Port(name string, port int32) v1.EndpointPort {
 	return v1.EndpointPort{
 		Name:     name,
 		Port:     port,
@@ -109,7 +109,7 @@ func port(name string, port int32) v1.EndpointPort {
 	}
 }
 
-func addresses(ips ...string) []v1.EndpointAddress {
+func Addresses(ips ...string) []v1.EndpointAddress {
 	var addrs []v1.EndpointAddress
 	for _, ip := range ips {
 		addrs = append(addrs, v1.EndpointAddress{IP: ip})

--- a/internal/featuretests/v2/authorization_test.go
+++ b/internal/featuretests/v2/authorization_test.go
@@ -11,12 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -85,7 +87,7 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 						&corev1.Secret{
 							ObjectMeta: fixture.ObjectMeta("certificate"),
 							Type:       "kubernetes.io/tls",
-							Data:       secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+							Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 						},
 						authzFilterFor(
 							fqdn,
@@ -174,7 +176,7 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 						&corev1.Secret{
 							ObjectMeta: fixture.ObjectMeta("certificate"),
 							Type:       "kubernetes.io/tls",
-							Data:       secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+							Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 						},
 						authzFilterFor(
 							fqdn,
@@ -490,7 +492,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 						&corev1.Secret{
 							ObjectMeta: fixture.ObjectMeta("certificate"),
 							Type:       "kubernetes.io/tls",
-							Data:       secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+							Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 						},
 						authzFilterFor(
 							fqdn,
@@ -536,9 +538,9 @@ func TestAuthorization(t *testing.T) {
 			rh.OnAdd(fixture.NewService("auth/oidc-server").
 				WithPorts(corev1.ServicePort{Port: 8081}))
 
-			rh.OnAdd(endpoints("auth", "oidc-server", corev1.EndpointSubset{
-				Addresses: addresses("192.168.183.21"),
-				Ports:     ports(port("", 8081)),
+			rh.OnAdd(featuretests.Endpoints("auth", "oidc-server", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.21"),
+				Ports:     featuretests.Ports(featuretests.Port("", 8081)),
 			}))
 
 			rh.OnAdd(&v1alpha1.ExtensionService{
@@ -553,15 +555,15 @@ func TestAuthorization(t *testing.T) {
 			rh.OnAdd(fixture.NewService("app-server").
 				WithPorts(corev1.ServicePort{Port: 80}))
 
-			rh.OnAdd(endpoints("auth", "app-server", corev1.EndpointSubset{
-				Addresses: addresses("192.168.183.21"),
-				Ports:     ports(port("", 80)),
+			rh.OnAdd(featuretests.Endpoints("auth", "app-server", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.21"),
+				Ports:     featuretests.Ports(featuretests.Port("", 80)),
 			}))
 
 			rh.OnAdd(&corev1.Secret{
 				ObjectMeta: fixture.ObjectMeta("certificate"),
 				Type:       "kubernetes.io/tls",
-				Data:       secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+				Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 			})
 
 			f(t, rh, c)

--- a/internal/featuretests/v2/backendcavalidation_test.go
+++ b/internal/featuretests/v2/backendcavalidation_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -36,7 +38,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			dag.CACertificateKey: []byte(CERTIFICATE),
+			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},
 	}
 
@@ -133,7 +135,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the cluster now has a certificate and subject name.
 	c.Request(clusterType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(CERTIFICATE), "subjname", "", nil),
+			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
 		),
 		TypeUrl: clusterType,
 	})
@@ -190,7 +192,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the cluster now has a certificate and subject name.
 	c.Request(clusterType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(CERTIFICATE), "subjname", "", nil),
+			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
 		),
 		TypeUrl: clusterType,
 	})

--- a/internal/featuretests/v2/backendclientauth_test.go
+++ b/internal/featuretests/v2/backendclientauth_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -67,7 +69,7 @@ func clientSecret() *v1.Secret {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 }
 
@@ -78,7 +80,7 @@ func caSecret() *v1.Secret {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			dag.CACertificateKey: []byte(CERTIFICATE),
+			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},
 	}
 }
@@ -117,7 +119,7 @@ func TestBackendClientAuthenticationWithHTTPProxy(t *testing.T) {
 
 	c.Request(clusterType).Equals(&v2.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/backend/443/d411a4160f", "default/backend/http", "default_backend_443"), []byte(CERTIFICATE), "subjname", "", sec1),
+			tlsCluster(cluster("default/backend/443/d411a4160f", "default/backend/http", "default_backend_443"), []byte(featuretests.CERTIFICATE), "subjname", "", sec1),
 		),
 		TypeUrl: clusterType,
 	})
@@ -208,7 +210,7 @@ func TestBackendClientAuthenticationWithExtensionService(t *testing.T) {
 						Namespace: "default",
 					},
 					Type: "kubernetes.io/tls",
-					Data: map[string][]byte{dag.CACertificateKey: []byte(CERTIFICATE)},
+					Data: map[string][]byte{dag.CACertificateKey: []byte(featuretests.CERTIFICATE)},
 				}},
 				SubjectName: "subjname"},
 			"subjname",

--- a/internal/featuretests/v2/cluster_test.go
+++ b/internal/featuretests/v2/cluster_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/corspolicy_test.go
+++ b/internal/featuretests/v2/corspolicy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/downstreamvalidation_test.go
+++ b/internal/featuretests/v2/downstreamvalidation_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -37,7 +39,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: v1.SecretTypeTLS,
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	rh.OnAdd(serverTLSSecret)
 
@@ -47,7 +49,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string][]byte{
-			dag.CACertificateKey: []byte(CERTIFICATE),
+			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},
 	}
 	rh.OnAdd(clientCASecret)

--- a/internal/featuretests/v2/endpoints_test.go
+++ b/internal/featuretests/v2/endpoints_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -52,17 +54,17 @@ func TestAddRemoveEndpoints(t *testing.T) {
 	// e1 is a simple endpoint for two hosts, and two ports
 	// it has a long name to check that it's clustername is _not_
 	// hashed.
-	e1 := endpoints(
+	e1 := featuretests.Endpoints(
 		"super-long-namespace-name-oh-boy",
 		"what-a-descriptive-service-name-you-must-be-so-proud",
 		v1.EndpointSubset{
-			Addresses: addresses(
+			Addresses: featuretests.Addresses(
 				"172.16.0.2",
 				"172.16.0.1",
 			),
-			Ports: ports(
-				port("https", 8443),
-				port("http", 8000),
+			Ports: featuretests.Ports(
+				featuretests.Port("https", 8443),
+				featuretests.Port("http", 8000),
 			),
 		},
 	)
@@ -134,27 +136,27 @@ func TestAddEndpointComplicated(t *testing.T) {
 		}),
 	)
 
-	e1 := endpoints(
+	e1 := featuretests.Endpoints(
 		"default",
 		"kuard",
 		v1.EndpointSubset{
-			Addresses: addresses(
+			Addresses: featuretests.Addresses(
 				"10.48.1.78",
 			),
-			NotReadyAddresses: addresses(
+			NotReadyAddresses: featuretests.Addresses(
 				"10.48.1.77",
 			),
-			Ports: ports(
-				port("foo", 8080),
+			Ports: featuretests.Ports(
+				featuretests.Port("foo", 8080),
 			),
 		},
 		v1.EndpointSubset{
-			Addresses: addresses(
+			Addresses: featuretests.Addresses(
 				"10.48.1.78",
 				"10.48.1.77",
 			),
-			Ports: ports(
-				port("admin", 9000),
+			Ports: featuretests.Ports(
+				featuretests.Port("admin", 9000),
 			),
 		},
 	)
@@ -204,27 +206,27 @@ func TestEndpointFilter(t *testing.T) {
 
 	// a single endpoint that represents several
 	// cluster load assignments.
-	rh.OnAdd(endpoints(
+	rh.OnAdd(featuretests.Endpoints(
 		"default",
 		"kuard",
 		v1.EndpointSubset{
-			Addresses: addresses(
+			Addresses: featuretests.Addresses(
 				"10.48.1.78",
 			),
-			NotReadyAddresses: addresses(
+			NotReadyAddresses: featuretests.Addresses(
 				"10.48.1.77",
 			),
-			Ports: ports(
-				port("foo", 8080),
+			Ports: featuretests.Ports(
+				featuretests.Port("foo", 8080),
 			),
 		},
 		v1.EndpointSubset{
-			Addresses: addresses(
+			Addresses: featuretests.Addresses(
 				"10.48.1.77",
 				"10.48.1.78",
 			),
-			Ports: ports(
-				port("admin", 9000),
+			Ports: featuretests.Ports(
+				featuretests.Port("admin", 9000),
 			),
 		},
 	))
@@ -269,10 +271,10 @@ func TestIssue602(t *testing.T) {
 		}),
 	)
 
-	e1 := endpoints("default", "simple", v1.EndpointSubset{
-		Addresses: addresses("192.168.183.24"),
-		Ports: ports(
-			port("", 8080),
+	e1 := featuretests.Endpoints("default", "simple", v1.EndpointSubset{
+		Addresses: featuretests.Addresses("192.168.183.24"),
+		Ports: featuretests.Ports(
+			featuretests.Port("", 8080),
 		),
 	})
 	rh.OnAdd(e1)
@@ -289,7 +291,7 @@ func TestIssue602(t *testing.T) {
 	})
 
 	// e2 is the same as e1, but without endpoint subsets
-	e2 := endpoints("default", "simple")
+	e2 := featuretests.Endpoints("default", "simple")
 	rh.OnUpdate(e1, e2)
 
 	c.Request(endpointType).Equals(&envoy_api_v2.DiscoveryResponse{

--- a/internal/featuretests/v2/envoy.go
+++ b/internal/featuretests/v2/envoy.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 // envoy helpers
 

--- a/internal/featuretests/v2/extensionservice_test.go
+++ b/internal/featuretests/v2/extensionservice_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -121,7 +123,7 @@ func extUpstreamValidation(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 					ValidationContext: &envoy_api_v2_auth.CertificateValidationContext{
 						TrustedCa: &envoy_api_v2_core.DataSource{
 							Specifier: &envoy_api_v2_core.DataSource_InlineBytes{
-								InlineBytes: []byte(CERTIFICATE),
+								InlineBytes: []byte(featuretests.CERTIFICATE),
 							},
 						},
 						MatchSubjectAltNames: []*matcher.StringMatcher{{
@@ -269,21 +271,21 @@ func TestExtensionService(t *testing.T) {
 			rh.OnAdd(&corev1.Secret{
 				ObjectMeta: fixture.ObjectMeta("ns/cacert"),
 				Data: map[string][]byte{
-					dag.CACertificateKey: []byte(CERTIFICATE),
+					dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 				},
 			})
 
 			rh.OnAdd(fixture.NewService("ns/svc1").WithPorts(corev1.ServicePort{Port: 8081}))
 			rh.OnAdd(fixture.NewService("ns/svc2").WithPorts(corev1.ServicePort{Port: 8082}))
 
-			rh.OnAdd(endpoints("ns", "svc1", corev1.EndpointSubset{
-				Addresses: addresses("192.168.183.20"),
-				Ports:     ports(port("", 8081)),
+			rh.OnAdd(featuretests.Endpoints("ns", "svc1", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.20"),
+				Ports:     featuretests.Ports(featuretests.Port("", 8081)),
 			}))
 
-			rh.OnAdd(endpoints("ns", "svc2", corev1.EndpointSubset{
-				Addresses: addresses("192.168.183.21"),
-				Ports:     ports(port("", 8082)),
+			rh.OnAdd(featuretests.Endpoints("ns", "svc2", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.21"),
+				Ports:     featuretests.Ports(featuretests.Port("", 8082)),
 			}))
 
 			f(t, rh, c)

--- a/internal/featuretests/v2/externalname_test.go
+++ b/internal/featuretests/v2/externalname_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/fallbackcert_test.go
+++ b/internal/featuretests/v2/fallbackcert_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -50,7 +52,7 @@ func TestFallbackCertificate(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	rh.OnAdd(sec1)
 
@@ -60,7 +62,7 @@ func TestFallbackCertificate(t *testing.T) {
 			Namespace: "admin",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	rh.OnAdd(fallbackSecret)

--- a/internal/featuretests/v2/featuretests.go
+++ b/internal/featuretests/v2/featuretests.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // Package featuretests provides end to end tests of specific features.
-package featuretests
+package v2
 
 import (
 	"context"

--- a/internal/featuretests/v2/headercondition_test.go
+++ b/internal/featuretests/v2/headercondition_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/headerpolicy_test.go
+++ b/internal/featuretests/v2/headerpolicy_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -160,7 +162,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	// Proxy with SNI

--- a/internal/featuretests/v2/httpproxy.go
+++ b/internal/featuretests/v2/httpproxy.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 // HTTPProxy helpers
 

--- a/internal/featuretests/v2/ingressclass_test.go
+++ b/internal/featuretests/v2/ingressclass_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
@@ -21,6 +21,7 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
+	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/status"
 	v1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 				},
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 
@@ -87,7 +88,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 				},
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 
@@ -107,7 +108,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 		rh.OnUpdate(ingressWrongClass, ingressNoClass)
@@ -279,7 +280,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 
@@ -309,7 +310,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 				},
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 
@@ -339,7 +340,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 				},
 			},
 			Spec: v1beta1.IngressSpec{
-				Backend: backend(svc),
+				Backend: featuretests.Backend(svc),
 			},
 		}
 		rh.OnUpdate(ingressMatchingClass, ingressNonMatchingClass)

--- a/internal/featuretests/v2/listeners_test.go
+++ b/internal/featuretests/v2/listeners_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -148,7 +150,7 @@ func TestTLSListener(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// i1 is a tls ingress
@@ -293,7 +295,7 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc1 := fixture.NewService("backend").
@@ -461,7 +463,7 @@ func TestLDSFilter(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// i1 is a tls ingress
@@ -620,7 +622,7 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// i1 is a tls ingress
@@ -716,7 +718,7 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// i1 is a tls ingress
@@ -811,7 +813,7 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// i1 is a tls ingress
@@ -919,7 +921,7 @@ func TestHTTPProxyHTTPS(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// p1 is a httpproxy that has TLS
@@ -1007,7 +1009,7 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	rh.OnAdd(secret1)
 

--- a/internal/featuretests/v2/loadbalancerpolicy_test.go
+++ b/internal/featuretests/v2/loadbalancerpolicy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/mirrorpolicy_test.go
+++ b/internal/featuretests/v2/mirrorpolicy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/replaceprefix_test.go
+++ b/internal/featuretests/v2/replaceprefix_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/retrypolicy_test.go
+++ b/internal/featuretests/v2/retrypolicy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
@@ -21,6 +21,7 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
+	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -47,7 +48,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend(s1),
+			Backend: featuretests.Backend(s1),
 		},
 	}
 	rh.OnAdd(i1)
@@ -76,7 +77,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend(s1),
+			Backend: featuretests.Backend(s1),
 		},
 	}
 	rh.OnUpdate(i1, i2)
@@ -105,7 +106,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend(s1),
+			Backend: featuretests.Backend(s1),
 		},
 	}
 	rh.OnUpdate(i2, i3)

--- a/internal/featuretests/v2/rootnamespaces_test.go
+++ b/internal/featuretests/v2/rootnamespaces_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/route_test.go
+++ b/internal/featuretests/v2/route_test.go
@@ -12,12 +12,14 @@
 // limitations under the License.
 
 // End to ends tests for translator to grpc operations.
-package featuretests
+package v2
 
 import (
 	"fmt"
 	"path"
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -348,7 +350,7 @@ func TestEditIngressInPlace(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	// i4 is the same as i3, and includes a TLS spec object to enable ingress_https routes
@@ -465,7 +467,7 @@ func TestSSLRedirectOverlay(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	rh.OnAdd(fixture.NewService("app-service").
@@ -532,7 +534,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata("wrong", RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata("wrong", featuretests.RSA_PRIVATE_KEY),
 	}
 	rh.OnAdd(secret)
 
@@ -580,7 +582,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	assertRDS(t, c, "2", virtualhosts(
@@ -743,7 +745,7 @@ func TestRDSFilter(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	s1 := fixture.NewService("app-service").
@@ -1212,7 +1214,7 @@ func TestRouteWithTLS(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	p1 := &contour_api_v1.HTTPProxy{
@@ -1283,7 +1285,7 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	p1 := &contour_api_v1.HTTPProxy{
@@ -1379,7 +1381,7 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	p1 := &contour_api_v1.HTTPProxy{
@@ -1660,7 +1662,7 @@ func TestHTTPProxyRouteWithTLS(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	proxy1 := &contour_api_v1.HTTPProxy{
@@ -1729,7 +1731,7 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	proxy1 := &contour_api_v1.HTTPProxy{
@@ -1821,7 +1823,7 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testin
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	})
 
 	proxy1 := &contour_api_v1.HTTPProxy{

--- a/internal/featuretests/v2/secrets_test.go
+++ b/internal/featuretests/v2/secrets_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -39,7 +41,7 @@ func TestSDSVisibility(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	// add secret
 	rh.OnAdd(s1)
@@ -107,7 +109,7 @@ func TestSDSShouldNotIncrementVersionNumberForUnrelatedSecret(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	// add secret
 	rh.OnAdd(s1)

--- a/internal/featuretests/v2/tcpproxy_test.go
+++ b/internal/featuretests/v2/tcpproxy_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -37,7 +39,7 @@ func TestTCPProxy(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("correct-backend").
@@ -112,7 +114,7 @@ func TestTCPProxyDelegation(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("app/backend").
@@ -272,7 +274,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("kubernetes").
@@ -354,7 +356,7 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("backend").
@@ -449,7 +451,7 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("backend").
@@ -738,7 +740,7 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	svc := fixture.NewService("backend").

--- a/internal/featuretests/v2/timeoutpolicy_test.go
+++ b/internal/featuretests/v2/timeoutpolicy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
@@ -22,6 +22,7 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -46,7 +47,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.IngressSpec{
-			Backend: backend(svc),
+			Backend: featuretests.Backend(svc),
 		},
 	}
 	rh.OnAdd(i1)

--- a/internal/featuretests/v2/timeouts_test.go
+++ b/internal/featuretests/v2/timeouts_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/tlscertificatedelegation_test.go
+++ b/internal/featuretests/v2/tlscertificatedelegation_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -42,7 +44,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 			Namespace: "secret",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 
 	// add a secret object secret/wildcard.

--- a/internal/featuretests/v2/tlsprotocolversion_test.go
+++ b/internal/featuretests/v2/tlsprotocolversion_test.go
@@ -11,10 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"
+
+	"github.com/projectcontour/contour/internal/featuretests"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
@@ -38,7 +40,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 			Namespace: "default",
 		},
 		Type: "kubernetes.io/tls",
-		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 	rh.OnAdd(sec1)
 
@@ -61,7 +63,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 				IngressRuleValue: v1beta1.IngressRuleValue{
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *backend(s1),
+							Backend: *featuretests.Backend(s1),
 						}},
 					},
 				},
@@ -107,7 +109,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 				IngressRuleValue: v1beta1.IngressRuleValue{
 					HTTP: &v1beta1.HTTPIngressRuleValue{
 						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *backend(s1),
+							Backend: *featuretests.Backend(s1),
 						}},
 					},
 				},

--- a/internal/featuretests/v2/upstreamprotocol_test.go
+++ b/internal/featuretests/v2/upstreamprotocol_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"

--- a/internal/featuretests/v2/websockets_test.go
+++ b/internal/featuretests/v2/websockets_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package featuretests
+package v2
 
 import (
 	"testing"


### PR DESCRIPTION
Refactors the featuretests package into a v2 package for Envoy API V2 types.

Common items are kept in the feature package for use by other versions.
    
Updates: #1898

Blocked on #2928 