### PR TITLE
cmd/contour: Remove xds-server-version config parameter

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -11,8 +11,6 @@ data:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
     #   specify the xDS versions to use when serving resources to Envoy.
-    #   xds-server-versions:
-    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -45,8 +45,6 @@ data:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
     #   specify the xDS versions to use when serving resources to Envoy.
-    #   xds-server-versions:
-    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -37,8 +36,6 @@ debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
   xds-server-type: contour
-  xds-server-versions:
-  - v2
 accesslog-format: envoy
 json-fields:
 - '@timestamp'
@@ -93,55 +90,6 @@ foo: bad
 `
 	_, err := Parse(strings.NewReader(badYAML))
 	require.Error(t, err)
-}
-
-func TestValidateXDSServerVersions(t *testing.T) {
-	type testcase struct {
-		versions      []ResourceVersion
-		want          []ResourceVersion
-		expectedError error
-	}
-
-	run := func(t *testing.T, name string, tc testcase) {
-		t.Helper()
-
-		t.Run(name, func(t *testing.T) {
-			t.Helper()
-
-			p := &Parameters{
-				Server: ServerParameters{
-					XDSServerVersions: tc.versions,
-				},
-			}
-			goterror := ValidateServerTypes(p)
-			assert.Equal(t, tc.want, p.Server.XDSServerVersions)
-			assert.Equal(t, tc.expectedError, goterror)
-		})
-	}
-
-	run(t, "simple", testcase{
-		versions:      []ResourceVersion{"v2"},
-		want:          []ResourceVersion{"v2"},
-		expectedError: nil,
-	})
-
-	run(t, "simple two versions", testcase{
-		versions:      []ResourceVersion{"v2", "v3"},
-		want:          []ResourceVersion{"v2", "v3"},
-		expectedError: nil,
-	})
-
-	run(t, "case invalid", testcase{
-		versions:      []ResourceVersion{"V2"},
-		want:          []ResourceVersion{"V2"},
-		expectedError: fmt.Errorf("invalid xDS version \"V2\""),
-	})
-
-	run(t, "duplicated versions", testcase{
-		versions:      []ResourceVersion{"v2", "v2", "v2"},
-		want:          []ResourceVersion{"v2"},
-		expectedError: nil,
-	})
 }
 
 func TestValidateClusterDNSFamilyType(t *testing.T) {


### PR DESCRIPTION
Remove the xds-server-version from the Contour configuration file. The original
intent was to allow users to specify the xDS resource version Contour would serve
to Envoy clients, but is now no longer needed.

Signed-off-by: Steve Sloka <slokas@vmware.com>