### PR TITLE
Release v1.8.2 onto branch release-1.8

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -47,11 +47,7 @@ spec:
     spec:
       containers:
       - name: contour
-        # This version is set to latest because Job specs are immutable;
-        # if we change this on each version, you can no longer upgrade
-        # just by applying the deployment YAML.
-        # See #2423, #2395, #2150, and #2030 for earlier questions about this.
-        image: docker.io/projectcontour/contour:latest
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: Always
         command:
         - contour

--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -36,7 +36,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.8.1
+  name: contour-certgen-v1.8.2
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0

--- a/examples/contour/03-contour.yaml
+++ b/examples/contour/03-contour.yaml
@@ -47,7 +47,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: Always
         name: contour
         ports:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -29,7 +29,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -105,7 +105,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -53,7 +53,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.15.0
+        image: docker.io/envoyproxy/envoy:v1.15.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1462,11 +1462,7 @@ spec:
     spec:
       containers:
       - name: contour
-        # This version is set to latest because Job specs are immutable;
-        # if we change this on each version, you can no longer upgrade
-        # just by applying the deployment YAML.
-        # See #2423, #2395, #2150, and #2030 for earlier questions about this.
-        image: docker.io/projectcontour/contour:latest
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: Always
         command:
         - contour
@@ -1796,7 +1792,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.15.0
+        image: docker.io/envoyproxy/envoy:v1.15.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1451,7 +1451,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1.8.1
+  name: contour-certgen-v1.8.2
   namespace: projectcontour
 spec:
   ttlSecondsAfterFinished: 0
@@ -1686,7 +1686,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -1772,7 +1772,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1848,7 +1848,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: docker.io/projectcontour/contour:v1.8.2
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:


### PR DESCRIPTION
Bumps the Envoy version to v1.15.1 to address Envoy CVEs (https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.1). 

Fixes #2925 
