### PR TITLE
build multi-arch Docker image for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
     - name: Build and Push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -19,5 +23,5 @@ jobs:
         TAG_LATEST: "false"
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        make push
+        make multiarch-build-push
         docker logout

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
     - name: Build and Push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.15.2 AS build
+ARG BUILDPLATFORM=linux/amd64
+
+FROM --platform=$BUILDPLATFORM golang:1.15.2 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org
@@ -14,13 +16,16 @@ COPY Makefile Makefile
 ARG BUILD_BRANCH
 ARG BUILD_SHA
 ARG BUILD_VERSION
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN make install \
+RUN make build \
 	    CGO_ENABLED=0 \
-	    GOOS=linux \
+		GOOS=${TARGETOS} \
+		GOARCH=${TARGETARCH} \
 	    BUILD_VERSION=${BUILD_VERSION} \
 	    BUILD_SHA=${BUILD_SHA} \
 	    BUILD_BRANCH=${BUILD_BRANCH}
 
 FROM scratch AS final
-COPY --from=build /go/bin/contour /bin/contour
+COPY --from=build /contour/contour /bin/contour

--- a/hack/actions/build-and-push-release-images.sh
+++ b/hack/actions/build-and-push-release-images.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 # This scripts sets TAG_LATEST based on whether the tag currently being
 # built is the highest semantic version tag that's not a pre-release
-# (alpha, beta, rc), and calls 'make push'.
+# (alpha, beta, rc), and calls 'make multiarch-build-push'.
 #
 # This script is intended to be run only for tag builds and will no-op
 # if GITHUB_REF is not in the format "refs/tags/<tag-name>".
@@ -54,4 +54,4 @@ echo "CURRENT_TAG: $CURRENT_TAG"
 echo "HIGHEST_SEMVER_TAG: $HIGHEST_SEMVER_TAG"
 echo "TAG_LATEST: $TAG_LATEST"
 
-make push TAG_LATEST="$TAG_LATEST"
+make multiarch-build-push TAG_LATEST="$TAG_LATEST"


### PR DESCRIPTION
Adds multi-arch Docker image support, and defaults to building
for linux/amd64 and linux/arm64. Uses the docker buildx plugin
along with go cross-compilation.

Closes #2868

Test images that I built via CI: https://hub.docker.com/layers/steveheptio/contour/latest/images/sha256-077a7a69520afcfb1618ee5d2ecada2d9249e644b411e3a63c2679cc55efca14?context=explore