### PR TITLE
internal/xds: Refactor xDS Server into a v2 package

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -40,6 +40,7 @@ import (
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/projectcontour/contour/internal/xds"
+	contour_xds_v2 "github.com/projectcontour/contour/internal/xds/v2"
 	"github.com/projectcontour/contour/internal/xdscache"
 	xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -623,12 +624,12 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 		switch ctx.XDSServerType {
 		case "contour":
-			grpcServer = xds.RegisterServer(
-				xds.NewContourServer(log, xdscache.ResourcesOf(resources)...),
+			grpcServer = contour_xds_v2.RegisterServer(
+				contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...),
 				registry,
 				ctx.grpcOptions(log)...)
 		case "envoy":
-			grpcServer = xds.RegisterServer(
+			grpcServer = contour_xds_v2.RegisterServer(
 				server.NewServer(context.Background(), snapshotCache, nil),
 				registry,
 				ctx.grpcOptions(log)...)

--- a/internal/featuretests/v2/featuretests.go
+++ b/internal/featuretests/v2/featuretests.go
@@ -37,7 +37,7 @@ import (
 	"github.com/projectcontour/contour/internal/sorter"
 	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/internal/workgroup"
-	"github.com/projectcontour/contour/internal/xds"
+	contour_xds_v2 "github.com/projectcontour/contour/internal/xds/v2"
 	"github.com/projectcontour/contour/internal/xdscache"
 	xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -130,8 +130,8 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
-	srv := xds.RegisterServer(
-		xds.NewContourServer(log, xdscache.ResourcesOf(resources)...),
+	srv := contour_xds_v2.RegisterServer(
+		contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...),
 		r /* Prometheus registry */)
 
 	var g workgroup.Group

--- a/internal/xds/resource.go
+++ b/internal/xds/resource.go
@@ -1,0 +1,32 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import "github.com/golang/protobuf/proto"
+
+// Resource represents a source of proto.Messages that can be registered
+// for interest.
+type Resource interface {
+	// Contents returns the contents of this resource.
+	Contents() []proto.Message
+
+	// Query returns an entry for each resource name supplied.
+	Query(names []string) []proto.Message
+
+	// Register registers ch to receive a value when Notify is called.
+	Register(chan int, int, ...string)
+
+	// TypeURL returns the typeURL of messages returned from Values.
+	TypeURL() string
+}

--- a/internal/xds/v2/server.go
+++ b/internal/xds/v2/server.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xds
+package v2
 
 import (
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"

--- a/internal/xdscache/v2/server_test.go
+++ b/internal/xdscache/v2/server_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/xds"
+	contour_xds_v2 "github.com/projectcontour/contour/internal/xds/v2"
 	"github.com/projectcontour/contour/internal/xdscache"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -63,7 +63,7 @@ func TestGRPC(t *testing.T) {
 				},
 			})
 
-			sds := v2.NewClusterDiscoveryServiceClient(cc)
+			sds := envoy_api_v2.NewClusterDiscoveryServiceClient(cc)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := sds.StreamClusters(ctx)
@@ -90,7 +90,7 @@ func TestGRPC(t *testing.T) {
 				}},
 			})
 
-			eds := v2.NewEndpointDiscoveryServiceClient(cc)
+			eds := envoy_api_v2.NewEndpointDiscoveryServiceClient(cc)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := eds.StreamEndpoints(ctx)
@@ -123,7 +123,7 @@ func TestGRPC(t *testing.T) {
 				},
 			})
 
-			lds := v2.NewListenerDiscoveryServiceClient(cc)
+			lds := envoy_api_v2.NewListenerDiscoveryServiceClient(cc)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := lds.StreamListeners(ctx)
@@ -155,7 +155,7 @@ func TestGRPC(t *testing.T) {
 				},
 			})
 
-			rds := v2.NewRouteDiscoveryServiceClient(cc)
+			rds := envoy_api_v2.NewRouteDiscoveryServiceClient(cc)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 			stream, err := rds.StreamRoutes(ctx)
@@ -206,7 +206,7 @@ func TestGRPC(t *testing.T) {
 				FieldLogger: log,
 			}
 
-			srv := xds.RegisterServer(xds.NewContourServer(log, xdscache.ResourcesOf(resources)...), nil)
+			srv := contour_xds_v2.RegisterServer(contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...), nil)
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			done := make(chan error, 1)
@@ -230,17 +230,17 @@ func TestGRPC(t *testing.T) {
 }
 
 func sendreq(t *testing.T, stream interface {
-	Send(*v2.DiscoveryRequest) error
+	Send(*envoy_api_v2.DiscoveryRequest) error
 }, typeurl string) {
 	t.Helper()
-	err := stream.Send(&v2.DiscoveryRequest{
+	err := stream.Send(&envoy_api_v2.DiscoveryRequest{
 		TypeUrl: typeurl,
 	})
 	require.NoError(t, err)
 }
 
 func checkrecv(t *testing.T, stream interface {
-	Recv() (*v2.DiscoveryResponse, error)
+	Recv() (*envoy_api_v2.DiscoveryResponse, error)
 }) {
 	t.Helper()
 	_, err := stream.Recv()
@@ -248,7 +248,7 @@ func checkrecv(t *testing.T, stream interface {
 }
 
 func checktimeout(t *testing.T, stream interface {
-	Recv() (*v2.DiscoveryResponse, error)
+	Recv() (*envoy_api_v2.DiscoveryResponse, error)
 }) {
 	t.Helper()
 	_, err := stream.Recv()


### PR DESCRIPTION
Refactors the xDS Server into a v2 package allowing for
a v3 server to be created seperate from the v2 instance.

Updates #1898

Signed-off-by: Steve Sloka <slokas@vmware.com>