### PR TITLE
testsuite: add a basic external auth test

### DIFF
--- a/_integration/testsuite/httpproxy/013-auth-basic-testserver.yaml
+++ b/_integration/testsuite/httpproxy/013-auth-basic-testserver.yaml
@@ -1,0 +1,316 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import data.contour.resources
+
+# Ensure that cert-manager is installed.
+# Version check the certificates resource.
+
+Group := "cert-manager.io"
+Version := "v1alpha3"
+
+have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+    sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+    "available versions:",
+    yaml.marshal(data.resources)
+  ])
+}
+
+---
+
+# Create a self-signed issuer to give us secrets.
+
+apiVersion: cert-manager.io/v1alpha3
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: echo
+spec:
+  dnsNames:
+  - echo.projectcontour.io
+  secretName: echo
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+# Separate testserver into its own namespace.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: testserver-auth
+
+---
+
+# Issue a self-signed certificate for testserver.
+
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  name: testserver
+  namespace: testserver-auth
+spec:
+  dnsNames:
+  - testserver
+  secretName: testserver
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testserver
+  namespace: testserver-auth
+  labels:
+    app.kubernetes.io/name: testserver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: testserver
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: testserver
+    spec:
+      containers:
+      - name: testserver
+        image: docker.io/projectcontour/contour-authserver:v2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /contour-authserver
+        args:
+        - testserver
+        - --address=:9443
+        - --tls-ca-path=/tls/ca.crt
+        - --tls-cert-path=/tls/tls.crt
+        - --tls-key-path=/tls/tls.key
+        ports:
+        - name: auth
+          containerPort: 9443
+          protocol: TCP
+        volumeMounts:
+        - name: tls
+          mountPath: /tls
+          readOnly: true
+      volumes:
+      - name: tls
+        secret:
+          secretName: testserver
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: testserver
+  namespace: testserver-auth
+  labels:
+    app.kubernetes.io/name: testserver
+spec:
+  ports:
+  - name: auth
+    protocol: TCP
+    port: 9443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: testserver
+  type: ClusterIP
+
+---
+
+apiVersion: projectcontour.io/v1alpha1
+kind: ExtensionService
+metadata:
+  name: testserver
+  namespace: testserver-auth
+spec:
+  services:
+  - name: testserver
+    port: 9443
+
+---
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: &fqdn echo.projectcontour.io
+    tls:
+      secretName: echo
+    authorization:
+      timeout: 500ms
+      extensionRef:
+        name: testserver
+        namespace: testserver-auth
+      authPolicy:
+        context:
+          hostname: *fqdn
+  routes:
+  - conditions:
+    - prefix: /first
+    authPolicy:
+      context:
+        target: first
+    services:
+    - name: echo
+      port: 80
+  - conditions:
+    - prefix: /second
+    authPolicy:
+      disabled: true
+    services:
+    - name: echo
+      port: 80
+  - services:
+    - name: echo
+      port: 80
+    authPolicy:
+      context:
+        target: default
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.response
+
+Response := client.Get({
+  "url": url.https(sprintf("/second/route/%d", [time.now_ns()])),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("auth-basic"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_200_response [msg] {
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.response
+
+Response := client.Get({
+  "url": url.https(sprintf("/first/route/%d", [time.now_ns()])),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("auth-basic"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_401_response [msg] {
+  not response.status_is(Response, 401)
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 401])
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.response
+
+# The `testserver` authorization server will accept any request with
+# "allow" in the path, so this request should succeed. We can tell that
+# the authorization server processed it by inspecting the context headers
+# that it injects.
+
+Response := client.Get({
+  "url": url.https(sprintf("/first/allow/%d", [time.now_ns()])),
+  "headers": {
+    "Host": "echo.projectcontour.io",
+    "User-Agent": client.ua("auth-basic"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+error_non_200_response [msg] {
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+}
+
+# Check route context key.
+error_missing_context [msg] {
+  not response.body_has_header_value(Response, "Auth-Context-Target", "first")
+  msg := sprintf("invalid global response context:\n%s", [
+    yaml.marshal(object.get(response.body(Response), "Headers", {}))
+  ])
+}
+
+# Check global context key.
+error_missing_context [msg] {
+  not response.body_has_header_value(Response, "Auth-Context-Hostname", "echo.projectcontour.io")
+  msg := sprintf("invalid global response context:\n%s", [
+    yaml.marshal(object.get(response.body(Response), "Headers", {}))
+  ])
+}
+
+
+

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -74,9 +74,15 @@ for t in $TAGS ; do
     kind::cluster::load docker.io/projectcontour/contour:$t
 done
 
-# Pull the util image & push image into the cluster.
-docker pull docker.io/kennethreitz/httpbin
-kind::cluster::load docker.io/kennethreitz/httpbin
+# Push test images into the cluster.
+for i in \
+    "agervais/ingress-conformance-echo:latest" \
+    "docker.io/kennethreitz/httpbin" \
+    "docker.io/projectcontour/contour-authserver:v2"
+do
+    docker pull "$i"
+    kind::cluster::load "$i"
+done
 
 # Install Contour.
 #

--- a/_integration/testsuite/policies/contour-response.rego
+++ b/_integration/testsuite/policies/contour-response.rego
@@ -61,3 +61,30 @@ is_4xx(resp) = true {
 } else = false {
   true
 }
+
+# Return true if the response body reports a header with the given value.
+#
+# This function expects the respose body to be a JSON object of the form:
+#     {
+#       "TestId": "echo",
+#       "Path": "/first/allow/3666",
+#       "Host": "echo.projectcontour.io:9443",
+#       "Method": "GET",
+#       "Proto": "HTTP/1.1",
+#       "Headers": {
+#         "Auth-Context-Hostname": [
+#           "echo.projectcontour.io",
+#           "something else",
+#         ],
+#       }
+#     }
+body_has_header_value(resp, name, value) = true {
+  response_body := body(resp)
+  response_headers := object.get(response_body, "Headers", {})
+  header_values := object.get(response_headers, name, set())
+
+  some v
+  header_values[v] == value
+} else = false {
+  true
+}


### PR DESCRIPTION
Add a basic integration test for an external authorization server. This
ensures that if the authorization server is present, context is propagated
correctly, and authorization can be disabled on routes.

This updates #2717.

Signed-off-by: James Peach <jpeach@vmware.com>