### PR TITLE
internal: update HTTPProxy & Ingress default min TLS version to 1.2

### DIFF
--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -226,15 +226,16 @@ func MatchesIngressClass(o metav1.ObjectMetaAccessor, ic string) bool {
 
 // MinTLSVersion returns the TLS protocol version specified by an ingress annotation
 // or default if non present.
-func MinTLSVersion(version string) envoy_api_v2_auth.TlsParameters_TlsProtocol {
+func MinTLSVersion(version string, defaultVal envoy_api_v2_auth.TlsParameters_TlsProtocol) envoy_api_v2_auth.TlsParameters_TlsProtocol {
 	switch version {
 	case "1.3":
 		return envoy_api_v2_auth.TlsParameters_TLSv1_3
 	case "1.2":
 		return envoy_api_v2_auth.TlsParameters_TLSv1_2
-	default:
-		// any other value is interpreted as TLS/1.1
+	case "1.1":
 		return envoy_api_v2_auth.TlsParameters_TLSv1_1
+	default:
+		return defaultVal
 	}
 }
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4656,7 +4656,7 @@ func TestDAGInsert(t *testing.T) {
 								routes: routes(
 									routeUpgrade("/", service(s1))),
 							},
-							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
 								CACertificate: &Secret{Object: cert1},
@@ -4683,7 +4683,7 @@ func TestDAGInsert(t *testing.T) {
 									service(s1),
 								),
 							},
-							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
 								CACertificate: &Secret{Object: cert1},
@@ -5317,7 +5317,7 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "example.com",
 							},
-							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:        secret(sec1),
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(service(s9)),
@@ -5375,7 +5375,7 @@ func TestDAGInsert(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name: "example.com",
 							},
-							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:        secret(sec1),
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(service(s9)),
@@ -5682,7 +5682,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: secret(fallbackCertificateSecret),
 						},
@@ -5777,7 +5777,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: secret(fallbackCertificateSecretRootNamespace),
 						},
@@ -5841,7 +5841,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: secret(fallbackCertificateSecretRootNamespace),
 						},
@@ -5978,7 +5978,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: secret(fallbackCertificateSecret),
 						},
@@ -5987,7 +5987,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "projectcontour.io",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: nil,
 						},
@@ -6038,7 +6038,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: nil,
 						},
@@ -6090,7 +6090,7 @@ func TestDAGInsert(t *testing.T) {
 								Name:   "example.com",
 								routes: routes(routeUpgrade("/", service(s9))),
 							},
-							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_1,
+							MinTLSVersion:       envoy_api_v2_auth.TlsParameters_TLSv1_2,
 							Secret:              secret(sec1),
 							FallbackCertificate: nil,
 						},
@@ -6721,7 +6721,7 @@ func securevirtualhost(name string, sec *v1.Secret, first *Route, rest ...*Route
 			Name:   name,
 			routes: routes(append([]*Route{first}, rest...)...),
 		},
-		MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+		MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 		Secret:        secret(sec),
 	}
 }

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
@@ -180,7 +181,8 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 
 			svhost := p.dag.EnsureSecureVirtualHost(host)
 			svhost.Secret = sec
-			svhost.MinTLSVersion = annotation.MinTLSVersion(tls.MinimumProtocolVersion)
+			// default to a minimum TLS version of 1.2 if it's not specified
+			svhost.MinTLSVersion = annotation.MinTLSVersion(tls.MinimumProtocolVersion, envoy_api_v2_auth.TlsParameters_TLSv1_2)
 
 			// Check if FallbackCertificate && ClientValidation are both enabled in the same vhost
 			if tls.EnableFallbackCertificate && tls.ClientValidation != nil {

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -16,6 +16,7 @@ package dag
 import (
 	"strings"
 
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -86,8 +87,8 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 			for _, host := range tls.Hosts {
 				svhost := p.dag.EnsureSecureVirtualHost(host)
 				svhost.Secret = sec
-				svhost.MinTLSVersion = annotation.MinTLSVersion(
-					annotation.CompatAnnotation(ing, "tls-minimum-protocol-version"))
+				// default to a minimum TLS version of 1.2 if it's not specified
+				svhost.MinTLSVersion = annotation.MinTLSVersion(annotation.CompatAnnotation(ing, "tls-minimum-protocol-version"), envoy_api_v2_auth.TlsParameters_TLSv1_2)
 			}
 		}
 	}

