### PR TITLE
WiP internal: program 503 routes for misconfigured services

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -462,11 +462,9 @@ func TestHTTPProxyMetrics(t *testing.T) {
 		wantIR: nil,
 		wantProxy: &metrics.RouteMetric{
 			Invalid: map[metrics.Meta]int{
-				{Namespace: "roots"}: 1,
+				{Namespace: "roots"}: 2,
 			},
-			Valid: map[metrics.Meta]int{
-				{Namespace: "roots", VHost: "example.com"}: 1,
-			},
+			Valid:    map[metrics.Meta]int{},
 			Orphaned: map[metrics.Meta]int{},
 			Root: map[metrics.Meta]int{
 				{Namespace: "roots", VHost: "example.com"}: 1,

--- a/internal/featuretests/v2/secrets_test.go
+++ b/internal/featuretests/v2/secrets_test.go
@@ -84,9 +84,10 @@ func TestSDSVisibility(t *testing.T) {
 	rh.OnAdd(i1)
 
 	// i1 has a default route to backend:80, but there is no matching service.
+	// Secret s1 will be served since there is still active route for generating 503 Service Unavailable response.
 	c.Request(secretType).Equals(&envoy_api_v2.DiscoveryResponse{
 		VersionInfo: "1",
-		Resources:   nil,
+		Resources:   resources(t, secret(s1)),
 		TypeUrl:     secretType,
 		Nonce:       "1",
 	})


### PR DESCRIPTION
Program Envoy with routes that return 503 for misconfigured services.
This avoids unnecessarily taking vhost down or leaking requests into
wrong backend when Ingress has several routes and one of those is
misconfigured.

Fixes #3039

Signed-off-by: Tero Saarni <tero.saarni@est.tech>