### PR TITLE
Add support for custom Envoy JSON fields

### DIFF
--- a/internal/envoy/v2/accesslog.go
+++ b/internal/envoy/v2/accesslog.go
@@ -38,19 +38,14 @@ func FileAccessLogEnvoy(path string) []*accesslog.AccessLog {
 
 // FileAccessLogJSON returns a new file based access log filter
 // that will log in JSON format
-func FileAccessLogJSON(path string, keys []string) []*accesslog.AccessLog {
+func FileAccessLogJSON(path string, fields config.AccessLogFields) []*accesslog.AccessLog {
 
 	jsonformat := &_struct.Struct{
 		Fields: make(map[string]*_struct.Value),
 	}
 
-	for _, k := range keys {
-		// This will silently ignore invalid headers.
-		// TODO(youngnick): this should tell users if a header is not valid
-		// https://github.com/projectcontour/contour/issues/1507
-		if template, ok := config.JSONFields[k]; ok {
-			jsonformat.Fields[k] = sv(template)
-		}
+	for k, v := range fields.AsFieldMap() {
+		jsonformat.Fields[k] = sv(v)
 	}
 
 	return []*accesslog.AccessLog{{

--- a/internal/xdscache/v2/listener.go
+++ b/internal/xdscache/v2/listener.go
@@ -96,7 +96,7 @@ type ListenerConfig struct {
 	// AccessLogFields sets the fields that should be shown in JSON logs.
 	// Valid entries are the keys from internal/envoy/accesslog.go:jsonheaders
 	// Defaults to a particular set of fields.
-	AccessLogFields []string
+	AccessLogFields config.AccessLogFields
 
 	// RequestTimeout configures the request_timeout for all Connection Managers.
 	RequestTimeout timeout.Setting
@@ -181,7 +181,7 @@ func (lvc *ListenerConfig) accesslogType() string {
 
 // accesslogFields returns the access log fields that should be configured
 // for Envoy, or a default set if not configured.
-func (lvc *ListenerConfig) accesslogFields() []string {
+func (lvc *ListenerConfig) accesslogFields() config.AccessLogFields {
 	if lvc.AccessLogFields != nil {
 		return lvc.AccessLogFields
 	}

--- a/pkg/config/accesslog.go
+++ b/pkg/config/accesslog.go
@@ -1,36 +1,7 @@
 package config
 
-//JSONFields is the canonical translation table for JSON fields to Envoy log template formats,
-//used for specifying fields for Envoy to log when JSON logging is enabled.
-//Only fields specified in this map may be used for JSON logging.
-var JSONFields = map[string]string{
-	"@timestamp":                "%START_TIME%",
-	"ts":                        "%START_TIME%",
-	"authority":                 "%REQ(:AUTHORITY)%",
-	"bytes_received":            "%BYTES_RECEIVED%",
-	"bytes_sent":                "%BYTES_SENT%",
-	"downstream_local_address":  "%DOWNSTREAM_LOCAL_ADDRESS%",
-	"downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
-	"duration":                  "%DURATION%",
-	"method":                    "%REQ(:METHOD)%",
-	"path":                      "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
-	"protocol":                  "%PROTOCOL%",
-	"request_id":                "%REQ(X-REQUEST-ID)%",
-	"requested_server_name":     "%REQUESTED_SERVER_NAME%",
-	"response_code":             "%RESPONSE_CODE%",
-	"response_flags":            "%RESPONSE_FLAGS%",
-	"uber_trace_id":             "%REQ(UBER-TRACE-ID)%",
-	"upstream_cluster":          "%UPSTREAM_CLUSTER%",
-	"upstream_host":             "%UPSTREAM_HOST%",
-	"upstream_local_address":    "%UPSTREAM_LOCAL_ADDRESS%",
-	"upstream_service_time":     "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
-	"user_agent":                "%REQ(USER-AGENT)%",
-	"x_forwarded_for":           "%REQ(X-FORWARDED-FOR)%",
-	"x_trace_id":                "%REQ(X-TRACE-ID)%",
-}
-
 // DefaultFields are fields that will be included by default when JSON logging is enabled.
-var DefaultFields = []string{
+var DefaultFields = AccessLogFields([]string{
 	"@timestamp",
 	"authority",
 	"bytes_received",
@@ -52,7 +23,80 @@ var DefaultFields = []string{
 	"upstream_service_time",
 	"user_agent",
 	"x_forwarded_for",
-}
+})
 
 // DEFAULT_ACCESS_LOG_TYPE is the default access log format.
 const DEFAULT_ACCESS_LOG_TYPE = EnvoyAccessLog
+
+// jsonFields is the canonical translation table for JSON fields to Envoy log template formats,
+// used for specifying fields for Envoy to log when JSON logging is enabled.
+var jsonFields = map[string]string{
+	"@timestamp":            "%START_TIME%",
+	"ts":                    "%START_TIME%",
+	"authority":             "%REQ(:AUTHORITY)%",
+	"method":                "%REQ(:METHOD)%",
+	"path":                  "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+	"request_id":            "%REQ(X-REQUEST-ID)%",
+	"uber_trace_id":         "%REQ(UBER-TRACE-ID)%",
+	"upstream_service_time": "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
+	"user_agent":            "%REQ(USER-AGENT)%",
+	"x_forwarded_for":       "%REQ(X-FORWARDED-FOR)%",
+	"x_trace_id":            "%REQ(X-TRACE-ID)%",
+}
+
+// envoySimpleOperators is the list of known supported Envoy log template keywords that do not
+// have arguments nor require canonical translations.
+var envoySimpleOperators = map[string]struct{}{
+	"BYTES_RECEIVED":                                {},
+	"BYTES_SENT":                                    {},
+	"CONNECTION_ID":                                 {},
+	"CONNECTION_TERMINATION_DETAILS":                {},
+	"DOWNSTREAM_DIRECT_REMOTE_ADDRESS":              {},
+	"DOWNSTREAM_DIRECT_REMOTE_ADDRESS_WITHOUT_PORT": {},
+	"DOWNSTREAM_LOCAL_ADDRESS":                      {},
+	"DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT":         {},
+	"DOWNSTREAM_LOCAL_PORT":                         {},
+	"DOWNSTREAM_LOCAL_SUBJECT":                      {},
+	"DOWNSTREAM_LOCAL_URI_SAN":                      {},
+	"DOWNSTREAM_PEER_CERT":                          {},
+	"DOWNSTREAM_PEER_CERT_V_END":                    {},
+	"DOWNSTREAM_PEER_CERT_V_START":                  {},
+	"DOWNSTREAM_PEER_FINGERPRINT_1":                 {},
+	"DOWNSTREAM_PEER_FINGERPRINT_256":               {},
+	"DOWNSTREAM_PEER_ISSUER":                        {},
+	"DOWNSTREAM_PEER_SERIAL":                        {},
+	"DOWNSTREAM_PEER_SUBJECT":                       {},
+	"DOWNSTREAM_PEER_URI_SAN":                       {},
+	"DOWNSTREAM_REMOTE_ADDRESS":                     {},
+	"DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT":        {},
+	"DOWNSTREAM_TLS_CIPHER":                         {},
+	"DOWNSTREAM_TLS_SESSION_ID":                     {},
+	"DOWNSTREAM_TLS_VERSION":                        {},
+	"DURATION":                                      {},
+	"GRPC_STATUS":                                   {},
+	"HOSTNAME":                                      {},
+	"LOCAL_REPLY_BODY":                              {},
+	"PROTOCOL":                                      {},
+	"REQUESTED_SERVER_NAME":                         {},
+	"REQUEST_DURATION":                              {},
+	"RESPONSE_CODE":                                 {},
+	"RESPONSE_CODE_DETAILS":                         {},
+	"RESPONSE_DURATION":                             {},
+	"RESPONSE_FLAGS":                                {},
+	"RESPONSE_TX_DURATION":                          {},
+	"ROUTE_NAME":                                    {},
+	"START_TIME":                                    {},
+	"UPSTREAM_CLUSTER":                              {},
+	"UPSTREAM_HOST":                                 {},
+	"UPSTREAM_LOCAL_ADDRESS":                        {},
+	"UPSTREAM_TRANSPORT_FAILURE_REASON":             {},
+}
+
+// envoyComplexOperators is the list of known Envoy log template keywords that require
+// arguments.
+var envoyComplexOperators = map[string]struct{}{
+	"REQ":        {},
+	"RESP":       {},
+	"START_TIME": {},
+	"TRAILER":    {},
+}

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -126,6 +126,48 @@ func TestValidateAccessLogType(t *testing.T) {
 	assert.NoError(t, JSONAccessLog.Validate())
 }
 
+func TestValidateAccessLogFields(t *testing.T) {
+	errorCases := [][]string{
+		{"dog", "cat"},
+		{"req"},
+		{"resp"},
+		{"trailer"},
+		{"@timestamp", "dog"},
+		{"@timestamp", "content-id=%REQ=dog%"},
+		{"@timestamp", "content-id=%dog(%"},
+		{"@timestamp", "content-id=%REQ()%"},
+		{"@timestamp", "content-id=%DOG%"},
+		{"@timestamp", "duration=my durations % are %DURATION%.0 and %REQ(:METHOD)%"},
+		{"invalid=%REQ%"},
+		{"invalid=%TRAILER%"},
+		{"invalid=%RESP%"},
+		{"@timestamp", "invalid=%START_TIME(%s.%6f):10%"},
+	}
+
+	for _, c := range errorCases {
+		assert.Error(t, AccessLogFields(c).Validate(), c)
+	}
+
+	successCases := [][]string{
+		{"@timestamp", "method"},
+		{"start_time"},
+		{"@timestamp", "response_duration"},
+		{"@timestamp", "duration=%DURATION%.0"},
+		{"@timestamp", "duration=My duration=%DURATION%.0"},
+		{"@timestamp", "duratin=%START_TIME(%s.%6f)%"},
+		{"@timestamp", "content-id=%REQ(X-CONTENT-ID)%"},
+		{"@timestamp", "content-id=%REQ(X-CONTENT-ID):10%"},
+		{"@timestamp", "length=%RESP(CONTENT-LENGTH):10%"},
+		{"@timestamp", "trailer=%TRAILER(CONTENT-LENGTH):10%"},
+		{"@timestamp", "duration=my durations are %DURATION%.0 and method is %REQ(:METHOD)%"},
+		{"dog=pug", "cat=black"},
+	}
+
+	for _, c := range successCases {
+		assert.NoError(t, AccessLogFields(c).Validate(), c)
+	}
+}
+
 func TestValidateHTTPVersionType(t *testing.T) {
 	assert.Error(t, HTTPVersionType("").Validate())
 	assert.Error(t, HTTPVersionType("foo").Validate())


### PR DESCRIPTION
Add support for custom Envoy JSON fields via `=` in the fields name. The specify custom field name and its Envoy format string use `=` in the field name. The syntax is the following: `field_name=Envoy format string`, where Envoy format string can have any command except `DYNAMIC_METADATA` and `FILTER_STATE` commands. 

Example of custom field:

```yaml
json-fields:
  - @timestamp
  - customer_id=%REQ(X-CUSTOMER-ID)%
```

Fixes #3032, Fixes #1507

cc @KauzClay

