### PR TITLE
doc: reclassify Contour configuration as deployment

### DIFF
--- a/site/_data/main-toc.yml
+++ b/site/_data/main-toc.yml
@@ -11,14 +11,14 @@ toc:
         url: /annotations
       - page: HTTPProxy Reference
         url: /httpproxy
-      - page: Contour Configuration Reference
-        url: /configuration
       - page: API Reference
         url: /api
-  - title: Deploy
+  - title: Deployment
     subfolderitems:
       - page: Deployment Options
         url: /deploy-options
+      - page: Contour Configuration
+        url: /configuration
       - page: Upgrading Contour
         link: /resources/upgrading
       - page: Enabling TLS between Envoy and Contour


### PR DESCRIPTION
Move the Contour configuration reference under the "Deployment" heading,
since it is more properly related to that. This leaves the "Configuration"
heading more strictly aligned with configuring the Contour API.

This updates #2070.

Signed-off-by: James Peach <jpeach@vmware.com>