### PR TITLE
site: fix broken documentation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,8 +316,7 @@ site-devel: ## Launch the website in a Docker container
 
 .PHONY: site-check
 site-check: ## Test the site's links
-	docker run --rm -v $$(pwd)/site:/site -it $(JEKYLL_IMAGE) \
-		bash -c "cd /site && bundle install --path bundler/cache && bundle exec jekyll build && htmlproofer --assume-extension /site/_site"
+	docker run --rm -v $$(pwd):/src -it $(JEKYLL_IMAGE) bash -c "cd /src && ./hack/site-proofing/cibuild"
 
 integration: ## Run integration tests against a real k8s cluster
 	./_integration/testsuite/make-kind-cluster.sh

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -7,7 +7,7 @@ group :jekyll_plugins do
     gem 'jekyll-feed', '~> 0.12.1' # Create an Atom feed using the official Jekyll feed gem
     gem 'jekyll-relative-links', '~> 0.6.1' # Used to auto generate md links to html links
     gem 'jekyll-paginate', '~> 1.1' # pagination object for collections (e.g. posts)
-    gem 'html-proofer', '~> 3.13' # Link validation
+    gem 'html-proofer', '~> 3.16' # Link validation
     gem "jekyll-github-metadata", github: "jekyll/github-metadata" # TODO fork repo and update github link reference
     gem 'jekyll-optional-front-matter', '~> 0.3.2' # Parse Markdown files that do not have front-matter callouts
     gem 'jekyll-titles-from-headings', '~> 0.5.3' # pull the page title from the first Markdown heading when none is specified.)

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -23,10 +23,10 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     forwardable-extended (2.6.0)
-    html-proofer (3.13.0)
+    html-proofer (3.16.0)
       addressable (~> 2.3)
       mercenary (~> 0.3)
-      nokogiri (~> 1.10)
+      nokogumbo (~> 2.0)
       parallel (~> 1.3)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
@@ -81,12 +81,14 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.4.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.18.0)
+    parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.1)
@@ -104,16 +106,16 @@ GEM
       faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
     unicode-display_width (1.6.0)
-    yell (2.2.0)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.13)
+  html-proofer (~> 3.16)
   jekyll (~> 4)
   jekyll-feed (~> 0.12.1)
   jekyll-github-metadata!
@@ -127,4 +129,4 @@ DEPENDENCIES
   jekyll-titles-from-headings (~> 0.5.3)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/site/_posts/2020-10-07-contour_v190.md
+++ b/site/_posts/2020-10-07-contour_v190.md
@@ -42,7 +42,7 @@ https://projectcontour.io/examples/authdemo/06-proxy-auth.yaml
 ``` 
 
 ## Cross-Origin Resource Sharing (CORS) Support
-Contour’s HTTPProxy API now supports specifying a [CORS policy](https://projectcontour.io/docs/main/httpproxy/#cors-policy), which configures Envoy’s [CORS filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cors_filter) to allow web applications to request resources from different origins.
+Contour’s HTTPProxy API now supports specifying a [CORS policy](https://projectcontour.io/docs/v1.9.0/httpproxy/#cors-policy), which configures Envoy’s [CORS filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cors_filter) to allow web applications to request resources from different origins.
 
 CORS uses additional HTTP headers to tell browsers to give a web application running at one origin access to selected resources from a different origin (domain, protocol, or port) from its own.
 

--- a/site/docs/main/README.md
+++ b/site/docs/main/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: httpproxy.md
+[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/kubernetes.md %}

--- a/site/docs/main/config/annotations.md
+++ b/site/docs/main/config/annotations.md
@@ -84,6 +84,6 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
 [13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
-[15]: httpproxy.md
+[15]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
 [17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/main/config/upstream-tls.md
+++ b/site/docs/main/config/upstream-tls.md
@@ -92,5 +92,5 @@ Envoy will send the certificate during TLS handshake when the backend applicatio
 Backend applications can validate the certificate to ensure that the connection is coming from Envoy.
 
 [1]: {% link docs/{{page.version}}/config/annotations.md %}
-[2]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
+[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.Service
 [3]: /docs/{{page.version}}/configuration#fallback-certificate

--- a/site/docs/main/deploy-options.md
+++ b/site/docs/main/deploy-options.md
@@ -202,6 +202,6 @@ $ kubectl delete ns projectcontour
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
-[9]: httpproxy.md
+[9]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}
 [11]: redeploy-envoy.md


### PR DESCRIPTION
After merging #3057, we have some broken links that still point to the
now-deleted httpproxy.md page.

This fixes #3063.

Signed-off-by: James Peach <jpeach@vmware.com>