### PR TITLE
internal/dag: default the authorization response timeout

### DIFF
--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -265,11 +265,16 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 
 				timeout, err := timeout.Parse(auth.ResponseTimeout)
 				if err != nil {
-					validCond.AddErrorf("AuthError", "AuthReponseTimeoutInvalid",
+					validCond.AddErrorf("AuthError", "AuthResponseTimeoutInvalid",
 						"Spec.Virtualhost.Authorization.ResponseTimeout is invalid: %s", err)
 					return
 				}
-				svhost.AuthorizationResponseTimeout = timeout
+
+				if timeout.UseDefault() {
+					svhost.AuthorizationResponseTimeout = ext.TimeoutPolicy.ResponseTimeout
+				} else {
+					svhost.AuthorizationResponseTimeout = timeout
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If the authorization spec on the virtual host doesn't set the response
timeout, default it from the corresponding `ExtensionService`.

This fixes #3025.

Signed-off-by: James Peach <jpeach@vmware.com>