### PR TITLE
deployment: Update rbac versions from v1beta1 to v1

### DIFF
--- a/examples/contour/02-job-certgen.yaml
+++ b/examples/contour/02-job-certgen.yaml
@@ -5,7 +5,7 @@ metadata:
   name: contour-certgen
   namespace: projectcontour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -19,7 +19,7 @@ subjects:
   name: contour-certgen
   namespace: projectcontour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen

--- a/examples/contour/02-rbac.yaml
+++ b/examples/contour/02-rbac.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour

--- a/examples/prometheus/03-prometheus-deployment.yaml
+++ b/examples/prometheus/03-prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -25,7 +25,7 @@ metadata:
   name: prometheus
   namespace: projectcontour-monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1408,7 +1408,7 @@ metadata:
   name: contour-certgen
   namespace: projectcontour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -1422,7 +1422,7 @@ subjects:
   name: contour-certgen
   namespace: projectcontour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen
@@ -1477,7 +1477,7 @@ spec:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour

--- a/examples/root-rbac/rbac.yaml
+++ b/examples/root-rbac/rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour
@@ -11,7 +11,7 @@ subjects:
     name: contour
     namespace: projectcontour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: root-httpproxy
@@ -25,7 +25,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: projectcontour
@@ -40,7 +40,7 @@ rules:
       - list
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: contour-secrets-root
   namespace: root-httpproxy
@@ -54,7 +54,7 @@ roleRef:
   name: contour-secrets-root
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: contour-secrets
   namespace: projectcontour
@@ -67,7 +67,7 @@ roleRef:
   kind: Role
   name: contour-secrets
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: contour


### PR DESCRIPTION
Update the apiVersions of resources in rbac group such as  ClusterRoleBinding, Role etc. to
v1 version from  v1beta1 as it's deprecated since kubernetes 1.17 version and will be removed
in 1.22 version.

Fixes #2991

Signed-off-by: hnarahari <hnarahari@vmware.com>