### PR TITLE
Update Envoy to v1.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
 PHONY = gencerts
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.15.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.16.0
 
 # The version of Jekyll is pinned in site/Gemfile.lock.
 # https://docs.netlify.com/configure-builds/common-configurations/#jekyll

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -53,7 +53,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.15.1
+        image: docker.io/envoyproxy/envoy:v1.16.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1802,7 +1802,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.15.1
+        image: docker.io/envoyproxy/envoy:v1.16.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
This PR updates `Makefile` to use the latest version of Envoy (v1.16.0).

It also updates the examples to reflect this change.

Fixes #3013 