### PR TITLE
Rename all the import aliases to make them consistent across the project

### DIFF
--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -14,7 +14,7 @@
 package v1alpha1
 
 import (
-	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -66,7 +66,7 @@ type ExtensionServiceSpec struct {
 
 	// UpstreamValidation defines how to verify the backend service's certificate
 	// +optional
-	UpstreamValidation *contourv1.UpstreamValidation `json:"validation,omitempty"`
+	UpstreamValidation *contour_api_v1.UpstreamValidation `json:"validation,omitempty"`
 
 	// Protocol may be used to specify (or override) the protocol used to reach this Service.
 	// Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
@@ -79,12 +79,12 @@ type ExtensionServiceSpec struct {
 	// that the `Cookie` load balancing strategy cannot be used here.
 	//
 	// +optional
-	LoadBalancerPolicy *contourv1.LoadBalancerPolicy `json:"loadBalancerPolicy,omitempty"`
+	LoadBalancerPolicy *contour_api_v1.LoadBalancerPolicy `json:"loadBalancerPolicy,omitempty"`
 
 	// The timeout policy for requests to the services.
 	//
 	// +optional
-	TimeoutPolicy *contourv1.TimeoutPolicy `json:"timeoutPolicy,omitempty"`
+	TimeoutPolicy *contour_api_v1.TimeoutPolicy `json:"timeoutPolicy,omitempty"`
 
 	// This field sets the version of the GRPC protocol that Envoy uses to
 	// send requests to the extension service. Since Contour always uses the
@@ -111,7 +111,7 @@ type ExtensionServiceStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	Conditions []contourv1.DetailedCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []contour_api_v1.DetailedCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // +genclient

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -18,7 +18,7 @@ import (
 
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/projectcontour/contour/internal/build"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
@@ -69,7 +69,7 @@ func main() {
 	case sdmShutdown.FullCommand():
 		sdmShutdownCtx.shutdownHandler()
 	case bootstrap.FullCommand():
-		if err := envoyv2.WriteBootstrap(bootstrapCtx); err != nil {
+		if err := envoy_v2.WriteBootstrap(bootstrapCtx); err != nil {
 			log.WithError(err).Fatal("failed to write bootstrap configuration")
 		}
 	case certgenApp.FullCommand():

--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"sync"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -99,7 +99,7 @@ func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 			// Create new informer for the new LoadBalancerStatus
 			factory := isw.clients.NewInformerFactory()
 			factory.ForResource(v1beta1.SchemeGroupVersion.WithResource("ingresses")).Informer().AddEventHandler(sau)
-			factory.ForResource(projcontour.HTTPProxyGVR).Informer().AddEventHandler(sau)
+			factory.ForResource(contour_api_v1.HTTPProxyGVR).Informer().AddEventHandler(sau)
 
 			shutdown = make(chan struct{})
 			ingressInformers.Add(1)

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -27,7 +27,7 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v2"
-	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
@@ -158,7 +158,7 @@ func validateCRDs(dynamicClient dynamic.Interface, log logrus.FieldLogger) {
 	for _, crd := range crds.Items {
 		log = log.WithField("crd", crd.GetName())
 
-		if group, _, _ := unstructured.NestedString(crd.Object, "spec", "group"); group != contourv1.GroupName {
+		if group, _, _ := unstructured.NestedString(crd.Object, "spec", "group"); group != contour_api_v1.GroupName {
 			log.Debugf("CRD is not in projectcontour.io API group, ignoring")
 			continue
 		}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -457,21 +457,21 @@ func ParseDNSLookupFamily(value string) (string, error) {
 
 // parseDefaultHTTPVersions parses a list of supported HTTP versions
 //  (of the form "HTTP/xx") into a slice of unique version constants.
-func parseDefaultHTTPVersions(versions []string) ([]envoyv2.HTTPVersionType, error) {
-	wanted := map[envoyv2.HTTPVersionType]struct{}{}
+func parseDefaultHTTPVersions(versions []string) ([]envoy_v2.HTTPVersionType, error) {
+	wanted := map[envoy_v2.HTTPVersionType]struct{}{}
 
 	for _, v := range versions {
 		switch strings.ToLower(v) {
 		case "http/1.1":
-			wanted[envoyv2.HTTPVersion1] = struct{}{}
+			wanted[envoy_v2.HTTPVersion1] = struct{}{}
 		case "http/2":
-			wanted[envoyv2.HTTPVersion2] = struct{}{}
+			wanted[envoy_v2.HTTPVersion2] = struct{}{}
 		default:
 			return nil, fmt.Errorf("invalid HTTP protocol version %q", v)
 		}
 	}
 
-	var parsed []envoyv2.HTTPVersionType
+	var parsed []envoy_v2.HTTPVersionType
 	for k := range wanted {
 		parsed = append(parsed, k)
 

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -563,7 +563,7 @@ func TestParseHTTPVersions(t *testing.T) {
 	cases := map[string]struct {
 		versions      []string
 		parseError    error
-		parseVersions []envoyv2.HTTPVersionType
+		parseVersions []envoy_v2.HTTPVersionType
 	}{
 		"empty": {
 			versions:      []string{},
@@ -578,17 +578,17 @@ func TestParseHTTPVersions(t *testing.T) {
 		"http/1.1": {
 			versions:      []string{"http/1.1", "HTTP/1.1"},
 			parseError:    nil,
-			parseVersions: []envoyv2.HTTPVersionType{envoyv2.HTTPVersion1},
+			parseVersions: []envoy_v2.HTTPVersionType{envoy_v2.HTTPVersion1},
 		},
 		"http/1.1+http/2": {
 			versions:      []string{"http/1.1", "http/2"},
 			parseError:    nil,
-			parseVersions: []envoyv2.HTTPVersionType{envoyv2.HTTPVersion1, envoyv2.HTTPVersion2},
+			parseVersions: []envoy_v2.HTTPVersionType{envoy_v2.HTTPVersion1, envoy_v2.HTTPVersion2},
 		},
 		"http/1.1+http/2 duplicated": {
 			versions:      []string{"http/1.1", "http/2", "http/1.1", "http/2"},
 			parseError:    nil,
-			parseVersions: []envoyv2.HTTPVersionType{envoyv2.HTTPVersion1, envoyv2.HTTPVersion2},
+			parseVersions: []envoy_v2.HTTPVersionType{envoy_v2.HTTPVersion1, envoy_v2.HTTPVersion2},
 		},
 	}
 

--- a/internal/annotation/annotations_test.go
+++ b/internal/annotation/annotations_test.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"testing"
 
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -404,7 +404,7 @@ func TestAnnotationKindValidation(t *testing.T) {
 			},
 		},
 		"httpproxy": {
-			obj: &projectcontour.HTTPProxy{},
+			obj: &contour_api_v1.HTTPProxy{},
 			annotations: map[string]status{
 				// Valid only on Service.
 				"projectcontour.io/max-requests": {
@@ -436,7 +436,7 @@ func TestAnnotationKindValidation(t *testing.T) {
 	for _, kind := range []string{
 		kindOf(&v1.Service{}),
 		kindOf(&v1beta1.Ingress{}),
-		kindOf(&projectcontour.HTTPProxy{}),
+		kindOf(&contour_api_v1.HTTPProxy{}),
 	} {
 		for key := range annotationsByKind[kind] {
 			t.Run(fmt.Sprintf("%s is known and valid for %s", key, kind),
@@ -588,9 +588,9 @@ func kindOf(obj interface{}) string {
 		return "Service"
 	case *v1beta1.Ingress:
 		return "Ingress"
-	case *projectcontour.HTTPProxy:
+	case *contour_api_v1.HTTPProxy:
 		return "HTTPProxy"
-	case *projectcontour.TLSCertificateDelegation:
+	case *contour_api_v1.TLSCertificateDelegation:
 		return "TLSCertificateDelegation"
 	default:
 		return ""

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -178,7 +178,7 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 		return e.Builder.Source.Insert(op.obj)
 	case opUpdate:
 		if cmp.Equal(op.oldObj, op.newObj,
-			cmpopts.IgnoreFields(projcontour.HTTPProxy{}, "Status"),
+			cmpopts.IgnoreFields(contour_api_v1.HTTPProxy{}, "Status"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")) {
 			e.WithField("op", "update").Debugf("%T skipping update, only status has changed", op.newObj)
 			return false
@@ -225,7 +225,7 @@ func (e *EventHandler) rebuildDAG() {
 func (e *EventHandler) setStatus(statuses map[types.NamespacedName]dag.Status) {
 	for _, st := range statuses {
 		switch obj := st.Object.(type) {
-		case *projcontour.HTTPProxy:
+		case *contour_api_v1.HTTPProxy:
 			err := e.StatusClient.SetStatus(st.Status, st.Description, obj)
 			if err != nil {
 				e.WithError(err).

--- a/internal/contour/metrics.go
+++ b/internal/contour/metrics.go
@@ -19,7 +19,7 @@ package contour
 import (
 	"time"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/metrics"
@@ -96,7 +96,7 @@ func calculateRouteMetric(statuses map[types.NamespacedName]dag.Status) metrics.
 
 	for _, v := range statuses {
 		switch o := v.Object.(type) {
-		case *projcontour.HTTPProxy:
+		case *contour_api_v1.HTTPProxy:
 			calcMetrics(v, proxyMetricValid, proxyMetricInvalid, proxyMetricOrphaned, proxyMetricTotal)
 			if o.Spec.VirtualHost != nil {
 				proxyMetricRoots[metrics.Meta{Namespace: v.Object.GetObjectMeta().GetNamespace()}]++

--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -16,7 +16,7 @@ package contour
 import (
 	"testing"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/metrics"
@@ -67,20 +67,20 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy1 is a valid httpproxy
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -89,20 +89,20 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy2 is invalid because it contains a service with negative port
-	proxy2 := &projcontour.HTTPProxy{
+	proxy2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: -80,
 				}},
@@ -111,20 +111,20 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy3 is invalid because it lives outside the roots namespace
-	proxy3 := &projcontour.HTTPProxy{
+	proxy3 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "finance",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foobar",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -133,17 +133,17 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	//// proxy4 is invalid because its match prefix does not match its parent's (proxy1)
-	//proxy4 := &projcontour.HTTPProxy{
+	//proxy4 := &contour_api_v1.HTTPProxy{
 	//	ObjectMeta: metav1.ObjectMeta{
 	//		Namespace: "roots",
 	//		Name:      "delegated",
 	//	},
-	//	Spec: projcontour.HTTPProxySpec{
-	//		Routes: []projcontour.Route{{
-	//			Conditions: []projcontour.MatchCondition{{
+	//	Spec: contour_api_v1.HTTPProxySpec{
+	//		Routes: []contour_api_v1.Route{{
+	//			Conditions: []contour_api_v1.MatchCondition{{
 	//				Prefix: "/doesnotmatch",
 	//			}},
-	//			Services: []projcontour.Service{{
+	//			Services: []contour_api_v1.Service{{
 	//				Name: "home",
 	//				Port: 8080,
 	//			}},
@@ -152,18 +152,18 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	//}
 
 	// proxy6 is invalid because it delegates to itself, producing a cycle
-	proxy6 := &projcontour.HTTPProxy{
+	proxy6 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "self",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "self",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
@@ -171,33 +171,33 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy7 delegates to proxy8, which is invalid because it delegates back to proxy7
-	proxy7 := &projcontour.HTTPProxy{
+	proxy7 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "child",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
 		},
 	}
 
-	proxy8 := &projcontour.HTTPProxy{
+	proxy8 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "child",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Includes: []projcontour.Include{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Includes: []contour_api_v1.Include{{
 				Name: "parent",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
@@ -205,23 +205,23 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	//// proxy9 is invalid because it has a route that both delegates and has a list of services
-	//proxy9 := &projcontour.HTTPProxy{
+	//proxy9 := &contour_api_v1.HTTPProxy{
 	//	ObjectMeta: metav1.ObjectMeta{
 	//		Namespace: "roots",
 	//		Name:      "parent",
 	//	},
-	//	Spec: projcontour.HTTPProxySpec{
-	//		VirtualHost: &projcontour.VirtualHost{
+	//	Spec: contour_api_v1.HTTPProxySpec{
+	//		VirtualHost: &contour_api_v1.VirtualHost{
 	//			Fqdn: "example.com",
 	//		},
-	//		Includes: []projcontour.Include{{
+	//		Includes: []contour_api_v1.Include{{
 	//			Name: "child",
-	//			Conditions: []projcontour.MatchCondition{{
+	//			Conditions: []contour_api_v1.MatchCondition{{
 	//				Prefix: "/foo",
 	//			}},
 	//		}},
-	//		Routes: []projcontour.Route{{
-	//			Services: []projcontour.Service{{
+	//		Routes: []contour_api_v1.Route{{
+	//			Services: []contour_api_v1.Service{{
 	//				Name: "kuard",
 	//				Port: 8080,
 	//			}},
@@ -230,40 +230,40 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	//}
 
 	// proxy10 delegates to proxy11 and proxy12.
-	proxy10 := &projcontour.HTTPProxy{
+	proxy10 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "validChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}, {
 				Name: "invalidChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/bar",
 				}},
 			}},
 		},
 	}
 
-	proxy11 := &projcontour.HTTPProxy{
+	proxy11 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "validChild",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo",
 					Port: 8080,
 				}},
@@ -272,17 +272,17 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy12 is invalid because it contains an invalid port
-	proxy12 := &projcontour.HTTPProxy{
+	proxy12 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidChild",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/bar",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo",
 					Port: 12345678,
 				}},
@@ -291,18 +291,18 @@ func TestHTTPProxyMetrics(t *testing.T) {
 	}
 
 	// proxy13 is invalid because it does not specify and FQDN
-	proxy13 := &projcontour.HTTPProxy{
+	proxy13 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo",
 					Port: 8080,
 				}},
@@ -310,16 +310,16 @@ func TestHTTPProxyMetrics(t *testing.T) {
 		},
 	}
 
-	proxy14 := &projcontour.HTTPProxy{
+	proxy14 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidParent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{},
-			Includes: []projcontour.Include{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{},
+			Includes: []contour_api_v1.Include{{
 				Name: "validChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/stretchr/testify/assert"
@@ -950,20 +950,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyMultipleBackends := &projcontour.HTTPProxy{
+	proxyMultipleBackends := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}, {
@@ -974,24 +974,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyMinTLS12 := &projcontour.HTTPProxy{
+	proxyMinTLS12 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             sec1.Name,
 					MinimumProtocolVersion: "1.2",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -999,24 +999,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyMinTLS13 := &projcontour.HTTPProxy{
+	proxyMinTLS13 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             sec1.Name,
 					MinimumProtocolVersion: "1.3",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1024,24 +1024,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyMinTLSInvalid := &projcontour.HTTPProxy{
+	proxyMinTLSInvalid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             sec1.Name,
 					MinimumProtocolVersion: "0.999",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1049,29 +1049,29 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyWeightsTwoRoutesDiffWeights := &projcontour.HTTPProxy{
+	proxyWeightsTwoRoutesDiffWeights := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   8080,
 					Weight: 90,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/b",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   8080,
 					Weight: 60,
@@ -1080,20 +1080,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyWeightsOneRouteDiffWeights := &projcontour.HTTPProxy{
+	proxyWeightsOneRouteDiffWeights := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   8080,
 					Weight: 90,
@@ -1106,24 +1106,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyRetryPolicyValidTimeout := &projcontour.HTTPProxy{
+	proxyRetryPolicyValidTimeout := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				RetryPolicy: &projcontour.RetryPolicy{
+				RetryPolicy: &contour_api_v1.RetryPolicy{
 					NumRetries:    6,
 					PerTryTimeout: "10s",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1131,24 +1131,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyRetryPolicyInvalidTimeout := &projcontour.HTTPProxy{
+	proxyRetryPolicyInvalidTimeout := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				RetryPolicy: &projcontour.RetryPolicy{
+				RetryPolicy: &contour_api_v1.RetryPolicy{
 					NumRetries:    6,
 					PerTryTimeout: "please",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1156,24 +1156,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyRetryPolicyZeroRetries := &projcontour.HTTPProxy{
+	proxyRetryPolicyZeroRetries := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				RetryPolicy: &projcontour.RetryPolicy{
+				RetryPolicy: &contour_api_v1.RetryPolicy{
 					NumRetries:    0,
 					PerTryTimeout: "10s",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1181,23 +1181,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyTimeoutPolicyInvalidResponse := &projcontour.HTTPProxy{
+	proxyTimeoutPolicyInvalidResponse := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "peanut",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1205,23 +1205,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyTimeoutPolicyValidResponse := &projcontour.HTTPProxy{
+	proxyTimeoutPolicyValidResponse := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "1m30s",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1229,23 +1229,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyTimeoutPolicyInfiniteResponse := &projcontour.HTTPProxy{
+	proxyTimeoutPolicyInfiniteResponse := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "bar.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "infinite",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1465,23 +1465,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyDelegatedTLSSecret := &projcontour.HTTPProxy{
+	proxyDelegatedTLSSecret := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-with-tls-delegation",
 			Namespace: s10.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "app-with-tls-delegation.127.0.0.1.nip.io",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "projectcontour/ssl-cert", // not delegated
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s10.Name,
 					Port: 80,
 				}},
@@ -1489,20 +1489,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1511,20 +1511,20 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy1a tcp forwards traffic to default/kuard:8080 by TLS pass-through it.
-	proxy1a := &projcontour.HTTPProxy{
+	proxy1a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-tcp",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1533,17 +1533,17 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy1b is a straight HTTP forward, no conditions.
-	proxy1b := &projcontour.HTTPProxy{
+	proxy1b := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1552,45 +1552,45 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy1c is a straight forward, with prefix and header conditions.
-	proxy1c := &projcontour.HTTPProxy{
+	proxy1c := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
-					Header: &projcontour.HeaderMatchCondition{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:    "x-request-id",
 						Present: true,
 					},
 				}, {
 					Prefix: "/kuard",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "e-tag",
 						Contains: "abcdef",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-timeout",
 						NotContains: "infinity",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "digest-auth",
 						Exact: "scott",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "digest-password",
 						NotExact: "tiger",
 					},
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1600,26 +1600,26 @@ func TestDAGInsert(t *testing.T) {
 
 	// proxy1d tcp forwards secure traffic to default/kuard:8080 by TLS pass-through it,
 	// insecure traffic is 301 upgraded.
-	proxy1d := &projcontour.HTTPProxy{
+	proxy1d := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-tcp",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
 			}},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -1629,27 +1629,27 @@ func TestDAGInsert(t *testing.T) {
 
 	// proxy1e tcp forwards secure traffic to default/kuard:8080 by TLS pass-through it,
 	// insecure traffic is not 301 upgraded because of the permitInsecure: true annotation.
-	proxy1e := &projcontour.HTTPProxy{
+	proxy1e := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-tcp",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				PermitInsecure: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s10.Name,
 					Port: 80,
 				}},
 			}},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s10.Name,
 					Port: 443,
 				}},
@@ -1659,20 +1659,20 @@ func TestDAGInsert(t *testing.T) {
 
 	//proxy1f is identical to proxy1 and ir1, except for a different service.
 	// Used to test priority when importing ir then httproxy.
-	proxy1f := &projcontour.HTTPProxy{
+	proxy1f := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s2a.Name,
 					Port: 8080,
 				}},
@@ -1680,28 +1680,28 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy2a := &projcontour.HTTPProxy{
+	proxy2a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "kubesystem",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
-				Conditions: []projcontour.MatchCondition{{
-					Header: &projcontour.HeaderMatchCondition{
+			Includes: []contour_api_v1.Include{{
+				Conditions: []contour_api_v1.MatchCondition{{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:    "x-request-id",
 						Present: true,
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-timeout",
 						NotContains: "infinity",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "digest-auth",
 						Exact: "scott",
 					},
@@ -1712,27 +1712,27 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy2b := &projcontour.HTTPProxy{
+	proxy2b := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuard",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "e-tag",
 						Contains: "abcdef",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "digest-password",
 						NotExact: "tiger",
 					},
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1740,23 +1740,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy2c := &projcontour.HTTPProxy{
+	proxy2c := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
+				HealthCheckPolicy: &contour_api_v1.HTTPHealthCheckPolicy{
 					Path: "/healthz",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1766,20 +1766,20 @@ func TestDAGInsert(t *testing.T) {
 
 	// proxy2d is a proxy with two routes that have the same prefix and a Contains header
 	// condition on the same header, differing only in the value of the condition.
-	proxy2d := &projcontour.HTTPProxy{
+	proxy2d := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{
+			Routes: []contour_api_v1.Route{
 				{
-					Conditions: []projcontour.MatchCondition{
+					Conditions: []contour_api_v1.MatchCondition{
 						{
-							Header: &projcontour.HeaderMatchCondition{
+							Header: &contour_api_v1.HeaderMatchCondition{
 								Name:     "e-tag",
 								Contains: "abc",
 							},
@@ -1788,15 +1788,15 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 						},
 					},
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "kuard",
 						Port: 8080,
 					}},
 				},
 				{
-					Conditions: []projcontour.MatchCondition{
+					Conditions: []contour_api_v1.MatchCondition{
 						{
-							Header: &projcontour.HeaderMatchCondition{
+							Header: &contour_api_v1.HeaderMatchCondition{
 								Name:     "e-tag",
 								Contains: "def",
 							},
@@ -1805,7 +1805,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 						},
 					},
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "kuard",
 						Port: 8080,
 					}},
@@ -1816,20 +1816,20 @@ func TestDAGInsert(t *testing.T) {
 
 	// proxy2e is a proxy with two routes that both have a condition on the same
 	// header, one using Contains and one using NotContains.
-	proxy2e := &projcontour.HTTPProxy{
+	proxy2e := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{
+			Routes: []contour_api_v1.Route{
 				{
-					Conditions: []projcontour.MatchCondition{
+					Conditions: []contour_api_v1.MatchCondition{
 						{
-							Header: &projcontour.HeaderMatchCondition{
+							Header: &contour_api_v1.HeaderMatchCondition{
 								Name:     "e-tag",
 								Contains: "abc",
 							},
@@ -1838,15 +1838,15 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 						},
 					},
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "kuard",
 						Port: 8080,
 					}},
 				},
 				{
-					Conditions: []projcontour.MatchCondition{
+					Conditions: []contour_api_v1.MatchCondition{
 						{
-							Header: &projcontour.HeaderMatchCondition{
+							Header: &contour_api_v1.HeaderMatchCondition{
 								Name:        "e-tag",
 								NotContains: "abc",
 							},
@@ -1855,7 +1855,7 @@ func TestDAGInsert(t *testing.T) {
 							Prefix: "/",
 						},
 					},
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "kuard",
 						Port: 8080,
 					}},
@@ -1865,23 +1865,23 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy6 has TLS and does not specify min tls version
-	proxy6 := &projcontour.HTTPProxy{
+	proxy6 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "foo.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: sec1.Name,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -1889,23 +1889,23 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy17 := &projcontour.HTTPProxy{
+	proxy17 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
-					UpstreamValidation: &projcontour.UpstreamValidation{
+					UpstreamValidation: &contour_api_v1.UpstreamValidation{
 						CACertificate: cert1.Name,
 						SubjectName:   "example.com",
 					},
@@ -1914,24 +1914,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 	protocolh2 := "h2"
-	proxy17h2 := &projcontour.HTTPProxy{
+	proxy17h2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:     "kuard",
 					Port:     8080,
 					Protocol: &protocolh2,
-					UpstreamValidation: &projcontour.UpstreamValidation{
+					UpstreamValidation: &contour_api_v1.UpstreamValidation{
 						CACertificate: cert1.Name,
 						SubjectName:   "example.com",
 					},
@@ -1941,26 +1941,26 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy18 is downstream validation, HTTP route
-	proxy18 := &projcontour.HTTPProxy{
+	proxy18 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: sec1.Name,
-					ClientValidation: &projcontour.DownstreamValidation{
+					ClientValidation: &contour_api_v1.DownstreamValidation{
 						CACertificate: cert1.Name,
 					},
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -1969,23 +1969,23 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy19 is downstream validation, TCP proxying
-	proxy19 := &projcontour.HTTPProxy{
+	proxy19 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: sec1.Name,
-					ClientValidation: &projcontour.DownstreamValidation{
+					ClientValidation: &contour_api_v1.DownstreamValidation{
 						CACertificate: cert1.Name,
 					},
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -1994,29 +1994,29 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy10 has a websocket route
-	proxy10 := &projcontour.HTTPProxy{
+	proxy10 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/websocket",
 				}},
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -2025,29 +2025,29 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy10b has a websocket route w/multiple upstreams
-	proxy10b := &projcontour.HTTPProxy{
+	proxy10b := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/websocket",
 				}},
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -2056,20 +2056,20 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy12 tests mirroring
-	proxy12 := &projcontour.HTTPProxy{
+	proxy12 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}, {
@@ -2082,20 +2082,20 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy13 has two mirrors, invalid.
-	proxy13 := &projcontour.HTTPProxy{
+	proxy13 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}, {
@@ -2116,24 +2116,24 @@ func TestDAGInsert(t *testing.T) {
 
 	// invalid because tcpproxy both includes another and
 	// has a list of services.
-	proxy37 := &projcontour.HTTPProxy{
+	proxy37 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: "roots",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2143,38 +2143,38 @@ func TestDAGInsert(t *testing.T) {
 
 	// Invalid because tcpproxy neither includes another httpproxy
 	// nor has a list of services.
-	proxy37a := &projcontour.HTTPProxy{
+	proxy37a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{},
+			TCPProxy: &contour_api_v1.TCPProxy{},
 		},
 	}
 
 	// proxy38 is invalid when combined with proxy39
 	// as the latter is a root.
-	proxy38 := &projcontour.HTTPProxy{
+	proxy38 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: s1.Namespace,
 				},
@@ -2182,20 +2182,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy39 := &projcontour.HTTPProxy{
+	proxy39 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2204,20 +2204,20 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy39broot is a valid TCPProxy which includes to another TCPProxy
-	proxy39broot := &projcontour.HTTPProxy{
+	proxy39broot := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: s1.Namespace,
 				},
@@ -2225,20 +2225,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy39brootplural := &projcontour.HTTPProxy{
+	proxy39brootplural := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				IncludesDeprecated: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				IncludesDeprecated: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: s1.Namespace,
 				},
@@ -2246,14 +2246,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy39bchild := &projcontour.HTTPProxy{
+	proxy39bchild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2261,14 +2261,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy40 := &projcontour.HTTPProxy{
+	proxy40 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2277,17 +2277,17 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// issue 2309, each route must have at least one service
-	proxy41 := &projcontour.HTTPProxy{
+	proxy41 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-service",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "missing-service.example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 				Services: nil, // missing
@@ -2295,27 +2295,27 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100 := &projcontour.HTTPProxy{
+	proxy100 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "marketingwww",
 				Namespace: "marketing",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2323,14 +2323,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100a := &projcontour.HTTPProxy{
+	proxy100a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "marketingwww",
 			Namespace: "marketing",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
@@ -2338,17 +2338,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100b := &projcontour.HTTPProxy{
+	proxy100b := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "marketingwww",
 			Namespace: "marketing",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/infotech",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
@@ -2356,29 +2356,29 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100c := &projcontour.HTTPProxy{
+	proxy100c := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "marketingwww",
 			Namespace: "marketing",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Includes: []projcontour.Include{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Includes: []contour_api_v1.Include{{
 				Name:      "marketingit",
 				Namespace: "it",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/it",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/infotech",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
 			}, {
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
@@ -2386,17 +2386,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy100d := &projcontour.HTTPProxy{
+	proxy100d := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "marketingit",
 			Namespace: "it",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "blog",
 					Port: 8080,
 				}},
@@ -2405,26 +2405,26 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy101 and proxy101a test inclusion without a specified namespace.
-	proxy101 := &projcontour.HTTPProxy{
+	proxy101 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "kuarder",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuarder",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2432,14 +2432,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy101a := &projcontour.HTTPProxy{
+	proxy101a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuarder",
 			Namespace: proxy101.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s2.Name,
 					Port: 8080,
 				}},
@@ -2448,22 +2448,22 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// invalid because two prefix conditions on route.
-	proxy102 := &projcontour.HTTPProxy{
+	proxy102 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/v1",
 				}, {
 					Prefix: "/api",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2472,26 +2472,26 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// invalid because two prefix conditions on include.
-	proxy103 := &projcontour.HTTPProxy{
+	proxy103 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "www",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/v1",
 				}, {
 					Prefix: "/api",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2499,19 +2499,19 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy103a := &projcontour.HTTPProxy{
+	proxy103a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: "teama",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/v1",
 				}, {
 					Prefix: "/api",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2519,26 +2519,26 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy104 := &projcontour.HTTPProxy{
+	proxy104 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "kuarder",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuarder",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2546,14 +2546,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy104a := &projcontour.HTTPProxy{
+	proxy104a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuarder",
 			Namespace: proxy104.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s2.Name,
 					Port: 8080,
 				}},
@@ -2561,26 +2561,26 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy105 := &projcontour.HTTPProxy{
+	proxy105 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "kuarder",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuarder",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2588,17 +2588,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy105a := &projcontour.HTTPProxy{
+	proxy105a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuarder",
 			Namespace: proxy105.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s2.Name,
 					Port: 8080,
 				}},
@@ -2606,26 +2606,26 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy106 := &projcontour.HTTPProxy{
+	proxy106 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "kuarder",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuarder/",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2633,17 +2633,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy106a := &projcontour.HTTPProxy{
+	proxy106a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuarder",
 			Namespace: proxy105.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s2.Name,
 					Port: 8080,
 				}},
@@ -2651,26 +2651,26 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy107 := &projcontour.HTTPProxy{
+	proxy107 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "kuarder",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/kuarder",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2678,17 +2678,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy107a := &projcontour.HTTPProxy{
+	proxy107a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuarder",
 			Namespace: proxy105.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/withavengeance",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s2.Name,
 					Port: 8080,
 				}},
@@ -2697,21 +2697,21 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy108 and proxy108a test duplicate conditions on include
-	proxy108 := &projcontour.HTTPProxy{
+	proxy108 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blogteama",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
@@ -2719,19 +2719,19 @@ func TestDAGInsert(t *testing.T) {
 			}, {
 				Name:      "blogteama",
 				Namespace: "teamb",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 8080,
 				}},
@@ -2739,14 +2739,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy108a := &projcontour.HTTPProxy{
+	proxy108a := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blogteama",
 			Namespace: "teama",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s12.Name,
 					Port: 8080,
 				}},
@@ -2754,14 +2754,14 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxy108b := &projcontour.HTTPProxy{
+	proxy108b := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blogteamb",
 			Namespace: "teamb",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s13.Name,
 					Port: 8080,
 				}},
@@ -2769,25 +2769,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyReplaceHostHeaderRoute := &projcontour.HTTPProxy{
+	proxyReplaceHostHeaderRoute := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "nginx",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "bar.com",
 					}},
@@ -2796,24 +2796,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyReplaceHostHeaderService := &projcontour.HTTPProxy{
+	proxyReplaceHostHeaderService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "nginx",
 					Port: 80,
-					RequestHeadersPolicy: &projcontour.HeadersPolicy{
-						Set: []projcontour.HeaderValue{{
+					RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+						Set: []contour_api_v1.HeaderValue{{
 							Name:  "Host",
 							Value: "bar.com",
 						}},
@@ -2823,25 +2823,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyReplaceHostHeaderMultiple := &projcontour.HTTPProxy{
+	proxyReplaceHostHeaderMultiple := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "nginx",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "bar.com",
 					}, {
@@ -2856,25 +2856,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyReplaceNonHostHeader := &projcontour.HTTPProxy{
+	proxyReplaceNonHostHeader := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "nginx",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "x-header",
 						Value: "bar.com",
 					}},
@@ -2883,25 +2883,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyReplaceHeaderEmptyValue := &projcontour.HTTPProxy{
+	proxyReplaceHeaderEmptyValue := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "nginx",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name: "x-header",
 					}},
 				},
@@ -2910,25 +2910,25 @@ func TestDAGInsert(t *testing.T) {
 	}
 
 	// proxy109 has a route that rewrites headers.
-	proxy109 := &projcontour.HTTPProxy{
+	proxy109 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "In-Foo",
 						Value: "bar",
 					}},
@@ -2936,8 +2936,8 @@ func TestDAGInsert(t *testing.T) {
 						"In-Baz",
 					},
 				},
-				ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Out-Foo",
 						Value: "bar",
 					}},
@@ -2949,25 +2949,25 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 	// proxy111 has a route that rewrites headers.
-	proxy111 := &projcontour.HTTPProxy{
+	proxy111 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
-				ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "bar.baz",
 					}},
@@ -2976,24 +2976,24 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 	// proxy112 has a route that rewrites headers.
-	proxy112 := &projcontour.HTTPProxy{
+	proxy112 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
-					ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-						Set: []projcontour.HeaderValue{{
+					ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+						Set: []contour_api_v1.HeaderValue{{
 							Name:  "Host",
 							Value: "bar.baz",
 						}},
@@ -3003,20 +3003,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 	protocol := "h2c"
-	proxy110 := &projcontour.HTTPProxy{
+	proxy110 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:     "kuard",
 					Port:     8080,
 					Protocol: &protocol,
@@ -3025,20 +3025,20 @@ func TestDAGInsert(t *testing.T) {
 		},
 	}
 
-	proxyExternalNameService := &projcontour.HTTPProxy{
+	proxyExternalNameService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s14.GetName(),
 					Port: 80,
 				}},
@@ -4329,17 +4329,17 @@ func TestDAGInsert(t *testing.T) {
 		},
 		"insert httproxy with invalid include": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "example-com",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
 						},
-						Includes: []projcontour.Include{{
-							Conditions: []projcontour.MatchCondition{{
+						Includes: []contour_api_v1.Include{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/finance",
 							}},
 							Name:      "non-existent",
@@ -5282,20 +5282,20 @@ func TestDAGInsert(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: sec1.Name,
 							},
 						},
-						TCPProxy: &projcontour.TCPProxy{
-							Services: []projcontour.Service{{
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{{
 								Name: s9.Name,
 								Port: 80,
 							}},
@@ -5332,27 +5332,27 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{
 				sec1,
 				s9,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: sec1.Name,
 							},
 						},
-						Routes: []projcontour.Route{{
+						Routes: []contour_api_v1.Route{{
 							PermitInsecure: true,
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: s9.Name,
 								Port: 80,
 							}},
 						}},
-						TCPProxy: &projcontour.TCPProxy{
-							Services: []projcontour.Service{{
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{{
 								Name: s9.Name,
 								Port: 80,
 							}},
@@ -5389,27 +5389,27 @@ func TestDAGInsert(t *testing.T) {
 		"httpproxy tcpproxy + tlspassthrough + permitinsecure": {
 			objs: []interface{}{
 				s9,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								Passthrough: true,
 							},
 						},
-						Routes: []projcontour.Route{{
+						Routes: []contour_api_v1.Route{{
 							PermitInsecure: true,
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: s9.Name,
 								Port: 80,
 							}},
 						}},
-						TCPProxy: &projcontour.TCPProxy{
-							Services: []projcontour.Service{{
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{{
 								Name: s9.Name,
 								Port: 80,
 							}},
@@ -5645,21 +5645,21 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5697,21 +5697,21 @@ func TestDAGInsert(t *testing.T) {
 				sec4,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5728,33 +5728,33 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecretRootNamespace,
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "fallbackcertdelegation",
 						Namespace: "root",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName:       "fallbacksecret",
 							TargetNamespaces: []string{"*"},
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5792,33 +5792,33 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecretRootNamespace,
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "fallbackcertdelegation",
 						Namespace: "root",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName:       "fallbacksecret",
 							TargetNamespaces: []string{"default"},
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5856,20 +5856,20 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5886,23 +5886,23 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								EnableFallbackCertificate: true,
-								ClientValidation: &projcontour.DownstreamValidation{
+								ClientValidation: &contour_api_v1.DownstreamValidation{
 									CACertificate: cert1.Name,
 								},
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -5919,42 +5919,42 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx-disabled",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "projectcontour.io",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: false,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -6002,20 +6002,20 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: sec1.Name,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -6053,21 +6053,21 @@ func TestDAGInsert(t *testing.T) {
 				sec1,
 				s9,
 				fallbackCertificateSecret,
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nginx",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                sec1.Name,
 								EnableFallbackCertificate: false,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "nginx",
 								Port: 80,
 							}},
@@ -6166,17 +6166,17 @@ func ingressrulevalue(backend *v1beta1.IngressBackend) v1beta1.IngressRuleValue 
 }
 
 func TestDAGRootNamespaces(t *testing.T) {
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "allowed1",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -6185,17 +6185,17 @@ func TestDAGRootNamespaces(t *testing.T) {
 	}
 
 	// proxy2 is like proxy1, but in a different namespace
-	proxy2 := &projcontour.HTTPProxy{
+	proxy2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "allowed2",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example2.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -6487,15 +6487,15 @@ func TestEnforceRoute(t *testing.T) {
 func TestValidateHeaderAlteration(t *testing.T) {
 	tests := []struct {
 		name    string
-		in      *projcontour.HeadersPolicy
+		in      *contour_api_v1.HeadersPolicy
 		want    *HeadersPolicy
 		wantErr error
 	}{{
 		name: "empty is fine",
 	}, {
 		name: "set two, remove one",
-		in: &projcontour.HeadersPolicy{
-			Set: []projcontour.HeaderValue{{
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
 				Name:  "K-Foo",
 				Value: "bar",
 			}, {
@@ -6513,8 +6513,8 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		},
 	}, {
 		name: "duplicate set",
-		in: &projcontour.HeadersPolicy{
-			Set: []projcontour.HeaderValue{{
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
 				Name:  "K-Foo",
 				Value: "bar",
 			}, {
@@ -6525,14 +6525,14 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		wantErr: errors.New(`duplicate header addition: "K-Foo"`),
 	}, {
 		name: "duplicate remove",
-		in: &projcontour.HeadersPolicy{
+		in: &contour_api_v1.HeadersPolicy{
 			Remove: []string{"K-Foo", "k-foo"},
 		},
 		wantErr: errors.New(`duplicate header removal: "K-Foo"`),
 	}, {
 		name: "invalid set header",
-		in: &projcontour.HeadersPolicy{
-			Set: []projcontour.HeaderValue{{
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
 				Name:  "  K-Foo",
 				Value: "bar",
 			}},
@@ -6540,14 +6540,14 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		wantErr: errors.New(`invalid set header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
 	}, {
 		name: "invalid remove header",
-		in: &projcontour.HeadersPolicy{
+		in: &contour_api_v1.HeadersPolicy{
 			Remove: []string{"  K-Foo"},
 		},
 		wantErr: errors.New(`invalid remove header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
 	}, {
 		name: "invalid set header (special headers)",
-		in: &projcontour.HeadersPolicy{
-			Set: []projcontour.HeaderValue{{
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
 				Name:  "Host",
 				Value: "bar",
 			}},
@@ -6555,8 +6555,8 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		wantErr: errors.New(`rewriting "Host" header is not supported`),
 	}, {
 		name: "percents are escaped",
-		in: &projcontour.HeadersPolicy{
-			Set: []projcontour.HeaderValue{{
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
 				Name:  "K-Foo",
 				Value: "100%",
 			}, {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"sync"
 
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -45,15 +45,15 @@ type KubernetesCache struct {
 	IngressClass string
 
 	ingresses            map[types.NamespacedName]*v1beta1.Ingress
-	httpproxies          map[types.NamespacedName]*projectcontour.HTTPProxy
+	httpproxies          map[types.NamespacedName]*contour_api_v1.HTTPProxy
 	secrets              map[types.NamespacedName]*v1.Secret
-	httpproxydelegations map[types.NamespacedName]*projectcontour.TLSCertificateDelegation
+	httpproxydelegations map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation
 	services             map[types.NamespacedName]*v1.Service
 	gatewayclasses       map[types.NamespacedName]*serviceapis.GatewayClass
 	gateways             map[types.NamespacedName]*serviceapis.Gateway
 	httproutes           map[types.NamespacedName]*serviceapis.HTTPRoute
 	tcproutes            map[types.NamespacedName]*serviceapis.TcpRoute
-	extensions           map[types.NamespacedName]*projectcontourv1alpha1.ExtensionService
+	extensions           map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
 
@@ -63,15 +63,15 @@ type KubernetesCache struct {
 // init creates the internal cache storage. It is called implicitly from the public API.
 func (kc *KubernetesCache) init() {
 	kc.ingresses = make(map[types.NamespacedName]*v1beta1.Ingress)
-	kc.httpproxies = make(map[types.NamespacedName]*projectcontour.HTTPProxy)
+	kc.httpproxies = make(map[types.NamespacedName]*contour_api_v1.HTTPProxy)
 	kc.secrets = make(map[types.NamespacedName]*v1.Secret)
-	kc.httpproxydelegations = make(map[types.NamespacedName]*projectcontour.TLSCertificateDelegation)
+	kc.httpproxydelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
 	kc.services = make(map[types.NamespacedName]*v1.Service)
 	kc.gatewayclasses = make(map[types.NamespacedName]*serviceapis.GatewayClass)
 	kc.gateways = make(map[types.NamespacedName]*serviceapis.Gateway)
 	kc.httproutes = make(map[types.NamespacedName]*serviceapis.HTTPRoute)
 	kc.tcproutes = make(map[types.NamespacedName]*serviceapis.TcpRoute)
-	kc.extensions = make(map[types.NamespacedName]*projectcontourv1alpha1.ExtensionService)
+	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
 
 // matchesIngressClass returns true if the given Kubernetes object
@@ -159,12 +159,12 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			kc.ingresses[k8s.NamespacedNameOf(obj)] = obj
 			return true
 		}
-	case *projectcontour.HTTPProxy:
+	case *contour_api_v1.HTTPProxy:
 		if kc.matchesIngressClass(obj) {
 			kc.httpproxies[k8s.NamespacedNameOf(obj)] = obj
 			return true
 		}
-	case *projectcontour.TLSCertificateDelegation:
+	case *contour_api_v1.TLSCertificateDelegation:
 		kc.httpproxydelegations[k8s.NamespacedNameOf(obj)] = obj
 		return true
 	case *serviceapis.GatewayClass:
@@ -195,7 +195,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding TcpRoute")
 		kc.tcproutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
-	case *projectcontourv1alpha1.ExtensionService:
+	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 		return true
 
@@ -238,12 +238,12 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
 		return ok
-	case *projectcontour.HTTPProxy:
+	case *contour_api_v1.HTTPProxy:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.httpproxies[m]
 		delete(kc.httpproxies, m)
 		return ok
-	case *projectcontour.TLSCertificateDelegation:
+	case *contour_api_v1.TLSCertificateDelegation:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.httpproxydelegations[m]
 		delete(kc.httpproxydelegations, m)
@@ -280,7 +280,7 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing TcpRoute")
 		delete(kc.tcproutes, m)
 		return ok
-	case *projectcontourv1alpha1.ExtensionService:
+	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.extensions[m]
 		delete(kc.extensions, m)
@@ -440,7 +440,7 @@ func (kc *KubernetesCache) LookupSecret(name types.NamespacedName, validate func
 	return s, nil
 }
 
-func (kc *KubernetesCache) LookupUpstreamValidation(uv *projectcontour.UpstreamValidation, namespace string) (*PeerValidationContext, error) {
+func (kc *KubernetesCache) LookupUpstreamValidation(uv *contour_api_v1.UpstreamValidation, namespace string) (*PeerValidationContext, error) {
 	if uv == nil {
 		// no upstream validation requested, nothing to do
 		return nil, nil
@@ -464,7 +464,7 @@ func (kc *KubernetesCache) LookupUpstreamValidation(uv *projectcontour.UpstreamV
 	}, nil
 }
 
-func (kc *KubernetesCache) LookupDownstreamValidation(vc *projectcontour.DownstreamValidation, namespace string) (*PeerValidationContext, error) {
+func (kc *KubernetesCache) LookupDownstreamValidation(vc *contour_api_v1.DownstreamValidation, namespace string) (*PeerValidationContext, error) {
 	secretName := types.NamespacedName{Name: vc.CACertificate, Namespace: namespace}
 	cacert, err := kc.LookupSecret(secretName, validCA)
 	if err != nil {

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"testing"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/stretchr/testify/assert"
@@ -183,13 +183,13 @@ func TestKubernetesCacheInsert(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "delegation",
 						Namespace: "default",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName: "secret",
 							TargetNamespaces: []string{
 								"extra",
@@ -222,13 +222,13 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					},
 				},
 
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "delegation",
 						Namespace: "default",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName: "secret",
 							TargetNamespaces: []string{
 								"*",
@@ -249,14 +249,14 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert secret referenced by httpproxy": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
-							TLS: &projcontour.TLS{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
@@ -275,26 +275,26 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert secret referenced by httpproxy via tls delegation": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "extra",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
-							TLS: &projcontour.TLS{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "default/secret",
 							},
 						},
 					},
 				},
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "delegation",
 						Namespace: "default",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName: "secret",
 							TargetNamespaces: []string{
 								"extra",
@@ -315,26 +315,26 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert secret referenced by httpproxy via wildcard tls delegation": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "extra",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
-							TLS: &projcontour.TLS{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "default/secret",
 							},
 						},
 					},
 				},
-				&projcontour.TLSCertificateDelegation{
+				&contour_api_v1.TLSCertificateDelegation{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "delegation",
 						Namespace: "default",
 					},
-					Spec: projcontour.TLSCertificateDelegationSpec{
-						Delegations: []projcontour.CertificateDelegation{{
+					Spec: contour_api_v1.TLSCertificateDelegationSpec{
+						Delegations: []contour_api_v1.CertificateDelegation{{
 							SecretName: "secret",
 							TargetNamespaces: []string{
 								"*",
@@ -372,23 +372,23 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert certificate secret referenced by httpproxy": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "example-com",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "kuard",
 								Port: 8080,
-								UpstreamValidation: &projcontour.UpstreamValidation{
+								UpstreamValidation: &contour_api_v1.UpstreamValidation{
 									CACertificate: "ca",
 									SubjectName:   "example.com",
 								},
@@ -491,7 +491,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert httpproxy empty ingress annotation": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kuard",
 					Namespace: "default",
@@ -500,7 +500,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert httpproxy incorrect contour.heptio.com/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simple",
 					Namespace: "default",
@@ -512,7 +512,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: false,
 		},
 		"insert httpproxy incorrect kubernetes.io/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simple",
 					Namespace: "default",
@@ -524,7 +524,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: false,
 		},
 		"insert httpproxy incorrect projectcontour.io/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "simple",
 					Namespace: "default",
@@ -536,7 +536,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: false,
 		},
 		"insert httpproxy: explicit contour.heptio.com/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kuard",
 					Namespace: "default",
@@ -548,7 +548,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert httpproxy explicit kubernetes.io/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kuard",
 					Namespace: "default",
@@ -560,7 +560,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert httpproxy explicit projectcontour.io/ingress.class": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kuard",
 					Namespace: "default",
@@ -571,8 +571,8 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert tls projcontour/v1.certificatedelegation": {
-			obj: &projcontour.TLSCertificateDelegation{
+		"insert tls contour_api_v1/v1.certificatedelegation": {
+			obj: &contour_api_v1.TLSCertificateDelegation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "delegate",
 					Namespace: "default",
@@ -581,7 +581,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert httpproxy": {
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httpproxy",
 					Namespace: "default",
@@ -648,14 +648,14 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert service referenced by httpproxy": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kuard",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+					Spec: contour_api_v1.HTTPProxySpec{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "service",
 							}},
 						}},
@@ -672,14 +672,14 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert service referenced by httpproxy tcpproxy": {
 			pre: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kuard",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						TCPProxy: &projcontour.TCPProxy{
-							Services: []projcontour.Service{{
+					Spec: contour_api_v1.HTTPProxySpec{
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{{
 								Name: "service",
 							}},
 						},
@@ -731,7 +731,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert extension service": {
-			obj: &projectcontourv1alpha1.ExtensionService{
+			obj: &contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
 			},
 			want: true,
@@ -841,13 +841,13 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove httpproxy": {
-			cache: cache(&projcontour.HTTPProxy{
+			cache: cache(&contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httpproxy",
 					Namespace: "default",
 				},
 			}),
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httpproxy",
 					Namespace: "default",
@@ -856,7 +856,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove httpproxy incorrect ingressclass": {
-			cache: cache(&projcontour.HTTPProxy{
+			cache: cache(&contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httpproxy",
 					Namespace: "default",
@@ -865,7 +865,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 					},
 				},
 			}),
-			obj: &projcontour.HTTPProxy{
+			obj: &contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httpproxy",
 					Namespace: "default",
@@ -937,10 +937,10 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove extension service": {
-			cache: cache(&projectcontourv1alpha1.ExtensionService{
+			cache: cache(&contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
 			}),
-			obj: &projectcontourv1alpha1.ExtensionService{
+			obj: &contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
 			},
 			want: true,

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -19,14 +19,14 @@ import (
 	"regexp"
 	"strings"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
 
 // mergePathMatchConditions merges the given slice of prefix MatchConditions into a single
 // prefix Condition.
 // pathMatchConditionsValid guarantees that if a prefix is present, it will start with a
 // / character, so we can simply concatenate.
-func mergePathMatchConditions(conds []projcontour.MatchCondition) MatchCondition {
+func mergePathMatchConditions(conds []contour_api_v1.MatchCondition) MatchCondition {
 	prefix := ""
 	for _, cond := range conds {
 		prefix = prefix + cond.Prefix
@@ -51,7 +51,7 @@ func mergePathMatchConditions(conds []projcontour.MatchCondition) MatchCondition
 
 // pathMatchConditionsValid validates a slice of MatchConditions can be correctly merged.
 // It encodes the business rules about what is allowed for prefix MatchConditions.
-func pathMatchConditionsValid(conds []projcontour.MatchCondition) error {
+func pathMatchConditionsValid(conds []contour_api_v1.MatchCondition) error {
 	prefixCount := 0
 
 	for _, cond := range conds {
@@ -69,7 +69,7 @@ func pathMatchConditionsValid(conds []projcontour.MatchCondition) error {
 	return nil
 }
 
-func mergeHeaderMatchConditions(conds []projcontour.MatchCondition) []HeaderMatchCondition {
+func mergeHeaderMatchConditions(conds []contour_api_v1.MatchCondition) []HeaderMatchCondition {
 	var hc []HeaderMatchCondition
 	for _, cond := range conds {
 		switch {
@@ -120,8 +120,8 @@ func mergeHeaderMatchConditions(conds []projcontour.MatchCondition) []HeaderMatc
 //
 // Note that there are additional, more complex scenarios that we could check for here. For
 // example, "exact: foo" and "notcontains: <any substring of foo>" are contradictory.
-func headerMatchConditionsValid(conditions []projcontour.MatchCondition) error {
-	seenMatchConditions := map[projcontour.HeaderMatchCondition]bool{}
+func headerMatchConditionsValid(conditions []contour_api_v1.MatchCondition) error {
+	seenMatchConditions := map[contour_api_v1.HeaderMatchCondition]bool{}
 	headersWithExactMatch := map[string]bool{}
 
 	for _, v := range conditions {
@@ -139,7 +139,7 @@ func headerMatchConditionsValid(conditions []projcontour.MatchCondition) error {
 			headersWithExactMatch[headerName] = true
 
 			// look for a NotExact condition on the same header with the same value
-			if seenMatchConditions[projcontour.HeaderMatchCondition{
+			if seenMatchConditions[contour_api_v1.HeaderMatchCondition{
 				Name:     headerName,
 				NotExact: v.Header.Exact,
 			}] {
@@ -147,7 +147,7 @@ func headerMatchConditionsValid(conditions []projcontour.MatchCondition) error {
 			}
 		case v.Header.NotExact != "":
 			// look for an Exact condition on the same header with the same value
-			if seenMatchConditions[projcontour.HeaderMatchCondition{
+			if seenMatchConditions[contour_api_v1.HeaderMatchCondition{
 				Name:  headerName,
 				Exact: v.Header.NotExact,
 			}] {
@@ -155,7 +155,7 @@ func headerMatchConditionsValid(conditions []projcontour.MatchCondition) error {
 			}
 		case v.Header.Contains != "":
 			// look for a NotContains condition on the same header with the same value
-			if seenMatchConditions[projcontour.HeaderMatchCondition{
+			if seenMatchConditions[contour_api_v1.HeaderMatchCondition{
 				Name:        headerName,
 				NotContains: v.Header.Contains,
 			}] {
@@ -163,7 +163,7 @@ func headerMatchConditionsValid(conditions []projcontour.MatchCondition) error {
 			}
 		case v.Header.NotContains != "":
 			// look for a Contains condition on the same header with the same value
-			if seenMatchConditions[projcontour.HeaderMatchCondition{
+			if seenMatchConditions[contour_api_v1.HeaderMatchCondition{
 				Name:     headerName,
 				Contains: v.Header.NotContains,
 			}] {

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -16,13 +16,13 @@ package dag
 import (
 	"testing"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPathMatchCondition(t *testing.T) {
 	tests := map[string]struct {
-		matchconditions []projcontour.MatchCondition
+		matchconditions []contour_api_v1.MatchCondition
 		want            MatchCondition
 	}{
 		"empty condition list": {
@@ -30,13 +30,13 @@ func TestPathMatchCondition(t *testing.T) {
 			want:            &PrefixMatchCondition{Prefix: "/"},
 		},
 		"single slash": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/",
 			}},
 			want: &PrefixMatchCondition{Prefix: "/"},
 		},
 		"two slashes": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/",
 			}, {
 				Prefix: "/",
@@ -44,7 +44,7 @@ func TestPathMatchCondition(t *testing.T) {
 			want: &PrefixMatchCondition{Prefix: "/"},
 		},
 		"mixed matchconditions": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/a/",
 			}, {
 				Prefix: "/b",
@@ -52,13 +52,13 @@ func TestPathMatchCondition(t *testing.T) {
 			want: &PrefixMatchCondition{Prefix: "/a/b"},
 		},
 		"trailing slash": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/a/",
 			}},
 			want: &PrefixMatchCondition{Prefix: "/a/"},
 		},
 		"trailing slash on second prefix condition": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/a",
 			},
 				{
@@ -67,7 +67,7 @@ func TestPathMatchCondition(t *testing.T) {
 			want: &PrefixMatchCondition{Prefix: "/a/b/"},
 		},
 		"nothing but slashes": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
 					Prefix: "///",
 				},
@@ -77,8 +77,8 @@ func TestPathMatchCondition(t *testing.T) {
 			want: &PrefixMatchCondition{Prefix: "/"},
 		},
 		"header condition": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: new(projcontour.HeaderMatchCondition),
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: new(contour_api_v1.HeaderMatchCondition),
 			}},
 			want: &PrefixMatchCondition{Prefix: "/"},
 		},
@@ -94,7 +94,7 @@ func TestPathMatchCondition(t *testing.T) {
 
 func TestHeaderMatchConditions(t *testing.T) {
 	tests := map[string]struct {
-		matchconditions []projcontour.MatchCondition
+		matchconditions []contour_api_v1.MatchCondition
 		want            []HeaderMatchCondition
 	}{
 		"empty condition list": {
@@ -102,20 +102,20 @@ func TestHeaderMatchConditions(t *testing.T) {
 			want:            nil,
 		},
 		"prefix": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/",
 			}},
 			want: nil,
 		},
 		"header condition empty": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: new(projcontour.HeaderMatchCondition),
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: new(contour_api_v1.HeaderMatchCondition),
 			}},
 			want: nil,
 		},
 		"header present": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:    "x-request-id",
 					Present: true,
 				},
@@ -126,8 +126,8 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"header name but missing condition": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name: "x-request-id",
 				},
 			}},
@@ -136,8 +136,8 @@ func TestHeaderMatchConditions(t *testing.T) {
 			want: nil,
 		},
 		"header contains": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-request-id",
 					Contains: "abcdef",
 				},
@@ -149,8 +149,8 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"header not contains": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:        "x-request-id",
 					NotContains: "abcdef",
 				},
@@ -163,8 +163,8 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"header exact": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:  "x-request-id",
 					Exact: "abcdef",
 				},
@@ -176,8 +176,8 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"header not exact": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-request-id",
 					NotExact: "abcdef",
 				},
@@ -190,13 +190,13 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"two header contains": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-request-id",
 					Contains: "abcdef",
 				},
 			}, {
-				Header: &projcontour.HeaderMatchCondition{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-request-id",
 					Contains: "cedfg",
 				},
@@ -212,13 +212,13 @@ func TestHeaderMatchConditions(t *testing.T) {
 			}},
 		},
 		"two header contains different case": {
-			matchconditions: []projcontour.MatchCondition{{
-				Header: &projcontour.HeaderMatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-request-id",
 					Contains: "abcdef",
 				},
 			}, {
-				Header: &projcontour.HeaderMatchCondition{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "X-Request-Id",
 					Contains: "abcdef",
 				},
@@ -245,7 +245,7 @@ func TestHeaderMatchConditions(t *testing.T) {
 
 func TestPrefixMatchConditionsValid(t *testing.T) {
 	tests := map[string]struct {
-		matchconditions []projcontour.MatchCondition
+		matchconditions []contour_api_v1.MatchCondition
 		want            bool
 	}{
 		"empty condition list": {
@@ -253,15 +253,15 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 			want:            true,
 		},
 		"valid path condition only": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/api",
 			}},
 			want: true,
 		},
 		"valid path condition with headers": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/api",
-				Header: &projcontour.HeaderMatchCondition{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-header",
 					Contains: "abc",
 				},
@@ -269,7 +269,7 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 			want: true,
 		},
 		"two prefix matchconditions": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/api",
 			}, {
 				Prefix: "/v1",
@@ -277,9 +277,9 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 			want: false,
 		},
 		"two prefix matchconditions with headers": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/api",
-				Header: &projcontour.HeaderMatchCondition{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-header",
 					Contains: "abc",
 				},
@@ -289,15 +289,15 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 			want: false,
 		},
 		"invalid prefix condition": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "api",
 			}},
 			want: false,
 		},
 		"invalid prefix condition with headers": {
-			matchconditions: []projcontour.MatchCondition{{
+			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "api",
-				Header: &projcontour.HeaderMatchCondition{
+				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-header",
 					Contains: "abc",
 				},
@@ -316,7 +316,7 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 
 func TestValidateHeaderMatchConditions(t *testing.T) {
 	tests := map[string]struct {
-		matchconditions []projcontour.MatchCondition
+		matchconditions []contour_api_v1.MatchCondition
 		wantErr         bool
 	}{
 		"empty condition list": {
@@ -324,7 +324,7 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr:         false,
 		},
 		"prefix only": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
 					Prefix: "/blog",
 				},
@@ -332,9 +332,9 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"valid matchconditions": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
@@ -343,16 +343,16 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"prefix matchconditions + valid headers": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
 					Prefix: "/blog",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-header",
 						NotContains: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "another-header",
 						NotContains: "123",
 					},
@@ -361,14 +361,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"multiple 'exact' matchconditions for the same header are invalid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "123",
 					},
@@ -377,14 +377,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: true,
 		},
 		"multiple 'exact' matchconditions for different headers are valid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-different-header",
 						Exact: "123",
 					},
@@ -393,14 +393,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"'exact' and 'notexact' matchconditions for the same header with the same value are invalid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						NotExact: "abc",
 					},
@@ -409,14 +409,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: true,
 		},
 		"'exact' and 'notexact' matchconditions for the same header with different values are valid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						NotExact: "def",
 					},
@@ -425,14 +425,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"'exact' and 'notexact' matchconditions for different headers with the same value are valid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-another-header",
 						NotExact: "abc",
 					},
@@ -441,14 +441,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"'contains' and 'notcontains' matchconditions for the same header with the same value are invalid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-header",
 						NotContains: "abc",
 					},
@@ -457,14 +457,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: true,
 		},
 		"'contains' and 'notcontains' matchconditions for the same header with different values are valid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-header",
 						NotContains: "def",
 					},
@@ -473,14 +473,14 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 			wantErr: false,
 		},
 		"'contains' and 'notcontains' matchconditions for different headers with the same value are valid": {
-			matchconditions: []projcontour.MatchCondition{
+			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-another-header",
 						NotContains: "abc",
 					},

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -18,8 +18,8 @@ import (
 	"sort"
 	"strings"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/timeout"
@@ -29,9 +29,9 @@ import (
 )
 
 // defaultExtensionRef populates the unset fields in ref with default values.
-func defaultExtensionRef(ref projcontour.ExtensionServiceReference) projcontour.ExtensionServiceReference {
+func defaultExtensionRef(ref contour_api_v1.ExtensionServiceReference) contour_api_v1.ExtensionServiceReference {
 	if ref.APIVersion == "" {
-		ref.APIVersion = projcontourv1alpha1.GroupVersion.String()
+		ref.APIVersion = contour_api_v1alpha1.GroupVersion.String()
 
 	}
 
@@ -98,7 +98,7 @@ func (p *HTTPProxyProcessor) Run(dag *DAG, source *KubernetesCache) {
 	}
 }
 
-func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
+func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 	sw, commit := p.dag.WithObject(proxy)
 	defer commit()
 
@@ -218,7 +218,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *projcontour.HTTPProxy) {
 				auth := proxy.Spec.VirtualHost.Authorization
 				ref := defaultExtensionRef(auth.ExtensionServiceRef)
 
-				if ref.APIVersion != projcontourv1alpha1.GroupVersion.String() {
+				if ref.APIVersion != contour_api_v1alpha1.GroupVersion.String() {
 					sw.SetInvalid("Spec.Virtualhost.Authorization.ServiceRef specifies an unsupported resource version %q",
 						auth.ExtensionServiceRef.APIVersion)
 					return
@@ -292,10 +292,10 @@ func addRoutes(vhost vhost, routes []*Route) {
 
 func (p *HTTPProxyProcessor) computeRoutes(
 	sw *ObjectStatusWriter,
-	rootProxy *projcontour.HTTPProxy,
-	proxy *projcontour.HTTPProxy,
-	conditions []projcontour.MatchCondition,
-	visited []*projcontour.HTTPProxy,
+	rootProxy *contour_api_v1.HTTPProxy,
+	proxy *contour_api_v1.HTTPProxy,
+	conditions []contour_api_v1.MatchCondition,
+	visited []*contour_api_v1.HTTPProxy,
 	enforceTLS bool,
 ) []*Route {
 	for _, v := range visited {
@@ -546,7 +546,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 // following the chain of spec.tcpproxy.include references. It returns true if processing
 // was successful, otherwise false if an error was encountered. The details of the error
 // will be recorded on the status of the relevant HTTPProxy object,
-func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *projcontour.HTTPProxy, visited []*projcontour.HTTPProxy, host string) bool {
+func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, httpproxy *contour_api_v1.HTTPProxy, visited []*contour_api_v1.HTTPProxy, host string) bool {
 	tcpproxy := httpproxy.Spec.TCPProxy
 	if tcpproxy == nil {
 		// nothing to do
@@ -639,13 +639,13 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(sw *ObjectStatusWriter, ht
 	return ok
 }
 
-// validHTTPProxies returns a slice of *projcontour.HTTPProxy objects.
+// validHTTPProxies returns a slice of *contour_api_v1.HTTPProxy objects.
 // invalid HTTPProxy objects are excluded from the slice and their status
 // updated accordingly.
-func (p *HTTPProxyProcessor) validHTTPProxies() []*projcontour.HTTPProxy {
+func (p *HTTPProxyProcessor) validHTTPProxies() []*contour_api_v1.HTTPProxy {
 	// ensure that a given fqdn is only referenced in a single HTTPProxy resource
-	var valid []*projcontour.HTTPProxy
-	fqdnHTTPProxies := make(map[string][]*projcontour.HTTPProxy)
+	var valid []*contour_api_v1.HTTPProxy
+	fqdnHTTPProxies := make(map[string][]*contour_api_v1.HTTPProxy)
 	for _, proxy := range p.source.httpproxies {
 		if proxy.Spec.VirtualHost == nil {
 			valid = append(valid, proxy)
@@ -789,7 +789,7 @@ func expandPrefixMatches(routes []*Route) []*Route {
 	return expandedRoutes
 }
 
-func getProtocol(service projcontour.Service, s *Service) (string, error) {
+func getProtocol(service contour_api_v1.Service, s *Service) (string, error) {
 	// Determine the protocol to use to speak to this Cluster.
 	var protocol string
 	if service.Protocol != nil {
@@ -828,7 +828,7 @@ func determineSNI(routeRequestHeaders *HeadersPolicy, clusterRequestHeaders *Hea
 	return service.ExternalName
 }
 
-func toCORSPolicy(policy *projcontour.CORSPolicy) (*CORSPolicy, error) {
+func toCORSPolicy(policy *contour_api_v1.CORSPolicy) (*CORSPolicy, error) {
 	if policy == nil {
 		return nil, nil
 	}
@@ -849,7 +849,7 @@ func toCORSPolicy(policy *projcontour.CORSPolicy) (*CORSPolicy, error) {
 	}, nil
 }
 
-func toStringSlice(hvs []projcontour.CORSHeaderValue) []string {
+func toStringSlice(hvs []contour_api_v1.CORSHeaderValue) []string {
 	s := make([]string, len(hvs))
 	for i, v := range hvs {
 		s[i] = string(v)
@@ -857,7 +857,7 @@ func toStringSlice(hvs []projcontour.CORSHeaderValue) []string {
 	return s
 }
 
-func includeMatchConditionsIdentical(includes []projcontour.Include) bool {
+func includeMatchConditionsIdentical(includes []contour_api_v1.Include) bool {
 	j := 0
 	for i := 1; i < len(includes); i++ {
 		// Now compare each include's set of conditions

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
@@ -30,7 +30,7 @@ import (
 
 // retryOn transforms a slice of retry on values to a comma-separated string.
 // CRD validation ensures that all retry on values are valid.
-func retryOn(ro []projcontour.RetryOn) string {
+func retryOn(ro []contour_api_v1.RetryOn) string {
 	if len(ro) == 0 {
 		return "5xx"
 	}
@@ -42,7 +42,7 @@ func retryOn(ro []projcontour.RetryOn) string {
 	return strings.Join(ss, ",")
 }
 
-func retryPolicy(rp *projcontour.RetryPolicy) *RetryPolicy {
+func retryPolicy(rp *contour_api_v1.RetryPolicy) *RetryPolicy {
 	if rp == nil {
 		return nil
 	}
@@ -65,12 +65,12 @@ func retryPolicy(rp *projcontour.RetryPolicy) *RetryPolicy {
 	}
 }
 
-func headersPolicyService(policy *projcontour.HeadersPolicy) (*HeadersPolicy, error) {
+func headersPolicyService(policy *contour_api_v1.HeadersPolicy) (*HeadersPolicy, error) {
 	return headersPolicyRoute(policy, false)
 
 }
 
-func headersPolicyRoute(policy *projcontour.HeadersPolicy, allowHostRewrite bool) (*HeadersPolicy, error) {
+func headersPolicyRoute(policy *contour_api_v1.HeadersPolicy, allowHostRewrite bool) (*HeadersPolicy, error) {
 	if policy == nil {
 		return nil, nil
 	}
@@ -170,7 +170,7 @@ func ingressTimeoutPolicy(ingress *v1beta1.Ingress, log logrus.FieldLogger) Time
 	}
 	// if the request timeout annotation is present on this ingress
 	// construct and use the HTTPProxy timeout policy logic.
-	tp, err := timeoutPolicy(&projcontour.TimeoutPolicy{
+	tp, err := timeoutPolicy(&contour_api_v1.TimeoutPolicy{
 		Response: response,
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func ingressTimeoutPolicy(ingress *v1beta1.Ingress, log logrus.FieldLogger) Time
 	return tp
 }
 
-func timeoutPolicy(tp *projcontour.TimeoutPolicy) (TimeoutPolicy, error) {
+func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy) (TimeoutPolicy, error) {
 	if tp == nil {
 		return TimeoutPolicy{
 			ResponseTimeout: timeout.DefaultSetting(),
@@ -205,7 +205,7 @@ func timeoutPolicy(tp *projcontour.TimeoutPolicy) (TimeoutPolicy, error) {
 	}, nil
 }
 
-func httpHealthCheckPolicy(hc *projcontour.HTTPHealthCheckPolicy) *HTTPHealthCheckPolicy {
+func httpHealthCheckPolicy(hc *contour_api_v1.HTTPHealthCheckPolicy) *HTTPHealthCheckPolicy {
 	if hc == nil {
 		return nil
 	}
@@ -219,7 +219,7 @@ func httpHealthCheckPolicy(hc *projcontour.HTTPHealthCheckPolicy) *HTTPHealthChe
 	}
 }
 
-func tcpHealthCheckPolicy(hc *projcontour.TCPHealthCheckPolicy) *TCPHealthCheckPolicy {
+func tcpHealthCheckPolicy(hc *contour_api_v1.TCPHealthCheckPolicy) *TCPHealthCheckPolicy {
 	if hc == nil {
 		return nil
 	}
@@ -233,7 +233,7 @@ func tcpHealthCheckPolicy(hc *projcontour.TCPHealthCheckPolicy) *TCPHealthCheckP
 
 // loadBalancerPolicy returns the load balancer strategy or
 // blank if no valid strategy is supplied.
-func loadBalancerPolicy(lbp *projcontour.LoadBalancerPolicy) string {
+func loadBalancerPolicy(lbp *contour_api_v1.LoadBalancerPolicy) string {
 	if lbp == nil {
 		return ""
 	}
@@ -256,7 +256,7 @@ func max(a, b uint32) uint32 {
 	return b
 }
 
-func prefixReplacementsAreValid(replacements []projcontour.ReplacePrefix) error {
+func prefixReplacementsAreValid(replacements []contour_api_v1.ReplacePrefix) error {
 	prefixes := map[string]bool{}
 
 	for _, r := range replacements {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -175,7 +175,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 
 func TestRetryPolicy(t *testing.T) {
 	tests := map[string]struct {
-		rp   *projcontour.RetryPolicy
+		rp   *contour_api_v1.RetryPolicy
 		want *RetryPolicy
 	}{
 		"nil retry policy": {
@@ -183,14 +183,14 @@ func TestRetryPolicy(t *testing.T) {
 			want: nil,
 		},
 		"empty policy": {
-			rp: &projcontour.RetryPolicy{},
+			rp: &contour_api_v1.RetryPolicy{},
 			want: &RetryPolicy{
 				RetryOn:    "5xx",
 				NumRetries: 1,
 			},
 		},
 		"explicitly zero retries": {
-			rp: &projcontour.RetryPolicy{
+			rp: &contour_api_v1.RetryPolicy{
 				NumRetries: 0, // zero value for NumRetries
 			},
 			want: &RetryPolicy{
@@ -199,7 +199,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		"no retry count, per try timeout": {
-			rp: &projcontour.RetryPolicy{
+			rp: &contour_api_v1.RetryPolicy{
 				PerTryTimeout: "10s",
 			},
 			want: &RetryPolicy{
@@ -209,7 +209,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		"explicit 0s timeout": {
-			rp: &projcontour.RetryPolicy{
+			rp: &contour_api_v1.RetryPolicy{
 				PerTryTimeout: "0s",
 			},
 			want: &RetryPolicy{
@@ -219,8 +219,8 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		"retry on": {
-			rp: &projcontour.RetryPolicy{
-				RetryOn: []projcontour.RetryOn{"gateway-error", "connect-failure"},
+			rp: &contour_api_v1.RetryPolicy{
+				RetryOn: []contour_api_v1.RetryOn{"gateway-error", "connect-failure"},
 			},
 			want: &RetryPolicy{
 				RetryOn:    "gateway-error,connect-failure",
@@ -228,7 +228,7 @@ func TestRetryPolicy(t *testing.T) {
 			},
 		},
 		"retriable status codes": {
-			rp: &projcontour.RetryPolicy{
+			rp: &contour_api_v1.RetryPolicy{
 				RetriableStatusCodes: []uint32{502, 503, 504},
 			},
 			want: &RetryPolicy{
@@ -249,7 +249,7 @@ func TestRetryPolicy(t *testing.T) {
 
 func TestTimeoutPolicy(t *testing.T) {
 	tests := map[string]struct {
-		tp      *projcontour.TimeoutPolicy
+		tp      *contour_api_v1.TimeoutPolicy
 		want    TimeoutPolicy
 		wantErr bool
 	}{
@@ -258,11 +258,11 @@ func TestTimeoutPolicy(t *testing.T) {
 			want: TimeoutPolicy{},
 		},
 		"empty timeout policy": {
-			tp:   &projcontour.TimeoutPolicy{},
+			tp:   &contour_api_v1.TimeoutPolicy{},
 			want: TimeoutPolicy{},
 		},
 		"valid response timeout": {
-			tp: &projcontour.TimeoutPolicy{
+			tp: &contour_api_v1.TimeoutPolicy{
 				Response: "1m30s",
 			},
 			want: TimeoutPolicy{
@@ -270,13 +270,13 @@ func TestTimeoutPolicy(t *testing.T) {
 			},
 		},
 		"invalid response timeout": {
-			tp: &projcontour.TimeoutPolicy{
+			tp: &contour_api_v1.TimeoutPolicy{
 				Response: "90", // 90 what?
 			},
 			wantErr: true,
 		},
 		"infinite response timeout": {
-			tp: &projcontour.TimeoutPolicy{
+			tp: &contour_api_v1.TimeoutPolicy{
 				Response: "infinite",
 			},
 			want: TimeoutPolicy{
@@ -284,7 +284,7 @@ func TestTimeoutPolicy(t *testing.T) {
 			},
 		},
 		"idle timeout": {
-			tp: &projcontour.TimeoutPolicy{
+			tp: &contour_api_v1.TimeoutPolicy{
 				Idle: "900s",
 			},
 			want: TimeoutPolicy{
@@ -309,7 +309,7 @@ func TestTimeoutPolicy(t *testing.T) {
 
 func TestLoadBalancerPolicy(t *testing.T) {
 	tests := map[string]struct {
-		lbp  *projcontour.LoadBalancerPolicy
+		lbp  *contour_api_v1.LoadBalancerPolicy
 		want string
 	}{
 		"nil": {
@@ -317,29 +317,29 @@ func TestLoadBalancerPolicy(t *testing.T) {
 			want: "",
 		},
 		"empty": {
-			lbp:  &projcontour.LoadBalancerPolicy{},
+			lbp:  &contour_api_v1.LoadBalancerPolicy{},
 			want: "",
 		},
 		"WeightedLeastRequest": {
-			lbp: &projcontour.LoadBalancerPolicy{
+			lbp: &contour_api_v1.LoadBalancerPolicy{
 				Strategy: "WeightedLeastRequest",
 			},
 			want: "WeightedLeastRequest",
 		},
 		"Random": {
-			lbp: &projcontour.LoadBalancerPolicy{
+			lbp: &contour_api_v1.LoadBalancerPolicy{
 				Strategy: "Random",
 			},
 			want: "Random",
 		},
 		"Cookie": {
-			lbp: &projcontour.LoadBalancerPolicy{
+			lbp: &contour_api_v1.LoadBalancerPolicy{
 				Strategy: "Cookie",
 			},
 			want: "Cookie",
 		},
 		"unknown": {
-			lbp: &projcontour.LoadBalancerPolicy{
+			lbp: &contour_api_v1.LoadBalancerPolicy{
 				Strategy: "please",
 			},
 			want: "",

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -16,7 +16,7 @@ package dag
 import (
 	"fmt"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -88,7 +88,7 @@ func (osw *ObjectStatusWriter) SetInvalid(format string, args ...interface{}) {
 
 func (osw *ObjectStatusWriter) SetValid() {
 	switch osw.obj.(type) {
-	case *projcontour.HTTPProxy:
+	case *contour_api_v1.HTTPProxy:
 		osw.WithValue("description", "valid HTTPProxy").WithValue("status", k8s.StatusValid)
 	default:
 		// not a supported type

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"testing"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/stretchr/testify/assert"
@@ -65,18 +65,18 @@ func TestDAGStatus(t *testing.T) {
 	// Common test fixtures (used across more than one test)
 
 	// proxyNoFQDN is invalid because it does not specify and FQDN
-	proxyNoFQDN := &projcontour.HTTPProxy{
+	proxyNoFQDN := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo",
 					Port: 8080,
 				}},
@@ -93,20 +93,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// Simple Valid HTTPProxy
-	proxyValidHomeService := &projcontour.HTTPProxy{
+	proxyValidHomeService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -122,55 +122,55 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// Multiple Includes, one invalid
-	proxyMultiIncludeOneInvalid := &projcontour.HTTPProxy{
+	proxyMultiIncludeOneInvalid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "validChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}, {
 				Name: "invalidChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/bar",
 				}},
 			}},
 		},
 	}
 
-	proxyIncludeValidChild := &projcontour.HTTPProxy{
+	proxyIncludeValidChild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "parentvalidchild",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "validChild",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
 		},
 	}
 
-	proxyChildValidFoo2 := &projcontour.HTTPProxy{
+	proxyChildValidFoo2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "validChild",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo2",
 					Port: 8080,
 				}},
@@ -178,14 +178,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyChildInvalidBadPort := &projcontour.HTTPProxy{
+	proxyChildInvalidBadPort := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidChild",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo3",
 					Port: 12345678,
 				}},
@@ -228,20 +228,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyTCPSharedService := &projcontour.HTTPProxy{
+	proxyTCPSharedService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx",
 			Namespace: fixture.ServiceRootsNginx.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretRootsCert.Name,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsNginx.Name,
 					Port: 80,
 				}},
@@ -264,20 +264,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyDelegatedTCPTLS := &projcontour.HTTPProxy{
+	proxyDelegatedTCPTLS := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-with-tls-delegation",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "app-with-tls-delegation.127.0.0.1.nip.io",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretProjectContourCert.Namespace + "/" + fixture.SecretProjectContourCert.Name,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: "sample-app",
 					Port: 80,
 				}},
@@ -301,20 +301,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyDelegatedTLS := &projcontour.HTTPProxy{
+	proxyDelegatedTLS := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-with-tls-delegation",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "app-with-tls-delegation.127.0.0.1.nip.io",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretProjectContourCert.Namespace + "/" + fixture.SecretProjectContourCert.Name,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "sample-app",
 					Port: 80,
 				}},
@@ -358,29 +358,29 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyPassthroughProxyNonSecure := &projcontour.HTTPProxy{
+	proxyPassthroughProxyNonSecure := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-tcp",
 			Namespace: serviceTLSPassthrough.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: serviceTLSPassthrough.Name,
 					Port: 80, // proxy non secure traffic to port 80
 				}},
 			}},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: serviceTLSPassthrough.Name,
 					Port: 443, // ssl passthrough to secure port
 				}},
@@ -404,46 +404,46 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyMultipleIncludersSite1 := &projcontour.HTTPProxy{
+	proxyMultipleIncludersSite1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "site1",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "site1.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "www",
 				Namespace: fixture.ServiceRootsKuard.Namespace,
 			}},
 		},
 	}
 
-	proxyMultipleIncludersSite2 := &projcontour.HTTPProxy{
+	proxyMultipleIncludersSite2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "site2",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "site2.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "www",
 				Namespace: fixture.ServiceRootsKuard.Namespace,
 			}},
 		},
 	}
 
-	proxyMultiIncludeChild := &projcontour.HTTPProxy{
+	proxyMultiIncludeChild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -477,20 +477,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyInvalidNegativePortHomeService is invalid because it contains a service with negative port
-	proxyInvalidNegativePortHomeService := &projcontour.HTTPProxy{
+	proxyInvalidNegativePortHomeService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: -80,
 				}},
@@ -506,20 +506,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyInvalidOutsideRootNamespace is invalid because it lives outside the roots namespace
-	proxyInvalidOutsideRootNamespace := &projcontour.HTTPProxy{
+	proxyInvalidOutsideRootNamespace := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "finance",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foobar",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -535,24 +535,24 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyInvalidIncludeCycle is invalid because it delegates to itself, producing a cycle
-	proxyInvalidIncludeCycle := &projcontour.HTTPProxy{
+	proxyInvalidIncludeCycle := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "self",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "self",
 				Namespace: "roots",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "green",
 					Port: 80,
 				}},
@@ -573,35 +573,35 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyIncludesProxyWithIncludeCycle delegates to proxy8, which is invalid because proxy8 delegates back to proxy8
-	proxyIncludesProxyWithIncludeCycle := &projcontour.HTTPProxy{
+	proxyIncludesProxyWithIncludeCycle := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "parent",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "child",
 				Namespace: "roots",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
 		},
 	}
 
-	proxyIncludedChildInvalidIncludeCycle := &projcontour.HTTPProxy{
+	proxyIncludedChildInvalidIncludeCycle := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "child",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Includes: []projcontour.Include{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Includes: []contour_api_v1.Include{{
 				Name:      "child",
 				Namespace: "roots",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
@@ -632,14 +632,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyIncludedChildValid := &projcontour.HTTPProxy{
+	proxyIncludedChildValid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "validChild",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "foo2",
 					Port: 8080,
 				}},
@@ -648,17 +648,17 @@ func TestDAGStatus(t *testing.T) {
 	}
 
 	// proxyNotRootIncludeRootProxy delegates to proxyWildCardFQDN but it is invalid because it is missing fqdn
-	proxyNotRootIncludeRootProxy := &projcontour.HTTPProxy{
+	proxyNotRootIncludeRootProxy := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidParent",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{},
-			Includes: []projcontour.Include{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{},
+			Includes: []contour_api_v1.Include{{
 				Name:      "validChild",
 				Namespace: "roots",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
 			}},
@@ -674,20 +674,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyWildCardFQDN is invalid because it contains a wildcarded fqdn
-	proxyWildCardFQDN := &projcontour.HTTPProxy{
+	proxyWildCardFQDN := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.*.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -703,20 +703,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyInvalidServiceInvalid is invalid because it references an invalid service
-	proxyInvalidServiceInvalid := &projcontour.HTTPProxy{
+	proxyInvalidServiceInvalid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidir",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "invalid",
 					Port: 8080,
 				}},
@@ -737,20 +737,20 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// proxyInvalidServicePortInvalid is invalid because it references an invalid port on a service
-	proxyInvalidServicePortInvalid := &projcontour.HTTPProxy{
+	proxyInvalidServicePortInvalid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "invalidir",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 9999,
 				}},
@@ -770,20 +770,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyValidExampleCom := &projcontour.HTTPProxy{
+	proxyValidExampleCom := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-com",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -791,17 +791,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyValidReuseExampleCom := &projcontour.HTTPProxy{
+	proxyValidReuseExampleCom := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "other-example",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -827,42 +827,42 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyRootIncludesRoot := &projcontour.HTTPProxy{
+	proxyRootIncludesRoot := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-blog",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "blog.containersteve.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "blog-containersteve-com",
 				},
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blog",
 				Namespace: "marketing",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 			}},
 		},
 	}
 
-	proxyRootIncludedByRoot := &projcontour.HTTPProxy{
+	proxyRootIncludedByRoot := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
 			Namespace: fixture.ServiceMarketingGreen.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "blog.containersteve.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "blog-containersteve-com",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceMarketingGreen.Name,
 					Port: 80,
 				}},
@@ -888,36 +888,36 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyIncludesRootDifferentFQDN := &projcontour.HTTPProxy{
+	proxyIncludesRootDifferentFQDN := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-blog",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "blog.containersteve.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blog",
 				Namespace: "marketing",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 			}},
 		},
 	}
 
-	proxyRootIncludedByRootDiffFQDN := &projcontour.HTTPProxy{
+	proxyRootIncludedByRootDiffFQDN := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
 			Namespace: fixture.ServiceMarketingGreen.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.containersteve.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceMarketingGreen.Name,
 					Port: 80,
 				}},
@@ -943,14 +943,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyValidIncludeBlogMarketing := &projcontour.HTTPProxy{
+	proxyValidIncludeBlogMarketing := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
 			Namespace: fixture.ServiceMarketingGreen.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceMarketingGreen.Name,
 					Port: 80,
 				}},
@@ -958,19 +958,19 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyRootValidIncludesBlogMarketing := &projcontour.HTTPProxy{
+	proxyRootValidIncludesBlogMarketing := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-blog",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      proxyValidIncludeBlogMarketing.Name,
 				Namespace: proxyValidIncludeBlogMarketing.Namespace,
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
 			}},
@@ -994,17 +994,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyValidWithMirror := &projcontour.HTTPProxy{
+	proxyValidWithMirror := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}, {
@@ -1031,17 +1031,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidTwoMirrors := &projcontour.HTTPProxy{
+	proxyInvalidTwoMirrors := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}, {
@@ -1069,30 +1069,30 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidDuplicateMatchConditionHeaders := &projcontour.HTTPProxy{
+	proxyInvalidDuplicateMatchConditionHeaders := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "1234",
 					},
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1111,48 +1111,48 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidDuplicateIncludeCondtionHeaders := &projcontour.HTTPProxy{
+	proxyInvalidDuplicateIncludeCondtionHeaders := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "delegated",
 				Namespace: "roots",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:  "x-header",
 						Exact: "1234",
 					},
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
 			}},
 		},
 	}
-	proxyValidDelegatedRoots := &projcontour.HTTPProxy{
+	proxyValidDelegatedRoots := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "delegated",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1178,30 +1178,30 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidRouteConditionHeaders := &projcontour.HTTPProxy{
+	proxyInvalidRouteConditionHeaders := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						NotExact: "abc",
 					},
 				}, {
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						NotExact: "1234",
 					},
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1220,24 +1220,24 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidMultiplePrefixes := &projcontour.HTTPProxy{
+	proxyInvalidMultiplePrefixes := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{
 					{
 						Prefix: "/api",
 					}, {
 						Prefix: "/v1",
 					},
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1257,19 +1257,19 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidTwoPrefixesWithInclude := &projcontour.HTTPProxy{
+	proxyInvalidTwoPrefixesWithInclude := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "child",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{
+				Conditions: []contour_api_v1.MatchCondition{
 					{
 						Prefix: "/api",
 					}, {
@@ -1277,8 +1277,8 @@ func TestDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1286,14 +1286,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyValidChildTeamA := &projcontour.HTTPProxy{
+	proxyValidChildTeamA := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "child",
 			Namespace: "teama",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1317,22 +1317,22 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidPrefixNoSlash := &projcontour.HTTPProxy{
+	proxyInvalidPrefixNoSlash := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{
 					{
 						Prefix: "api",
 					},
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1352,26 +1352,26 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidIncludePrefixNoSlash := &projcontour.HTTPProxy{
+	proxyInvalidIncludePrefixNoSlash := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "www",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "child",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{
+				Conditions: []contour_api_v1.MatchCondition{
 					{
 						Prefix: "api",
 					},
 				},
 			}},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1395,24 +1395,24 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidTCPProxyIncludeAndService := &projcontour.HTTPProxy{
+	proxyInvalidTCPProxyIncludeAndService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: "roots",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1432,19 +1432,19 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPNoServiceOrInclusion := &projcontour.HTTPProxy{
+	proxyTCPNoServiceOrInclusion := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{},
+			TCPProxy: &contour_api_v1.TCPProxy{},
 		},
 	}
 
@@ -1460,20 +1460,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPIncludesFoo := &projcontour.HTTPProxy{
+	proxyTCPIncludesFoo := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "passthrough.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "foo",
 					Namespace: fixture.ServiceRootsKuard.Namespace,
 				},
@@ -1493,20 +1493,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyValidTCPRoot := &projcontour.HTTPProxy{
+	proxyValidTCPRoot := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1532,14 +1532,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPValidChildFoo := &projcontour.HTTPProxy{
+	proxyTCPValidChildFoo := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1565,33 +1565,33 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidConflictingIncludeConditions := &projcontour.HTTPProxy{
+	proxyInvalidConflictingIncludeConditions := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blogteama",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
 			}, {
 				Name:      "blogteamb",
 				Namespace: "teamb",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1599,17 +1599,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyValidBlogTeamA := &projcontour.HTTPProxy{
+	proxyValidBlogTeamA := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "blogteama",
 			Name:      "teama",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceTeamAKuard.Name,
 					Port: 8080,
 				}},
@@ -1617,17 +1617,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyValidBlogTeamB := &projcontour.HTTPProxy{
+	proxyValidBlogTeamB := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "blogteamb",
 			Name:      "teamb",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceTeamBKuard.Name,
 					Port: 8080,
 				}},
@@ -1660,20 +1660,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidConflictHeaderConditions := &projcontour.HTTPProxy{
+	proxyInvalidConflictHeaderConditions := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blogteama",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
-					Header: &projcontour.HeaderMatchCondition{
+				Conditions: []contour_api_v1.MatchCondition{{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
@@ -1681,18 +1681,18 @@ func TestDAGStatus(t *testing.T) {
 			}, {
 				Name:      "blogteamb",
 				Namespace: "teamb",
-				Conditions: []projcontour.MatchCondition{{
-					Header: &projcontour.HeaderMatchCondition{
+				Conditions: []contour_api_v1.MatchCondition{{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1727,21 +1727,21 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidDuplicateHeaderAndPathConditions := &projcontour.HTTPProxy{
+	proxyInvalidDuplicateHeaderAndPathConditions := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blogteama",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
@@ -1749,19 +1749,19 @@ func TestDAGStatus(t *testing.T) {
 			}, {
 				Name:      "blogteamb",
 				Namespace: "teamb",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -1796,16 +1796,16 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidMissingInclude := &projcontour.HTTPProxy{
+	proxyInvalidMissingInclude := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name: "child",
 			}},
 		},
@@ -1823,20 +1823,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPInvalidMissingService := &projcontour.HTTPProxy{
+	proxyTCPInvalidMissingService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-tcp-proxy-service",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: "not-found",
 					Port: 8080,
 				}},
@@ -1856,20 +1856,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPInvalidPortNotMatched := &projcontour.HTTPProxy{
+	proxyTCPInvalidPortNotMatched := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tcp-proxy-service-missing-port",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 9999,
 				}},
@@ -1889,17 +1889,17 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPInvalidMissingTLS := &projcontour.HTTPProxy{
+	proxyTCPInvalidMissingTLS := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-tls",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1919,25 +1919,25 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyInvalidMissingServiceWithTCPProxy := &projcontour.HTTPProxy{
+	proxyInvalidMissingServiceWithTCPProxy := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-route-service",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretRootsCert.Name,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{
 					{Name: "missing", Port: 9000},
 				},
 			}},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1957,25 +1957,25 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyRoutePortNotMatchedWithTCP := &projcontour.HTTPProxy{
+	proxyRoutePortNotMatchedWithTCP := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-route-service-port",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretRootsCert.Name,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{
 					{Name: fixture.ServiceRootsKuard.Name, Port: 9999},
 				},
 			}},
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -1995,20 +1995,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	proxyTCPValidIncludeChild := &projcontour.HTTPProxy{
+	proxyTCPValidIncludeChild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "validtcpproxy",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretRootsCert.Name,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				Include: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Include: &contour_api_v1.TCPProxyInclude{
 					Name:      "child",
 					Namespace: fixture.ServiceRootsKuard.Namespace,
 				},
@@ -2016,20 +2016,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyTCPValidIncludesChild := &projcontour.HTTPProxy{
+	proxyTCPValidIncludesChild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "validtcpproxy",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: fixture.SecretRootsCert.Name,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{
-				IncludesDeprecated: &projcontour.TCPProxyInclude{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				IncludesDeprecated: &contour_api_v1.TCPProxyInclude{
 					Name:      "child",
 					Namespace: fixture.ServiceRootsKuard.Namespace,
 				},
@@ -2037,14 +2037,14 @@ func TestDAGStatus(t *testing.T) {
 		},
 	}
 
-	proxyTCPValidChild := &projcontour.HTTPProxy{
+	proxyTCPValidChild := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "child",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			TCPProxy: &projcontour.TCPProxy{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			TCPProxy: &contour_api_v1.TCPProxy{
+				Services: []contour_api_v1.Service{{
 					Name: fixture.ServiceRootsKuard.Name,
 					Port: 8080,
 				}},
@@ -2092,17 +2092,17 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	// issue 2309
-	proxyInvalidNoServices := &projcontour.HTTPProxy{
+	proxyInvalidNoServices := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "missing-service",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "missing-service.example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 				Services: nil, // missing
@@ -2122,24 +2122,24 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	fallbackCertificate := &projcontour.HTTPProxy{
+	fallbackCertificate := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:                "ssl-cert",
 					EnableFallbackCertificate: true,
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -2177,27 +2177,27 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	fallbackCertificateWithClientValidation := &projcontour.HTTPProxy{
+	fallbackCertificateWithClientValidation := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:                "ssl-cert",
 					EnableFallbackCertificate: true,
-					ClientValidation: &projcontour.DownstreamValidation{
+					ClientValidation: &contour_api_v1.DownstreamValidation{
 						CACertificate: "something",
 					},
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -2218,22 +2218,22 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	tlsPassthroughAndValidation := &projcontour.HTTPProxy{
+	tlsPassthroughAndValidation := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
-					ClientValidation: &projcontour.DownstreamValidation{
+					ClientValidation: &contour_api_v1.DownstreamValidation{
 						CACertificate: "aCAcert",
 					},
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{},
+			TCPProxy: &contour_api_v1.TCPProxy{},
 		},
 	}
 
@@ -2249,20 +2249,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	tlsPassthroughAndSecretName := &projcontour.HTTPProxy{
+	tlsPassthroughAndSecretName := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: true,
 					SecretName:  fixture.SecretRootsCert.Name,
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{},
+			TCPProxy: &contour_api_v1.TCPProxy{},
 		},
 	}
 
@@ -2281,20 +2281,20 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	tlsNoPassthroughOrSecretName := &projcontour.HTTPProxy{
+	tlsNoPassthroughOrSecretName := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					Passthrough: false,
 					SecretName:  "",
 				},
 			},
-			TCPProxy: &projcontour.TCPProxy{},
+			TCPProxy: &contour_api_v1.TCPProxy{},
 		},
 	}
 
@@ -2313,13 +2313,13 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	emptyProxy := &projcontour.HTTPProxy{
+	emptyProxy := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "empty",
 			Namespace: "roots",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
 		},
@@ -2337,22 +2337,22 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	invalidRequestHeadersPolicyService := &projcontour.HTTPProxy{
+	invalidRequestHeadersPolicyService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalidRHPService",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{
 					{
 						Name: fixture.ServiceRootsKuard.Name,
 						Port: 8080,
-						RequestHeadersPolicy: &projcontour.HeadersPolicy{
-							Set: []projcontour.HeaderValue{{
+						RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+							Set: []contour_api_v1.HeaderValue{{
 								Name:  "Host",
 								Value: "external.com",
 							}},
@@ -2375,22 +2375,22 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	invalidResponseHeadersPolicyService := &projcontour.HTTPProxy{
+	invalidResponseHeadersPolicyService := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalidRHPService",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{
 					{
 						Name: fixture.ServiceRootsKuard.Name,
 						Port: 8080,
-						ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-							Set: []projcontour.HeaderValue{{
+						ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+							Set: []contour_api_v1.HeaderValue{{
 								Name:  "Host",
 								Value: "external.com",
 							}},
@@ -2413,24 +2413,24 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	invalidResponseHeadersPolicyRoute := &projcontour.HTTPProxy{
+	invalidResponseHeadersPolicyRoute := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalidRHPRoute",
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{
 					{
 						Name: fixture.ServiceRootsKuard.Name,
 						Port: 8080,
 					},
 				},
-				ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "external.com",
 					}},
@@ -2452,22 +2452,22 @@ func TestDAGStatus(t *testing.T) {
 	})
 
 	proxyAuthFallback := fixture.NewProxy("roots/fallback-incompat").
-		WithSpec(projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "invalid.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:                "ssl-cert",
 					EnableFallbackCertificate: true,
 				},
-				Authorization: &projcontour.AuthorizationServer{
-					ExtensionServiceRef: projcontour.ExtensionServiceReference{
+				Authorization: &contour_api_v1.AuthorizationServer{
+					ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 						Namespace: "auth",
 						Name:      "extension",
 					},
 				},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{Name: "app-server", Port: 80}},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		})
 
@@ -2483,23 +2483,23 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	invalidResponseTimeout := &projcontour.HTTPProxy{
+	invalidResponseTimeout := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 			Name:      "invalid-timeouts",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{
+			Routes: []contour_api_v1.Route{
 				{
-					Services: []projcontour.Service{
+					Services: []contour_api_v1.Service{
 						{
 							Name: fixture.ServiceRootsKuard.Name,
 						},
 					},
-					TimeoutPolicy: &projcontour.TimeoutPolicy{
+					TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 						Response: "invalid-val",
 					},
 				},
@@ -2522,23 +2522,23 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	invalidIdleTimeout := &projcontour.HTTPProxy{
+	invalidIdleTimeout := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: fixture.ServiceRootsKuard.Namespace,
 			Name:      "invalid-timeouts",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{
+			Routes: []contour_api_v1.Route{
 				{
-					Services: []projcontour.Service{
+					Services: []contour_api_v1.Service{
 						{
 							Name: fixture.ServiceRootsKuard.Name,
 						},
 					},
-					TimeoutPolicy: &projcontour.TimeoutPolicy{
+					TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 						Idle: "invalid-val",
 					},
 				},

--- a/internal/featuretests/authorization_test.go
+++ b/internal/featuretests/authorization_test.go
@@ -24,9 +24,9 @@ import (
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoy_config_filter_http_ext_authz_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -52,16 +52,16 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 	p := fixture.NewProxy("proxy").
 		WithFQDN(fqdn).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
-			ExtensionServiceRef: projcontour.ExtensionServiceReference{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 				Namespace: "auth",
 				Name:      "extension",
 			},
 			ResponseTimeout: "10m",
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{Name: "app-server", Port: 80}},
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		})
 
@@ -76,9 +76,9 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 			defaultHTTPListener(),
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls(fqdn,
@@ -100,10 +100,10 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 						),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener()),
-	}).Status(p).Like(projcontour.HTTPProxyStatus{
+	}).Status(p).Like(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusValid,
 	})
 }
@@ -114,16 +114,16 @@ func authzInvalidResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c 
 	p := fixture.NewProxy("proxy").
 		WithFQDN(fqdn).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
-			ExtensionServiceRef: projcontour.ExtensionServiceReference{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 				Namespace: "auth",
 				Name:      "extension",
 			},
 			ResponseTimeout: "invalid-timeout",
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{Name: "app-server", Port: 80}},
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		})
 
@@ -135,7 +135,7 @@ func authzInvalidResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c 
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl:   listenerType,
 		Resources: resources(t, staticListener()),
-	}).Status(p).Equals(projcontour.HTTPProxyStatus{
+	}).Status(p).Equals(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusInvalid,
 		Description:   `Spec.Virtualhost.Authorization.ResponseTimeout is invalid: unable to parse timeout string "invalid-timeout": time: invalid duration "invalid-timeout"`,
 	})
@@ -147,16 +147,16 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 	p := fixture.NewProxy("proxy").
 		WithFQDN(fqdn).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
-			ExtensionServiceRef: projcontour.ExtensionServiceReference{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 				Namespace: "auth",
 				Name:      "extension",
 			},
 			FailOpen: true,
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{Name: "app-server", Port: 80}},
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		})
 
@@ -168,9 +168,9 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 			defaultHTTPListener(),
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls(fqdn,
@@ -193,10 +193,10 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 						),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener()),
-	}).Status(p).Like(projcontour.HTTPProxyStatus{
+	}).Status(p).Like(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusValid,
 	})
 }
@@ -205,15 +205,15 @@ func authzFallbackIncompat(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	p := fixture.NewProxy("proxy").
 		WithFQDN("echo.projectcontour.io").
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
-			ExtensionServiceRef: projcontour.ExtensionServiceReference{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 				Namespace: "auth",
 				Name:      "extension",
 			},
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{Name: "app-server", Port: 80}},
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		})
 
@@ -224,7 +224,7 @@ func authzFallbackIncompat(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl:   listenerType,
 		Resources: resources(t, staticListener()),
-	}).Status(p).Equals(projcontour.HTTPProxyStatus{
+	}).Status(p).Equals(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusInvalid,
 		Description:   `Spec.Virtualhost.TLS fallback & client authorization are incompatible`,
 	})
@@ -234,7 +234,7 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	const enabled = "enabled.projectcontour.io"
 	const disabled = "disabled.projectcontour.io"
 
-	var extensionRef = projcontour.ExtensionServiceReference{
+	var extensionRef = contour_api_v1.ExtensionServiceReference{
 		Namespace: "auth",
 		Name:      "extension",
 	}
@@ -242,18 +242,18 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	rh.OnAdd(fixture.NewProxy("enabled").
 		WithFQDN(enabled).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
 			ExtensionServiceRef: extensionRef,
-			AuthPolicy:          &projcontour.AuthorizationPolicy{Disabled: false},
+			AuthPolicy:          &contour_api_v1.AuthorizationPolicy{Disabled: false},
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/disabled")),
-				Services:   []projcontour.Service{{Name: "app-server", Port: 80}},
-				AuthPolicy: &projcontour.AuthorizationPolicy{Disabled: true},
+				Services:   []contour_api_v1.Service{{Name: "app-server", Port: 80}},
+				AuthPolicy: &contour_api_v1.AuthorizationPolicy{Disabled: true},
 			}, {
 				Conditions: matchconditions(prefixMatchCondition("/default")),
-				Services:   []projcontour.Service{{Name: "app-server", Port: 80}},
+				Services:   []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		}),
 	)
@@ -261,18 +261,18 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	rh.OnAdd(fixture.NewProxy("disabled").
 		WithFQDN(disabled).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
 			ExtensionServiceRef: extensionRef,
-			AuthPolicy:          &projcontour.AuthorizationPolicy{Disabled: true},
+			AuthPolicy:          &contour_api_v1.AuthorizationPolicy{Disabled: true},
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/enabled")),
-				Services:   []projcontour.Service{{Name: "app-server", Port: 80}},
-				AuthPolicy: &projcontour.AuthorizationPolicy{},
+				Services:   []contour_api_v1.Service{{Name: "app-server", Port: 80}},
+				AuthPolicy: &contour_api_v1.AuthorizationPolicy{},
 			}, {
 				Conditions: matchconditions(prefixMatchCondition("/default")),
-				Services:   []projcontour.Service{{Name: "app-server", Port: 80}},
+				Services:   []contour_api_v1.Service{{Name: "app-server", Port: 80}},
 			}},
 		}),
 	)
@@ -291,9 +291,9 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: routeType,
 		Resources: resources(t,
-			envoyv2.RouteConfiguration(
+			envoy_v2.RouteConfiguration(
 				path.Join("https", disabled),
-				envoyv2.VirtualHost(disabled,
+				envoy_v2.VirtualHost(disabled,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/enabled"),
 						Action: routeCluster("default/app-server/80/da39a3ee5e"),
@@ -305,9 +305,9 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 					},
 				),
 			),
-			envoyv2.RouteConfiguration(
+			envoy_v2.RouteConfiguration(
 				path.Join("https", enabled),
-				envoyv2.VirtualHost(enabled,
+				envoy_v2.VirtualHost(enabled,
 					&envoy_api_v2_route.Route{
 						Match:                routePrefix("/disabled"),
 						Action:               routeCluster("default/app-server/80/da39a3ee5e"),
@@ -319,9 +319,9 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 					},
 				),
 			),
-			envoyv2.RouteConfiguration(
+			envoy_v2.RouteConfiguration(
 				"ingress_http",
-				envoyv2.VirtualHost(disabled,
+				envoy_v2.VirtualHost(disabled,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/enabled"),
 						Action: withRedirect(),
@@ -331,7 +331,7 @@ func authzOverrideDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 						Action: withRedirect(),
 					},
 				),
-				envoyv2.VirtualHost(enabled,
+				envoy_v2.VirtualHost(enabled,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/disabled"),
 						Action: withRedirect(),
@@ -352,33 +352,33 @@ func authzMergeRouteContext(t *testing.T, rh cache.ResourceEventHandler, c *Cont
 	rh.OnAdd(fixture.NewProxy("proxy-root").
 		WithFQDN(fqdn).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{
-			ExtensionServiceRef: projcontour.ExtensionServiceReference{
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
 				Namespace: "auth",
 				Name:      "extension",
 			},
-			AuthPolicy: &projcontour.AuthorizationPolicy{
+			AuthPolicy: &contour_api_v1.AuthorizationPolicy{
 				Context: map[string]string{
 					"root-element":   "root",
 					"common-element": "root",
 				},
 			},
 		}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Includes: []projcontour.Include{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Includes: []contour_api_v1.Include{{
 				Name: "proxy-leaf",
 			}},
 		}),
 	)
 
 	rh.OnAdd(fixture.NewProxy("proxy-leaf").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "app-server",
 					Port: 80,
 				}},
-				AuthPolicy: &projcontour.AuthorizationPolicy{
+				AuthPolicy: &contour_api_v1.AuthorizationPolicy{
 					Context: map[string]string{
 						"common-element": "leaf",
 						"leaf-element":   "leaf",
@@ -399,9 +399,9 @@ func authzMergeRouteContext(t *testing.T, rh cache.ResourceEventHandler, c *Cont
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: routeType,
 		Resources: resources(t,
-			envoyv2.RouteConfiguration(
+			envoy_v2.RouteConfiguration(
 				path.Join("https", fqdn),
-				envoyv2.VirtualHost(fqdn,
+				envoy_v2.VirtualHost(fqdn,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/app-server/80/da39a3ee5e"),
@@ -416,9 +416,9 @@ func authzMergeRouteContext(t *testing.T, rh cache.ResourceEventHandler, c *Cont
 					},
 				),
 			),
-			envoyv2.RouteConfiguration(
+			envoy_v2.RouteConfiguration(
 				"ingress_http",
-				envoyv2.VirtualHost(fqdn,
+				envoy_v2.VirtualHost(fqdn,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withRedirect(),
@@ -435,17 +435,17 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	invalid := fixture.NewProxy("proxy").
 		WithFQDN(fqdn).
 		WithCertificate("certificate").
-		WithAuthServer(projcontour.AuthorizationServer{}).
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithAuthServer(contour_api_v1.AuthorizationServer{}).
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "app-server",
 					Port: 80,
 				}},
 			}},
 		})
 
-	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = projcontour.ExtensionServiceReference{
+	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = contour_api_v1.ExtensionServiceReference{
 		APIVersion: "foo/bar",
 		Namespace:  "",
 		Name:       "",
@@ -457,12 +457,12 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl:   listenerType,
 		Resources: resources(t, staticListener()),
-	}).Status(invalid).Equals(projcontour.HTTPProxyStatus{
+	}).Status(invalid).Equals(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusInvalid,
 		Description:   `Spec.Virtualhost.Authorization.ServiceRef specifies an unsupported resource version "foo/bar"`,
 	})
 
-	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = projcontour.ExtensionServiceReference{
+	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = contour_api_v1.ExtensionServiceReference{
 		APIVersion: "projectcontour.io/v1alpha1",
 		Namespace:  "missing",
 		Name:       "extension",
@@ -474,12 +474,12 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl:   listenerType,
 		Resources: resources(t, staticListener()),
-	}).Status(invalid).Equals(projcontour.HTTPProxyStatus{
+	}).Status(invalid).Equals(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusInvalid,
 		Description:   `Spec.Virtualhost.Authorization.ServiceRef extension service "missing/extension" not found`,
 	})
 
-	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = projcontour.ExtensionServiceReference{
+	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = contour_api_v1.ExtensionServiceReference{
 		Namespace: "auth",
 		Name:      "extension",
 	}
@@ -493,9 +493,9 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 			defaultHTTPListener(),
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls(fqdn,
@@ -518,10 +518,10 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 						),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener()),
-	}).Status(invalid).Like(projcontour.HTTPProxyStatus{
+	}).Status(invalid).Like(contour_api_v1.HTTPProxyStatus{
 		CurrentStatus: k8s.StatusValid,
 	})
 }

--- a/internal/featuretests/backendcavalidation_test.go
+++ b/internal/featuretests/backendcavalidation_test.go
@@ -17,9 +17,9 @@ import (
 	"testing"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,18 +44,18 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		Annotate("contour.heptio.com/upstream-protocol.tls", "securebackend,443").
 		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8080)})
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 443,
 				}},
@@ -71,11 +71,11 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -90,21 +90,21 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 443,
-					UpstreamValidation: &projcontour.UpstreamValidation{
+					UpstreamValidation: &contour_api_v1.UpstreamValidation{
 						CACertificate: secret.Name,
 						SubjectName:   "subjname",
 					},
@@ -119,11 +119,11 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -149,19 +149,19 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 
 	rh.OnDelete(p2)
 
-	hp1 := &projcontour.HTTPProxy{
+	hp1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/a")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 443,
-					UpstreamValidation: &projcontour.UpstreamValidation{
+					UpstreamValidation: &contour_api_v1.UpstreamValidation{
 						CACertificate: secret.Name,
 						SubjectName:   "subjname",
 					},
@@ -176,11 +176,11 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),

--- a/internal/featuretests/cluster_test.go
+++ b/internal/featuretests/cluster_test.go
@@ -18,8 +18,8 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
@@ -424,9 +424,9 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			DefaultCluster(&envoy_api_v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
 				AltStatName:          "default_kuard_8080",
-				ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+				ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 				EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-					EdsConfig:   envoyv2.ConfigSource("contour"),
+					EdsConfig:   envoy_v2.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				CircuitBreakers: &envoy_cluster.CircuitBreakers{
@@ -457,9 +457,9 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 			DefaultCluster(&envoy_api_v2.Cluster{
 				Name:                 "default/kuard/8080/da39a3ee5e",
 				AltStatName:          "default_kuard_8080",
-				ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+				ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 				EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-					EdsConfig:   envoyv2.ConfigSource("contour"),
+					EdsConfig:   envoy_v2.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				CircuitBreakers: &envoy_cluster.CircuitBreakers{
@@ -483,27 +483,27 @@ func TestClusterPerServiceParameters(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromString("8080")}),
 	)
 
-	rh.OnAdd(&projcontour.HTTPProxy{
+	rh.OnAdd(&contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 60,
@@ -531,32 +531,32 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromString("8080")}),
 	)
 
-	rh.OnAdd(&projcontour.HTTPProxy{
+	rh.OnAdd(&contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+				LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 					Strategy: "Random",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/b",
 				}},
-				LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+				LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 					Strategy: "WeightedLeastRequest",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
@@ -569,9 +569,9 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 			DefaultCluster(&envoy_api_v2.Cluster{
 				Name:                 "default/kuard/80/58d888c08a",
 				AltStatName:          "default_kuard_80",
-				ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+				ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 				EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-					EdsConfig:   envoyv2.ConfigSource("contour"),
+					EdsConfig:   envoy_v2.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				LbPolicy: envoy_api_v2.Cluster_RANDOM,
@@ -579,9 +579,9 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 			DefaultCluster(&envoy_api_v2.Cluster{
 				Name:                 "default/kuard/80/8bf87fefba",
 				AltStatName:          "default_kuard_80",
-				ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+				ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 				EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-					EdsConfig:   envoyv2.ConfigSource("contour"),
+					EdsConfig:   envoy_v2.ConfigSource("contour"),
 					ServiceName: "default/kuard",
 				},
 				LbPolicy: envoy_api_v2.Cluster_LEAST_REQUEST,
@@ -599,21 +599,21 @@ func TestClusterWithHealthChecks(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromString("8080")}),
 	)
 
-	rh.OnAdd(&projcontour.HTTPProxy{
+	rh.OnAdd(&contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
+				HealthCheckPolicy: &contour_api_v1.HTTPHealthCheckPolicy{
 					Path: "/healthz",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90,
@@ -639,27 +639,27 @@ func TestUnreferencedService(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromString("8080")}),
 	)
 
-	rh.OnAdd(&projcontour.HTTPProxy{
+	rh.OnAdd(&contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "www.example.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/b",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 60,

--- a/internal/featuretests/corspolicy_test.go
+++ b/internal/featuretests/corspolicy_test.go
@@ -16,12 +16,12 @@ package featuretests
 import (
 	"testing"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
@@ -38,14 +38,14 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Allow origin
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin: []string{"*"},
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -53,10 +53,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowCredentials: &wrappers.BoolValue{Value: false},
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
@@ -77,15 +77,15 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Allow credentials
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -93,10 +93,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -117,16 +117,16 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Allow methods
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
-					AllowMethods:     []projcontour.CORSHeaderValue{"GET", "POST", "OPTIONS"},
+					AllowMethods:     []contour_api_v1.CORSHeaderValue{"GET", "POST", "OPTIONS"},
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -134,10 +134,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -159,16 +159,16 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Allow headers
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
-					AllowHeaders:     []projcontour.CORSHeaderValue{"custom-header-1", "custom-header-2"},
+					AllowHeaders:     []contour_api_v1.CORSHeaderValue{"custom-header-1", "custom-header-2"},
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -176,10 +176,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -201,16 +201,16 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Expose headers
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
-					ExposeHeaders:    []projcontour.CORSHeaderValue{"custom-header-1", "custom-header-2"},
+					ExposeHeaders:    []contour_api_v1.CORSHeaderValue{"custom-header-1", "custom-header-2"},
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -218,10 +218,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -244,16 +244,16 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Max Age
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
 					MaxAge:           "10m",
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -261,10 +261,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -286,16 +286,16 @@ func TestCorsPolicy(t *testing.T) {
 
 	// Disable preflight request caching
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
 					MaxAge:           "0s",
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -303,10 +303,10 @@ func TestCorsPolicy(t *testing.T) {
 		}),
 	)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.CORSVirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.CORSVirtualHost("hello.world",
 					&envoy_api_v2_route.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{{
 							MatchPattern: &matcher.StringMatcher_Exact{
@@ -327,18 +327,18 @@ func TestCorsPolicy(t *testing.T) {
 	})
 
 	// Virtual hosts with an invalid max age in their policy are not added
-	invvhost := &projcontour.HTTPProxy{
+	invvhost := &contour_api_v1.HTTPProxy{
 		ObjectMeta: fixture.ObjectMeta("simple"),
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				CORSPolicy: &projcontour.CORSPolicy{
+				CORSPolicy: &contour_api_v1.CORSPolicy{
 					AllowOrigin:      []string{"*"},
 					AllowCredentials: true,
 					MaxAge:           "-10m",
 				},
-			}, Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			}, Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -348,12 +348,12 @@ func TestCorsPolicy(t *testing.T) {
 
 	rh.OnAdd(invvhost)
 
-	c.Request(routeType).Equals(&v2.DiscoveryResponse{
+	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http")),
+			envoy_v2.RouteConfiguration("ingress_http")),
 		TypeUrl: routeType,
 	}).Status(invvhost).Like(
-		projcontour.HTTPProxyStatus{CurrentStatus: k8s.StatusInvalid},
+		contour_api_v1.HTTPProxyStatus{CurrentStatus: k8s.StatusInvalid},
 	)
 
 }

--- a/internal/featuretests/endpoints_test.go
+++ b/internal/featuretests/endpoints_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 )
@@ -36,9 +36,9 @@ func TestAddRemoveEndpoints(t *testing.T) {
 
 	rh.OnAdd(fixture.NewProxy("super-long-namespace-name-oh-boy/proxy").
 		WithFQDN("proxy.example.com").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "what-a-descriptive-service-name-you-must-be-so-proud",
 					Port: 8000,
 				}, {
@@ -74,16 +74,16 @@ func TestAddRemoveEndpoints(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http",
-				Endpoints: envoyv2.WeightedEndpoints(1,
-					envoyv2.SocketAddress("172.16.0.1", 8000), // endpoints and cluster names should be sorted
-					envoyv2.SocketAddress("172.16.0.2", 8000),
+				Endpoints: envoy_v2.WeightedEndpoints(1,
+					envoy_v2.SocketAddress("172.16.0.1", 8000), // endpoints and cluster names should be sorted
+					envoy_v2.SocketAddress("172.16.0.2", 8000),
 				),
 			},
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https",
-				Endpoints: envoyv2.WeightedEndpoints(1,
-					envoyv2.SocketAddress("172.16.0.1", 8443),
-					envoyv2.SocketAddress("172.16.0.2", 8443),
+				Endpoints: envoy_v2.WeightedEndpoints(1,
+					envoy_v2.SocketAddress("172.16.0.1", 8443),
+					envoy_v2.SocketAddress("172.16.0.2", 8443),
 				),
 			},
 		),
@@ -95,8 +95,8 @@ func TestAddRemoveEndpoints(t *testing.T) {
 
 	c.Request(endpointType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
-			envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+			envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+			envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 		),
 		TypeUrl: endpointType,
 	})
@@ -113,20 +113,20 @@ func TestAddEndpointComplicated(t *testing.T) {
 
 	rh.OnAdd(fixture.NewProxy("kuard").
 		WithFQDN("kuard.example.com").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/admin",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 9000,
 				}},
@@ -166,15 +166,15 @@ func TestAddEndpointComplicated(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "default/kuard/admin",
-				Endpoints: envoyv2.WeightedEndpoints(1,
-					envoyv2.SocketAddress("10.48.1.77", 9000),
-					envoyv2.SocketAddress("10.48.1.78", 9000),
+				Endpoints: envoy_v2.WeightedEndpoints(1,
+					envoy_v2.SocketAddress("10.48.1.77", 9000),
+					envoy_v2.SocketAddress("10.48.1.78", 9000),
 				),
 			},
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "default/kuard/foo",
-				Endpoints: envoyv2.WeightedEndpoints(1,
-					envoyv2.SocketAddress("10.48.1.78", 8080),
+				Endpoints: envoy_v2.WeightedEndpoints(1,
+					envoy_v2.SocketAddress("10.48.1.78", 8080),
 				),
 			},
 		),
@@ -192,9 +192,9 @@ func TestEndpointFilter(t *testing.T) {
 
 	rh.OnAdd(fixture.NewProxy("default/kuard").
 		WithFQDN("kuard.example.com").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -234,7 +234,7 @@ func TestEndpointFilter(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "default/kuard/foo",
-				Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("10.48.1.78", 8080)),
+				Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("10.48.1.78", 8080)),
 			},
 		),
 	})
@@ -242,7 +242,7 @@ func TestEndpointFilter(t *testing.T) {
 	c.Request(endpointType, "default/kuard/bar").Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: endpointType,
 		Resources: resources(t,
-			envoyv2.ClusterLoadAssignment("default/kuard/bar"),
+			envoy_v2.ClusterLoadAssignment("default/kuard/bar"),
 		),
 	})
 }
@@ -259,9 +259,9 @@ func TestIssue602(t *testing.T) {
 
 	rh.OnAdd(fixture.NewProxy("simple").
 		WithFQDN("simple.example.com").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "simple",
 					Port: 8080,
 				}},
@@ -282,7 +282,7 @@ func TestIssue602(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.ClusterLoadAssignment{
 				ClusterName: "default/simple",
-				Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080)),
+				Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080)),
 			},
 		),
 		TypeUrl: endpointType,
@@ -293,7 +293,7 @@ func TestIssue602(t *testing.T) {
 	rh.OnUpdate(e1, e2)
 
 	c.Request(endpointType).Equals(&envoy_api_v2.DiscoveryResponse{
-		Resources: resources(t, envoyv2.ClusterLoadAssignment("default/simple")),
+		Resources: resources(t, envoy_v2.ClusterLoadAssignment("default/simple")),
 		TypeUrl:   endpointType,
 	})
 }

--- a/internal/featuretests/extensionservice_test.go
+++ b/internal/featuretests/extensionservice_test.go
@@ -21,10 +21,10 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -48,7 +48,7 @@ func extBasic(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 			DefaultCluster(
 				h2cCluster(cluster("extension/ns/ext", "extension/ns/ext", "extension_ns_ext")),
 				&envoy_api_v2.Cluster{
-					TransportSocket: envoyv2.UpstreamTLSTransportSocket(
+					TransportSocket: envoy_v2.UpstreamTLSTransportSocket(
 						&envoy_api_v2_auth.UpstreamTlsContext{
 							CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
 								AlpnProtocols: []string{"h2"},
@@ -66,8 +66,8 @@ func extBasic(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 		Resources: resources(t, &envoy_api_v2.ClusterLoadAssignment{
 			ClusterName: "extension/ns/ext",
 			Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
-				envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.20", 8081))[0],
-				envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.21", 8082))[0],
+				envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.20", 8081))[0],
+				envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.21", 8082))[0],
 			},
 		}),
 	})
@@ -102,7 +102,7 @@ func extUpstreamValidation(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 			Services: []v1alpha1.ExtensionServiceTarget{
 				{Name: "svc1", Port: 8081},
 			},
-			UpstreamValidation: &projcontour.UpstreamValidation{
+			UpstreamValidation: &contour_api_v1.UpstreamValidation{
 				CACertificate: "cacert",
 				SubjectName:   "ext.projectcontour.io",
 			},
@@ -112,7 +112,7 @@ func extUpstreamValidation(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	rh.OnAdd(ext)
 
 	// Enabling validation add SNI as well as CA and server altname validation.
-	tlsSocket := envoyv2.UpstreamTLSTransportSocket(
+	tlsSocket := envoy_v2.UpstreamTLSTransportSocket(
 		&envoy_api_v2_auth.UpstreamTlsContext{
 			Sni: "ext.projectcontour.io",
 			CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
@@ -152,7 +152,7 @@ func extUpstreamValidation(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 			Services: []v1alpha1.ExtensionServiceTarget{
 				{Name: "svc1", Port: 8081},
 			},
-			UpstreamValidation: &projcontour.UpstreamValidation{
+			UpstreamValidation: &contour_api_v1.UpstreamValidation{
 				CACertificate: "missing",
 				SubjectName:   "ext.projectcontour.io",
 			},
@@ -215,7 +215,7 @@ func extInvalidTimeout(_ *testing.T, rh cache.ResourceEventHandler, c *Contour) 
 				{Name: "svc1", Port: 8081},
 				{Name: "svc2", Port: 8082},
 			},
-			TimeoutPolicy: &projcontour.TimeoutPolicy{
+			TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 				Response: "invalid",
 			},
 		},
@@ -234,7 +234,7 @@ func extInconsistentProto(_ *testing.T, rh cache.ResourceEventHandler, c *Contou
 				{Name: "svc1", Port: 8081},
 			},
 			Protocol: pointer.StringPtr("h2c"),
-			UpstreamValidation: &projcontour.UpstreamValidation{
+			UpstreamValidation: &contour_api_v1.UpstreamValidation{
 				CACertificate: "cacert",
 				SubjectName:   "ext.projectcontour.io",
 			},

--- a/internal/featuretests/externalname_test.go
+++ b/internal/featuretests/externalname_test.go
@@ -19,8 +19,8 @@ import (
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -62,8 +62,8 @@ func TestExternalNameService(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/kuard/80/da39a3ee5e"),
@@ -85,9 +85,9 @@ func TestExternalNameService(t *testing.T) {
 
 	rh.OnAdd(fixture.NewProxy("kuard").
 		WithFQDN("kuard.projectcontour.io").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -97,8 +97,8 @@ func TestExternalNameService(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("kuard.projectcontour.io",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("kuard.projectcontour.io",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/kuard/80/da39a3ee5e"),
@@ -118,17 +118,17 @@ func TestExternalNameService(t *testing.T) {
 
 	// After we set the Host header, the cluster should remain
 	// the same, but the Route should do update the Host header.
-	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(projcontour.HTTPProxySpec{}))
+	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(contour_api_v1.HTTPProxySpec{}))
 	rh.OnAdd(fixture.NewProxy("kuard").
 		WithFQDN("kuard.projectcontour.io").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "external.address",
 					}},
@@ -140,8 +140,8 @@ func TestExternalNameService(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: routeType,
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("kuard.projectcontour.io",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("kuard.projectcontour.io",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
@@ -162,18 +162,18 @@ func TestExternalNameService(t *testing.T) {
 	// should still find that the same configuration applies, but
 	// TLS is enabled and the SNI server name is overwritten from
 	// the Host header.
-	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(projcontour.HTTPProxySpec{}))
+	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(contour_api_v1.HTTPProxySpec{}))
 	rh.OnAdd(fixture.NewProxy("kuard").
 		WithFQDN("kuard.projectcontour.io").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Protocol: pointer.StringPtr("h2"),
 					Name:     s1.Name,
 					Port:     80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "external.address",
 					}},
@@ -185,8 +185,8 @@ func TestExternalNameService(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: routeType,
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("kuard.projectcontour.io",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("kuard.projectcontour.io",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
@@ -205,8 +205,8 @@ func TestExternalNameService(t *testing.T) {
 					Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
 				},
 				&envoy_api_v2.Cluster{
-					TransportSocket: envoyv2.UpstreamTLSTransportSocket(
-						envoyv2.UpstreamTLSContext(nil, "external.address", nil, "h2"),
+					TransportSocket: envoy_v2.UpstreamTLSTransportSocket(
+						envoy_v2.UpstreamTLSContext(nil, "external.address", nil, "h2"),
 					),
 				},
 			),
@@ -217,18 +217,18 @@ func TestExternalNameService(t *testing.T) {
 	// means HTTP/1.1 over TLS) rather than HTTP/2. We should get
 	// TLS enabled with the overridden SNI name. but no HTTP/2
 	// protocol config.
-	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(projcontour.HTTPProxySpec{}))
+	rh.OnDelete(fixture.NewProxy("kuard").WithSpec(contour_api_v1.HTTPProxySpec{}))
 	rh.OnAdd(fixture.NewProxy("kuard").
 		WithFQDN("kuard.projectcontour.io").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Protocol: pointer.StringPtr("tls"),
 					Name:     s1.Name,
 					Port:     80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "external.address",
 					}},
@@ -240,8 +240,8 @@ func TestExternalNameService(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		TypeUrl: routeType,
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("kuard.projectcontour.io",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("kuard.projectcontour.io",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
@@ -257,8 +257,8 @@ func TestExternalNameService(t *testing.T) {
 			DefaultCluster(
 				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_api_v2.Cluster{
-					TransportSocket: envoyv2.UpstreamTLSTransportSocket(
-						envoyv2.UpstreamTLSContext(nil, "external.address", nil),
+					TransportSocket: envoy_v2.UpstreamTLSTransportSocket(
+						envoy_v2.UpstreamTLSContext(nil, "external.address", nil),
 					),
 				},
 			),

--- a/internal/featuretests/featuretests.go
+++ b/internal/featuretests/featuretests.go
@@ -27,7 +27,7 @@ import (
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -256,12 +256,12 @@ type statusResult struct {
 	*Contour
 
 	Err  error
-	Have *projcontour.HTTPProxyStatus
+	Have *contour_api_v1.HTTPProxyStatus
 }
 
 // Equals asserts that the status result is not an error and matches
 // the wanted status exactly.
-func (s *statusResult) Equals(want projcontour.HTTPProxyStatus) *Contour {
+func (s *statusResult) Equals(want contour_api_v1.HTTPProxyStatus) *Contour {
 	s.T.Helper()
 
 	// We should never get an error fetching the status for an
@@ -276,7 +276,7 @@ func (s *statusResult) Equals(want projcontour.HTTPProxyStatus) *Contour {
 
 // Like asserts that the status result is not an error and matches
 // non-empty fields in the wanted status.
-func (s *statusResult) Like(want projcontour.HTTPProxyStatus) *Contour {
+func (s *statusResult) Like(want contour_api_v1.HTTPProxyStatus) *Contour {
 	s.T.Helper()
 
 	// We should never get an error fetching the status for an
@@ -287,15 +287,15 @@ func (s *statusResult) Like(want projcontour.HTTPProxyStatus) *Contour {
 
 	if len(want.CurrentStatus) > 0 {
 		assert.Equal(s.T,
-			projcontour.HTTPProxyStatus{CurrentStatus: want.CurrentStatus},
-			projcontour.HTTPProxyStatus{CurrentStatus: s.Have.CurrentStatus},
+			contour_api_v1.HTTPProxyStatus{CurrentStatus: want.CurrentStatus},
+			contour_api_v1.HTTPProxyStatus{CurrentStatus: s.Have.CurrentStatus},
 		)
 	}
 
 	if len(want.Description) > 0 {
 		assert.Equal(s.T,
-			projcontour.HTTPProxyStatus{Description: want.Description},
-			projcontour.HTTPProxyStatus{Description: s.Have.Description},
+			contour_api_v1.HTTPProxyStatus{Description: want.Description},
+			contour_api_v1.HTTPProxyStatus{Description: s.Have.Description},
 		)
 	}
 

--- a/internal/featuretests/headercondition_test.go
+++ b/internal/featuretests/headercondition_test.go
@@ -18,9 +18,9 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,15 +43,15 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
 	)
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -60,7 +60,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/"),
 					headerContainsMatchCondition("x-header", "abc"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -69,7 +69,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/blog"),
 					headerContainsMatchCondition("x-header", "abc"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc3",
 					Port: 80,
 				}},
@@ -80,8 +80,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/blog", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -111,10 +111,10 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	})
 
 	proxy2 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -123,7 +123,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/"),
 					headerNotContainsMatchCondition("x-header", "123"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -132,7 +132,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/blog"),
 					headerNotContainsMatchCondition("x-header", "abc"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc3",
 					Port: 80,
 				}},
@@ -143,8 +143,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/blog", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -174,10 +174,10 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	})
 
 	proxy3 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -186,7 +186,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/"),
 					headerExactMatchCondition("x-header", "abc"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -195,7 +195,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/blog"),
 					headerExactMatchCondition("x-header", "123"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc3",
 					Port: 80,
 				}},
@@ -206,8 +206,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/blog", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -237,10 +237,10 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	})
 
 	proxy4 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -249,7 +249,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/"),
 					headerNotExactMatchCondition("x-header", "abc"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -258,7 +258,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/blog"),
 					headerNotExactMatchCondition("x-header", "123"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc3",
 					Port: 80,
 				}},
@@ -269,8 +269,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/blog", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -300,10 +300,10 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	})
 
 	proxy5 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
@@ -312,7 +312,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/"),
 					headerPresentMatchCondition("x-header"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -321,7 +321,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 					prefixMatchCondition("/blog"),
 					headerPresentMatchCondition("x-header"),
 				),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc3",
 					Port: 80,
 				}},
@@ -332,8 +332,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/blog", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -363,15 +363,15 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	// proxy with two routes that have the same prefix and a Contains header
 	// condition on the same header, differing only in the value of the condition.
 	proxy6 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{
 				{
 					Conditions: matchconditions(
 						prefixMatchCondition("/"),
 						headerContainsMatchCondition("x-header", "abc"),
 					),
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "svc1",
 						Port: 80,
 					}},
@@ -381,7 +381,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 						prefixMatchCondition("/"),
 						headerContainsMatchCondition("x-header", "def"),
 					),
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "svc2",
 						Port: 80,
 					}},
@@ -393,8 +393,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/", dag.HeaderMatchCondition{
 							Name:      "x-header",
@@ -422,15 +422,15 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 	// proxy with two routes that both have a condition on the same
 	// header, one using Contains and one using NotContains.
 	proxy7 := fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{
 				{
 					Conditions: matchconditions(
 						prefixMatchCondition("/"),
 						headerContainsMatchCondition("x-header", "abc"),
 					),
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "svc1",
 						Port: 80,
 					}},
@@ -440,7 +440,7 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 						prefixMatchCondition("/"),
 						headerNotContainsMatchCondition("x-header", "abc"),
 					),
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: "svc2",
 						Port: 80,
 					}},
@@ -452,8 +452,8 @@ func TestConditions_ContainsHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/", dag.HeaderMatchCondition{
 							Name:      "x-header",

--- a/internal/featuretests/headerpolicy_test.go
+++ b/internal/featuretests/headerpolicy_test.go
@@ -20,8 +20,8 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,15 +37,15 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 	)
 
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "goodbye.planet",
 					}},
@@ -56,8 +56,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeHostRewrite("default/svc1/80/da39a3ee5e", "goodbye.planet"),
@@ -70,15 +70,15 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	// Non-Host header
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "x-header",
 						Value: "goodbye.planet",
 					}},
@@ -89,8 +89,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/svc1/80/da39a3ee5e"),
@@ -112,15 +112,15 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	// Empty value for replaceHeader in HeadersPolicy
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "hello.world"},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc1",
 					Port: 80,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name: "Host",
 					}},
 				},
@@ -130,8 +130,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/svc1/80/da39a3ee5e"),
@@ -165,18 +165,18 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	// Proxy with SNI
 	rh.OnAdd(fixture.NewProxy("simple").WithSpec(
-		projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "hello.world",
-				TLS:  &projcontour.TLS{SecretName: "foo"},
+				TLS:  &contour_api_v1.TLS{SecretName: "foo"},
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "externalname",
 					Port: 443,
 				}},
-				RequestHeadersPolicy: &projcontour.HeadersPolicy{
-					Set: []projcontour.HeaderValue{{
+				RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+					Set: []contour_api_v1.HeaderValue{{
 						Name:  "Host",
 						Value: "goodbye.planet",
 					}},
@@ -187,8 +187,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/"),
 						Action: &envoy_api_v2_route.Route_Redirect{
@@ -200,8 +200,8 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 						},
 					}),
 			),
-			envoyv2.RouteConfiguration("https/hello.world",
-				envoyv2.VirtualHost("hello.world",
+			envoy_v2.RouteConfiguration("https/hello.world",
+				envoy_v2.VirtualHost("hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeHostRewrite("default/externalname/443/da39a3ee5e", "goodbye.planet"),

--- a/internal/featuretests/httpproxy.go
+++ b/internal/featuretests/httpproxy.go
@@ -16,58 +16,58 @@ package featuretests
 // HTTPProxy helpers
 
 import (
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
 
-func matchconditions(first projcontour.MatchCondition, rest ...projcontour.MatchCondition) []projcontour.MatchCondition {
-	return append([]projcontour.MatchCondition{first}, rest...)
+func matchconditions(first contour_api_v1.MatchCondition, rest ...contour_api_v1.MatchCondition) []contour_api_v1.MatchCondition {
+	return append([]contour_api_v1.MatchCondition{first}, rest...)
 }
 
-func prefixMatchCondition(prefix string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
+func prefixMatchCondition(prefix string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
 		Prefix: prefix,
 	}
 }
 
-func headerContainsMatchCondition(name, value string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
-		Header: &projcontour.HeaderMatchCondition{
+func headerContainsMatchCondition(name, value string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
+		Header: &contour_api_v1.HeaderMatchCondition{
 			Name:     name,
 			Contains: value,
 		},
 	}
 }
 
-func headerNotContainsMatchCondition(name, value string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
-		Header: &projcontour.HeaderMatchCondition{
+func headerNotContainsMatchCondition(name, value string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
+		Header: &contour_api_v1.HeaderMatchCondition{
 			Name:        name,
 			NotContains: value,
 		},
 	}
 }
 
-func headerExactMatchCondition(name, value string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
-		Header: &projcontour.HeaderMatchCondition{
+func headerExactMatchCondition(name, value string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
+		Header: &contour_api_v1.HeaderMatchCondition{
 			Name:  name,
 			Exact: value,
 		},
 	}
 }
 
-func headerNotExactMatchCondition(name, value string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
-		Header: &projcontour.HeaderMatchCondition{
+func headerNotExactMatchCondition(name, value string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
+		Header: &contour_api_v1.HeaderMatchCondition{
 			Name:     name,
 			NotExact: value,
 		},
 	}
 }
 
-func headerPresentMatchCondition(name string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
-		Header: &projcontour.HeaderMatchCondition{
+func headerPresentMatchCondition(name string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
+		Header: &contour_api_v1.HeaderMatchCondition{
 			Name:    name,
 			Present: true,
 		},

--- a/internal/featuretests/ingressclass_test.go
+++ b/internal/featuretests/ingressclass_test.go
@@ -18,9 +18,9 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/k8s"
 	v1 "k8s.io/api/core/v1"
@@ -65,8 +65,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -95,7 +95,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -114,7 +114,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -124,8 +124,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -141,7 +141,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// verify ingress is gone
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -152,12 +152,12 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// --- ingress class matches explicitly
 		proxyValid := fixture.NewProxy(HTTPProxyName).
 			Annotate("contour.heptio.com/ingress.class", "linkerd").
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -168,8 +168,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -183,12 +183,12 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// --- wrong ingress class specified
 		proxyWrongClass := fixture.NewProxy(HTTPProxyName).
 			Annotate("kubernetes.io/ingress.class", "contour").
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -200,19 +200,19 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// ingress class does not match ingress controller, ignored.
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
 
 		// --- no ingress class specified
 		proxyNoClass := fixture.NewProxy(HTTPProxyName).
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -224,7 +224,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// ingress class does not match ingress controller, ignored.
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -234,8 +234,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -251,7 +251,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		// verify ingress is gone
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -287,8 +287,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -317,8 +317,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -346,7 +346,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -356,8 +356,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -373,7 +373,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		// verify ingress is gone
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -383,12 +383,12 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 	{
 		// --- no ingress class specified
 		proxyNoClass := fixture.NewProxy(HTTPProxyName).
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -399,8 +399,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -414,12 +414,12 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		// --- matching ingress class specified
 		proxyMatchingClass := fixture.NewProxy(HTTPProxyName).
 			Annotate("kubernetes.io/ingress.class", "contour").
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -430,8 +430,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -445,12 +445,12 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		// --- non-matching ingress class specified
 		proxyNonMatchingClass := fixture.NewProxy(HTTPProxyName).
 			Annotate("kubernetes.io/ingress.class", "invalid").
-			WithSpec(projcontour.HTTPProxySpec{
-				VirtualHost: &projcontour.VirtualHost{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
 					Fqdn: "www.example.com",
 				},
-				Routes: []projcontour.Route{{
-					Services: []projcontour.Service{{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
 						Name: svc.Name,
 						Port: int(svc.Spec.Ports[0].Port),
 					}},
@@ -462,7 +462,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		// ingress class does not match ingress controller, ignored.
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -472,8 +472,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -489,7 +489,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		// verify ingress is gone
 		c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 			Resources: resources(t,
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 			TypeUrl: routeType,
 		})
@@ -508,14 +508,14 @@ func TestIngressClassUpdate(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
-	vhost := &projcontour.HTTPProxy{
+	vhost := &contour_api_v1.HTTPProxy{
 		ObjectMeta: fixture.ObjectMeta("default/kuard"),
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.projectcontour.io",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -532,8 +532,8 @@ func TestIngressClassUpdate(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("kuard.projectcontour.io",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("kuard.projectcontour.io",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/kuard/8080/da39a3ee5e"),
@@ -543,7 +543,7 @@ func TestIngressClassUpdate(t *testing.T) {
 		),
 		TypeUrl: routeType,
 	}).Status(vhost).Like(
-		projcontour.HTTPProxyStatus{CurrentStatus: k8s.StatusValid},
+		contour_api_v1.HTTPProxyStatus{CurrentStatus: k8s.StatusValid},
 	)
 
 	// Updating to the non-configured ingress class should remove the
@@ -557,7 +557,7 @@ func TestIngressClassUpdate(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http"),
+			envoy_v2.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 	}).NoStatus(vhost)

--- a/internal/featuretests/listeners_test.go
+++ b/internal/featuretests/listeners_test.go
@@ -19,9 +19,9 @@ import (
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
 	v1 "k8s.io/api/core/v1"
@@ -68,9 +68,9 @@ func TestNonTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:          "ingress_http",
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -127,9 +127,9 @@ func TestNonTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:          "ingress_http",
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -198,22 +198,22 @@ func TestTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:          "ingress_http",
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls("kuard.example.com", s1,
 						httpsFilterFor("kuard.example.com"),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -256,16 +256,16 @@ func TestTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls("kuard.example.com", s1,
 						httpsFilterFor("kuard.example.com"),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -300,24 +300,24 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 
 	// p1 is a tls httpproxy
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: secret1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             secret1.Name,
 					MinimumProtocolVersion: "1.1",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc1.Name,
 					Port: int(svc1.Spec.Ports[0].Port),
 				}},
@@ -326,24 +326,24 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 	}
 
 	// p2 is a tls httpproxy
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: secret1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             secret1.Name,
 					MinimumProtocolVersion: "1.3",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc1.Name,
 					Port: int(svc1.Spec.Ports[0].Port),
 				}},
@@ -364,16 +364,16 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 
 	l1 := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			filterchaintls("kuard.example.com", secret1,
 				httpsFilterFor("kuard.example.com"),
 				nil, "h2", "http/1.1"),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 
 	// add service
@@ -386,11 +386,11 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			l1,
 			staticListener(),
@@ -413,22 +413,22 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 	rh.OnAdd(secret1)
 	l2 := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
-			envoyv2.FilterChainTLS(
+			envoy_v2.FilterChainTLS(
 				"kuard.example.com",
-				envoyv2.DownstreamTLSContext(
+				envoy_v2.DownstreamTLSContext(
 					&dag.Secret{Object: secret1},
 					envoy_api_v2_auth.TlsParameters_TLSv1_3,
 					nil,
 					"h2", "http/1.1"),
-				envoyv2.Filters(httpsFilterFor("kuard.example.com")),
+				envoy_v2.Filters(httpsFilterFor("kuard.example.com")),
 			),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 
 	// add ingress and assert the existence of ingress_http and ingres_https
@@ -437,11 +437,11 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			l2,
 			staticListener(),
@@ -503,16 +503,16 @@ func TestLDSFilter(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_https",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					filterchaintls("kuard.example.com", s1,
 						httpsFilterFor("kuard.example.com"),
 						nil, "h2", "http/1.1"),
 				},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 		),
 		TypeUrl: listenerType,
@@ -523,11 +523,11 @@ func TestLDSFilter(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 		),
 		TypeUrl: listenerType,
@@ -593,12 +593,12 @@ func TestLDSIngressHTTPUseProxyProtocol(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.ProxyProtocol(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.ProxyProtocol(),
 				),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),
@@ -670,28 +670,28 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 
 	ingress_https := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.ProxyProtocol(),
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.ProxyProtocol(),
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			filterchaintls("kuard.example.com", s1,
 				httpsFilterFor("kuard.example.com"),
 				nil, "h2", "http/1.1"),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.ProxyProtocol(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.ProxyProtocol(),
 				),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			ingress_https,
 			staticListener(),
@@ -768,24 +768,24 @@ func TestLDSCustomAddressAndPort(t *testing.T) {
 
 	ingress_http := &envoy_api_v2.Listener{
 		Name:    "ingress_http",
-		Address: envoyv2.SocketAddress("127.0.0.100", 9100),
-		FilterChains: envoyv2.FilterChains(
-			envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+		Address: envoy_v2.SocketAddress("127.0.0.100", 9100),
+		FilterChains: envoy_v2.FilterChains(
+			envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 		),
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	ingress_https := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("127.0.0.200", 9200),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("127.0.0.200", 9200),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			filterchaintls("kuard.example.com", s1,
 				httpsFilterFor("kuard.example.com"),
 				nil, "h2", "http/1.1"),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
@@ -861,30 +861,30 @@ func TestLDSCustomAccessLogPaths(t *testing.T) {
 
 	ingress_http := &envoy_api_v2.Listener{
 		Name:    "ingress_http",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-		FilterChains: envoyv2.FilterChains(
-			envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/tmp/http_access.log"), 0),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+		FilterChains: envoy_v2.FilterChains(
+			envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/tmp/http_access.log"), 0),
 		),
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	ingress_https := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			filterchaintls("kuard.example.com", s1,
-				envoyv2.HTTPConnectionManagerBuilder().
-					AddFilter(envoyv2.FilterMisdirectedRequests("kuard.example.com")).
+				envoy_v2.HTTPConnectionManagerBuilder().
+					AddFilter(envoy_v2.FilterMisdirectedRequests("kuard.example.com")).
 					DefaultFilters().
 					RouteConfigName("https/kuard.example.com").
 					MetricsPrefix(xdscache_v2.ENVOY_HTTPS_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy("/tmp/https_access.log")).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy("/tmp/https_access.log")).
 					Get(),
 				nil, "h2", "http/1.1"),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -923,23 +923,23 @@ func TestHTTPProxyHTTPS(t *testing.T) {
 	}
 
 	// p1 is a httpproxy that has TLS
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "secret",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 8080,
 				}},
@@ -961,25 +961,25 @@ func TestHTTPProxyHTTPS(t *testing.T) {
 
 	ingressHTTP := &envoy_api_v2.Listener{
 		Name:    "ingress_http",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-		FilterChains: envoyv2.FilterChains(
-			envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+		FilterChains: envoy_v2.FilterChains(
+			envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 		),
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 
 	ingressHTTPS := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
 			filterchaintls("example.com", s1,
 				httpsFilterFor("example.com"),
 				nil, "h2", "http/1.1"),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 	c.Request(listenerType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
@@ -1015,24 +1015,24 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
 	// p1 is a tls httpproxy
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             "secret",
 					MinimumProtocolVersion: "1.1",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "backend",
 					Port: 80,
 				}},
@@ -1043,22 +1043,22 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 
 	l1 := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
-			envoyv2.FilterChainTLS(
+			envoy_v2.FilterChainTLS(
 				"kuard.example.com",
-				envoyv2.DownstreamTLSContext(
+				envoy_v2.DownstreamTLSContext(
 					&dag.Secret{Object: secret1},
 					envoy_api_v2_auth.TlsParameters_TLSv1_2,
 					nil,
 					"h2", "http/1.1"),
-				envoyv2.Filters(httpsFilterFor("kuard.example.com")),
+				envoy_v2.Filters(httpsFilterFor("kuard.example.com")),
 			),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 
 	// verify that p1's TLS 1.1 minimum has been upgraded to 1.2
@@ -1066,11 +1066,11 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			l1,
 			staticListener(),
@@ -1079,25 +1079,25 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 	})
 
 	// p2 is a tls httpproxy
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName:             "secret",
 					MinimumProtocolVersion: "1.3",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "backend",
 					Port: 80,
 				}},
@@ -1108,22 +1108,22 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 
 	l2 := &envoy_api_v2.Listener{
 		Name:    "ingress_https",
-		Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-		ListenerFilters: envoyv2.ListenerFilters(
-			envoyv2.TLSInspector(),
+		Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v2.ListenerFilters(
+			envoy_v2.TLSInspector(),
 		),
 		FilterChains: []*envoy_api_v2_listener.FilterChain{
-			envoyv2.FilterChainTLS(
+			envoy_v2.FilterChainTLS(
 				"kuard.example.com",
-				envoyv2.DownstreamTLSContext(
+				envoy_v2.DownstreamTLSContext(
 					&dag.Secret{Object: secret1},
 					envoy_api_v2_auth.TlsParameters_TLSv1_3,
 					nil,
 					"h2", "http/1.1"),
-				envoyv2.Filters(httpsFilterFor("kuard.example.com")),
+				envoy_v2.Filters(httpsFilterFor("kuard.example.com")),
 			),
 		},
-		SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+		SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 	}
 
 	// verify that p2's TLS 1.3 minimum has NOT been downgraded to 1.2
@@ -1131,11 +1131,11 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			l2,
 			staticListener(),
@@ -1151,20 +1151,20 @@ func TestLDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	rh.OnAdd(fixture.NewService("marketing/green").
 		WithPorts(v1.ServicePort{Name: "http", Port: 80}))
 
-	child := &projcontour.HTTPProxy{
+	child := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
 			Namespace: "marketing",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.containersteve.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "green",
 					Port: 80,
 				}},
@@ -1173,17 +1173,17 @@ func TestLDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	}
 	rh.OnAdd(child)
 
-	root := &projcontour.HTTPProxy{
+	root := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-blog",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "blog.containersteve.com",
 			},
-			Includes: []projcontour.Include{{
-				Conditions: []projcontour.MatchCondition{{
+			Includes: []contour_api_v1.Include{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
 				Name:      child.Name,
@@ -1199,11 +1199,11 @@ func TestLDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:    "ingress_http",
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManager("ingress_http", envoyv2.FileAccessLogEnvoy("/dev/stdout"), 0),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManager("ingress_http", envoy_v2.FileAccessLogEnvoy("/dev/stdout"), 0),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			},
 			staticListener(),
 		),

--- a/internal/featuretests/loadbalancerpolicy_test.go
+++ b/internal/featuretests/loadbalancerpolicy_test.go
@@ -18,8 +18,8 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -38,13 +38,13 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 	// simple single service
 	proxy1 := fixture.NewProxy("simple").
 		WithFQDN("www.example.com").
-		WithSpec(projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/cart")),
-				LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+				LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 					Strategy: "Cookie",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -54,8 +54,8 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("www.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("www.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/cart"),
 						Action: withSessionAffinity(routeCluster("default/app/80/e4f81994fe")),
@@ -71,13 +71,13 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 		proxy1,
 		fixture.NewProxy("simple").
 			WithFQDN("www.example.com").
-			WithSpec(projcontour.HTTPProxySpec{
-				Routes: []projcontour.Route{{
+			WithSpec(contour_api_v1.HTTPProxySpec{
+				Routes: []contour_api_v1.Route{{
 					Conditions: matchconditions(prefixMatchCondition("/cart")),
-					LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+					LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 						Strategy: "Cookie",
 					},
-					Services: []projcontour.Service{{
+					Services: []contour_api_v1.Service{{
 						Name: s1.Name,
 						Port: 80,
 					}, {
@@ -90,8 +90,8 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("www.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("www.example.com",
 					&envoy_api_v2_route.Route{
 						Match: routePrefix("/cart"),
 						Action: withSessionAffinity(

--- a/internal/featuretests/mirrorpolicy_test.go
+++ b/internal/featuretests/mirrorpolicy_test.go
@@ -18,9 +18,9 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,16 +38,16 @@ func TestMirrorPolicy(t *testing.T) {
 	rh.OnAdd(svc1)
 	rh.OnAdd(svc2)
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "example.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "example.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc1.Name,
 					Port: 8080,
 				}, {
@@ -62,8 +62,8 @@ func TestMirrorPolicy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost(p1.Spec.VirtualHost.Fqdn,
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost(p1.Spec.VirtualHost.Fqdn,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withMirrorPolicy(routeCluster("default/kuard/8080/da39a3ee5e"), "default/mirror/8080/da39a3ee5e"),

--- a/internal/featuretests/retrypolicy_test.go
+++ b/internal/featuretests/retrypolicy_test.go
@@ -19,8 +19,8 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -54,8 +54,8 @@ func TestRetryPolicy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx,gateway-error", 7, 120*time.Millisecond),
@@ -83,8 +83,8 @@ func TestRetryPolicy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx,gateway-error", 7, 120*time.Millisecond),
@@ -112,8 +112,8 @@ func TestRetryPolicy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx,gateway-error", 7, 120*time.Millisecond),
@@ -126,19 +126,19 @@ func TestRetryPolicy(t *testing.T) {
 
 	rh.OnDelete(i3)
 
-	hp1 := &projcontour.HTTPProxy{
+	hp1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test3.test.com"},
-			Routes: []projcontour.Route{{
-				RetryPolicy: &projcontour.RetryPolicy{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test3.test.com"},
+			Routes: []contour_api_v1.Route{{
+				RetryPolicy: &contour_api_v1.RetryPolicy{
 					NumRetries:    5,
 					PerTryTimeout: "105s",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -149,8 +149,8 @@ func TestRetryPolicy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost(hp1.Spec.VirtualHost.Fqdn,
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost(hp1.Spec.VirtualHost.Fqdn,
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withRetryPolicy(routeCluster("default/backend/80/da39a3ee5e"), "5xx", 5, 105*time.Second),

--- a/internal/featuretests/route_test.go
+++ b/internal/featuretests/route_test.go
@@ -21,10 +21,10 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
@@ -86,8 +86,8 @@ func TestEditIngress(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*", &envoy_api_v2_route.Route{
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*", &envoy_api_v2_route.Route{
 					Match:  routePrefix("/"),
 					Action: routecluster("default/kuard/80/da39a3ee5e"),
 				}),
@@ -121,8 +121,8 @@ func TestEditIngress(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*", &envoy_api_v2_route.Route{
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*", &envoy_api_v2_route.Route{
 					Match:  routePrefix("/testing"),
 					Action: routecluster("default/kuard/80/da39a3ee5e"),
 				}),
@@ -180,8 +180,8 @@ func TestIngressPathRouteWithoutHost(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/hello"),
 						Action: routecluster("default/hello/80/da39a3ee5e"),
@@ -230,8 +230,8 @@ func TestEditIngressInPlace(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routecluster("default/wowie/80/da39a3ee5e"),
@@ -273,8 +273,8 @@ func TestEditIngressInPlace(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "3",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/whoop"),
 						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
@@ -325,15 +325,15 @@ func TestEditIngressInPlace(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "4",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/whoop"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
@@ -391,20 +391,20 @@ func TestEditIngressInPlace(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "5",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("hello.example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("hello.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/whoop"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/hello.example.com",
-				envoyv2.VirtualHost("hello.example.com",
+			envoy_v2.RouteConfiguration("https/hello.example.com",
+				envoy_v2.VirtualHost("hello.example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/whoop"),
 						Action: routecluster("default/kerpow/9000/da39a3ee5e"),
@@ -497,18 +497,18 @@ func TestSSLRedirectOverlay(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 8009, TargetPort: intstr.FromInt(8080)}))
 
 	assertRDS(t, c, "5", virtualhosts(
-		envoyv2.VirtualHost("example.com",
+		envoy_v2.VirtualHost("example.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 				Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 			},
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"), // match all
-				Action: envoyv2.UpgradeHTTPS(),
+				Action: envoy_v2.UpgradeHTTPS(),
 			},
 		),
 	), virtualhosts(
-		envoyv2.VirtualHost("example.com",
+		envoy_v2.VirtualHost("example.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 				Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
@@ -565,7 +565,7 @@ func TestInvalidCertInIngress(t *testing.T) {
 	})
 
 	assertRDS(t, c, "1", virtualhosts(
-		envoyv2.VirtualHost("kuard.io",
+		envoy_v2.VirtualHost("kuard.io",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -584,14 +584,14 @@ func TestInvalidCertInIngress(t *testing.T) {
 	})
 
 	assertRDS(t, c, "2", virtualhosts(
-		envoyv2.VirtualHost("kuard.io",
+		envoy_v2.VirtualHost("kuard.io",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
 			},
 		),
 	), virtualhosts(
-		envoyv2.VirtualHost("kuard.io",
+		envoy_v2.VirtualHost("kuard.io",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -639,7 +639,7 @@ func TestIssue257(t *testing.T) {
 	rh.OnAdd(s1)
 
 	assertRDS(t, c, "2", virtualhosts(
-		envoyv2.VirtualHost("*",
+		envoy_v2.VirtualHost("*",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -692,7 +692,7 @@ func TestIssue257(t *testing.T) {
 	rh.OnUpdate(i1, i2)
 
 	assertRDS(t, c, "3", virtualhosts(
-		envoyv2.VirtualHost("kuard.db.gd-ms.com",
+		envoy_v2.VirtualHost("kuard.db.gd-ms.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -779,20 +779,20 @@ func TestRDSFilter(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "5",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("example.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"), // match all
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/example.com",
-				envoyv2.VirtualHost("example.com",
+			envoy_v2.RouteConfiguration("https/example.com",
+				envoy_v2.VirtualHost("example.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk"),
 						Action: routecluster("nginx-ingress/challenge-service/8009/da39a3ee5e"),
@@ -867,8 +867,8 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/kuard"),
 						Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -878,7 +878,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 						Action: routecluster("default/kuard/80/da39a3ee5e"),
 					},
 				),
-				envoyv2.VirtualHost("test-gui",
+				envoy_v2.VirtualHost("test-gui",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routecluster("default/test-gui/80/da39a3ee5e"),
@@ -920,7 +920,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	}
 	rh.OnAdd(i1)
 	assertRDS(t, c, "1", virtualhosts(
-		envoyv2.VirtualHost("*",
+		envoy_v2.VirtualHost("*",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -981,7 +981,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	}
 	rh.OnUpdate(i3, i4)
 	assertRDS(t, c, "3", virtualhosts(
-		envoyv2.VirtualHost("*",
+		envoy_v2.VirtualHost("*",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -1006,7 +1006,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	}
 	rh.OnUpdate(i4, i5)
 	assertRDS(t, c, "4", virtualhosts(
-		envoyv2.VirtualHost("*",
+		envoy_v2.VirtualHost("*",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -1032,18 +1032,18 @@ func TestRDSAssertNoDataRaceDuringInsertAndStream(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			rh.OnAdd(&projcontour.HTTPProxy{
+			rh.OnAdd(&contour_api_v1.HTTPProxy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("simple-%d", i),
 					Namespace: "default",
 				},
-				Spec: projcontour.HTTPProxySpec{
-					VirtualHost: &projcontour.VirtualHost{Fqdn: fmt.Sprintf("example-%d.com", i)},
-					Routes: []projcontour.Route{{
-						Conditions: []projcontour.MatchCondition{{
+				Spec: contour_api_v1.HTTPProxySpec{
+					VirtualHost: &contour_api_v1.VirtualHost{Fqdn: fmt.Sprintf("example-%d.com", i)},
+					Routes: []contour_api_v1.Route{{
+						Conditions: []contour_api_v1.MatchCondition{{
 							Prefix: "/",
 						}},
-						Services: []projcontour.Service{{
+						Services: []contour_api_v1.Service{{
 							Name: "kuard",
 							Port: 80,
 						}},
@@ -1116,7 +1116,7 @@ func TestRDSIngressSpecMissingHTTPKey(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 9001, TargetPort: intstr.FromInt(8080)}))
 
 	assertRDS(t, c, "2", virtualhosts(
-		envoyv2.VirtualHost("test2.test.com",
+		envoy_v2.VirtualHost("test2.test.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/"),
 				Action: routecluster("default/network-test/9001/da39a3ee5e"),
@@ -1132,18 +1132,18 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 	rh.OnAdd(fixture.NewService("kuard").
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}))
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90, // ignored
@@ -1154,7 +1154,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 
 	rh.OnAdd(p1)
 	assertRDS(t, c, "1", virtualhosts(
-		envoyv2.VirtualHost("test2.test.com",
+		envoy_v2.VirtualHost("test2.test.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/a"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -1162,18 +1162,18 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 		),
 	), nil)
 
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90,
@@ -1188,7 +1188,7 @@ func TestRouteWithAServiceWeight(t *testing.T) {
 
 	rh.OnUpdate(p1, p2)
 	assertRDS(t, c, "2", virtualhosts(
-		envoyv2.VirtualHost("test2.test.com",
+		envoy_v2.VirtualHost("test2.test.com",
 			&envoy_api_v2_route.Route{
 				Match: routePrefix("/a"),
 				Action: routeweightedcluster(
@@ -1215,23 +1215,23 @@ func TestRouteWithTLS(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/a",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
@@ -1245,16 +1245,16 @@ func TestRouteWithTLS(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 						Match:  routePrefix("/a"),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/a"),
 						Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -1286,31 +1286,31 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/insecure",
 				}},
 				PermitInsecure: true,
-				Services: []projcontour.Service{{Name: "kuard",
+				Services: []contour_api_v1.Service{{Name: "kuard",
 					Port: 80,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/secure",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -1324,11 +1324,11 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/insecure"),
@@ -1336,8 +1336,8 @@ func TestRouteWithTLS_InsecurePaths(t *testing.T) {
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
 						Action: routecluster("default/svc2/80/da39a3ee5e"),
@@ -1382,32 +1382,32 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/insecure",
 				}},
 				PermitInsecure: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
 			}, {
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/secure",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -1421,20 +1421,20 @@ func TestRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/insecure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
 						Action: routecluster("default/svc2/80/da39a3ee5e"),
@@ -1491,8 +1491,8 @@ func TestRoutePrefixRouteRegex(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("*",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("*",
 					&envoy_api_v2_route.Route{
 						Match:  routeRegex("/[^/]+/invoices(/.*|/?)"),
 						Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -1513,12 +1513,12 @@ func assertRDS(t *testing.T, c *Contour, versioninfo string, ingressHTTP, ingres
 	t.Helper()
 
 	routes := []*envoy_api_v2.RouteConfiguration{
-		envoyv2.RouteConfiguration("ingress_http", ingressHTTP...),
+		envoy_v2.RouteConfiguration("ingress_http", ingressHTTP...),
 	}
 
 	for _, vh := range ingressHTTPS {
 		routes = append(routes,
-			envoyv2.RouteConfiguration(path.Join("https", vh.Name), vh))
+			envoy_v2.RouteConfiguration(path.Join("https", vh.Name), vh))
 	}
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
@@ -1535,7 +1535,7 @@ type weightedcluster struct {
 }
 
 func routeRegex(regex string, headers ...dag.HeaderMatchCondition) *envoy_api_v2_route.RouteMatch {
-	return envoyv2.RouteMatch(&dag.Route{
+	return envoy_v2.RouteMatch(&dag.Route{
 		PathMatchCondition: &dag.RegexMatchCondition{
 			Regex: regex,
 		},
@@ -1584,16 +1584,16 @@ func TestHTTPProxyRouteWithAServiceWeight(t *testing.T) {
 	rh.OnAdd(fixture.NewService("kuard").
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}))
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: conditions(prefixCondition("/a")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90, // ignored
@@ -1604,7 +1604,7 @@ func TestHTTPProxyRouteWithAServiceWeight(t *testing.T) {
 
 	rh.OnAdd(proxy1)
 	assertRDS(t, c, "1", virtualhosts(
-		envoyv2.VirtualHost("test2.test.com",
+		envoy_v2.VirtualHost("test2.test.com",
 			&envoy_api_v2_route.Route{
 				Match:  routePrefix("/a"),
 				Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -1612,16 +1612,16 @@ func TestHTTPProxyRouteWithAServiceWeight(t *testing.T) {
 		),
 	), nil)
 
-	proxy2 := &projcontour.HTTPProxy{
+	proxy2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: conditions(prefixCondition("/a")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name:   "kuard",
 					Port:   80,
 					Weight: 90,
@@ -1636,7 +1636,7 @@ func TestHTTPProxyRouteWithAServiceWeight(t *testing.T) {
 
 	rh.OnUpdate(proxy1, proxy2)
 	assertRDS(t, c, "2", virtualhosts(
-		envoyv2.VirtualHost("test2.test.com",
+		envoy_v2.VirtualHost("test2.test.com",
 			&envoy_api_v2_route.Route{
 				Match: routePrefix("/a"),
 				Action: routeweightedcluster(
@@ -1663,21 +1663,21 @@ func TestHTTPProxyRouteWithTLS(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				Conditions: conditions(prefixCondition("/a")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
@@ -1691,16 +1691,16 @@ func TestHTTPProxyRouteWithTLS(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/a"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/a"),
 						Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -1732,27 +1732,27 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths(t *testing.T) {
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				Conditions:     conditions(prefixCondition("/insecure")),
 				PermitInsecure: true,
-				Services: []projcontour.Service{{Name: "kuard",
+				Services: []contour_api_v1.Service{{Name: "kuard",
 					Port: 80,
 				}},
 			}, {
 				Conditions: conditions(prefixCondition("/secure")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -1766,11 +1766,11 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/insecure"),
@@ -1778,8 +1778,8 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths(t *testing.T) {
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
 						Action: routecluster("default/svc2/80/da39a3ee5e"),
@@ -1824,28 +1824,28 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testin
 		Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 	})
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "test2.test.com",
-				TLS: &projcontour.TLS{
+				TLS: &contour_api_v1.TLS{
 					SecretName: "example-tls",
 				},
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				Conditions:     conditions(prefixCondition("/insecure")),
 				PermitInsecure: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "kuard",
 					Port: 80,
 				}},
 			}, {
 				Conditions: conditions(prefixCondition("/secure")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "svc2",
 					Port: 80,
 				}},
@@ -1859,20 +1859,20 @@ func TestHTTPProxyRouteWithTLS_InsecurePaths_DisablePermitInsecureTrue(t *testin
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/insecure"),
-						Action: envoyv2.UpgradeHTTPS(),
+						Action: envoy_v2.UpgradeHTTPS(),
 					},
 				),
 			),
-			envoyv2.RouteConfiguration("https/test2.test.com",
-				envoyv2.VirtualHost("test2.test.com",
+			envoy_v2.RouteConfiguration("https/test2.test.com",
+				envoy_v2.VirtualHost("test2.test.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/secure"),
 						Action: routecluster("default/svc2/80/da39a3ee5e"),
@@ -1897,17 +1897,17 @@ func TestRDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(svc1)
 
-	child := &projcontour.HTTPProxy{
+	child := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blog",
 			Namespace: svc1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "www.containersteve.com",
 			},
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: svc1.Name,
 					Port: 80,
 				}},
@@ -1916,16 +1916,16 @@ func TestRDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	}
 	rh.OnAdd(child)
 
-	root := &projcontour.HTTPProxy{
+	root := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-blog",
 			Namespace: "default",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "blog.containersteve.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      child.Name,
 				Namespace: child.Namespace,
 			}},
@@ -1938,8 +1938,8 @@ func TestRDSHTTPProxyRootCannotDelegateToAnotherRoot(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("www.containersteve.com",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("www.containersteve.com",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: routecluster("marketing/green/80/da39a3ee5e"),
@@ -1968,21 +1968,21 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc3)
 
-	proxyRoot := &projcontour.HTTPProxy{
+	proxyRoot := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root",
 			Namespace: svc1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Includes: []projcontour.Include{{
+			Includes: []contour_api_v1.Include{{
 				Name:      "blogteama",
 				Namespace: "teama",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
@@ -1990,19 +1990,19 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 			}, {
 				Name:      "blogteama",
 				Namespace: "teamb",
-				Conditions: []projcontour.MatchCondition{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/blog",
-					Header: &projcontour.HeaderMatchCondition{
+					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:     "x-header",
 						Contains: "abc",
 					},
 				}},
 			}},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc1.Name,
 					Port: 8080,
 				}},
@@ -2010,14 +2010,14 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 		},
 	}
 
-	proxyChildA := &projcontour.HTTPProxy{
+	proxyChildA := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blogteama",
 			Namespace: "teama",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: svc2.Name,
 					Port: 8080,
 				}},
@@ -2025,14 +2025,14 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 		},
 	}
 
-	proxyChildB := &projcontour.HTTPProxy{
+	proxyChildB := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blogteamb",
 			Namespace: "teamb",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			Routes: []projcontour.Route{{
-				Services: []projcontour.Service{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
 					Name: svc3.Name,
 					Port: 8080,
 				}},
@@ -2046,7 +2046,7 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "2",
 		Resources: routeResources(t,
-			envoyv2.RouteConfiguration("ingress_http"),
+			envoy_v2.RouteConfiguration("ingress_http"),
 		),
 		TypeUrl: routeType,
 		Nonce:   "2",
@@ -2055,10 +2055,10 @@ func TestRDSHTTPProxyDuplicateIncludeConditions(t *testing.T) {
 
 func virtualhosts(v ...*envoy_api_v2_route.VirtualHost) []*envoy_api_v2_route.VirtualHost { return v }
 
-func conditions(c ...projcontour.MatchCondition) []projcontour.MatchCondition { return c }
+func conditions(c ...contour_api_v1.MatchCondition) []contour_api_v1.MatchCondition { return c }
 
-func prefixCondition(prefix string) projcontour.MatchCondition {
-	return projcontour.MatchCondition{
+func prefixCondition(prefix string) contour_api_v1.MatchCondition {
+	return contour_api_v1.MatchCondition{
 		Prefix: prefix,
 	}
 }

--- a/internal/featuretests/secrets_test.go
+++ b/internal/featuretests/secrets_test.go
@@ -19,7 +19,7 @@ import (
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -231,7 +231,7 @@ func TestSDSshouldNotPublishInvalidSecret(t *testing.T) {
 }
 
 func secret(sec *v1.Secret) *envoy_api_v2_auth.Secret {
-	return envoyv2.Secret(&dag.Secret{
+	return envoy_v2.Secret(&dag.Secret{
 		Object: sec,
 	})
 }

--- a/internal/featuretests/timeoutpolicy_test.go
+++ b/internal/featuretests/timeoutpolicy_test.go
@@ -19,7 +19,7 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/contour"
 	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -149,19 +149,19 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 	rh.OnDelete(i4)
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "600", // not 600s
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},
@@ -178,16 +178,16 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: p1.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "3m",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},
@@ -211,16 +211,16 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p3 := &projcontour.HTTPProxy{
+	p3 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: p2.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Response: "infinity",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},
@@ -253,19 +253,19 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
-	p1 := &projcontour.HTTPProxy{
+	p1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: svc.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Idle: "600", // not 600s
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},
@@ -282,16 +282,16 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p2 := &projcontour.HTTPProxy{
+	p2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: p1.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Idle: "3m",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},
@@ -315,16 +315,16 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p3 := &projcontour.HTTPProxy{
+	p3 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: p2.ObjectMeta,
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &projcontour.TimeoutPolicy{
+				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
 					Idle: "infinity",
 				},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: svc.Name,
 					Port: 8080,
 				}},

--- a/internal/featuretests/timeouts_test.go
+++ b/internal/featuretests/timeouts_test.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/timeout"
 	xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
@@ -36,18 +36,18 @@ func TestTimeoutsNotSpecified(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
-	hp1 := &projcontour.HTTPProxy{
+	hp1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -61,12 +61,12 @@ func TestTimeoutsNotSpecified(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:          xdscache_v2.ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(xdscache_v2.ENVOY_HTTP_LISTENER).
 					MetricsPrefix(xdscache_v2.ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(xdscache_v2.DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(xdscache_v2.DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					Get(),
 				),
@@ -89,18 +89,18 @@ func TestNonZeroTimeoutsSpecified(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
-	hp1 := &projcontour.HTTPProxy{
+	hp1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -114,12 +114,12 @@ func TestNonZeroTimeoutsSpecified(t *testing.T) {
 		Resources: resources(t,
 			&envoy_api_v2.Listener{
 				Name:          xdscache_v2.ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(xdscache_v2.ENVOY_HTTP_LISTENER).
 					MetricsPrefix(xdscache_v2.ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(xdscache_v2.DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(xdscache_v2.DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					ConnectionIdleTimeout(timeout.DurationSetting(7 * time.Second)).
 					StreamIdleTimeout(timeout.DurationSetting(70 * time.Second)).

--- a/internal/featuretests/websockets_test.go
+++ b/internal/featuretests/websockets_test.go
@@ -18,8 +18,8 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -65,8 +65,8 @@ func TestWebsocketsIngress(t *testing.T) {
 	// check legacy websocket annotation
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("websocket.hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("websocket.hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/"),
 						Action: withWebsocket(routeCluster("default/ws/80/da39a3ee5e")),
@@ -107,8 +107,8 @@ func TestWebsocketsIngress(t *testing.T) {
 	// check websocket annotation
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("websocket.hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("websocket.hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/ws2"),
 						Action: withWebsocket(routeCluster("default/ws/80/da39a3ee5e")),
@@ -132,30 +132,30 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s2)
 
-	hp1 := &projcontour.HTTPProxy{
+	hp1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "websocket.hello.world"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "websocket.hello.world"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
 			}, {
 				Conditions:       matchconditions(prefixMatchCondition("/ws-1")),
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
 			}, {
 				Conditions:       matchconditions(prefixMatchCondition("/ws-2")),
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -166,8 +166,8 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("websocket.hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("websocket.hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/ws-2"),
 						Action: withWebsocket(routeCluster("default/ws/80/da39a3ee5e")),
@@ -186,23 +186,23 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	hp2 := &projcontour.HTTPProxy{
+	hp2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{Fqdn: "websocket.hello.world"},
-			Routes: []projcontour.Route{{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "websocket.hello.world"},
+			Routes: []contour_api_v1.Route{{
 				Conditions: matchconditions(prefixMatchCondition("/")),
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
 			}, {
 				Conditions:       matchconditions(prefixMatchCondition("/ws-1")),
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}, {
@@ -212,7 +212,7 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 			}, {
 				Conditions:       matchconditions(prefixMatchCondition("/ws-2")),
 				EnableWebsockets: true,
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: s1.Name,
 					Port: 80,
 				}},
@@ -223,8 +223,8 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
-			envoyv2.RouteConfiguration("ingress_http",
-				envoyv2.VirtualHost("websocket.hello.world",
+			envoy_v2.RouteConfiguration("ingress_http",
+				envoy_v2.VirtualHost("websocket.hello.world",
 					&envoy_api_v2_route.Route{
 						Match:  routePrefix("/ws-2"),
 						Action: withWebsocket(routeCluster("default/ws/80/da39a3ee5e")),

--- a/internal/fixture/httpproxy.go
+++ b/internal/fixture/httpproxy.go
@@ -14,11 +14,11 @@
 package fixture
 
 import (
-	v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
 
 // ProxyBuilder is a builder object to make creating HTTPProxy fixtures more succinct.
-type ProxyBuilder v1.HTTPProxy
+type ProxyBuilder contour_api_v1.HTTPProxy
 
 // NewProxy creates a new ProxyBuilder with the specified object name.
 func NewProxy(name string) *ProxyBuilder {
@@ -34,14 +34,14 @@ func NewProxy(name string) *ProxyBuilder {
 
 func (b *ProxyBuilder) ensureVirtualHost() {
 	if b.Spec.VirtualHost == nil {
-		b.Spec.VirtualHost = &v1.VirtualHost{}
+		b.Spec.VirtualHost = &contour_api_v1.VirtualHost{}
 	}
 }
 
 func (b *ProxyBuilder) ensureTLS() {
 	b.ensureVirtualHost()
 	if b.Spec.VirtualHost.TLS == nil {
-		b.Spec.VirtualHost.TLS = &v1.TLS{}
+		b.Spec.VirtualHost.TLS = &contour_api_v1.TLS{}
 	}
 }
 
@@ -58,7 +58,7 @@ func (b *ProxyBuilder) Label(k string, v string) *ProxyBuilder {
 }
 
 // WithSpec updates the builder's Spec field, returning the build proxy.
-func (b *ProxyBuilder) WithSpec(spec v1.HTTPProxySpec) *v1.HTTPProxy {
+func (b *ProxyBuilder) WithSpec(spec contour_api_v1.HTTPProxySpec) *contour_api_v1.HTTPProxy {
 	oldSpec := b.Spec
 
 	b.Spec = spec
@@ -69,7 +69,7 @@ func (b *ProxyBuilder) WithSpec(spec v1.HTTPProxySpec) *v1.HTTPProxy {
 		b.Spec.VirtualHost = oldSpec.VirtualHost
 	}
 
-	return (*v1.HTTPProxy)(b)
+	return (*contour_api_v1.HTTPProxy)(b)
 }
 
 func (b *ProxyBuilder) WithFQDN(fqdn string) *ProxyBuilder {
@@ -84,7 +84,7 @@ func (b *ProxyBuilder) WithCertificate(secretName string) *ProxyBuilder {
 	return b
 }
 
-func (b *ProxyBuilder) WithAuthServer(auth v1.AuthorizationServer) *ProxyBuilder {
+func (b *ProxyBuilder) WithAuthServer(auth contour_api_v1.AuthorizationServer) *ProxyBuilder {
 	b.ensureTLS()
 	b.Spec.VirtualHost.Authorization = &auth
 	return b

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -16,8 +16,8 @@ package k8s
 import (
 	"context"
 
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,8 +87,8 @@ type UnstructuredConverter struct {
 // NewUnstructuredConverter returns a new UnstructuredConverter initialized
 func NewUnstructuredConverter() (*UnstructuredConverter, error) {
 	schemeBuilder := runtime.SchemeBuilder{
-		projectcontour.AddToScheme,
-		projectcontourv1alpha1.AddToScheme,
+		contour_api_v1.AddToScheme,
+		contour_api_v1alpha1.AddToScheme,
 		scheme.AddToScheme,
 		serviceapis.AddToScheme,
 		v1beta1.AddToScheme,

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"testing"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -60,20 +60,20 @@ func TestConvertUnstructured(t *testing.T) {
 		})
 	}
 
-	proxy1 := &projcontour.HTTPProxy{
+	proxy1 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "roots",
 			Name:      "example",
 		},
-		Spec: projcontour.HTTPProxySpec{
-			VirtualHost: &projcontour.VirtualHost{
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
 			},
-			Routes: []projcontour.Route{{
-				Conditions: []projcontour.MatchCondition{{
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
 					Prefix: "/foo",
 				}},
-				Services: []projcontour.Service{{
+				Services: []contour_api_v1.Service{{
 					Name: "home",
 					Port: 8080,
 				}},
@@ -81,13 +81,13 @@ func TestConvertUnstructured(t *testing.T) {
 		},
 	}
 
-	proxyTLSCert1 := &projcontour.TLSCertificateDelegation{
+	proxyTLSCert1 := &contour_api_v1.TLSCertificateDelegation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "delegation",
 			Namespace: "example",
 		},
-		Spec: projcontour.TLSCertificateDelegationSpec{
-			Delegations: []projcontour.CertificateDelegation{{
+		Spec: contour_api_v1.TLSCertificateDelegationSpec{
+			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: "sec1",
 				TargetNamespaces: []string{
 					"targetns",
@@ -271,7 +271,7 @@ func TestConvertUnstructured(t *testing.T) {
 
 	run(t, "invalidunstructured", testcase{
 		obj:       proxyInvalidUnstructured,
-		want:      &projcontour.HTTPProxy{},
+		want:      &contour_api_v1.HTTPProxy{},
 		wantError: errors.New("unable to convert unstructured object to projectcontour.io/v1, Kind=HTTPProxy: cannot convert int to string"),
 	})
 
@@ -316,7 +316,7 @@ func TestConvertUnstructured(t *testing.T) {
 				},
 			},
 		},
-		want: &projectcontourv1alpha1.ExtensionService{
+		want: &contour_api_v1alpha1.ExtensionService{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "extension",
 				Namespace: "default",

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -14,7 +14,7 @@
 package k8s
 
 import (
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
@@ -31,9 +31,9 @@ func IsStatusEqual(objA, objB interface{}) bool {
 		case *v1beta1.Ingress:
 			return equality.Semantic.DeepEqual(a.Status, b.Status)
 		}
-	case *projcontour.HTTPProxy:
+	case *contour_api_v1.HTTPProxy:
 		switch b := objB.(type) {
-		case *projcontour.HTTPProxy:
+		case *contour_api_v1.HTTPProxy:
 			return equality.Semantic.DeepEqual(a.Status, b.Status)
 		}
 	}

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -14,9 +14,8 @@
 package k8s
 
 import (
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,9 +33,9 @@ import (
 // DefaultResources ...
 func DefaultResources() []schema.GroupVersionResource {
 	return []schema.GroupVersionResource{
-		projectcontour.HTTPProxyGVR,
-		projectcontour.TLSCertificateDelegationGVR,
-		projectcontourv1alpha1.ExtensionServiceGVR,
+		contour_api_v1.HTTPProxyGVR,
+		contour_api_v1.TLSCertificateDelegationGVR,
+		contour_api_v1alpha1.ExtensionServiceGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 		v1beta1.SchemeGroupVersion.WithResource("ingresses"),
 	}

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -14,7 +14,7 @@
 package k8s
 
 import (
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -40,9 +40,9 @@ func KindOf(obj interface{}) string {
 			return "Endpoints"
 		case *v1beta1.Ingress:
 			return "Ingress"
-		case *projectcontour.HTTPProxy:
+		case *contour_api_v1.HTTPProxy:
 			return "HTTPProxy"
-		case *projectcontour.TLSCertificateDelegation:
+		case *contour_api_v1.TLSCertificateDelegation:
 			return "TLSCertificateDelegation"
 		case *v1alpha1.ExtensionService:
 			return "ExtensionService"
@@ -69,8 +69,8 @@ func VersionOf(obj interface{}) string {
 			return v1.SchemeGroupVersion.String()
 		case *v1beta1.Ingress:
 			return v1beta1.SchemeGroupVersion.String()
-		case *projectcontour.HTTPProxy, *projectcontour.TLSCertificateDelegation:
-			return projectcontour.GroupVersion.String()
+		case *contour_api_v1.HTTPProxy, *contour_api_v1.TLSCertificateDelegation:
+			return contour_api_v1.GroupVersion.String()
 		case *v1alpha1.ExtensionService:
 			return v1alpha1.GroupVersion.String()
 		case *unstructured.Unstructured:

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"testing"
 
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -21,8 +21,8 @@ func TestKindOf(t *testing.T) {
 		{"Endpoints", &v1.Endpoints{}},
 		{"Pod", &v1.Pod{}},
 		{"Ingress", &v1beta1.Ingress{}},
-		{"HTTPProxy", &projectcontour.HTTPProxy{}},
-		{"TLSCertificateDelegation", &projectcontour.TLSCertificateDelegation{}},
+		{"HTTPProxy", &contour_api_v1.HTTPProxy{}},
+		{"TLSCertificateDelegation", &contour_api_v1.TLSCertificateDelegation{}},
 		{"ExtensionService", &v1alpha1.ExtensionService{}},
 		{"Foo", &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -46,8 +46,8 @@ func TestVersionOf(t *testing.T) {
 		{"v1", &v1.Service{}},
 		{"v1", &v1.Endpoints{}},
 		{"networking.k8s.io/v1beta1", &v1beta1.Ingress{}},
-		{"projectcontour.io/v1", &projectcontour.HTTPProxy{}},
-		{"projectcontour.io/v1", &projectcontour.TLSCertificateDelegation{}},
+		{"projectcontour.io/v1", &contour_api_v1.HTTPProxy{}},
+		{"projectcontour.io/v1", &contour_api_v1.TLSCertificateDelegation{}},
 		{"projectcontour.io/v1alpha1", &v1alpha1.ExtensionService{}},
 		{"test.projectcontour.io/v1", &unstructured.Unstructured{
 			Object: map[string]interface{}{

--- a/internal/k8s/status_test.go
+++ b/internal/k8s/status_test.go
@@ -20,8 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,8 +28,8 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 	type testcase struct {
 		msg      string
 		desc     string
-		existing *projectcontour.HTTPProxy
-		expected *projectcontour.HTTPProxy
+		existing *contour_api_v1.HTTPProxy
+		expected *contour_api_v1.HTTPProxy
 	}
 
 	run := func(t *testing.T, name string, tc testcase) {
@@ -44,13 +43,13 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 				Updater: suc,
 			}
 
-			suc.AddObject(tc.existing.Name, tc.existing.Namespace, projcontour.HTTPProxyGVR, tc.existing)
+			suc.AddObject(tc.existing.Name, tc.existing.Namespace, contour_api_v1.HTTPProxyGVR, tc.existing)
 
 			if err := proxysw.SetStatus(tc.msg, tc.desc, tc.existing); err != nil {
 				t.Fatal(fmt.Errorf("unable to set proxy status: %s", err))
 			}
 
-			toProxy := suc.GetObject(tc.existing.Name, tc.existing.Namespace, projcontour.HTTPProxyGVR)
+			toProxy := suc.GetObject(tc.existing.Name, tc.existing.Namespace, contour_api_v1.HTTPProxyGVR)
 
 			if toProxy == nil && tc.expected == nil {
 				return
@@ -67,22 +66,22 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 	run(t, "simple update", testcase{
 		msg:  "valid",
 		desc: "this is a valid HTTPProxy",
-		existing: &projcontour.HTTPProxy{
+		existing: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "",
 				Description:   "",
 			},
 		},
-		expected: &projcontour.HTTPProxy{
+		expected: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "valid",
 				Description:   "this is a valid HTTPProxy",
 			},
@@ -92,22 +91,22 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 	run(t, "no update", testcase{
 		msg:  "valid",
 		desc: "this is a valid HTTPProxy",
-		existing: &projcontour.HTTPProxy{
+		existing: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "valid",
 				Description:   "this is a valid HTTPProxy",
 			},
 		},
-		expected: &projcontour.HTTPProxy{
+		expected: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "valid",
 				Description:   "this is a valid HTTPProxy",
 			},
@@ -117,22 +116,22 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 	run(t, "replace existing status", testcase{
 		msg:  "valid",
 		desc: "this is a valid HTTPProxy",
-		existing: &projcontour.HTTPProxy{
+		existing: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "invalid",
 				Description:   "boo hiss",
 			},
 		},
-		expected: &projcontour.HTTPProxy{
+		expected: &contour_api_v1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
 			},
-			Status: projcontour.HTTPProxyStatus{
+			Status: contour_api_v1.HTTPProxyStatus{
 				CurrentStatus: "valid",
 				Description:   "this is a valid HTTPProxy",
 			},
@@ -143,7 +142,7 @@ func TestSetHTTPProxyStatus(t *testing.T) {
 func TestGetStatus(t *testing.T) {
 	type testcase struct {
 		input          interface{}
-		expectedStatus *projcontour.HTTPProxyStatus
+		expectedStatus *contour_api_v1.HTTPProxyStatus
 		expectedError  error
 	}
 

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -16,7 +16,7 @@ package k8s
 import (
 	"fmt"
 
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -55,10 +55,10 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		typed = o.DeepCopy()
 		gvr = v1beta1.SchemeGroupVersion.WithResource("ingresses")
 		kind = "ingress"
-	case *projcontour.HTTPProxy:
-		o.GetObjectKind().SetGroupVersionKind(projcontour.SchemeGroupVersion.WithKind("httpproxy"))
+	case *contour_api_v1.HTTPProxy:
+		o.GetObjectKind().SetGroupVersionKind(contour_api_v1.SchemeGroupVersion.WithKind("httpproxy"))
 		typed = o.DeepCopy()
-		gvr = projcontour.SchemeGroupVersion.WithResource("httpproxies")
+		gvr = contour_api_v1.SchemeGroupVersion.WithResource("httpproxies")
 		kind = "httpproxy"
 	default:
 		s.Logger.
@@ -95,7 +95,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 				dco := o.DeepCopy()
 				dco.Status.LoadBalancer = s.LBStatus
 				return dco
-			case *projcontour.HTTPProxy:
+			case *contour_api_v1.HTTPProxy:
 				dco := o.DeepCopy()
 				dco.Status.LoadBalancer = s.LBStatus
 				return dco

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -184,7 +184,7 @@ type sauTestcase struct {
 func TestStatusAddressUpdater_OnAdd(t *testing.T) {
 
 	ingressGVR := v1beta1.SchemeGroupVersion.WithResource("ingresses")
-	proxyGVR := projcontour.SchemeGroupVersion.WithResource("httpproxies")
+	proxyGVR := contour_api_v1.SchemeGroupVersion.WithResource("httpproxies")
 
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
@@ -320,7 +320,7 @@ func TestStatusAddressUpdater_OnAdd(t *testing.T) {
 func TestStatusAddressUpdater_OnUpdate(t *testing.T) {
 
 	ingressGVR := v1beta1.SchemeGroupVersion.WithResource("ingresses")
-	proxyGVR := projcontour.SchemeGroupVersion.WithResource("httpproxies")
+	proxyGVR := contour_api_v1.SchemeGroupVersion.WithResource("httpproxies")
 
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
@@ -468,8 +468,8 @@ func simpleIngressGenerator(name, ingressClass string, lbstatus v1.LoadBalancerS
 	}
 }
 
-func simpleProxyGenerator(name, ingressClass string, lbstatus v1.LoadBalancerStatus) *projcontour.HTTPProxy {
-	return &projcontour.HTTPProxy{
+func simpleProxyGenerator(name, ingressClass string, lbstatus v1.LoadBalancerStatus) *contour_api_v1.HTTPProxy {
+	return &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: name,
@@ -478,7 +478,7 @@ func simpleProxyGenerator(name, ingressClass string, lbstatus v1.LoadBalancerSta
 			},
 		},
 
-		Status: projcontour.HTTPProxyStatus{
+		Status: contour_api_v1.HTTPProxyStatus{
 			LoadBalancer: lbstatus,
 		},
 	}

--- a/internal/xdscache/v2/cluster.go
+++ b/internal/xdscache/v2/cluster.go
@@ -23,7 +23,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
 )
@@ -99,12 +99,12 @@ func (v *clusterVisitor) visit(vertex dag.Vertex) {
 	case *dag.Cluster:
 		name := envoy.Clustername(cluster)
 		if _, ok := v.clusters[name]; !ok {
-			v.clusters[name] = envoyv2.Cluster(cluster)
+			v.clusters[name] = envoy_v2.Cluster(cluster)
 		}
 	case *dag.ExtensionCluster:
 		name := cluster.Name
 		if _, ok := v.clusters[name]; !ok {
-			v.clusters[name] = envoyv2.ExtensionCluster(cluster)
+			v.clusters[name] = envoy_v2.ExtensionCluster(cluster)
 		}
 	}
 

--- a/internal/xdscache/v2/cluster_test.go
+++ b/internal/xdscache/v2/cluster_test.go
@@ -22,8 +22,8 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -45,9 +45,9 @@ func TestClusterCacheContents(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -55,9 +55,9 @@ func TestClusterCacheContents(t *testing.T) {
 				cluster(&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -86,9 +86,9 @@ func TestClusterCacheQuery(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -97,9 +97,9 @@ func TestClusterCacheQuery(t *testing.T) {
 				cluster(&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -110,9 +110,9 @@ func TestClusterCacheQuery(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -121,9 +121,9 @@ func TestClusterCacheQuery(t *testing.T) {
 				cluster(&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -134,9 +134,9 @@ func TestClusterCacheQuery(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -187,9 +187,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -221,9 +221,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
 					},
 				}),
@@ -259,9 +259,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/80/da39a3ee5e",
 					AltStatName:          "default_kuard_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
 					Http2ProtocolOptions: &envoy_api_v2_core.Http2ProtocolOptions{},
@@ -292,29 +292,29 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "beurocra-7fe4b4/tiny-cog-7fe4b4/443/da39a3ee5e",
 					AltStatName:          "beurocratic-company-test-domain-1_tiny-cog-department-test-instance_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "beurocratic-company-test-domain-1/tiny-cog-department-test-instance/svc-0",
 					},
 				}),
 		},
 		"two service ports": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -340,18 +340,18 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/da39a3ee5e",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 				},
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/8080/da39a3ee5e",
 					AltStatName:          "default_backend_8080",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/alt",
 					},
 				},
@@ -359,23 +359,23 @@ func TestClusterVisit(t *testing.T) {
 		},
 		"httpproxy with simple path healthcheck": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
+						Routes: []contour_api_v1.Route{{
+							HealthCheckPolicy: &contour_api_v1.HTTPHealthCheckPolicy{
 								Path: "/healthy",
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -393,9 +393,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/c184349821",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					HealthChecks: []*envoy_api_v2_core.HealthCheck{{
@@ -416,17 +416,17 @@ func TestClusterVisit(t *testing.T) {
 		},
 		"httpproxy with custom healthcheck": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							HealthCheckPolicy: &projcontour.HTTPHealthCheckPolicy{
+						Routes: []contour_api_v1.Route{{
+							HealthCheckPolicy: &contour_api_v1.HTTPHealthCheckPolicy{
 								Host:                    "foo-bar-host",
 								Path:                    "/healthy",
 								TimeoutSeconds:          99,
@@ -434,10 +434,10 @@ func TestClusterVisit(t *testing.T) {
 								UnhealthyThresholdCount: 97,
 								HealthyThresholdCount:   96,
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -455,9 +455,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/7f8051653a",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					HealthChecks: []*envoy_api_v2_core.HealthCheck{{
@@ -478,23 +478,23 @@ func TestClusterVisit(t *testing.T) {
 		},
 		"httpproxy with RoundRobin lb algorithm": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+						Routes: []contour_api_v1.Route{{
+							LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 								Strategy: "RoundRobin",
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -512,9 +512,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/da39a3ee5e",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 				},
@@ -522,23 +522,23 @@ func TestClusterVisit(t *testing.T) {
 		},
 		"httpproxy with WeightedLeastRequest lb algorithm": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+						Routes: []contour_api_v1.Route{{
+							LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 								Strategy: "WeightedLeastRequest",
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -556,9 +556,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/8bf87fefba",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					LbPolicy: envoy_api_v2.Cluster_LEAST_REQUEST,
@@ -567,23 +567,23 @@ func TestClusterVisit(t *testing.T) {
 		},
 		"httpproxy with Random lb algorithm": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+						Routes: []contour_api_v1.Route{{
+							LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 								Strategy: "Random",
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -601,9 +601,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/58d888c08a",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 					LbPolicy: envoy_api_v2.Cluster_RANDOM,
@@ -614,23 +614,23 @@ func TestClusterVisit(t *testing.T) {
 		// HTTPProxy has LB algorithm as a route-level construct, so it's not possible.
 		"httpproxy with unknown lb algorithm": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							LoadBalancerPolicy: &projcontour.LoadBalancerPolicy{
+						Routes: []contour_api_v1.Route{{
+							LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
 								Strategy: "lulz",
 							},
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -648,9 +648,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/backend/80/da39a3ee5e",
 					AltStatName:          "default_backend_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/backend/http",
 					},
 				},
@@ -690,9 +690,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/80/da39a3ee5e",
 					AltStatName:          "default_kuard_80",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
 					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
@@ -737,9 +737,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
 					},
 				}),
@@ -776,9 +776,9 @@ func TestClusterVisit(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/kuard/443/da39a3ee5e",
 					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/kuard/https",
 					},
 				}),
@@ -815,7 +815,7 @@ func cluster(c *envoy_api_v2.Cluster) *envoy_api_v2.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &envoy_api_v2.Cluster{
 		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
-		CommonLbConfig: envoyv2.ClusterCommonLBConfig(),
+		CommonLbConfig: envoy_v2.ClusterCommonLBConfig(),
 		LbPolicy:       envoy_api_v2.Cluster_ROUND_ROBIN,
 	}
 

--- a/internal/xdscache/v2/endpointstranslator.go
+++ b/internal/xdscache/v2/endpointstranslator.go
@@ -20,11 +20,11 @@ import (
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
+	resource2 "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
@@ -71,8 +71,8 @@ func RecalculateEndpoints(port v1.ServicePort, ep *v1.Endpoints) []*LoadBalancin
 			sort.Slice(addresses, func(i, j int) bool { return addresses[i].IP < addresses[j].IP })
 
 			for _, a := range addresses {
-				addr := envoyv2.SocketAddress(a.IP, int(p.Port))
-				lb = append(lb, envoyv2.LBEndpoint(addr))
+				addr := envoy_v2.SocketAddress(a.IP, int(p.Port))
+				lb = append(lb, envoy_v2.LBEndpoint(addr))
 			}
 		}
 	}
@@ -122,7 +122,7 @@ func (c *EndpointsCache) Recalculate() map[string]*envoy_api_v2.ClusterLoadAssig
 		}
 
 		// Look up each service, and if we have endpoints for that service,
-		// attach them as a new LocalityEndpoints resource.
+		// attach them as a new LocalityEndpoints resource2.
 		for _, w := range cluster.Services {
 			n := types.NamespacedName{Namespace: w.ServiceNamespace, Name: w.ServiceName}
 			if lb := RecalculateEndpoints(w.ServicePort, c.endpoints[n]); lb != nil {
@@ -402,4 +402,4 @@ func (e *EndpointsTranslator) Query(names []string) []proto.Message {
 	return protobuf.AsMessages(values)
 }
 
-func (*EndpointsTranslator) TypeURL() string { return resource.EndpointType }
+func (*EndpointsTranslator) TypeURL() string { return resource2.EndpointType }

--- a/internal/xdscache/v2/endpointstranslator_test.go
+++ b/internal/xdscache/v2/endpointstranslator_test.go
@@ -20,7 +20,7 @@ import (
 	envoy_api_v2_endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/stretchr/testify/require"
@@ -38,13 +38,13 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 		},
 		"simple": {
 			contents: clusterloadassignments(
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			),
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			},
 		},
@@ -68,40 +68,40 @@ func TestEndpointCacheQuery(t *testing.T) {
 	}{
 		"exact match": {
 			contents: clusterloadassignments(
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			),
 			query: []string{"default/httpbin-org"},
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			},
 		},
 		"partial match": {
 			contents: clusterloadassignments(
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			),
 			query: []string{"default/kuard/8080", "default/httpbin-org"},
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
-				envoyv2.ClusterLoadAssignment("default/kuard/8080"),
+				envoy_v2.ClusterLoadAssignment("default/kuard/8080"),
 			},
 		},
 		"no match": {
 			contents: clusterloadassignments(
-				envoyv2.ClusterLoadAssignment("default/httpbin-org",
-					envoyv2.SocketAddress("10.10.10.10", 80),
+				envoy_v2.ClusterLoadAssignment("default/httpbin-org",
+					envoy_v2.SocketAddress("10.10.10.10", 80),
 				),
 			),
 			query: []string{"default/kuard/8080"},
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/kuard/8080"),
+				envoy_v2.ClusterLoadAssignment("default/kuard/8080"),
 			},
 		},
 	}
@@ -169,7 +169,7 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				&envoy_api_v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/b"},
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/simple",
-					Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080)),
+					Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080)),
 				},
 			},
 		},
@@ -190,11 +190,11 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				&envoy_api_v2.ClusterLoadAssignment{ClusterName: "default/httpbin-org/b"},
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/simple",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("23.23.247.89", 80), // addresses should be sorted
-						envoyv2.SocketAddress("50.17.192.147", 80),
-						envoyv2.SocketAddress("50.17.206.192", 80),
-						envoyv2.SocketAddress("50.19.99.160", 80),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("23.23.247.89", 80), // addresses should be sorted
+						envoy_v2.SocketAddress("50.17.192.147", 80),
+						envoy_v2.SocketAddress("50.17.206.192", 80),
+						envoy_v2.SocketAddress("50.19.99.160", 80),
 					),
 				},
 			},
@@ -213,11 +213,11 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 				// Results should be sorted by cluster name.
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/a",
-					Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("10.10.1.1", 8675)),
+					Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("10.10.1.1", 8675)),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/b",
-					Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("10.10.1.1", 309)),
+					Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("10.10.1.1", 309)),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{ClusterName: "default/simple"},
 			},
@@ -236,16 +236,16 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/a",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("10.10.1.1", 8675), // addresses should be sorted
-						envoyv2.SocketAddress("10.10.2.2", 8675),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("10.10.1.1", 8675), // addresses should be sorted
+						envoy_v2.SocketAddress("10.10.2.2", 8675),
 					),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/b",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("10.10.1.1", 309),
-						envoyv2.SocketAddress("10.10.2.2", 309),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("10.10.1.1", 309),
+						envoy_v2.SocketAddress("10.10.2.2", 309),
 					),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{ClusterName: "default/simple"},
@@ -274,15 +274,15 @@ func TestEndpointsTranslatorAddEndpoints(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/a",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("10.10.1.1", 8675),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("10.10.1.1", 8675),
 					),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org/b",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("10.10.1.1", 309),
-						envoyv2.SocketAddress("10.10.2.2", 309),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("10.10.1.1", 309),
+						envoy_v2.SocketAddress("10.10.2.2", 309),
 					),
 				},
 				&envoy_api_v2.ClusterLoadAssignment{ClusterName: "default/simple"},
@@ -359,9 +359,9 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/simple"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+				envoy_v2.ClusterLoadAssignment("default/simple"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 			},
 		},
 		"remove different": {
@@ -382,10 +382,10 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/simple",
-					Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080)),
+					Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080)),
 				},
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 			},
 		},
 		"remove non existent": {
@@ -397,9 +397,9 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				),
 			}),
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/simple"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+				envoy_v2.ClusterLoadAssignment("default/simple"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 			},
 		},
 		"remove long name": {
@@ -435,9 +435,9 @@ func TestEndpointsTranslatorRemoveEndpoints(t *testing.T) {
 				},
 			),
 			want: []proto.Message{
-				envoyv2.ClusterLoadAssignment("default/simple"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
-				envoyv2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
+				envoy_v2.ClusterLoadAssignment("default/simple"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/http"),
+				envoy_v2.ClusterLoadAssignment("super-long-namespace-name-oh-boy/what-a-descriptive-service-name-you-must-be-so-proud/https"),
 			},
 		},
 	}
@@ -483,8 +483,8 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/simple",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("192.168.183.24", 8080)),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("192.168.183.24", 8080)),
 				},
 			},
 		},
@@ -511,11 +511,11 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/httpbin-org",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("23.23.247.89", 80),
-						envoyv2.SocketAddress("50.17.192.147", 80),
-						envoyv2.SocketAddress("50.17.206.192", 80),
-						envoyv2.SocketAddress("50.19.99.160", 80),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("23.23.247.89", 80),
+						envoy_v2.SocketAddress("50.17.192.147", 80),
+						envoy_v2.SocketAddress("50.17.206.192", 80),
+						envoy_v2.SocketAddress("50.19.99.160", 80),
 					),
 				},
 			},
@@ -539,8 +539,8 @@ func TestEndpointsTranslatorRecomputeClusterLoadAssignment(t *testing.T) {
 			want: []proto.Message{
 				&envoy_api_v2.ClusterLoadAssignment{
 					ClusterName: "default/secure/https",
-					Endpoints: envoyv2.WeightedEndpoints(1,
-						envoyv2.SocketAddress("192.168.183.24", 8443)),
+					Endpoints: envoy_v2.WeightedEndpoints(1,
+						envoy_v2.SocketAddress("192.168.183.24", 8443)),
 				},
 			},
 		},
@@ -585,7 +585,7 @@ func TestEndpointsTranslatorScaleToZeroEndpoints(t *testing.T) {
 	want := []proto.Message{
 		&envoy_api_v2.ClusterLoadAssignment{
 			ClusterName: "default/simple",
-			Endpoints:   envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080)),
+			Endpoints:   envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080)),
 		},
 	}
 
@@ -646,9 +646,9 @@ func TestEndpointsTranslatorWeightedService(t *testing.T) {
 	// Each helper builds a `LocalityLbEndpoints` with one
 	// entry, so we can compose the final result by reaching
 	// in an taking the first element of each slice.
-	w0 := envoyv2.Endpoints(envoyv2.SocketAddress("192.168.183.24", 8080))
-	w1 := envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080))
-	w2 := envoyv2.WeightedEndpoints(2, envoyv2.SocketAddress("192.168.183.24", 8080))
+	w0 := envoy_v2.Endpoints(envoy_v2.SocketAddress("192.168.183.24", 8080))
+	w1 := envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080))
+	w2 := envoy_v2.WeightedEndpoints(2, envoy_v2.SocketAddress("192.168.183.24", 8080))
 
 	want := []proto.Message{
 		&envoy_api_v2.ClusterLoadAssignment{
@@ -704,9 +704,9 @@ func TestEndpointsTranslatorDefaultWeightedService(t *testing.T) {
 	// Each helper builds a `LocalityLbEndpoints` with one
 	// entry, so we can compose the final result by reaching
 	// in an taking the first element of each slice.
-	w0 := envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080))
-	w1 := envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080))
-	w2 := envoyv2.WeightedEndpoints(1, envoyv2.SocketAddress("192.168.183.24", 8080))
+	w0 := envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080))
+	w1 := envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080))
+	w2 := envoy_v2.WeightedEndpoints(1, envoy_v2.SocketAddress("192.168.183.24", 8080))
 
 	want := []proto.Message{
 		&envoy_api_v2.ClusterLoadAssignment{

--- a/internal/xdscache/v2/listener.go
+++ b/internal/xdscache/v2/listener.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
 	"github.com/projectcontour/contour/internal/timeout"
@@ -87,7 +87,7 @@ type ListenerConfig struct {
 	// supported versions are accepted. This is applied to both
 	// HTTP and HTTPS listeners but has practical effect only for
 	// HTTPS, because we don't support h2c.
-	DefaultHTTPVersions []envoyv2.HTTPVersionType
+	DefaultHTTPVersions []envoy_v2.HTTPVersionType
 
 	// AccessLogType defines if Envoy logs should be output as Envoy's default or JSON.
 	// Valid values: 'envoy', 'json'
@@ -192,18 +192,18 @@ func (lvc *ListenerConfig) accesslogFields() []string {
 func (lvc *ListenerConfig) newInsecureAccessLog() []*envoy_api_v2_accesslog.AccessLog {
 	switch lvc.accesslogType() {
 	case "json":
-		return envoyv2.FileAccessLogJSON(lvc.httpAccessLog(), lvc.accesslogFields())
+		return envoy_v2.FileAccessLogJSON(lvc.httpAccessLog(), lvc.accesslogFields())
 	default:
-		return envoyv2.FileAccessLogEnvoy(lvc.httpAccessLog())
+		return envoy_v2.FileAccessLogEnvoy(lvc.httpAccessLog())
 	}
 }
 
 func (lvc *ListenerConfig) newSecureAccessLog() []*envoy_api_v2_accesslog.AccessLog {
 	switch lvc.accesslogType() {
 	case "json":
-		return envoyv2.FileAccessLogJSON(lvc.httpsAccessLog(), lvc.accesslogFields())
+		return envoy_v2.FileAccessLogJSON(lvc.httpsAccessLog(), lvc.accesslogFields())
 	default:
-		return envoyv2.FileAccessLogEnvoy(lvc.httpsAccessLog())
+		return envoy_v2.FileAccessLogEnvoy(lvc.httpsAccessLog())
 	}
 }
 
@@ -228,7 +228,7 @@ type ListenerCache struct {
 
 // NewListenerCache returns an instance of a ListenerCache
 func NewListenerCache(config ListenerConfig, address string, port int) *ListenerCache {
-	stats := envoyv2.StatsListener(address, port)
+	stats := envoy_v2.StatsListener(address, port)
 	return &ListenerCache{
 		Config: config,
 		staticValues: map[string]*envoy_api_v2.Listener{
@@ -304,7 +304,7 @@ func visitListeners(root dag.Vertex, lvc *ListenerConfig) map[string]*envoy_api_
 	lv := listenerVisitor{
 		ListenerConfig: lvc,
 		listeners: map[string]*envoy_api_v2.Listener{
-			ENVOY_HTTPS_LISTENER: envoyv2.Listener(
+			ENVOY_HTTPS_LISTENER: envoy_v2.Listener(
 				ENVOY_HTTPS_LISTENER,
 				lvc.httpsAddress(),
 				lvc.httpsPort(),
@@ -317,8 +317,8 @@ func visitListeners(root dag.Vertex, lvc *ListenerConfig) map[string]*envoy_api_
 
 	if lv.http {
 		// Add a listener if there are vhosts bound to http.
-		cm := envoyv2.HTTPConnectionManagerBuilder().
-			Codec(envoyv2.CodecForVersions(lv.DefaultHTTPVersions...)).
+		cm := envoy_v2.HTTPConnectionManagerBuilder().
+			Codec(envoy_v2.CodecForVersions(lv.DefaultHTTPVersions...)).
 			DefaultFilters().
 			RouteConfigName(ENVOY_HTTP_LISTENER).
 			MetricsPrefix(ENVOY_HTTP_LISTENER).
@@ -330,7 +330,7 @@ func visitListeners(root dag.Vertex, lvc *ListenerConfig) map[string]*envoy_api_
 			ConnectionShutdownGracePeriod(lvc.ConnectionShutdownGracePeriod).
 			Get()
 
-		lv.listeners[ENVOY_HTTP_LISTENER] = envoyv2.Listener(
+		lv.listeners[ENVOY_HTTP_LISTENER] = envoy_v2.Listener(
 			ENVOY_HTTP_LISTENER,
 			lvc.httpAddress(),
 			lvc.httpPort(),
@@ -353,15 +353,15 @@ func visitListeners(root dag.Vertex, lvc *ListenerConfig) map[string]*envoy_api_
 
 func proxyProtocol(useProxy bool) []*envoy_api_v2_listener.ListenerFilter {
 	if useProxy {
-		return envoyv2.ListenerFilters(
-			envoyv2.ProxyProtocol(),
+		return envoy_v2.ListenerFilters(
+			envoy_v2.ProxyProtocol(),
 		)
 	}
 	return nil
 }
 
 func secureProxyProtocol(useProxy bool) []*envoy_api_v2_listener.ListenerFilter {
-	return append(proxyProtocol(useProxy), envoyv2.TLSInspector())
+	return append(proxyProtocol(useProxy), envoy_v2.TLSInspector())
 }
 
 func (v *listenerVisitor) visit(vertex dag.Vertex) {
@@ -386,7 +386,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			var authFilter *http.HttpFilter
 
 			if vh.AuthorizationService != nil {
-				authFilter = envoyv2.FilterExternalAuthz(
+				authFilter = envoy_v2.FilterExternalAuthz(
 					vh.AuthorizationService.Name,
 					vh.AuthorizationFailOpen,
 					vh.AuthorizationResponseTimeout,
@@ -400,10 +400,10 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			// metrics prefix to keep compatibility with previous
 			// Contour versions since the metrics prefix will be
 			// coded into monitoring dashboards.
-			filters = envoyv2.Filters(
-				envoyv2.HTTPConnectionManagerBuilder().
-					Codec(envoyv2.CodecForVersions(v.DefaultHTTPVersions...)).
-					AddFilter(envoyv2.FilterMisdirectedRequests(vh.VirtualHost.Name)).
+			filters = envoy_v2.Filters(
+				envoy_v2.HTTPConnectionManagerBuilder().
+					Codec(envoy_v2.CodecForVersions(v.DefaultHTTPVersions...)).
+					AddFilter(envoy_v2.FilterMisdirectedRequests(vh.VirtualHost.Name)).
 					DefaultFilters().
 					AddFilter(authFilter).
 					RouteConfigName(path.Join("https", vh.VirtualHost.Name)).
@@ -417,10 +417,10 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 					Get(),
 			)
 
-			alpnProtos = envoyv2.ProtoNamesForVersions(v.DefaultHTTPVersions...)
+			alpnProtos = envoy_v2.ProtoNamesForVersions(v.DefaultHTTPVersions...)
 		} else {
-			filters = envoyv2.Filters(
-				envoyv2.TCPProxy(ENVOY_HTTPS_LISTENER,
+			filters = envoy_v2.Filters(
+				envoy_v2.TCPProxy(ENVOY_HTTPS_LISTENER,
 					vh.TCPProxy,
 					v.ListenerConfig.newSecureAccessLog()),
 			)
@@ -437,7 +437,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			// Choose the higher of the configured or requested TLS version.
 			vers := max(v.ListenerConfig.minTLSVersion(), vh.MinTLSVersion)
 
-			downstreamTLS = envoyv2.DownstreamTLSContext(
+			downstreamTLS = envoy_v2.DownstreamTLSContext(
 				vh.Secret,
 				vers,
 				vh.DownstreamValidation,
@@ -445,25 +445,25 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 		}
 
 		v.listeners[ENVOY_HTTPS_LISTENER].FilterChains = append(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains,
-			envoyv2.FilterChainTLS(vh.VirtualHost.Name, downstreamTLS, filters))
+			envoy_v2.FilterChainTLS(vh.VirtualHost.Name, downstreamTLS, filters))
 
 		// If this VirtualHost has enabled the fallback certificate then set a default
 		// FilterChain which will allow routes with this vhost to accept non-SNI TLS requests.
 		// Note that we don't add the misdirected requests filter on this chain because at this
 		// point we don't actually know the full set of server names that will be bound to the
 		// filter chain through the ENVOY_FALLBACK_ROUTECONFIG route configuration.
-		if vh.FallbackCertificate != nil && !envoyv2.ContainsFallbackFilterChain(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains) {
+		if vh.FallbackCertificate != nil && !envoy_v2.ContainsFallbackFilterChain(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains) {
 			// Construct the downstreamTLSContext passing the configured fallbackCertificate. The TLS minProtocolVersion will use
 			// the value defined in the Contour Configuration file if defined.
-			downstreamTLS = envoyv2.DownstreamTLSContext(
+			downstreamTLS = envoy_v2.DownstreamTLSContext(
 				vh.FallbackCertificate,
 				v.ListenerConfig.minTLSVersion(),
 				vh.DownstreamValidation,
 				alpnProtos...)
 
 			// Default filter chain
-			filters = envoyv2.Filters(
-				envoyv2.HTTPConnectionManagerBuilder().
+			filters = envoy_v2.Filters(
+				envoy_v2.HTTPConnectionManagerBuilder().
 					DefaultFilters().
 					RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
 					MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -477,7 +477,7 @@ func (v *listenerVisitor) visit(vertex dag.Vertex) {
 			)
 
 			v.listeners[ENVOY_HTTPS_LISTENER].FilterChains = append(v.listeners[ENVOY_HTTPS_LISTENER].FilterChains,
-				envoyv2.FilterChainTLSFallback(downstreamTLS, filters))
+				envoy_v2.FilterChainTLSFallback(downstreamTLS, filters))
 		}
 
 	default:

--- a/internal/xdscache/v2/listener_test.go
+++ b/internal/xdscache/v2/listener_test.go
@@ -23,9 +23,9 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/golang/protobuf/proto"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
 	v1 "k8s.io/api/core/v1"
@@ -46,16 +46,16 @@ func TestListenerCacheContents(t *testing.T) {
 		"simple": {
 			contents: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 			want: []proto.Message{
 				&envoy_api_v2.Listener{
 					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-					SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+					Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+					FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 				},
 			},
 		},
@@ -80,43 +80,43 @@ func TestListenerCacheQuery(t *testing.T) {
 		"exact match": {
 			contents: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 			query: []string{ENVOY_HTTP_LISTENER},
 			want: []proto.Message{
 				&envoy_api_v2.Listener{
 					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-					SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+					Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+					FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 				},
 			},
 		},
 		"partial match": {
 			contents: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 			query: []string{ENVOY_HTTP_LISTENER, "stats-listener"},
 			want: []proto.Message{
 				&envoy_api_v2.Listener{
 					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-					SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+					Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+					FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+					SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 				},
 			},
 		},
 		"no match": {
 			contents: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 			query: []string{"stats-listener"},
 			want:  nil,
@@ -135,20 +135,20 @@ func TestListenerCacheQuery(t *testing.T) {
 
 func TestListenerVisit(t *testing.T) {
 	httpsFilterFor := func(vhost string) *envoy_api_v2_listener.Filter {
-		return envoyv2.HTTPConnectionManagerBuilder().
-			AddFilter(envoyv2.FilterMisdirectedRequests(vhost)).
+		return envoy_v2.HTTPConnectionManagerBuilder().
+			AddFilter(envoy_v2.FilterMisdirectedRequests(vhost)).
 			DefaultFilters().
 			MetricsPrefix(ENVOY_HTTPS_LISTENER).
 			RouteConfigName(path.Join("https", vhost)).
-			AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+			AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 			Get()
 	}
 
-	fallbackCertFilter := envoyv2.HTTPConnectionManagerBuilder().
+	fallbackCertFilter := envoy_v2.HTTPConnectionManagerBuilder().
 		DefaultFilters().
 		MetricsPrefix(ENVOY_HTTPS_LISTENER).
 		RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
-		AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+		AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 		Get()
 
 	tests := map[string]struct {
@@ -188,27 +188,27 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"one http only httpproxy": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -231,9 +231,9 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"simple ingress with secret": {
@@ -284,23 +284,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"multiple tls ingress with secrets should be sorted": {
@@ -373,29 +373,29 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedfirst.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("sortedfirst.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("sortedfirst.example.com")),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedsecond.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("sortedsecond.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("sortedsecond.example.com")),
 				}},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"simple ingress with missing secret": {
@@ -446,27 +446,27 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"simple httpproxy with secret": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -497,23 +497,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"ingress with allow-http: false": {
@@ -584,18 +584,18 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"http listener on non default port": { // issue 72
@@ -652,23 +652,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("127.0.0.100", 9100),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("127.0.0.100", 9100),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("127.0.0.200", 9200),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("127.0.0.200", 9200),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"use proxy proto": {
@@ -722,27 +722,27 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.ProxyProtocol(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.ProxyProtocol(),
 				),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.ProxyProtocol(),
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.ProxyProtocol(),
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"--envoy-http-access-log": {
@@ -797,29 +797,29 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress(DEFAULT_HTTP_LISTENER_ADDRESS, DEFAULT_HTTP_LISTENER_PORT),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy("/tmp/http_access.log"), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress(DEFAULT_HTTP_LISTENER_ADDRESS, DEFAULT_HTTP_LISTENER_PORT),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy("/tmp/http_access.log"), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress(DEFAULT_HTTPS_LISTENER_ADDRESS, DEFAULT_HTTPS_LISTENER_PORT),
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				Address: envoy_v2.SocketAddress(DEFAULT_HTTPS_LISTENER_ADDRESS, DEFAULT_HTTPS_LISTENER_PORT),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters: envoyv2.Filters(envoyv2.HTTPConnectionManagerBuilder().
-						AddFilter(envoyv2.FilterMisdirectedRequests("whatever.example.com")).
+					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
+						AddFilter(envoy_v2.FilterMisdirectedRequests("whatever.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "whatever.example.com")).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy("/tmp/https_access.log")).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy("/tmp/https_access.log")).
 						Get()),
 				}},
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"tls-min-protocol-version from config": {
@@ -873,23 +873,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"tls-min-protocol-version from config overridden by annotation": {
@@ -946,23 +946,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"tls-min-protocol-version from config overridden by legacy annotation": {
@@ -1019,23 +1019,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoyv2.Filters(httpsFilterFor("whatever.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"tls-min-protocol-version from config overridden by httpproxy": {
@@ -1043,21 +1043,21 @@ func TestListenerVisit(t *testing.T) {
 				MinimumTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_3,
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:             "secret",
 								MinimumProtocolVersion: "1.2",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1088,23 +1088,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_3, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with fallback certificate": {
@@ -1113,22 +1113,22 @@ func TestListenerVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{
+						Routes: []contour_api_v1.Route{
 							{
-								Services: []projcontour.Service{
+								Services: []contour_api_v1.Service{
 									{
 										Name: "backend",
 										Port: 80,
@@ -1170,30 +1170,30 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(fallbackCertFilter),
+					Filters:         envoy_v2.Filters(fallbackCertFilter),
 					Name:            "fallback-certificate",
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"multiple httpproxies with fallback certificate": {
@@ -1202,22 +1202,22 @@ func TestListenerVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple2",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.another.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{
+						Routes: []contour_api_v1.Route{
 							{
-								Services: []projcontour.Service{
+								Services: []contour_api_v1.Service{
 									{
 										Name: "backend",
 										Port: 80,
@@ -1227,22 +1227,22 @@ func TestListenerVisit(t *testing.T) {
 						},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{
+						Routes: []contour_api_v1.Route{
 							{
-								Services: []projcontour.Service{
+								Services: []contour_api_v1.Service{
 									{
 										Name: "backend",
 										Port: 80,
@@ -1284,39 +1284,39 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{
 					{
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"www.another.com"},
 						},
 						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:         envoyv2.Filters(httpsFilterFor("www.another.com")),
+						Filters:         envoy_v2.Filters(httpsFilterFor("www.another.com")),
 					},
 					{
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"www.example.com"},
 						},
 						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+						Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 					},
 					{
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							TransportProtocol: "tls",
 						},
 						TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-						Filters:         envoyv2.Filters(fallbackCertFilter),
+						Filters:         envoy_v2.Filters(fallbackCertFilter),
 						Name:            "fallback-certificate",
 					}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with fallback certificate - no cert passed": {
@@ -1325,22 +1325,22 @@ func TestListenerVisit(t *testing.T) {
 				Namespace: "",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{
+						Routes: []contour_api_v1.Route{
 							{
-								Services: []projcontour.Service{
+								Services: []contour_api_v1.Service{
 									{
 										Name: "backend",
 										Port: 80,
@@ -1380,22 +1380,22 @@ func TestListenerVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: false,
 							},
 						},
-						Routes: []projcontour.Route{
+						Routes: []contour_api_v1.Route{
 							{
-								Services: []projcontour.Service{
+								Services: []contour_api_v1.Service{
 									{
 										Name: "backend",
 										Port: 80,
@@ -1429,23 +1429,23 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoyv2.FilterChains(envoyv2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				Address:       envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains:  envoy_v2.FilterChains(envoy_v2.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG), 0)),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters:         envoyv2.Filters(httpsFilterFor("www.example.com")),
+					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with connection idle timeout set in visitor config": {
@@ -1453,20 +1453,20 @@ func TestListenerVisit(t *testing.T) {
 				ConnectionIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1489,17 +1489,17 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						DefaultFilters().
 						ConnectionIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 						Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with stream idle timeout set in visitor config": {
@@ -1507,20 +1507,20 @@ func TestListenerVisit(t *testing.T) {
 				StreamIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1543,17 +1543,17 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						DefaultFilters().
 						StreamIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 						Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with max connection duration set in visitor config": {
@@ -1561,20 +1561,20 @@ func TestListenerVisit(t *testing.T) {
 				MaxConnectionDuration: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1597,17 +1597,17 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						DefaultFilters().
 						MaxConnectionDuration(timeout.DurationSetting(90 * time.Second)).
 						Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpproxy with connection shutdown grace period set in visitor config": {
@@ -1615,20 +1615,20 @@ func TestListenerVisit(t *testing.T) {
 				ConnectionShutdownGracePeriod: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1651,17 +1651,17 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(
-					envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(
+					envoy_v2.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						DefaultFilters().
 						ConnectionShutdownGracePeriod(timeout.DurationSetting(90 * time.Second)).
 						Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpsproxy with secret with connection idle timeout set in visitor config": {
@@ -1669,20 +1669,20 @@ func TestListenerVisit(t *testing.T) {
 				ConnectionIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1713,37 +1713,37 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					ConnectionIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 					Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters: envoyv2.Filters(envoyv2.HTTPConnectionManagerBuilder().
-						AddFilter(envoyv2.FilterMisdirectedRequests("www.example.com")).
+					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
+						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "www.example.com")).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						ConnectionIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 						Get()),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpsproxy with secret with stream idle timeout set in visitor config": {
@@ -1751,20 +1751,20 @@ func TestListenerVisit(t *testing.T) {
 				StreamIdleTimeout: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1795,37 +1795,37 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					StreamIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 					Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters: envoyv2.Filters(envoyv2.HTTPConnectionManagerBuilder().
-						AddFilter(envoyv2.FilterMisdirectedRequests("www.example.com")).
+					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
+						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "www.example.com")).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						StreamIdleTimeout(timeout.DurationSetting(90 * time.Second)).
 						Get()),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpsproxy with secret with max connection duration set in visitor config": {
@@ -1833,20 +1833,20 @@ func TestListenerVisit(t *testing.T) {
 				MaxConnectionDuration: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1877,37 +1877,37 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					MaxConnectionDuration(timeout.DurationSetting(90 * time.Second)).
 					Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters: envoyv2.Filters(envoyv2.HTTPConnectionManagerBuilder().
-						AddFilter(envoyv2.FilterMisdirectedRequests("www.example.com")).
+					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
+						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "www.example.com")).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						MaxConnectionDuration(timeout.DurationSetting(90 * time.Second)).
 						Get()),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 		"httpsproxy with secret with connection shutdown grace period set in visitor config": {
@@ -1915,20 +1915,20 @@ func TestListenerVisit(t *testing.T) {
 				ConnectionShutdownGracePeriod: timeout.DurationSetting(90 * time.Second),
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1959,37 +1959,37 @@ func TestListenerVisit(t *testing.T) {
 			},
 			want: listenermap(&envoy_api_v2.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoyv2.FilterChains(envoyv2.HTTPConnectionManagerBuilder().
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v2.FilterChains(envoy_v2.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
-					AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+					AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 					DefaultFilters().
 					ConnectionShutdownGracePeriod(timeout.DurationSetting(90 * time.Second)).
 					Get(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}, &envoy_api_v2.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+				Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_api_v2_listener.FilterChain{{
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
-					Filters: envoyv2.Filters(envoyv2.HTTPConnectionManagerBuilder().
-						AddFilter(envoyv2.FilterMisdirectedRequests("www.example.com")).
+					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
+						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(path.Join("https", "www.example.com")).
-						AccessLoggers(envoyv2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
+						AccessLoggers(envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG)).
 						ConnectionShutdownGracePeriod(timeout.DurationSetting(90 * time.Second)).
 						Get()),
 				}},
-				ListenerFilters: envoyv2.ListenerFilters(
-					envoyv2.TLSInspector(),
+				ListenerFilters: envoy_v2.ListenerFilters(
+					envoy_v2.TLSInspector(),
 				),
-				SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 			}),
 		},
 	}
@@ -2014,8 +2014,8 @@ func transportSocket(secretname string, tlsMinProtoVersion envoy_api_v2_auth.Tls
 			Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 		},
 	}
-	return envoyv2.DownstreamTLSTransportSocket(
-		envoyv2.DownstreamTLSContext(secret, tlsMinProtoVersion, nil, alpnprotos...),
+	return envoy_v2.DownstreamTLSTransportSocket(
+		envoy_v2.DownstreamTLSContext(secret, tlsMinProtoVersion, nil, alpnprotos...),
 	)
 }
 

--- a/internal/xdscache/v2/route.go
+++ b/internal/xdscache/v2/route.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
 )
@@ -106,7 +106,7 @@ func visitRoutes(root dag.Vertex) map[string]*envoy_api_v2.RouteConfiguration {
 	// SNI names disjoint when we later configure the listener.
 	rv := routeVisitor{
 		routes: map[string]*envoy_api_v2.RouteConfiguration{
-			ENVOY_HTTP_LISTENER: envoyv2.RouteConfiguration(ENVOY_HTTP_LISTENER),
+			ENVOY_HTTP_LISTENER: envoy_v2.RouteConfiguration(ENVOY_HTTP_LISTENER),
 		},
 	}
 
@@ -133,20 +133,20 @@ func (v *routeVisitor) onVirtualHost(vh *dag.VirtualHost) {
 			// to a SecureVirtualHost that requires upgrade, this logic can move to
 			// envoy.RouteRoute.
 			routes = append(routes, &envoy_api_v2_route.Route{
-				Match:  envoyv2.RouteMatch(route),
-				Action: envoyv2.UpgradeHTTPS(),
+				Match:  envoy_v2.RouteMatch(route),
+				Action: envoy_v2.UpgradeHTTPS(),
 			})
 		} else {
 			rt := &envoy_api_v2_route.Route{
-				Match:  envoyv2.RouteMatch(route),
-				Action: envoyv2.RouteRoute(route),
+				Match:  envoy_v2.RouteMatch(route),
+				Action: envoy_v2.RouteRoute(route),
 			}
 			if route.RequestHeadersPolicy != nil {
-				rt.RequestHeadersToAdd = envoyv2.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+				rt.RequestHeadersToAdd = envoy_v2.HeaderValueList(route.RequestHeadersPolicy.Set, false)
 				rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
 			}
 			if route.ResponseHeadersPolicy != nil {
-				rt.ResponseHeadersToAdd = envoyv2.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
+				rt.ResponseHeadersToAdd = envoy_v2.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
 				rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
 			}
 			routes = append(routes, rt)
@@ -157,10 +157,10 @@ func (v *routeVisitor) onVirtualHost(vh *dag.VirtualHost) {
 		sortRoutes(routes)
 
 		var evh *envoy_api_v2_route.VirtualHost
-		if cp := envoyv2.CORSPolicy(vh.CORSPolicy); cp != nil {
-			evh = envoyv2.CORSVirtualHost(vh.Name, cp, routes...)
+		if cp := envoy_v2.CORSPolicy(vh.CORSPolicy); cp != nil {
+			evh = envoy_v2.CORSVirtualHost(vh.Name, cp, routes...)
 		} else {
-			evh = envoyv2.VirtualHost(vh.Name, routes...)
+			evh = envoy_v2.VirtualHost(vh.Name, routes...)
 		}
 
 		v.routes[ENVOY_HTTP_LISTENER].VirtualHosts = append(v.routes[ENVOY_HTTP_LISTENER].VirtualHosts, evh)
@@ -177,15 +177,15 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 		}
 
 		rt := &envoy_api_v2_route.Route{
-			Match:  envoyv2.RouteMatch(route),
-			Action: envoyv2.RouteRoute(route),
+			Match:  envoy_v2.RouteMatch(route),
+			Action: envoy_v2.RouteRoute(route),
 		}
 		if route.RequestHeadersPolicy != nil {
-			rt.RequestHeadersToAdd = envoyv2.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+			rt.RequestHeadersToAdd = envoy_v2.HeaderValueList(route.RequestHeadersPolicy.Set, false)
 			rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
 		}
 		if route.ResponseHeadersPolicy != nil {
-			rt.ResponseHeadersToAdd = envoyv2.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
+			rt.ResponseHeadersToAdd = envoy_v2.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
 			rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
 		}
 
@@ -194,12 +194,12 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 			// Apply per-route authorization policy modifications.
 			if route.AuthDisabled {
 				rt.TypedPerFilterConfig = map[string]*any.Any{
-					"envoy.filters.http.ext_authz": envoyv2.RouteAuthzDisabled(),
+					"envoy.filters.http.ext_authz": envoy_v2.RouteAuthzDisabled(),
 				}
 			} else {
 				if len(route.AuthContext) > 0 {
 					rt.TypedPerFilterConfig = map[string]*any.Any{
-						"envoy.filters.http.ext_authz": envoyv2.RouteAuthzContext(route.AuthContext),
+						"envoy.filters.http.ext_authz": envoy_v2.RouteAuthzContext(route.AuthContext),
 					}
 				}
 			}
@@ -214,14 +214,14 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 		name := path.Join("https", svh.VirtualHost.Name)
 
 		if _, ok := v.routes[name]; !ok {
-			v.routes[name] = envoyv2.RouteConfiguration(name)
+			v.routes[name] = envoy_v2.RouteConfiguration(name)
 		}
 
 		var evh *envoy_api_v2_route.VirtualHost
-		if cp := envoyv2.CORSPolicy(svh.CORSPolicy); cp != nil {
-			evh = envoyv2.CORSVirtualHost(svh.VirtualHost.Name, cp, routes...)
+		if cp := envoy_v2.CORSPolicy(svh.CORSPolicy); cp != nil {
+			evh = envoy_v2.CORSVirtualHost(svh.VirtualHost.Name, cp, routes...)
 		} else {
-			evh = envoyv2.VirtualHost(svh.VirtualHost.Name, routes...)
+			evh = envoy_v2.VirtualHost(svh.VirtualHost.Name, routes...)
 		}
 
 		v.routes[name].VirtualHosts = append(v.routes[name].VirtualHosts, evh)
@@ -232,14 +232,14 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 		if svh.FallbackCertificate != nil {
 			// Add fallback route if not already
 			if _, ok := v.routes[ENVOY_FALLBACK_ROUTECONFIG]; !ok {
-				v.routes[ENVOY_FALLBACK_ROUTECONFIG] = envoyv2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG)
+				v.routes[ENVOY_FALLBACK_ROUTECONFIG] = envoy_v2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG)
 			}
 
 			var fvh *envoy_api_v2_route.VirtualHost
-			if cp := envoyv2.CORSPolicy(svh.CORSPolicy); cp != nil {
-				fvh = envoyv2.CORSVirtualHost(svh.Name, cp, routes...)
+			if cp := envoy_v2.CORSPolicy(svh.CORSPolicy); cp != nil {
+				fvh = envoy_v2.CORSVirtualHost(svh.Name, cp, routes...)
 			} else {
-				fvh = envoyv2.VirtualHost(svh.Name, routes...)
+				fvh = envoy_v2.VirtualHost(svh.Name, routes...)
 			}
 
 			v.routes[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts = append(v.routes[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts, fvh)

--- a/internal/xdscache/v2/route_test.go
+++ b/internal/xdscache/v2/route_test.go
@@ -23,9 +23,9 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -142,7 +142,7 @@ func TestRouteVisit(t *testing.T) {
 		"nothing": {
 			objs: nil,
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("ingress_http"),
 			),
 		},
 		"one http only ingress with service": {
@@ -171,8 +171,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -219,8 +219,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routeRegex("/[^/]+/invoices(/.*|/?)"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -231,17 +231,17 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"one http only httpproxy": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -263,8 +263,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/backend/80/da39a3ee5e"),
@@ -311,8 +311,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -372,16 +372,16 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -392,23 +392,23 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"simple httpproxy with secret": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 8080,
 							}},
@@ -439,8 +439,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -453,8 +453,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/backend/8080/da39a3ee5e"),
@@ -517,9 +517,9 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http"),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http"),
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -582,8 +582,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -596,8 +596,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -655,8 +655,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/ws1"),
 							Action: websocketroute("default/kuard/8080/da39a3ee5e"),
@@ -698,8 +698,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/8080/da39a3ee5e"),
@@ -737,8 +737,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routetimeout("default/kuard/8080/da39a3ee5e", 0),
@@ -776,8 +776,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routetimeout("default/kuard/8080/da39a3ee5e", 90*time.Second),
@@ -826,8 +826,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("my-very-very-long-service-host-name.subdomain.boring-dept.my.company",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("my-very-very-long-service-host-name.subdomain.boring-dept.my.company",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routecluster("default/kuard/80/da39a3ee5e"),
@@ -865,8 +865,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 0),
@@ -905,8 +905,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0),
@@ -946,8 +946,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 7, 0),
@@ -986,8 +986,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond),
@@ -1026,8 +1026,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("*",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("*",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: routeretry("default/kuard/8080/da39a3ee5e", "5xx,gateway-error", 0, 150*time.Millisecond),
@@ -1039,20 +1039,20 @@ func TestRouteVisit(t *testing.T) {
 
 		"httpproxy no weights defined": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1090,8 +1090,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -1114,20 +1114,20 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy one weight defined": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1166,8 +1166,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -1190,20 +1190,20 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy all weights defined": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name:   "backend",
 								Port:   80,
 								Weight: 22,
@@ -1243,8 +1243,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -1267,15 +1267,15 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy w/ missing fqdn": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{},
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1297,25 +1297,25 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http"), // should be blank, no fqdn defined.
+				envoy_v2.RouteConfiguration("ingress_http"), // should be blank, no fqdn defined.
 			),
 		},
 		"httpproxy with pathPrefix": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1353,8 +1353,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -1377,20 +1377,20 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with mirror policy": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1429,8 +1429,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/"),
 							Action: withMirrorPolicy(routecluster("default/backend/80/da39a3ee5e"), "default/backendtwo/80/da39a3ee5e"),
@@ -1441,23 +1441,23 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with pathPrefix with tls": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1503,8 +1503,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -1517,8 +1517,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -1540,27 +1540,27 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with pathPrefix includes": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Includes: []projcontour.Include{{
+						Includes: []contour_api_v1.Include{{
 							Name:      "child",
 							Namespace: "teama",
-							Conditions: []projcontour.MatchCondition{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/blog",
 							}},
 						}},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -1570,17 +1570,17 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "child",
 						Namespace: "teama",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+					Spec: contour_api_v1.HTTPProxySpec{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/info",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1628,8 +1628,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match:  routePrefix("/blog/info"),
 							Action: routecluster("teama/backend/80/da39a3ee5e"),
@@ -1656,21 +1656,21 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with corsPolicy": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							CORSPolicy: &projcontour.CORSPolicy{
+							CORSPolicy: &contour_api_v1.CORSPolicy{
 								AllowOrigin:  []string{"*"},
-								AllowMethods: []projcontour.CORSHeaderValue{"GET, PUT, POST"},
+								AllowMethods: []contour_api_v1.CORSHeaderValue{"GET, PUT, POST"},
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1692,8 +1692,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.CORSVirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.CORSVirtualHost("www.example.com",
 						&envoy_api_v2_route.CorsPolicy{
 							AllowCredentials: &wrappers.BoolValue{Value: false},
 							AllowOriginStringMatch: []*matcher.StringMatcher{{
@@ -1714,24 +1714,24 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with corsPolicy with tls": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							CORSPolicy: &projcontour.CORSPolicy{
+							CORSPolicy: &contour_api_v1.CORSPolicy{
 								AllowOrigin:  []string{"*"},
-								AllowMethods: []projcontour.CORSHeaderValue{"GET, PUT, POST"},
+								AllowMethods: []contour_api_v1.CORSHeaderValue{"GET, PUT, POST"},
 							},
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1761,8 +1761,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.CORSVirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.CORSVirtualHost("www.example.com",
 						&envoy_api_v2_route.CorsPolicy{
 							AllowCredentials: &wrappers.BoolValue{Value: false},
 							AllowOriginStringMatch: []*matcher.StringMatcher{{
@@ -1785,8 +1785,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.CORSVirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.CORSVirtualHost("www.example.com",
 						&envoy_api_v2_route.CorsPolicy{
 							AllowCredentials: &wrappers.BoolValue{Value: false},
 							AllowOriginStringMatch: []*matcher.StringMatcher{{
@@ -1806,25 +1806,25 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with header contains conditions": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}, {
-								Header: &projcontour.HeaderMatchCondition{
+								Header: &contour_api_v1.HeaderMatchCondition{
 									Name:     "x-header",
 									Contains: "abc",
 								},
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1846,8 +1846,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/", dag.HeaderMatchCondition{
 								Name:      "x-header",
@@ -1861,28 +1861,28 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with header notcontains conditions": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{
 								{
 									Prefix: "/",
 								},
 								{
-									Header: &projcontour.HeaderMatchCondition{
+									Header: &contour_api_v1.HeaderMatchCondition{
 										Name:        "x-header",
 										NotContains: "abc",
 									},
 								},
 							},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1904,8 +1904,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/", dag.HeaderMatchCondition{
 								Name:      "x-header",
@@ -1920,28 +1920,28 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with header exact match conditions": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{
 								{
 									Prefix: "/",
 								},
 								{
-									Header: &projcontour.HeaderMatchCondition{
+									Header: &contour_api_v1.HeaderMatchCondition{
 										Name:  "x-header",
 										Exact: "abc",
 									},
 								},
 							},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -1963,8 +1963,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/", dag.HeaderMatchCondition{
 								Name:      "x-header",
@@ -1979,28 +1979,28 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with header exact not match conditions": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{
 								{
 									Prefix: "/",
 								},
 								{
-									Header: &projcontour.HeaderMatchCondition{
+									Header: &contour_api_v1.HeaderMatchCondition{
 										Name:     "x-header",
 										NotExact: "abc",
 									},
 								},
 							},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -2022,8 +2022,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/", dag.HeaderMatchCondition{
 								Name:      "x-header",
@@ -2038,28 +2038,28 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with header header present conditions": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{
 								{
 									Prefix: "/",
 								},
 								{
-									Header: &projcontour.HeaderMatchCondition{
+									Header: &contour_api_v1.HeaderMatchCondition{
 										Name:    "x-header",
 										Present: true,
 									},
 								},
 							},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -2081,8 +2081,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/", dag.HeaderMatchCondition{
 								Name:      "x-header",
@@ -2095,25 +2095,25 @@ func TestRouteVisit(t *testing.T) {
 		},
 		"httpproxy with route-level header manipulation": {
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
-							RequestHeadersPolicy: &projcontour.HeadersPolicy{
-								Set: []projcontour.HeaderValue{{
+							RequestHeadersPolicy: &contour_api_v1.HeadersPolicy{
+								Set: []contour_api_v1.HeaderValue{{
 									Name:  "In-Foo",
 									Value: "bar",
 								}},
@@ -2121,8 +2121,8 @@ func TestRouteVisit(t *testing.T) {
 									"In-Baz",
 								},
 							},
-							ResponseHeadersPolicy: &projcontour.HeadersPolicy{
-								Set: []projcontour.HeaderValue{{
+							ResponseHeadersPolicy: &contour_api_v1.HeadersPolicy{
+								Set: []contour_api_v1.HeaderValue{{
 									Name:  "Out-Foo",
 									Value: "bar",
 								}},
@@ -2148,8 +2148,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2190,24 +2190,24 @@ func TestRouteVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2261,8 +2261,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2275,8 +2275,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2294,8 +2294,8 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					)),
-				envoyv2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2321,24 +2321,24 @@ func TestRouteVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: false,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2348,24 +2348,24 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-enabled",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "projectcontour.io",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2419,8 +2419,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2432,7 +2432,7 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					),
-					envoyv2.VirtualHost("www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2445,8 +2445,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/projectcontour.io",
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration("https/projectcontour.io",
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2464,8 +2464,8 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					)),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2483,8 +2483,8 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					)),
-				envoyv2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2510,24 +2510,24 @@ func TestRouteVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2537,24 +2537,24 @@ func TestRouteVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-enabled",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "projectcontour.io",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2608,8 +2608,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2621,7 +2621,7 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					),
-					envoyv2.VirtualHost("www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2634,8 +2634,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/projectcontour.io",
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration("https/projectcontour.io",
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2653,8 +2653,8 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					)),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2672,8 +2672,8 @@ func TestRouteVisit(t *testing.T) {
 							},
 						},
 					)),
-				envoyv2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
-					envoyv2.VirtualHost("projectcontour.io",
+				envoy_v2.RouteConfiguration(ENVOY_FALLBACK_ROUTECONFIG,
+					envoy_v2.VirtualHost("projectcontour.io",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2690,7 +2690,7 @@ func TestRouteVisit(t *testing.T) {
 								},
 							},
 						},
-					), envoyv2.VirtualHost("www.example.com",
+					), envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -2716,24 +2716,24 @@ func TestRouteVisit(t *testing.T) {
 				Namespace: "badnamespace",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: true,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2786,7 +2786,7 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: routeConfigurations(envoyv2.RouteConfiguration("ingress_http")),
+			want: routeConfigurations(envoy_v2.RouteConfiguration("ingress_http")),
 		},
 		"httpproxy with fallback certificate - no fqdn enabled": {
 			fallbackCertificate: &types.NamespacedName{
@@ -2794,24 +2794,24 @@ func TestRouteVisit(t *testing.T) {
 				Namespace: "default",
 			},
 			objs: []interface{}{
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName:                "secret",
 								EnableFallbackCertificate: false,
 							},
 						},
-						Routes: []projcontour.Route{{
-							Conditions: []projcontour.MatchCondition{{
+						Routes: []contour_api_v1.Route{{
+							Conditions: []contour_api_v1.MatchCondition{{
 								Prefix: "/",
 							}},
-							Services: []projcontour.Service{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}, {
@@ -2865,8 +2865,8 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoyv2.RouteConfiguration("ingress_http",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("ingress_http",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Redirect{
@@ -2879,8 +2879,8 @@ func TestRouteVisit(t *testing.T) {
 						},
 					),
 				),
-				envoyv2.RouteConfiguration("https/www.example.com",
-					envoyv2.VirtualHost("www.example.com",
+				envoy_v2.RouteConfiguration("https/www.example.com",
+					envoy_v2.VirtualHost("www.example.com",
 						&envoy_api_v2_route.Route{
 							Match: routePrefix("/"),
 							Action: &envoy_api_v2_route.Route_Route{
@@ -3123,7 +3123,7 @@ func routeretry(cluster string, retryOn string, numRetries uint32, perTryTimeout
 }
 
 func routeRegex(regex string, headers ...dag.HeaderMatchCondition) *envoy_api_v2_route.RouteMatch {
-	return envoyv2.RouteMatch(&dag.Route{
+	return envoy_v2.RouteMatch(&dag.Route{
 		PathMatchCondition: &dag.RegexMatchCondition{
 			Regex: regex,
 		},
@@ -3132,7 +3132,7 @@ func routeRegex(regex string, headers ...dag.HeaderMatchCondition) *envoy_api_v2
 }
 
 func routePrefix(prefix string, headers ...dag.HeaderMatchCondition) *envoy_api_v2_route.RouteMatch {
-	return envoyv2.RouteMatch(&dag.Route{
+	return envoy_v2.RouteMatch(&dag.Route{
 		PathMatchCondition: &dag.PrefixMatchCondition{
 			Prefix: prefix,
 		},

--- a/internal/xdscache/v2/secret.go
+++ b/internal/xdscache/v2/secret.go
@@ -23,7 +23,7 @@ import (
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/sorter"
 )
@@ -95,7 +95,7 @@ func visitSecrets(root dag.Vertex) map[string]*envoy_api_v2_auth.Secret {
 func (v *secretVisitor) addSecret(s *dag.Secret) {
 	name := envoy.Secretname(s)
 	if _, ok := v.secrets[name]; !ok {
-		envoySecret := envoyv2.Secret(s)
+		envoySecret := envoy_v2.Secret(s)
 		v.secrets[envoySecret.Name] = envoySecret
 	}
 }

--- a/internal/xdscache/v2/secret_test.go
+++ b/internal/xdscache/v2/secret_test.go
@@ -19,7 +19,7 @@ import (
 	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/golang/protobuf/proto"
-	projcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -313,20 +313,20 @@ func TestSecretVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -355,40 +355,40 @@ func TestSecretVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www1.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-b",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www2.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
@@ -417,40 +417,40 @@ func TestSecretVisit(t *testing.T) {
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-a",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www1.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret-a",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},
 						}},
 					},
 				},
-				&projcontour.HTTPProxy{
+				&contour_api_v1.HTTPProxy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple-b",
 						Namespace: "default",
 					},
-					Spec: projcontour.HTTPProxySpec{
-						VirtualHost: &projcontour.VirtualHost{
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
 							Fqdn: "www2.example.com",
-							TLS: &projcontour.TLS{
+							TLS: &contour_api_v1.TLS{
 								SecretName: "secret-b",
 							},
 						},
-						Routes: []projcontour.Route{{
-							Services: []projcontour.Service{{
+						Routes: []contour_api_v1.Route{{
+							Services: []contour_api_v1.Service{{
 								Name: "backend",
 								Port: 80,
 							}},

--- a/internal/xdscache/v2/visitor_test.go
+++ b/internal/xdscache/v2/visitor_test.go
@@ -21,7 +21,7 @@ import (
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/projectcontour/contour/internal/dag"
-	envoyv2 "github.com/projectcontour/contour/internal/envoy/v2"
+	envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,9 +65,9 @@ func TestVisitClusters(t *testing.T) {
 				&envoy_api_v2.Cluster{
 					Name:                 "default/example/443/da39a3ee5e",
 					AltStatName:          "default_example_443",
-					ClusterDiscoveryType: envoyv2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
+					ClusterDiscoveryType: envoy_v2.ClusterDiscoveryType(envoy_api_v2.Cluster_EDS),
 					EdsClusterConfig: &envoy_api_v2.Cluster_EdsClusterConfig{
-						EdsConfig:   envoyv2.ConfigSource("contour"),
+						EdsConfig:   envoy_v2.ConfigSource("contour"),
 						ServiceName: "default/example",
 					},
 				},
@@ -130,18 +130,18 @@ func TestVisitListeners(t *testing.T) {
 			want: listenermap(
 				&envoy_api_v2.Listener{
 					Name:    ENVOY_HTTPS_LISTENER,
-					Address: envoyv2.SocketAddress("0.0.0.0", 8443),
+					Address: envoy_v2.SocketAddress("0.0.0.0", 8443),
 					FilterChains: []*envoy_api_v2_listener.FilterChain{{
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"tcpproxy.example.com"},
 						},
 						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1),
-						Filters:         envoyv2.Filters(envoyv2.TCPProxy(ENVOY_HTTPS_LISTENER, p1, envoyv2.FileAccessLogEnvoy(DEFAULT_HTTPS_ACCESS_LOG))),
+						Filters:         envoy_v2.Filters(envoy_v2.TCPProxy(ENVOY_HTTPS_LISTENER, p1, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTPS_ACCESS_LOG))),
 					}},
-					ListenerFilters: envoyv2.ListenerFilters(
-						envoyv2.TLSInspector(),
+					ListenerFilters: envoy_v2.ListenerFilters(
+						envoy_v2.TLSInspector(),
 					),
-					SocketOptions: envoyv2.TCPKeepaliveSocketOptions(),
+					SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
 				},
 			),
 		},


### PR DESCRIPTION
Renames all the import aliases to make them consistent across the project.
    
Fixes #2938
    
Signed-off-by: Steve Sloka <slokas@vmware.com>
