### PR TITLE
testsuite: use official ingress-conformance-echo image

### DIFF
--- a/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
+++ b/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
@@ -12,6 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Conformance server source: https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
+# Per-commit conformance images: https://console.cloud.google.com/gcr/images/k8s-staging-ingressconformance/GLOBAL
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,10 +31,20 @@ spec:
     spec:
       containers:
       - name: conformance-echo
-        image: agervais/ingress-conformance-echo:latest
+        image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
         env:
-        - name: TEST_ID
+        - name: INGRESS_NAME
           value: *name
+        - name: SERVICE_NAME
+          value: *name
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - name: http-api
           containerPort: 3000

--- a/_integration/testsuite/httpproxy/002-header-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/002-header-condition-match.yaml
@@ -194,31 +194,32 @@ error[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
 
 random := sprintf("%d", [time.now_ns()])
 
 cases := {
-  { "header": "Target-Present", "value": random, "status": 200, "testid": "echo-header-present" },
+  { "header": "Target-Present", "value": random, "status": 200, "service": "echo-header-present" },
 
   { "header": "Target-Contains", "value": random, "status": 404 },
-  { "header": "Target-Contains", "value": "ContainsValue", "status": 200, "testid": "echo-header-contains" },
-  { "header": "Target-Contains", "value": "xxx ContainsValue xxx", "status": 200, "testid": "echo-header-contains" },
+  { "header": "Target-Contains", "value": "ContainsValue", "status": 200, "service": "echo-header-contains" },
+  { "header": "Target-Contains", "value": "xxx ContainsValue xxx", "status": 200, "service": "echo-header-contains" },
 
   { "header": "Target-NotContains", "value": "ContainsValue", "status": 404 },
   { "header": "Target-NotContains", "value": "xxx ContainsValue xxx", "status": 404 },
-  { "header": "Target-NotContains", "value": random , "status": 200, "testid": "echo-header-notcontains" },
+  { "header": "Target-NotContains", "value": random , "status": 200, "service": "echo-header-notcontains" },
 
   { "header": "Target-Exact", "value": random , "status": 404 },
   { "header": "Target-Exact", "value": "NotExactValue", "status": 404 },
-  { "header": "Target-Exact", "value": "ExactValue", "status": 200, "testid": "echo-header-exact" },
+  { "header": "Target-Exact", "value": "ExactValue", "status": 200, "service": "echo-header-exact" },
 
-  { "header": "Target-NotExact", "value": random , "status": 200, "testid": "echo-header-notexact" },
-  { "header": "Target-NotExact", "value": "NotExactValue" , "status": 200, "testid": "echo-header-notexact" },
+  { "header": "Target-NotExact", "value": random , "status": 200, "service": "echo-header-notexact" },
+  { "header": "Target-NotExact", "value": "NotExactValue" , "status": 200, "service": "echo-header-notexact" },
   { "header": "Target-NotExact", "value": "ExactValue" , "status": 404 },
 
 }
 
-requests[{ "req": req, "wanted_status": status, "wanted_testid": testid }] {
+requests[{ "req": req, "wanted_status": status, "wanted_service": service }] {
   case := cases[_]
 
   req := {
@@ -232,41 +233,28 @@ requests[{ "req": req, "wanted_status": status, "wanted_testid": testid }] {
   }
 
   status := case.status
-  testid := case.testid
+  service := case.service
 }
 
 error_if_wrong_status[msg] {
-  request := requests[_]
-  response := http.send(request.req)
+  req := requests[_]
+  resp := http.send(req.req)
 
-  response.status_code != request.wanted_status
+  not response.status_is(resp, req.wanted_status)
+
   msg := sprintf("got status %d, wanted %d", [
-    response.status_code,
-    request.wanted_status,
+    response.status_code(resp),
+    req.wanted_status,
   ])
 }
 
-error_if_missing_testid[msg] {
-  request := requests[_]
-  response := http.send(request.req)
+error_wrong_routing[msg] {
+  req := requests[_]
+  resp := http.send(req.req)
 
-  response.status_code == 200
-  not response.body.TestId
+  not req.wanted_service == response.service(resp)
 
-  msg := sprintf("got status %d, but no testid", [
-    response.status_code,
-  ])
-}
-
-error_if_wrong_testid[msg] {
-  request := requests[_]
-  response := http.send(request.req)
-
-  response.status_code == 200
-  response.body.TestId != request.wanted_testid
-
-  msg := sprintf("got testid %s, wanted %s", [
-    response.body.TestId,
-    request.wanted_testid,
+  msg := sprintf("got service %s, wanted %q", [
+    response.service(resp), req.wanted_service,
   ])
 }

--- a/_integration/testsuite/httpproxy/003-path-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/003-path-condition-match.yaml
@@ -123,6 +123,7 @@ error_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
 
 cases := [
   [ "/", "echo-slash-default" ],
@@ -147,10 +148,10 @@ request_for_path[path] = request {
   }
 }
 
-response_for_path[path] = response {
+response_for_path[path] = resp {
   path := cases[_][0]
   request := request_for_path[path]
-  response := http.send(request)
+  resp := http.send(request)
 }
 
 # Ensure that we get a response for each test case.
@@ -160,23 +161,25 @@ error_missing_responses {
 
 error_non_200_response [msg] {
   path := cases[_][0]
-  response := response_for_path[path]
+  resp := response_for_path[path]
 
-  response.status_code != 200
+  not response.status_is(resp, 200)
+
   msg :=  sprintf("got status %d for path %q, wanted %d", [
-    response.status_code, path, 200,
+    response.status_code(resp), path, 200,
   ])
 }
 
-error_path_routing_mismatch[msg] {
+error_wrong_routing[msg] {
   c := cases[_]
 
   path := c[0]
-  testid := c[1]
-  response := response_for_path[path]
+  svc := c[1]
+  resp := response_for_path[path]
 
-  response.body.TestId != testid
+  not svc == response.service(resp)
+
   msg :=  sprintf("got wrong service %q for path %q, wanted %q", [
-    response.body.TestId, path, testid,
+    response.service(resp), path, svc,
   ])
 }

--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -131,8 +131,9 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
 
-TestID := "echo-one"
+Service := "echo-one"
 
 Response := client.Get({
   "url": url.https(sprintf("/https-sni-enforcement/%d", [time.now_ns()])),
@@ -148,18 +149,18 @@ error_no_response {
 }
 
 error_non_200_response [msg] {
-  Response.status_code != 200
+  not response.status_is(Response, 200)
 
   msg :=  sprintf("got status %d, wanted %d", [
-    Response.status_code, 200
+    response.status_code(Response), 200
   ])
 }
 
-error_path_routing_mismatch[msg] {
-  Response.body.TestId != TestID
+error_wrong_routing[msg] {
+  not response.service(Response) == Service
 
   msg :=  sprintf("got wrong service %q, wanted %q", [
-    Response.body.TestId, TestID,
+    response.service(Response), Service,
   ])
 }
 
@@ -240,8 +241,9 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
 
-TestID := "echo-two"
+Service := "echo-two"
 
 Response := client.Get({
   "url": url.https(sprintf("/https-sni-enforcement/%d", [time.now_ns()])),
@@ -257,18 +259,18 @@ error_no_response {
 }
 
 error_non_200_response [msg] {
-  Response.status_code != 200
+  not response.status_is(Response, 200)
 
   msg :=  sprintf("got status %d, wanted %d", [
-    Response.status_code, 200
+    response.status_code(Response), 200
   ])
 }
 
-error_path_routing_mismatch[msg] {
-  Response.body.TestId != TestID
+error_wrong_routing[msg] {
+  not response.service(Response) == Service
 
   msg :=  sprintf("got wrong service %q, wanted %q", [
-    Response.body.TestId, TestID,
+    response.service(Response), Service,
   ])
 }
 

--- a/_integration/testsuite/httpproxy/005-pod-restart.yaml
+++ b/_integration/testsuite/httpproxy/005-pod-restart.yaml
@@ -15,32 +15,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: &name ingress-conformance-echo
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: *name
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: *name
-    spec:
-      containers:
-      - name: conformance-echo
-        image: agervais/ingress-conformance-echo:latest
-        env:
-        - name: TEST_ID
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        ports:
-        - name: http-api
-          containerPort: 3000
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 3000
+  name: ingress-conformance-echo
+$apply: fixture
 
 ---
 
@@ -73,8 +49,8 @@ RunId := data.test.params["run-id"]
 error_pod_unready [msg] {
   pod := data.resources.pods[_]
 
-  pod.metadata.labels["app.kubernetes.io/name"] == "ingress-conformance-echo"
-  pod.metadata.annotations["modden/run-id"] == RunId
+  object.get(pod.metadata.labels, "app.kubernetes.io/name", "") == "ingress-conformance-echo"
+  object.get(pod.metadata.annotations, "integration-tester/run-id", "") == RunId
 
   # Find combinations of _ and i where the condition is Ready/True.
   cond := pod.status.conditions[i]
@@ -86,9 +62,11 @@ error_pod_unready [msg] {
 
 ---
 
-import data.contour.http.response
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
+
+Service := "ingress-conformance-echo"
 
 Response := client.Get({
   "url": url.http(sprintf("/pre-delete/%d", [time.now_ns()])),
@@ -99,20 +77,19 @@ Response := client.Get({
 })
 
 error_non_200_response [msg] {
-  Response.status_code != 200
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+  not response.status_is(Response, 200)
+
+  msg := sprintf("got status %d, wanted %d", [
+    response.status_code(Response), 200,
+   ])
 }
 
-error_missing_testid [msg] {
-  not response.has_testid(Response)
-  msg := "response has missing body or test ID"
-}
+error_wrong_routing[msg] {
+  not response.service(Response) == Service
 
-error[msg] {
-  testid := response.testid(Response)
-  not data.resources.pods[testid]
-
-  msg := sprintf("no pod for test ID %q", [testid])
+  msg := sprintf("got service %q, wanted %q", [
+    response.service(Response), Service,
+  ])
 }
 
 ---
@@ -138,9 +115,11 @@ error_pod_exists [msg] {
 
 ---
 
-import data.contour.http.response
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.response
+
+Service := "ingress-conformance-echo"
 
 Response := client.Get({
   "url": url.http(sprintf("/post-delete/%d", [time.now_ns()])),
@@ -155,14 +134,17 @@ error_non_200_response [msg] {
   msg :=  sprintf("got status %d, wanted %d", [Response.status_code, 200])
 }
 
-error_missing_testid [msg] {
-  not response.has_testid(Response)
-  msg := "response has missing body or test ID"
+error_wrong_routing[msg] {
+  not response.service(Response) == Service
+
+  msg := sprintf("got service %q, wanted %q", [
+    response.service(Response), Service,
+  ])
 }
 
 error[msg] {
-  testid := response.testid(Response)
-  not data.resources.pods[testid]
+  pod := response.pod(Response)
 
-  msg := sprintf("no pod for test ID %q", [testid])
+  not data.resources.pods[pod]
+  msg := sprintf("no pod for pod name %q", [pod])
 }

--- a/_integration/testsuite/httpproxy/006-merge-slash.yaml
+++ b/_integration/testsuite/httpproxy/006-merge-slash.yaml
@@ -88,7 +88,7 @@ error_unexpected_path [msg] {
   merged := concat("/", [ p | parts[i] != ""; p := parts[i] ])
 
   # Get the Path field, or empty string if it's not present.
-  path := object.get(body, "Path", "")
+  path := object.get(body, "path", "")
 
   not contains(path, merged)
 

--- a/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
+++ b/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
@@ -376,26 +376,14 @@ Response := client.Get({
 })
 
 error_non_200_response [msg] {
-  not Response
-  msg := "no response"
-}
-
-error_non_200_response [msg] {
-  status := object.get(Response, "status_code", 000)
-  status != 200
-  msg := sprintf("got status %d, wanted %d", [status, 200])
-}
-
-error_wrong_routing [msg] {
-  not response.has_testid(Response)
-  msg := "response has missing body or test ID"
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
 }
 
 error_wrong_routing[msg] {
   wanted := "echo-no-auth"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
 }
 
 ---
@@ -422,26 +410,14 @@ Response := client.Get({
 })
 
 error_non_200_response [msg] {
-  not Response
-  msg := "no response"
-}
-
-error_non_200_response [msg] {
-  status := object.get(Response, "status_code", 000)
-  status != 200
-  msg := sprintf("got status %d, wanted %d", [status, 200])
-}
-
-error_wrong_routing [msg] {
-  not response.has_testid(Response)
-  msg := "response has missing body or test ID"
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
 }
 
 error_wrong_routing[msg] {
   wanted := "echo-with-auth"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
 }
 
 # TODO(jpeach): Need to test that requests without a client certificate

--- a/_integration/testsuite/httpproxy/008-tcproute-https-termination.yaml
+++ b/_integration/testsuite/httpproxy/008-tcproute-https-termination.yaml
@@ -136,20 +136,12 @@ Response := client.Get({
 })
 
 error_non_200_response [msg] {
-  not Response
-  msg := "no response"
+  not response.status_is(Response, 200)
+  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
 }
-
-error_non_200_response [msg] {
-  status := object.get(Response, "status_code", 000)
-  status != 200
-  msg := sprintf("got status %d, wanted %d", [status, 200])
-}
-
 
 error_wrong_routing[msg] {
   wanted := "echo-tcpproxy"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
 }

--- a/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
+++ b/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
@@ -151,16 +151,10 @@ error_non_200_response [msg] {
   msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
 }
 
-error_wrong_routing [msg] {
-  not response.has_testid(Response)
-  msg := "response has missing body or test ID"
-}
-
 error_wrong_routing[msg] {
   wanted := "echo"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
 }
 
 ---

--- a/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
+++ b/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
@@ -132,18 +132,18 @@ import data.contour.http.client.url
 import data.contour.http.response
 
 cases := {
-  { "path": "/", "testid": "echo-app" },
-  { "path": "/app", "testid": "echo-app" },
-  { "path": "/admin", "testid": "echo-admin" },
-  { "path": "/admin/", "testid": "echo-admin" },
-  { "path": "/admin/app", "testid": "echo-admin" },
+  { "path": "/", "service": "echo-app" },
+  { "path": "/app", "service": "echo-app" },
+  { "path": "/admin", "service": "echo-admin" },
+  { "path": "/admin/", "service": "echo-admin" },
+  { "path": "/admin/app", "service": "echo-admin" },
 }
 
-responses[{"testid": testid, "response": response}] {
+responses[{"service": service, "response": response}] {
   case := cases[_]
 
   path:= case.path
-  testid := case.testid
+  service := case.service
   response := client.Get({
     "url": url.http(case.path),
     "headers": {
@@ -160,10 +160,9 @@ error_missing_response {
 error_misrouted_request[msg] {
   r := responses[_]
 
-  response.testid(r.response) != r.testid
+  not response.service(r.response) == r.service
 
-  msg := sprintf("got testid %s, wanted %s", [
-    response.testid(r.response),
-    r.testid
+  msg := sprintf("got service %q, wanted %q", [
+    response.service(r.response), r.service
   ])
 }

--- a/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
+++ b/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
@@ -110,9 +110,8 @@ error_non_200_response [msg] {
 
 error_wrong_routing [msg] {
   wanted := "echo"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("SNI request got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("SNI request got test ID %q, wanted %q", [response.service(Response), wanted])
 }
 
 ---
@@ -139,7 +138,6 @@ error_non_200_response [msg] {
 
 error_wrong_routing [msg] {
   wanted := "echo"
-  testid := response.testid(Response)
-  testid != wanted
-  msg := sprintf("fallback request got test ID %q, wanted %q", [testid, wanted])
+  not response.service(Response) == wanted
+  msg := sprintf("SNI request got test ID %q, wanted %q", [response.service(Response), wanted])
 }

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -75,10 +75,7 @@ for t in $TAGS ; do
 done
 
 # Push test images into the cluster.
-for i in \
-    "agervais/ingress-conformance-echo:latest" \
-    "docker.io/kennethreitz/httpbin" \
-    "docker.io/projectcontour/contour-authserver:v2"
+for i in $(find "$HERE" -name "*.yaml" | xargs awk '$1=="image:"{print $2}')
 do
     docker pull "$i"
     kind::cluster::load "$i"

--- a/_integration/testsuite/policies/contour-response.rego
+++ b/_integration/testsuite/policies/contour-response.rego
@@ -14,17 +14,52 @@
 
 package contour.http.response
 
-has_testid(resp) = true {
-  resp.body.TestId
-}
-
-has_testid(resp) = false {
-  not resp.body
-}
-
-has_testid(resp) = false {
-  not resp.body.TestId
-}
+# This package contains helper functions for processing the body of
+# ingress-conformance-echo server response. The general form of the
+# response body is a JSON payload similar to this:
+#
+# {
+#  "path": "/f11887",
+#  "host": "echo.projectcontour.io",
+#  "method": "GET",
+#  "proto": "HTTP/1.1",
+#  "headers": {
+#   "Accept": [
+#    "*/*"
+#   ],
+#   "Content-Length": [
+#    "0"
+#   ],
+#   "Target-Present": [
+#    "true"
+#   ],
+#   "User-Agent": [
+#    "curl/7.72.0"
+#   ],
+#   "X-Envoy-Expected-Rq-Timeout-Ms": [
+#    "15000"
+#   ],
+#   "X-Envoy-Internal": [
+#    "true"
+#   ],
+#   "X-Forwarded-For": [
+#    "172.18.0.1"
+#   ],
+#   "X-Forwarded-Proto": [
+#    "http"
+#   ],
+#   "X-Request-Id": [
+#    "3f37abbf-35f5-423c-aafe-20b5bdaba157"
+#   ],
+#   "X-Request-Start": [
+#    "t=1602828253.669"
+#   ]
+#  },
+#  "namespace": "default",
+#  "ingress": "ingress-conformance-echo",
+#  "service": "ingress-conformance-echo",
+#  "pod": "ingress-conformance-echo-57bcd796dd-qhbpw"
+# }
 
 # Return the HTTP response body, or an empty object if there is no body.
 body(resp) = value {
@@ -38,11 +73,24 @@ body(resp) = value {
   value := resp.body
 }
 
-# Get the TestId element from a ingress-conformance-echo response
-# body. Returns "" if there is no body or no TestId response.
-testid(resp) = value {
+# Get the "service" element from a ingress-conformance-echo response
+# body. Returns "" if there is no body or no "service" element in the
+# response.
+service(resp) = value {
   b := body(resp)
-  value := object.get(b, "TestId", "")
+  value := object.get(b, "service", "")
+} else = "" {
+  true
+}
+
+# Get the "pod" element from a ingress-conformance-echo response
+# body. Returns "" if there is no body or no "pod" element in the
+# response.
+pod(resp) = value {
+  b := body(resp)
+  value := object.get(b, "pod", "")
+} else = "" {
+  true
 }
 
 # Return true if the response status matches.
@@ -50,6 +98,13 @@ status_is(resp, expected_code) = true {
   status_code := object.get(resp, "status_code", 0)
   status_code == expected_code
 } else = false {
+  true
+}
+
+# Return true if the response status matches.
+status_code(resp) = code {
+  code := object.get(resp, "status_code", 0)
+} else = 0 {
   true
 }
 
@@ -63,24 +118,9 @@ is_4xx(resp) = true {
 }
 
 # Return true if the response body reports a header with the given value.
-#
-# This function expects the respose body to be a JSON object of the form:
-#     {
-#       "TestId": "echo",
-#       "Path": "/first/allow/3666",
-#       "Host": "echo.projectcontour.io:9443",
-#       "Method": "GET",
-#       "Proto": "HTTP/1.1",
-#       "Headers": {
-#         "Auth-Context-Hostname": [
-#           "echo.projectcontour.io",
-#           "something else",
-#         ],
-#       }
-#     }
 body_has_header_value(resp, name, value) = true {
   response_body := body(resp)
-  response_headers := object.get(response_body, "Headers", {})
+  response_headers := object.get(response_body, "headers", {})
   header_values := object.get(response_headers, name, set())
 
   some v


### PR DESCRIPTION
Switch the integration test suite over to use the official
ingress-conformance-echo image. The echo server no longer emits the
value of the `TEST_ID` environment variable, but we can switch to using
`SERVICE_NAME` for the same purpose. Adding some policy helpers makes
this more consistent across test scripts.

This fixes #3034.

Signed-off-by: James Peach <jpeach@vmware.com>