### PR TITLE
cmd/contour: deprecate TLS versions for gRPC XDS

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -385,6 +385,7 @@ func (ctx *serveContext) tlsconfig(log logrus.FieldLogger) *tls.Config {
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    certPool,
 			Rand:         rand.Reader,
+			MinVersion:   tls.VersionTLS12,
 		}, nil
 	}
 


### PR DESCRIPTION
Set the minimum TLS version to TLSv1.2 for gRPC XDS interface, removing
support for TLSv1.0 and TLSv1.1, which are now deprecated.

Fixes #2944

Signed-off-by: Tero Saarni <tero.saarni@est.tech>