--- a/internal/featuretests/envoy.go
+++ b/internal/featuretests/envoy.go
@@ -296,7 +296,7 @@ func filterchaintls(domain string, secret *v1.Secret, filter *envoy_api_v2_liste
 		domain,
 		envoy_v2.DownstreamTLSContext(
 			&dag.Secret{Object: secret},
-			envoy_api_v2_auth.TlsParameters_TLSv1_1,
+			envoy_api_v2_auth.TlsParameters_TLSv1_2,
 			peerValidationContext,
 			alpn...),
 		envoy_v2.Filters(filter),

--- a/internal/featuretests/listeners_test.go
+++ b/internal/featuretests/listeners_test.go
@@ -310,7 +310,7 @@ func TestHTTPProxyTLSListener(t *testing.T) {
 				Fqdn: "kuard.example.com",
 				TLS: &contour_api_v1.TLS{
 					SecretName:             secret1.Name,
-					MinimumProtocolVersion: "1.1",
+					MinimumProtocolVersion: "1.2",
 				},
 			},
 			Routes: []contour_api_v1.Route{{

--- a/internal/xdscache/v2/listener_test.go
+++ b/internal/xdscache/v2/listener_test.go
@@ -297,7 +297,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
@@ -386,13 +386,13 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedfirst.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("sortedfirst.example.com")),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"sortedsecond.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("sortedsecond.example.com")),
 				}},
 				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
@@ -507,7 +507,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy_v2.ListenerFilters(
@@ -589,7 +589,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy_v2.ListenerFilters(
@@ -665,7 +665,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
@@ -739,7 +739,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("whatever.example.com")),
 				}},
 				SocketOptions: envoy_v2.TCPKeepaliveSocketOptions(),
@@ -810,7 +810,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"whatever.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v2.FilterMisdirectedRequests("whatever.example.com")).
 						DefaultFilters().
@@ -1180,7 +1180,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}, {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
@@ -1295,14 +1295,14 @@ func TestListenerVisit(t *testing.T) {
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"www.another.com"},
 						},
-						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 						Filters:         envoy_v2.Filters(httpsFilterFor("www.another.com")),
 					},
 					{
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"www.example.com"},
 						},
-						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 						Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 					},
 					{
@@ -1439,7 +1439,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(httpsFilterFor("www.example.com")),
 				}},
 				ListenerFilters: envoy_v2.ListenerFilters(
@@ -1730,7 +1730,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
@@ -1812,7 +1812,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
@@ -1894,7 +1894,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
@@ -1976,7 +1976,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						ServerNames: []string{"www.example.com"},
 					},
-					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters: envoy_v2.Filters(envoy_v2.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v2.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().

--- a/site/docs/main/annotations.md
+++ b/site/docs/main/annotations.md
@@ -46,7 +46,7 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
  - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt][2], if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
  - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout][3], specified as a [golang duration][4]. By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
  - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].
- - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support.
+ - `projectcontour.io/tls-minimum-protocol-version`: [The minimum TLS protocol version][7] the TLS listener should support. Valid options are `1.3`, `1.2` (default), `1.1`.
  - `projectcontour.io/websocket-routes`: [The routes supporting websocket protocol][8], the annotation value contains a list of route paths separated by a comma that must match with the ones defined in the `Ingress` definition. Defaults to Envoy's default behavior which is `use_websocket` to `false`.
 
 ## Contour specific Service annotations

--- a/site/docs/main/httpproxy.md
+++ b/site/docs/main/httpproxy.md
@@ -249,8 +249,8 @@ See TLS Certificate Delegation below for more information.
 The TLS **Minimum Protocol Version** a vhost should negotiate can be specified by setting the `spec.virtualhost.tls.minimumProtocolVersion`:
 
 - 1.3
-- 1.2
-- 1.1 (Default)
+- 1.2  (Default)
+- 1.1
 
 ##### Fallback Certificate
 


### PR DESCRIPTION
Changes the default minimum TLS protocol version from 1.1 to 1.2 for
HTTPProxies and Ingresses that don't specify it, since 1.1 is now
end-of-life. 1.1 can still be used, but it must be explicitly configured.

Updates #2777

Signed-off-by: Steve Kriss <krisss@vmware.com>