### PR TITLE
testsuite: add Contour installation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,7 @@ site-check: ## Test the site's links
 
 integration: ## Run integration tests against a real k8s cluster
 	./_integration/testsuite/make-kind-cluster.sh
+	./_integration/testsuite/install-contour-working.sh
 	./_integration/testsuite/install-fallback-certificate.sh
 	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml
 	./_integration/testsuite/cleanup.sh

--- a/_integration/testsuite/README.md
+++ b/_integration/testsuite/README.md
@@ -3,14 +3,30 @@
 For now, run integration tests manually.
 
 The [make-kind-cluster.sh](./make-kind-cluster.sh) script will bring up
-a local kind cluster. It will build Contour from the working repository
-and install it, along with [cert-manager](https://cert-manager.io),
-which is needed for tests that use TLS.
+a local kind cluster. This underlying VM [config](./kind-expose-port.yaml)
+forwards the Envoy ports 80 and 443 locally as port 9080 and 9443.
+The script installs [cert-manager](https://cert-manager.io), which is
+needed for tests that use TLS.
 
-You will need to install the [Integration Tester for Kubernetes](https://github.com/projectcontour/integration-tester).
+The [install-contour-working.sh](.install-contour-working.sh) script
+builds and installs Contour from the working repository.
 
-To run the tests, use the [run-test-case.sh](./run-test-case.sh)
-script. The test output can be verbose, so prefer to run one at a time.
+The [install-contour-release.sh](.install-contour-release.sh) script
+installs a specified Contour release. This is useful for doing upgrade
+testing. For example:
+
+```bash
+$ ./install-contour-release.sh v1.9.0
+...
+```
+
+To run the integration tests, you will need to install
+[Integration Tester for Kubernetes](https://github.com/projectcontour/integration-tester)
+on your development machine.
+Use the [run-test-case.sh](./run-test-case.sh) script to actually run the tests.
+The test output can be verbose, so prefer to run one at a time.
+This script assumes that HTTP and HTTPS ports are forwarded by the
+[make-kind-cluster.sh](./make-kind-cluster.sh) script.
 
 The tests for the HTTPProxy API are in the [httpproxy](./httpproxy)
 directory, with one feature tested per test document. The

--- a/_integration/testsuite/install-contour-working.sh
+++ b/_integration/testsuite/install-contour-working.sh
@@ -1,0 +1,77 @@
+#! /usr/bin/env bash
+
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# install-contour-working.sh: Install Contour from the working repo.
+
+readonly KIND=${KIND:-kind}
+readonly KUBECTL=${KUBECTL:-kubectl}
+
+readonly CLUSTERNAME=${CLUSTERNAME:-contour-integration}
+readonly WAITTIME=${WAITTIME:-5m}
+
+readonly HERE=$(cd $(dirname $0) && pwd)
+readonly REPO=$(cd ${HERE}/../.. && pwd)
+
+# List of tags to apply to the image built from the working directory.
+# The "working" tag is applied to unambigiously reference the working
+# image, since "master" and "latest" could also come from the Docker
+# registry.
+readonly TAGS="master latest working"
+
+kind::cluster::exists() {
+    ${KIND} get clusters | grep -q "$1"
+}
+
+kind::cluster::load() {
+    ${KIND} load docker-image \
+        --name "${CLUSTERNAME}" \
+        "$@"
+}
+
+if ! kind::cluster::exists "$CLUSTERNAME" ; then
+    echo "cluster $CLUSTERNAME does not exist"
+    exit 2
+fi
+
+# Build the current version of Contour.
+make -C ${REPO} container IMAGE=docker.io/projectcontour/contour VERSION="v$$"
+
+for t in $TAGS ; do
+    docker tag \
+        docker.io/projectcontour/contour:"v$$" \
+        docker.io/projectcontour/contour:$t
+done
+
+# Push the Contour build image into the cluster.
+for t in $TAGS ; do
+    kind::cluster::load docker.io/projectcontour/contour:$t
+done
+
+# Install Contour.
+#
+# NOTE(jpeach): The certgen job uses the ":latest" tag with the
+# "Latest" pull policy, which forces the kubelet to re-fetch from
+# DockerHub, which is why we have to whack the image pull policy.
+for y in ${REPO}/examples/contour/*.yaml ; do
+  ${KUBECTL} apply -f <(sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' < "$y")
+done
+
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=contour deployments --for=condition=Available
+${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=envoy pods --for=condition=Ready

--- a/_integration/testsuite/install-fallback-certificate.sh
+++ b/_integration/testsuite/install-fallback-certificate.sh
@@ -24,20 +24,10 @@ set -o nounset
 readonly KIND=${KIND:-kind}
 readonly KUBECTL=${KUBECTL:-kubectl}
 
-readonly CLUSTERNAME=${CLUSTER:-contour-integration}
 readonly WAITTIME=${WAITTIME:-5m}
 
 readonly HERE=$(cd $(dirname $0) && pwd)
 readonly REPO=$(cd ${HERE}/../.. && pwd)
-
-kind::cluster::exists() {
-    ${KIND} get clusters | grep -q "$1"
-}
-
-if ! kind::cluster::exists "$CLUSTERNAME" ; then
-    echo "cluster $CLUSTERNAME does not exist"
-    exit 2
-fi
 
 ${KUBECTL} apply -f - <<EOF
 apiVersion: cert-manager.io/v1alpha2


### PR DESCRIPTION
Separate the Contour installation from the script that builds a kind
cluster for integration testing. This makes it easier to install a
released version of Contour and test upgrading.

Signed-off-by: James Peach <jpeach@vmware.com>