### PR TITLE
.github/workflows: automatically tag new release images as 'latest'

### DIFF
--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -24,5 +24,5 @@ jobs:
         TAG_LATEST: "false"
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        make push
+        ./hack/actions/build-and-push-release-images.sh
         docker logout

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@ LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v 127.0.0.1 | hea
 # Sets GIT_REF to a tag if it's present, otherwise the short git sha will be used.
 GIT_REF = $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=8 --verify HEAD)
 VERSION ?= $(GIT_REF)
-# Used for the tag-latest action.
-# The tag-latest action will be a noop unless this is explicitly
-# set outside this Makefile, as a safety valve.
-LATEST_VERSION ?= NOLATEST
 
 # Stash the ISO 8601 date. Note that the GMT offset is missing the :
 # separator, but there doesn't seem to be a way to do that without
@@ -102,15 +98,6 @@ push: container
 	docker push $(IMAGE):$(VERSION)
 ifeq ($(TAG_LATEST), true)
 	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-	docker push $(IMAGE):latest
-endif
-
-tag-latest: ## Tag the Docker registry container image at $LATEST_VERSION as :latest
-ifeq ($(LATEST_VERSION), NOLATEST)
-	@echo "LATEST_VERSION not set, not proceeding"
-else
-	docker pull $(IMAGE):$(LATEST_VERSION)
-	docker tag $(IMAGE):$(LATEST_VERSION) $(IMAGE):latest
 	docker push $(IMAGE):latest
 endif
 

--- a/hack/actions/build-and-push-release-images.sh
+++ b/hack/actions/build-and-push-release-images.sh
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This scripts sets TAG_LATEST based on whether the tag currently being
+# built is the highest semantic version tag that's not a pre-release
+# (alpha, beta, rc), and calls 'make push'.
+#
+# This script is intended to be run only for tag builds and will no-op
+# if GITHUB_REF is not in the format "refs/tags/<tag-name>".
+# Ref. https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+
+# Check if the current build is for a tag and exit early if not.
+REF_TYPE=$(echo "$GITHUB_REF" | cut -d / -f 2)
+if [[ "$REF_TYPE" != "tags" ]]; then
+    echo "REF_TYPE \"$REF_TYPE\" is not a tag, exiting"
+    exit 0
+fi
+
+# Get the current tag name.
+CURRENT_TAG=$(echo "$GITHUB_REF" | cut -d / -f 3)
+if [[ -z "$CURRENT_TAG" ]]; then
+    echo "Error getting current tag name from GITHUB_REF \"$GITHUB_REF\""
+    exit 1
+fi
+
+# Fetch all tags so we can check if the current tag
+# is the highest semver.
+git fetch --tags
+
+HIGHEST_SEMVER_TAG=""
+
+# The --sort=-v:refname flag treats tag names as versions, so gives
+# us semantic sorting rather than lexicographic (alphabetic) sorting.
+for t in $(git tag -l --sort=-v:refname); do
+    # Skip pre-release tags
+    if [[ "$t" == *"beta"* || "$t" == *"alpha"* || "$t" == *"rc"* ]]; then
+        continue
+    fi
+    HIGHEST_SEMVER_TAG="$t"
+    break
+done
+
+# Set TAG_LATEST based on whether the current tag is the highest semver tag.
+if [[ "$CURRENT_TAG" == "$HIGHEST_SEMVER_TAG" ]]; then
+    TAG_LATEST="true"
+else
+    TAG_LATEST="false"
+fi
+
+echo "CURRENT_TAG: $CURRENT_TAG"
+echo "HIGHEST_SEMVER_TAG: $HIGHEST_SEMVER_TAG"
+echo "TAG_LATEST: $TAG_LATEST"
+
+make push TAG_LATEST="$TAG_LATEST"

--- a/site/_resources/release-process.md
+++ b/site/_resources/release-process.md
@@ -122,36 +122,6 @@ $ git tag -a v1.2.1 -m 'contour 1.2.1'
 $ git push --tags
 ```
 
-## Updating the `:latest` tag
-
-If you've cut a new production-ready release, you'll need to update `:latest` on Docker Hub as well.
-
-Firstly, you'll need to be:
-
-- logged in to Docker Hub
-- A member of the projectcontour Docker Hub org with push rights.
-
-Once that's all true, do the following steps:
-
-```shell
-$ docker login
-Authenticating with existing credentials...
-Login Succeeded
-# The make target will do what you need
-# If you don't set the version, it will be a noop
-$ make tag-latest REGISTRY=docker.io/projectcontour LATEST_VERSION=v1.6.0
-docker pull docker.io/projectcontour/contour:v1.0.0
-v1.0.0: Pulling from docker.io/projectcontour/contour
-Digest: sha256:7af8d77b3fcdbebec31abd1059aedacc119b3561b933976402c87f31a309ec53
-Status: Image is up to date for projectcontour/contour:v1.0.0
-docker.io/projectcontour/contour:v1.0.0
-docker tag docker.io/projectcontour/contour:v1.0.0 docker.io/projectcontour/contour:latest
-docker push docker.io/projectcontour/contour:latest
-The push refers to repository [docker.io/projectcontour/contour]
-43ef43ac3a59: Layer already exists
-latest: digest: sha256:7af8d77b3fcdbebec31abd1059aedacc119b3561b933976402c87f31a309ec53 size: 527
-```
-
 ## Finishing up
 
 If you've made a production release (that is, a final release or a patch release), you have a couple of things left to do.


### PR DESCRIPTION
Adds logic to release tag builds to detect if the tag being built
is the highest semantic version that's not a pre-release, and if
so, sets TAG_LATEST to true so the image will be tagged as 'latest'
in addition to the version-specific tag.

Closes #1844

Signed-off-by: Steve Kriss <krisss@vmware.com>