### PR TITLE
site: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Tell us about a problem you are experiencing
+title: ''
+labels: kind/bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -1,6 +1,10 @@
 ---
 name: Feature enhancement request
 about: Suggest an idea for this project
+title: ''
+labels: kind/feature
+assignees: ''
+
 ---
 
 **Please describe the problem you have**


### PR DESCRIPTION
Add initial labels when issues are submitted. This ensures that when
contributors file issues they get an initial `kind/bug` or `kind/feature`
label.

Signed-off-by: James Peach <jpeach@vmware.com>