### PR TITLE
cmd/contour: fix bootstrap xDS version default

### DIFF
--- a/_integration/testsuite/install-contour-working.sh
+++ b/_integration/testsuite/install-contour-working.sh
@@ -31,9 +31,9 @@ readonly REPO=$(cd ${HERE}/../.. && pwd)
 
 # List of tags to apply to the image built from the working directory.
 # The "working" tag is applied to unambigiously reference the working
-# image, since "master" and "latest" could also come from the Docker
+# image, since "main" and "latest" could also come from the Docker
 # registry.
-readonly TAGS="master latest working"
+readonly TAGS="main latest working"
 
 kind::cluster::exists() {
     ${KIND} get clusters | grep -q "$1"

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -34,6 +34,6 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Flag("envoy-cert-file", "gRPC Client cert filename for Envoy to load.").Envar("ENVOY_CERT_FILE").StringVar(&config.GrpcClientCert)
 	bootstrap.Flag("envoy-key-file", "gRPC Client key filename for Envoy to load.").Envar("ENVOY_KEY_FILE").StringVar(&config.GrpcClientKey)
 	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&config.Namespace)
-	bootstrap.Flag("xds-resource-version", "The versions of the xDS resources to request from Contour.").StringVar((*string)(&config.XDSResourceVersion))
+	bootstrap.Flag("xds-resource-version", "The versions of the xDS resources to request from Contour.").Default("v2").StringVar((*string)(&config.XDSResourceVersion))
 	return bootstrap, &config
 }


### PR DESCRIPTION
Set "v2" as the xDS bootstrap default (for now) so that the bootstrapper
doesn't fail if the flag isn't given. Fix the integration test script
to populate the right image tags.

Signed-off-by: James Peach <jpeach@vmware.com>