### PR TITLE
site: add `lifecycle/needs-triage` label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Tell us about a problem you are experiencing
 title: ''
-labels: kind/bug
+labels: kind/bug, lifecycle/needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -2,7 +2,7 @@
 name: Feature enhancement request
 about: Suggest an idea for this project
 title: ''
-labels: kind/feature
+labels: kind/feature, lifecycle/needs-triage
 assignees: ''
 
 ---

--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -221,6 +221,11 @@ default:
         - name: question
 
 # Lifecycle.
+    - color: ff5050
+      description: Indicates that an issue needs to be triaged by a project contributor.
+      name: lifecycle/needs-triage
+      target: both
+      addedBy: anyone
     - color: d3e2f0
       description: Indicates that an issue or PR should not be auto-closed due to staleness.
       name: lifecycle/frozen


### PR DESCRIPTION
Add a `lifecycle/needs-triage` label and apply it on all new
issues opened with the issue templates.

This fixes #2981.

Signed-off-by: James Peach <jpeach@vmware.com>