### PR TITLE
internal/k8s: add a Contour scheme constructor

### DIFF
--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -16,15 +16,10 @@ package k8s
 import (
 	"context"
 
-	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
-	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
 )
 
 // DynamicClientHandler converts *unstructured.Unstructured from the
@@ -86,23 +81,12 @@ type UnstructuredConverter struct {
 
 // NewUnstructuredConverter returns a new UnstructuredConverter initialized
 func NewUnstructuredConverter() (*UnstructuredConverter, error) {
-	schemeBuilder := runtime.SchemeBuilder{
-		contour_api_v1.AddToScheme,
-		contour_api_v1alpha1.AddToScheme,
-		scheme.AddToScheme,
-		serviceapis.AddToScheme,
-		v1beta1.AddToScheme,
-	}
-
-	uc := &UnstructuredConverter{
-		scheme: runtime.NewScheme(),
-	}
-
-	if err := schemeBuilder.AddToScheme(uc.scheme); err != nil {
+	s, err := NewContourScheme()
+	if err != nil {
 		return nil, err
 	}
 
-	return uc, nil
+	return &UnstructuredConverter{scheme: s}, nil
 }
 
 // FromUnstructured converts an unstructured.Unstructured to typed struct. If obj

--- a/internal/k8s/scheme.go
+++ b/internal/k8s/scheme.go
@@ -1,0 +1,43 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	serviceapis "sigs.k8s.io/service-apis/api/v1alpha1"
+)
+
+// NewContourScheme returns a scheme that includes all the API types
+// that Contour supports as well as the core Kubernetes API types from
+// the default scheme.
+func NewContourScheme() (*runtime.Scheme, error) {
+	s := runtime.NewScheme()
+	b := runtime.SchemeBuilder{
+		contour_api_v1.AddToScheme,
+		contour_api_v1alpha1.AddToScheme,
+		scheme.AddToScheme,
+		serviceapis.AddToScheme,
+		v1beta1.AddToScheme,
+	}
+
+	if err := b.AddToScheme(s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}


### PR DESCRIPTION
Add a constructor to generate a scheme that includes all the
Contour API types.

This updates #2818.

Signed-off-by: James Peach <jpeach@vmware.com>