### PR TITLE
config: Change xds-server-version to be plural and serve multiple xDS versions

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -48,7 +48,6 @@ import (
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	"gopkg.in/alecthomas/kingpin.v2"
 	corev1 "k8s.io/api/core/v1"
 	networking_api_v1beta1 "k8s.io/api/networking/v1beta1"
@@ -649,31 +648,32 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		}
 		log.Printf("informer caches synced")
 
-		var grpcServer *grpc.Server
+		grpcServer := xds.NewServer(registry, ctx.grpcOptions(log)...)
 
 		switch ctx.Config.Server.XDSServerType {
-		case config.ContourServerType:
-			switch ctx.Config.Server.XDSServerVersion {
-			case config.XDSv3:
-				grpcServer = contour_xds_v3.RegisterServer(
-					contour_xds_v3.NewContourServer(log, xdscache.ResourcesOf(resources)...),
-					registry,
-					ctx.grpcOptions(log)...)
-			default:
-				grpcServer = contour_xds_v2.RegisterServer(
-					contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...),
-					registry,
-					ctx.grpcOptions(log)...)
-			}
 		case config.EnvoyServerType:
-			switch ctx.Config.Server.XDSServerVersion {
-			case config.XDSv3:
-				log.Fatalf("xDS server type %q not yet implemented for server type %q!", ctx.Config.Server.XDSServerVersion, ctx.Config.Server.XDSServerType)
-			default:
-				grpcServer = contour_xds_v2.RegisterServer(
-					envoy_server_v2.NewServer(context.Background(), snapshotCache, nil),
-					registry,
-					ctx.grpcOptions(log)...)
+			for _, ver := range ctx.Config.Server.XDSServerVersions {
+				switch ver {
+				case config.XDSv2:
+					contour_xds_v2.RegisterServer(envoy_server_v2.NewServer(context.Background(), snapshotCache, nil), grpcServer)
+				case config.XDSv3:
+					log.Fatalf("xDS server type %q not yet implemented for server type %q!", ver, ctx.Config.Server.XDSServerType)
+				default:
+					log.Fatalf("xDS server version %q is not valid", ver)
+				}
+			}
+		case config.ContourServerType:
+			for _, ver := range ctx.Config.Server.XDSServerVersions {
+				switch ver {
+				case config.XDSv2:
+					server := contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...)
+					contour_xds_v2.RegisterServer(server, grpcServer)
+				case config.XDSv3:
+					server := contour_xds_v3.NewContourServer(log, xdscache.ResourcesOf(resources)...)
+					contour_xds_v3.RegisterServer(server, grpcServer)
+				default:
+					log.Fatalf("xDS server version %q is not valid", ver)
+				}
 			}
 		default:
 			// XXX(jpeach) can't happen due to config validation.
@@ -691,7 +691,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			log = log.WithField("insecure", true)
 		}
 
-		log.Infof("started xDS server type: %q version: %q", ctx.Config.Server.XDSServerType, ctx.Config.Server.XDSServerVersion)
+		log.Infof("started xDS server type: %q versions: %q", ctx.Config.Server.XDSServerType, ctx.Config.Server.XDSServerVersions)
 		defer log.Info("stopped xDS server")
 
 		go func() {

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -10,8 +10,9 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
-    #   specify the xDS version to use when serving resources to Envoy.
-    #   xds-server-version: v2
+    #   specify the xDS versions to use when serving resources to Envoy.
+    #   xds-server-versions:
+    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -44,8 +44,9 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
-    #   specify the xDS version to use when serving resources to Envoy.
-    #   xds-server-version: v2
+    #   specify the xDS versions to use when serving resources to Envoy.
+    #   xds-server-versions:
+    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/internal/xds/server.go
+++ b/internal/xds/server.go
@@ -1,0 +1,45 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+)
+
+// If registry is non-nil gRPC server metrics will be automatically
+// configured and enabled.
+func NewServer(registry *prometheus.Registry, opts ...grpc.ServerOption) *grpc.Server {
+	var metrics *grpc_prometheus.ServerMetrics
+
+	// TODO: Decouple registry from this.
+	if registry != nil {
+		metrics = grpc_prometheus.NewServerMetrics()
+		registry.MustRegister(metrics)
+
+		opts = append(opts,
+			grpc.StreamInterceptor(metrics.StreamServerInterceptor()),
+			grpc.UnaryInterceptor(metrics.UnaryServerInterceptor()),
+		)
+	}
+
+	g := grpc.NewServer(opts...)
+
+	if metrics != nil {
+		metrics.InitializeMetrics(g)
+	}
+
+	return g
+}

--- a/internal/xdscache/v2/server_test.go
+++ b/internal/xdscache/v2/server_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/internal/xds"
+
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
@@ -206,7 +208,8 @@ func TestGRPC(t *testing.T) {
 				FieldLogger: log,
 			}
 
-			srv := contour_xds_v2.RegisterServer(contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...), nil)
+			srv := xds.NewServer(nil)
+			contour_xds_v2.RegisterServer(contour_xds_v2.NewContourServer(log, xdscache.ResourcesOf(resources)...), srv)
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			done := make(chan error, 1)

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -111,7 +111,7 @@ The server configuration block can be used to configure various settings for the
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | xds-server-type | string | contour | This field specifies the xDS Server to use. Options are `contour` or `envoy`.  |
-| xds-server-version | string | v2 | This field specifies the xDS Server version to use. Options are `v2` or `v3`.  |
+| xds-server-versions | []string | [v2] | This field specifies the xDS Server versions to use. Options are `v2` & `v3`.  |
 {: class="table thead-dark table-bordered"}
 <br>
 
@@ -130,6 +130,9 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
+    #   specify the xDS versions to use when serving resources to Envoy.
+    #   xds-server-versions:
+    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true


### PR DESCRIPTION
Changes the xds-server-version config item to be plural so that users can specify a set
of xDS versions Contour will serve. Defaults to V2 only for now.

Updates #1898
Updates #3047 

Signed-off-by: Steve Sloka <slokas@vmware.com>