### PR TITLE
Updates Docs Site HTTProxy Example

### DIFF
--- a/site/examples/kuard-httpproxy.yaml
+++ b/site/examples/kuard-httpproxy.yaml
@@ -46,7 +46,7 @@ spec:
     fqdn: kuard.local
   routes: 
     - conditions:
-      - path: /
+      - prefix: /
       services:
         - name: kuard
           port: 80


### PR DESCRIPTION
Updates the documentation site HTTProxy example to use `prefix` instead of `path`.

Fixes: https://github.com/projectcontour/contour/issues/3065

/assign @stevesloka @jpeach 
/cc @Miciah 

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>