### PR TITLE
site: change navbar element type

### DIFF
--- a/site/_includes/nav.html
+++ b/site/_includes/nav.html
@@ -8,7 +8,7 @@
   {% assign toc = site.data[tocTemplateName].toc %}
 
   {% for item in toc %}
-  <h3>{{ item.title }}</h3>
+  <p class="h4">{{ item.title }}</p>
   <ul>
     {% for entry in item.subfolderitems %}
     <li>


### PR DESCRIPTION
The leftmost navbar headings are `h1` elements, which means that table
of contents generators would notice them. However, for the structure of
the documentation, they should be ignored and we shoild only have to
care about the `h` elelements in the main page.

To fix this, we can use a `p` element styled like a heading. This also
fixes the inline per-page TOC which can otherwise erroneously display
the nav headings.

Signed-off-by: James Peach <jpeach@vmware.com>