### PR TITLE
internal/envoy: Add xDS v3 bootstrap config file

### DIFF
--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -34,5 +34,6 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Flag("envoy-cert-file", "gRPC Client cert filename for Envoy to load.").Envar("ENVOY_CERT_FILE").StringVar(&config.GrpcClientCert)
 	bootstrap.Flag("envoy-key-file", "gRPC Client key filename for Envoy to load.").Envar("ENVOY_KEY_FILE").StringVar(&config.GrpcClientKey)
 	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&config.Namespace)
+	bootstrap.Flag("xds-resource-version", "The versions of the xDS resources to request from Contour.").StringVar((*string)(&config.XDSResourceVersion))
 	return bootstrap, &config
 }

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/pkg/config"
 )
 
 // SDSResourcesSubdirectory stores the subdirectory name where SDS path resources are stored to.
@@ -34,7 +35,7 @@ const SDSTLSCertificateFile = "xds-tls-certificate.json"
 // CA certificates for Envoy to use for the XDS gRPC connection.
 const SDSValidationContextFile = "xds-validation-context.json"
 
-// BootstrapConfig holds configuration values for a v2.Bootstrap.
+// BootstrapConfig holds configuration values for a Bootstrap configuration.
 type BootstrapConfig struct {
 	// AdminAccessLogPath is the path to write the access log for the administration server.
 	// Defaults to /dev/null.
@@ -55,6 +56,10 @@ type BootstrapConfig struct {
 	// XDSGRPCPort is the management server port that provides the v2 gRPC API.
 	// Defaults to 8001.
 	XDSGRPCPort int
+
+	// XDSResourceVersion defines the XDS Server Version to use.
+	// Defaults to "v2"
+	XDSResourceVersion config.ResourceVersion
 
 	// Namespace is the namespace where Contour is running
 	Namespace string

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -1,0 +1,320 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package envoy contains APIs for translating between Contour
+// objects and Envoy configuration APIs and types.
+
+package v3
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	envoy_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// WriteBootstrap writes bootstrap configuration to files.
+func WriteBootstrap(c *envoy.BootstrapConfig) error {
+	// Create Envoy bootstrap config and associated resource files.
+	steps, err := bootstrap(c)
+	if err != nil {
+		return err
+	}
+
+	if c.ResourcesDir != "" {
+		if err := os.MkdirAll(path.Join(c.ResourcesDir, "sds"), 0750); err != nil {
+			return err
+		}
+	}
+
+	// Write all configuration files out to filesystem.
+	for _, step := range steps {
+		if err := envoy.WriteConfig(step(c)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type bootstrapf func(*envoy.BootstrapConfig) (string, proto.Message)
+
+// bootstrap creates a new v3 bootstrap configuration and associated resource files.
+func bootstrap(c *envoy.BootstrapConfig) ([]bootstrapf, error) {
+	var steps []bootstrapf
+
+	if c.GrpcClientCert == "" && c.GrpcClientKey == "" && c.GrpcCABundle == "" {
+		steps = append(steps,
+			func(*envoy.BootstrapConfig) (string, proto.Message) {
+				return c.Path, bootstrapConfig(c)
+			})
+
+		return steps, nil
+	}
+
+	for _, f := range []string{c.GrpcClientCert, c.GrpcClientKey, c.GrpcCABundle} {
+		// If any of of the TLS options is not empty, they all must be not empty.
+		if f == "" {
+			return nil, fmt.Errorf(
+				"you must supply all TLS parameters - %q, %q, %q, or none of them",
+				"--envoy-cafile", "--envoy-cert-file", "--envoy-key-file")
+		}
+
+		if !c.SkipFilePathCheck {
+			// If the TLS secrets aren't set up properly,
+			// some files may not be present. In this case,
+			// envoy will reject the bootstrap configuration,
+			// but there is no way to detect and fix that. If
+			// we check and fail here, that is visible in the
+			// Pod lifecycle and therefore fixable.
+			fi, err := os.Stat(f)
+			if err != nil {
+				return nil, err
+			}
+			if fi.Size() == 0 {
+				return nil, fmt.Errorf("%q is empty", f)
+			}
+		}
+	}
+
+	if c.ResourcesDir == "" {
+		// For backwards compatibility, the old behavior
+		// is to use direct certificate and key file paths in
+		// bootstrap config. Envoy does not support rotation
+		// of xDS certificate files in this case.
+
+		steps = append(steps,
+			func(*envoy.BootstrapConfig) (string, proto.Message) {
+				b := bootstrapConfig(c)
+				b.StaticResources.Clusters[0].TransportSocket = UpstreamTLSTransportSocket(
+					upstreamFileTLSContext(c))
+				return c.Path, b
+			})
+
+		return steps, nil
+	}
+
+	// xDS certificate rotation is supported by Envoy by using SDS path based resource files.
+	// These files are JSON representation of the SDS protobuf messages that normally get sent over the xDS connection,
+	// but for xDS connection itself, bootstrapping is done by storing the SDS resources in a local filesystem.
+	// Envoy will monitor and reload the resource files and the certificate and key files referred from the SDS resources.
+	//
+	// Two files are written to ResourcesDir:
+	// - SDS resource for xDS client certificate and key for authenticating Envoy towards Contour.
+	// - SDS resource for trusted CA certificate for validating Contour server certificate.
+	sdsTLSCertificatePath := path.Join(c.ResourcesDir, envoy.SDSResourcesSubdirectory, envoy.SDSTLSCertificateFile)
+	sdsValidationContextPath := path.Join(c.ResourcesDir, envoy.SDSResourcesSubdirectory, envoy.SDSValidationContextFile)
+
+	steps = append(steps,
+		func(*envoy.BootstrapConfig) (string, proto.Message) {
+			return sdsTLSCertificatePath, tlsCertificateSdsSecretConfig(c)
+		},
+		func(*envoy.BootstrapConfig) (string, proto.Message) {
+			return sdsValidationContextPath, validationContextSdsSecretConfig(c)
+		},
+		func(*envoy.BootstrapConfig) (string, proto.Message) {
+			b := bootstrapConfig(c)
+			b.StaticResources.Clusters[0].TransportSocket = UpstreamTLSTransportSocket(
+				upstreamSdsTLSContext(sdsTLSCertificatePath, sdsValidationContextPath))
+			return c.Path, b
+		},
+	)
+
+	return steps, nil
+}
+
+func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
+	return &envoy_bootstrap_v3.Bootstrap{
+		DynamicResources: &envoy_bootstrap_v3.Bootstrap_DynamicResources{
+			LdsConfig: ConfigSource("contour"),
+			CdsConfig: ConfigSource("contour"),
+		},
+		StaticResources: &envoy_bootstrap_v3.Bootstrap_StaticResources{
+			Clusters: []*envoy_cluster_v3.Cluster{{
+				Name:                 "contour",
+				AltStatName:          strings.Join([]string{c.Namespace, "contour", strconv.Itoa(c.GetXdsGRPCPort())}, "_"),
+				ConnectTimeout:       protobuf.Duration(5 * time.Second),
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
+				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
+					ClusterName: "contour",
+					Endpoints: Endpoints(
+						SocketAddress(c.GetXdsAddress(), c.GetXdsGRPCPort()),
+					),
+				},
+				UpstreamConnectionOptions: &envoy_cluster_v3.UpstreamConnectionOptions{
+					TcpKeepalive: &envoy_core_v3.TcpKeepalive{
+						KeepaliveProbes:   protobuf.UInt32(3),
+						KeepaliveTime:     protobuf.UInt32(30),
+						KeepaliveInterval: protobuf.UInt32(5),
+					},
+				},
+				Http2ProtocolOptions: new(envoy_core_v3.Http2ProtocolOptions), // enables http2
+				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
+					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+						Priority:           envoy_core_v3.RoutingPriority_HIGH,
+						MaxConnections:     protobuf.UInt32(100000),
+						MaxPendingRequests: protobuf.UInt32(100000),
+						MaxRequests:        protobuf.UInt32(60000000),
+						MaxRetries:         protobuf.UInt32(50),
+					}, {
+						Priority:           envoy_core_v3.RoutingPriority_DEFAULT,
+						MaxConnections:     protobuf.UInt32(100000),
+						MaxPendingRequests: protobuf.UInt32(100000),
+						MaxRequests:        protobuf.UInt32(60000000),
+						MaxRetries:         protobuf.UInt32(50),
+					}},
+				},
+			}, {
+				Name:                 "service-stats",
+				AltStatName:          strings.Join([]string{c.Namespace, "service-stats", strconv.Itoa(c.GetAdminPort())}, "_"),
+				ConnectTimeout:       protobuf.Duration(250 * time.Millisecond),
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_LOGICAL_DNS),
+				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
+				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
+					ClusterName: "service-stats",
+					Endpoints: Endpoints(
+						SocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
+					),
+				},
+			}},
+		},
+		Admin: &envoy_bootstrap_v3.Admin{
+			AccessLogPath: c.GetAdminAccessLogPath(),
+			Address:       SocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
+		},
+	}
+}
+
+func upstreamFileTLSContext(c *envoy.BootstrapConfig) *envoy_tls_v3.UpstreamTlsContext {
+	context := &envoy_tls_v3.UpstreamTlsContext{
+		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+			TlsCertificates: []*envoy_tls_v3.TlsCertificate{{
+				CertificateChain: &envoy_core_v3.DataSource{
+					Specifier: &envoy_core_v3.DataSource_Filename{
+						Filename: c.GrpcClientCert,
+					},
+				},
+				PrivateKey: &envoy_core_v3.DataSource{
+					Specifier: &envoy_core_v3.DataSource_Filename{
+						Filename: c.GrpcClientKey,
+					},
+				},
+			}},
+			ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContext{
+				ValidationContext: &envoy_tls_v3.CertificateValidationContext{
+					TrustedCa: &envoy_core_v3.DataSource{
+						Specifier: &envoy_core_v3.DataSource_Filename{
+							Filename: c.GrpcCABundle,
+						},
+					},
+					// TODO(youngnick): Does there need to be a flag wired down to here?
+					MatchSubjectAltNames: []*envoy_matcher_v3.StringMatcher{{
+						MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{
+							Exact: "contour",
+						}},
+					},
+				},
+			},
+		},
+	}
+	return context
+}
+
+func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_tls_v3.UpstreamTlsContext {
+	context := &envoy_tls_v3.UpstreamTlsContext{
+		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+			TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
+				SdsConfig: &envoy_core_v3.ConfigSource{
+					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{
+						Path: certificateSdsFile,
+					},
+				},
+			}},
+			ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
+				ValidationContextSdsSecretConfig: &envoy_tls_v3.SdsSecretConfig{
+					SdsConfig: &envoy_core_v3.ConfigSource{
+						ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{
+							Path: validationSdsFile,
+						},
+					},
+				},
+			},
+		},
+	}
+	return context
+}
+
+// tlsCertificateSdsSecretConfig creates DiscoveryResponse with file based SDS resource
+// including paths to TLS certificates and key
+func tlsCertificateSdsSecretConfig(c *envoy.BootstrapConfig) *envoy_service_discovery_v3.DiscoveryResponse {
+	secret := &envoy_tls_v3.Secret{
+		Type: &envoy_tls_v3.Secret_TlsCertificate{
+			TlsCertificate: &envoy_tls_v3.TlsCertificate{
+				CertificateChain: &envoy_core_v3.DataSource{
+					Specifier: &envoy_core_v3.DataSource_Filename{
+						Filename: c.GrpcClientCert,
+					},
+				},
+				PrivateKey: &envoy_core_v3.DataSource{
+					Specifier: &envoy_core_v3.DataSource_Filename{
+						Filename: c.GrpcClientKey,
+					},
+				},
+			},
+		},
+	}
+
+	return &envoy_service_discovery_v3.DiscoveryResponse{
+		Resources: []*any.Any{protobuf.MustMarshalAny(secret)},
+	}
+}
+
+// validationContextSdsSecretConfig creates DiscoveryResponse with file based SDS resource
+// including path to CA certificate bundle
+func validationContextSdsSecretConfig(c *envoy.BootstrapConfig) *envoy_service_discovery_v3.DiscoveryResponse {
+	secret := &envoy_tls_v3.Secret{
+		Type: &envoy_tls_v3.Secret_ValidationContext{
+			ValidationContext: &envoy_tls_v3.CertificateValidationContext{
+				TrustedCa: &envoy_core_v3.DataSource{
+					Specifier: &envoy_core_v3.DataSource_Filename{
+						Filename: c.GrpcCABundle,
+					},
+				},
+				MatchSubjectAltNames: []*envoy_matcher_v3.StringMatcher{{
+					MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{
+						Exact: "contour",
+					}},
+				},
+			},
+		},
+	}
+
+	return &envoy_service_discovery_v3.DiscoveryResponse{
+		Resources: []*any.Any{protobuf.MustMarshalAny(secret)},
+	}
+}

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -1,0 +1,1075 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"path"
+	"testing"
+
+	envoy_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBootstrap(t *testing.T) {
+	tests := map[string]struct {
+		config                        envoy.BootstrapConfig
+		wantedBootstrapConfig         string
+		wantedTLSCertificateConfig    string
+		wantedValidationContextConfig string
+		wantedError                   bool
+	}{
+		"default configuration": {
+			config: envoy.BootstrapConfig{
+				Path:      "envoy.json",
+				Namespace: "testing-ns"},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+	 	"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+ 	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--admin-address=8.8.8.8 --admin-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:         "envoy.json",
+				AdminAddress: "8.8.8.8",
+				AdminPort:    9200,
+				Namespace:    "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9200",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "8.8.8.8",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "8.8.8.8",
+        "port_value": 9200
+      }
+    }
+  }
+}`,
+		},
+		"AdminAccessLogPath": { // TODO(dfc) doesn't appear to be exposed via contour bootstrap
+			config: envoy.BootstrapConfig{
+				Path:               "envoy.json",
+				AdminAccessLogPath: "/var/log/admin.log",
+				Namespace:          "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/var/log/admin.log",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--xds-address=8.8.8.8 --xds-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:        "envoy.json",
+				XDSAddress:  "8.8.8.8",
+				XDSGRPCPort: 9200,
+				Namespace:   "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_9200",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "8.8.8.8",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--stats-address=8.8.8.8 --stats-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:      "envoy.json",
+				Namespace: "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+ "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--envoy-cafile=CA.cert --envoy-client-cert=client.cert --envoy-client-key=client.key": {
+			config: envoy.BootstrapConfig{
+				Path:              "envoy.json",
+				Namespace:         "testing-ns",
+				GrpcCABundle:      "CA.cert",
+				GrpcClientCert:    "client.cert",
+				GrpcClientKey:     "client.key",
+				SkipFilePathCheck: true,
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "http2_protocol_options": {},
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        },
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "common_tls_context": {
+              "tls_certificates": [
+                {
+                  "certificate_chain": {
+                    "filename": "client.cert"
+                  },
+                  "private_key": {
+                    "filename": "client.key"
+                  }
+                }
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                  "filename": "CA.cert"
+                },
+		"match_subject_alt_names": [
+		  {
+		    "exact": "contour"
+		  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+ 		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--resources-dir tmp --envoy-cafile=CA.cert --envoy-client-cert=client.cert --envoy-client-key=client.key": {
+			config: envoy.BootstrapConfig{
+				Path:              "envoy.json",
+				Namespace:         "testing-ns",
+				ResourcesDir:      "resources",
+				GrpcCABundle:      "CA.cert",
+				GrpcClientCert:    "client.cert",
+				GrpcClientKey:     "client.key",
+				SkipFilePathCheck: true,
+			},
+			wantedBootstrapConfig: `{
+        "static_resources": {
+          "clusters": [
+            {
+              "name": "contour",
+              "alt_stat_name": "testing-ns_contour_8001",
+              "type": "STRICT_DNS",
+              "connect_timeout": "5s",
+              "load_assignment": {
+                "cluster_name": "contour",
+                "endpoints": [
+                  {
+                    "lb_endpoints": [
+                      {
+                        "endpoint": {
+                          "address": {
+                            "socket_address": {
+                              "address": "127.0.0.1",
+                              "port_value": 8001
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "circuit_breakers": {
+                "thresholds": [
+                  {
+                    "priority": "HIGH",
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 60000000,
+                    "max_retries": 50
+                  },
+                  {
+                    "max_connections": 100000,
+                    "max_pending_requests": 100000,
+                    "max_requests": 60000000,
+                    "max_retries": 50
+                  }
+                ]
+              },
+              "http2_protocol_options": {},
+              "transport_socket": {
+                "name": "envoy.transport_sockets.tls",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+                  "common_tls_context": {
+                    "tls_certificate_sds_secret_configs": [
+                      {
+                        "sds_config": {
+                          "path": "resources/sds/xds-tls-certificate.json"
+                        }
+                      }
+                    ],
+                    "validation_context_sds_secret_config": {
+                      "sds_config": {
+                        "path": "resources/sds/xds-validation-context.json"
+                      }
+                    }
+                  }
+                }
+              },
+              "upstream_connection_options": {
+                "tcp_keepalive": {
+                  "keepalive_probes": 3,
+                  "keepalive_time": 30,
+                  "keepalive_interval": 5
+                }
+              }
+            },
+            {
+              "name": "service-stats",
+              "alt_stat_name": "testing-ns_service-stats_9001",
+              "type": "LOGICAL_DNS",
+              "connect_timeout": "0.250s",
+              "load_assignment": {
+                "cluster_name": "service-stats",
+                "endpoints": [
+                  {
+                    "lb_endpoints": [
+                      {
+                        "endpoint": {
+                          "address": {
+                            "socket_address": {
+                              "address": "127.0.0.1",
+                              "port_value": 9001
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "dynamic_resources": {
+          "lds_config": {
+            "api_config_source": {
+              "api_type": "GRPC",
+              "transport_api_version": "V3",
+              "grpc_services": [
+                {
+                  "envoy_grpc": {
+                    "cluster_name": "contour"
+                  }
+                }
+              ]
+            },
+            "resource_api_version": "V3"
+          },
+          "cds_config": {
+            "api_config_source": {
+              "api_type": "GRPC",
+              "transport_api_version": "V3",
+              "grpc_services": [
+                {
+                  "envoy_grpc": {
+                    "cluster_name": "contour"
+                  }
+                }
+              ]
+            },
+            "resource_api_version": "V3"
+          }
+        },
+        "admin": {
+          "access_log_path": "/dev/null",
+          "address": {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 9001
+            }
+          }
+        }
+    }`,
+			wantedTLSCertificateConfig: `{
+      "resources": [
+        {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+          "tls_certificate": {
+            "certificate_chain": {
+              "filename": "client.cert"
+            },
+            "private_key": {
+              "filename": "client.key"
+            }
+          }
+        }
+      ]
+    }`,
+			wantedValidationContextConfig: `{
+      "resources": [
+        {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+          "validation_context": {
+            "trusted_ca": {
+              "filename": "CA.cert"
+            },
+            "match_subject_alt_names": [
+              {
+                "exact": "contour"
+              }
+            ]
+          }
+        }
+      ]
+    }`,
+		},
+		"return error when not providing all certificate related parameters": {
+			config: envoy.BootstrapConfig{
+				Path:           "envoy.json",
+				Namespace:      "testing-ns",
+				ResourcesDir:   "resources",
+				GrpcClientCert: "client.cert",
+				GrpcClientKey:  "client.key",
+			},
+			wantedError: true,
+		}}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			steps, gotError := bootstrap(&tc.config)
+			assert.Equal(t, gotError != nil, tc.wantedError)
+
+			gotConfigs := map[string]proto.Message{}
+			for _, step := range steps {
+				path, config := step(&tc.config)
+				gotConfigs[path] = config
+			}
+
+			sdsTLSCertificatePath := path.Join(tc.config.ResourcesDir, envoy.SDSResourcesSubdirectory, envoy.SDSTLSCertificateFile)
+			sdsValidationContextPath := path.Join(tc.config.ResourcesDir, envoy.SDSResourcesSubdirectory, envoy.SDSValidationContextFile)
+
+			if tc.wantedBootstrapConfig != "" {
+				want := new(envoy_bootstrap_v3.Bootstrap)
+				unmarshal(t, tc.wantedBootstrapConfig, want)
+				protobuf.ExpectEqual(t, want, gotConfigs[tc.config.Path])
+				delete(gotConfigs, tc.config.Path)
+			}
+
+			if tc.wantedTLSCertificateConfig != "" {
+				want := new(envoy_service_discovery_v3.DiscoveryResponse)
+				unmarshal(t, tc.wantedTLSCertificateConfig, want)
+				protobuf.ExpectEqual(t, want, gotConfigs[sdsTLSCertificatePath])
+				delete(gotConfigs, sdsTLSCertificatePath)
+			}
+
+			if tc.wantedValidationContextConfig != "" {
+				want := new(envoy_service_discovery_v3.DiscoveryResponse)
+				unmarshal(t, tc.wantedValidationContextConfig, want)
+				protobuf.ExpectEqual(t, want, gotConfigs[sdsValidationContextPath])
+				delete(gotConfigs, sdsValidationContextPath)
+			}
+
+			if len(gotConfigs) > 0 {
+				t.Fatalf("got more configs than wanted: %s", gotConfigs)
+			}
+		})
+	}
+}
+
+func unmarshal(t *testing.T, data string, pb proto.Message) {
+	err := jsonpb.UnmarshalString(data, pb)
+	checkErr(t, err)
+}
+
+func checkErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -1,0 +1,44 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+// ConfigSource returns a *envoy_core_v3.ConfigSource for cluster.
+func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
+	return &envoy_core_v3.ConfigSource{
+		ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+		ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &envoy_core_v3.ApiConfigSource{
+				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				GrpcServices: []*envoy_core_v3.GrpcService{{
+					TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+							ClusterName: cluster,
+						},
+					},
+				}},
+			},
+		},
+	}
+}
+
+// ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
+func ClusterDiscoveryType(t envoy_cluster_v3.Cluster_DiscoveryType) *envoy_cluster_v3.Cluster_Type {
+	return &envoy_cluster_v3.Cluster_Type{Type: t}
+}

--- a/internal/envoy/v3/endpoint.go
+++ b/internal/envoy/v3/endpoint.go
@@ -1,0 +1,43 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+)
+
+// LBEndpoint creates a new LbEndpoint.
+func LBEndpoint(addr *envoy_core_v3.Address) *envoy_endpoint_v3.LbEndpoint {
+	return &envoy_endpoint_v3.LbEndpoint{
+		HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+			Endpoint: &envoy_endpoint_v3.Endpoint{
+				Address: addr,
+			},
+		},
+	}
+}
+
+// Endpoints returns a slice of LocalityLbEndpoints.
+// The slice contains one entry, with one LbEndpoint per
+// *envoy_core_v3.Address supplied.
+func Endpoints(addrs ...*envoy_core_v3.Address) []*envoy_endpoint_v3.LocalityLbEndpoints {
+	lbendpoints := make([]*envoy_endpoint_v3.LbEndpoint, 0, len(addrs))
+	for _, addr := range addrs {
+		lbendpoints = append(lbendpoints, LBEndpoint(addr))
+	}
+	return []*envoy_endpoint_v3.LocalityLbEndpoints{{
+		LbEndpoints: lbendpoints,
+	}}
+}

--- a/internal/envoy/v3/endpoint_test.go
+++ b/internal/envoy/v3/endpoint_test.go
@@ -1,0 +1,33 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+func TestLBEndpoint(t *testing.T) {
+	got := LBEndpoint(SocketAddress("microsoft.com", 81))
+	want := &envoy_endpoint_v3.LbEndpoint{
+		HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+			Endpoint: &envoy_endpoint_v3.Endpoint{
+				Address: SocketAddress("microsoft.com", 81),
+			},
+		},
+	}
+	protobuf.ExpectEqual(t, want, got)
+}

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -1,0 +1,47 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+// SocketAddress creates a new TCP envoy_core_v3.Address.
+func SocketAddress(address string, port int) *envoy_core_v3.Address {
+	if address == "::" {
+		return &envoy_core_v3.Address{
+			Address: &envoy_core_v3.Address_SocketAddress{
+				SocketAddress: &envoy_core_v3.SocketAddress{
+					Protocol:   envoy_core_v3.SocketAddress_TCP,
+					Address:    address,
+					Ipv4Compat: true,
+					PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
+						PortValue: uint32(port),
+					},
+				},
+			},
+		}
+	}
+	return &envoy_core_v3.Address{
+		Address: &envoy_core_v3.Address_SocketAddress{
+			SocketAddress: &envoy_core_v3.SocketAddress{
+				Protocol: envoy_core_v3.SocketAddress_TCP,
+				Address:  address,
+				PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
+					PortValue: uint32(port),
+				},
+			},
+		},
+	}
+}

--- a/internal/envoy/v3/socket.go
+++ b/internal/envoy/v3/socket.go
@@ -1,0 +1,40 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// UpstreamTLSTransportSocket returns a custom transport socket using the UpstreamTlsContext provided.
+func UpstreamTLSTransportSocket(tls *envoy_tls_v3.UpstreamTlsContext) *envoy_core_v3.TransportSocket {
+	return &envoy_core_v3.TransportSocket{
+		Name: "envoy.transport_sockets.tls",
+		ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: protobuf.MustMarshalAny(tls),
+		},
+	}
+}
+
+// DownstreamTLSTransportSocket returns a custom transport socket using the DownstreamTlsContext provided.
+func DownstreamTLSTransportSocket(tls *envoy_tls_v3.DownstreamTlsContext) *envoy_core_v3.TransportSocket {
+	return &envoy_core_v3.TransportSocket{
+		Name: "envoy.transport_sockets.tls",
+		ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: protobuf.MustMarshalAny(tls),
+		},
+	}
+}

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -59,14 +59,14 @@ func ValidateServerTypes(p *Parameters) error {
 
 }
 
-// ServerVersion is a version of an xDS server.
-type ServerVersion string
+// ResourceVersion is a version of an xDS server.
+type ResourceVersion string
 
-const XDSv2 ServerVersion = "v2"
-const XDSv3 ServerVersion = "v3"
+const XDSv2 ResourceVersion = "v2"
+const XDSv3 ResourceVersion = "v3"
 
 // Validate the xDS server versions.
-func (s ServerVersion) Validate() error {
+func (s ResourceVersion) Validate() error {
 	switch s {
 	case XDSv2, XDSv3:
 		return nil
@@ -253,7 +253,7 @@ type ServerParameters struct {
 
 	// Defines the XDS Server Versions to use for `contour serve`
 	// Defaults to "v2"
-	XDSServerVersions []ServerVersion `yaml:"xds-server-versions"`
+	XDSServerVersions []ResourceVersion `yaml:"xds-server-versions"`
 }
 
 // LeaderElectionParameters holds the config bits for leader election
@@ -471,9 +471,9 @@ func (p *Parameters) Validate() error {
 	return nil
 }
 
-func uniqueServerVersions(input []ServerVersion) []ServerVersion {
-	keys := make(map[ServerVersion]bool)
-	var list []ServerVersion
+func uniqueServerVersions(input []ResourceVersion) []ResourceVersion {
+	keys := make(map[ResourceVersion]bool)
+	var list []ResourceVersion
 	for _, entry := range input {
 		if _, value := keys[entry]; !value {
 			keys[entry] = true
@@ -493,7 +493,7 @@ func Defaults() Parameters {
 		Kubeconfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		Server: ServerParameters{
 			XDSServerType:     ContourServerType,
-			XDSServerVersions: []ServerVersion{XDSv2},
+			XDSServerVersions: []ResourceVersion{XDSv2},
 		},
 		IngressStatusAddress:  "",
 		AccessLogFormat:       DEFAULT_ACCESS_LOG_TYPE,

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -97,8 +97,8 @@ foo: bad
 
 func TestValidateXDSServerVersions(t *testing.T) {
 	type testcase struct {
-		versions      []ServerVersion
-		want          []ServerVersion
+		versions      []ResourceVersion
+		want          []ResourceVersion
 		expectedError error
 	}
 
@@ -120,26 +120,26 @@ func TestValidateXDSServerVersions(t *testing.T) {
 	}
 
 	run(t, "simple", testcase{
-		versions:      []ServerVersion{"v2"},
-		want:          []ServerVersion{"v2"},
+		versions:      []ResourceVersion{"v2"},
+		want:          []ResourceVersion{"v2"},
 		expectedError: nil,
 	})
 
 	run(t, "simple two versions", testcase{
-		versions:      []ServerVersion{"v2", "v3"},
-		want:          []ServerVersion{"v2", "v3"},
+		versions:      []ResourceVersion{"v2", "v3"},
+		want:          []ResourceVersion{"v2", "v3"},
 		expectedError: nil,
 	})
 
 	run(t, "case invalid", testcase{
-		versions:      []ServerVersion{"V2"},
-		want:          []ServerVersion{"V2"},
+		versions:      []ResourceVersion{"V2"},
+		want:          []ResourceVersion{"V2"},
 		expectedError: fmt.Errorf("invalid xDS version \"V2\""),
 	})
 
 	run(t, "duplicated versions", testcase{
-		versions:      []ServerVersion{"v2", "v2", "v2"},
-		want:          []ServerVersion{"v2"},
+		versions:      []ResourceVersion{"v2", "v2", "v2"},
+		want:          []ResourceVersion{"v2"},
 		expectedError: nil,
 	})
 }


### PR DESCRIPTION
Adds new config file option to generate a v3 xDS boostrap configuration file.
To generate the v3 version a new arg is passed to the bootstrap config file (`--xds-server-version`)
which defaults to v2, but passing v3 will generate a v3 config.

Updates #1898