### PR TITLE
site/_data: Add Hacktoberfest label

### DIFF
--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -308,5 +308,10 @@ default:
       name: size/XXL
       target: prs
       addedBy: prow
+    - color: 7057ff
+      description: Denotes an issue ready for any "Hacktoberfest" contributor.
+      name: 'Hacktoberfest'
+      target: issues
+      addedBy: anyone
 
 repos:


### PR DESCRIPTION
Adds the Hacktoberfest label to the Contour repo to help users who
want to participate in the hacktoberfest program: https://hacktoberfest.digitalocean.com/

Signed-off-by: Steve Sloka <slokas@vmware.com>