### PR TITLE
internal/contour: don't trigger DAG rebuild on ManagedFields change

### DIFF
--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -178,7 +178,9 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 	case opUpdate:
 		if cmp.Equal(op.oldObj, op.newObj,
 			cmpopts.IgnoreFields(contour_api_v1.HTTPProxy{}, "Status"),
-			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")) {
+			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields"),
+		) {
 			e.WithField("op", "update").Debugf("%T skipping update, only status has changed", op.newObj)
 			return false
 		}


### PR DESCRIPTION
Ignores ManagedFields when checking if an object update should trigger
a DAG rebuild. Previously, ManagedFields would get updated when an
object's status changed, resulting in an extraneous DAG update.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Reviewers: I don't think this *needs* to go in 1.9 if we want to hold it back, since it doesn't seem to cause material perf issues.