### PR TITLE
deps: upgrade k8s.io/klog to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.2.0
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/controller-tools v0.2.9

--- a/internal/k8s/log.go
+++ b/internal/k8s/log.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/klog"
+	klog "k8s.io/klog/v2"
 )
 
 type klogParams struct {


### PR DESCRIPTION
Updates k8s.io/klog to v2.2.0 to match the version used by
k8s.io/client-go.

Closes #3038

Signed-off-by: Steve Kriss <krisss@vmware.com>