### PR TITLE
internal/envoy: Refactor the regex file into the v2 package

### DIFF
--- a/internal/envoy/v2/regex.go
+++ b/internal/envoy/v2/regex.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package v2
 
 import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"

--- a/internal/envoy/v2/regex_test.go
+++ b/internal/envoy/v2/regex_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package v2
 
 import (
 	"testing"

--- a/internal/envoy/v2/route.go
+++ b/internal/envoy/v2/route.go
@@ -63,7 +63,7 @@ func RouteMatch(route *dag.Route) *envoy_api_v2_route.RouteMatch {
 	case *dag.RegexMatchCondition:
 		return &envoy_api_v2_route.RouteMatch{
 			PathSpecifier: &envoy_api_v2_route.RouteMatch_SafeRegex{
-				SafeRegex: envoy.SafeRegexMatch(c.Regex),
+				SafeRegex: SafeRegexMatch(c.Regex),
 			},
 			Headers: headerMatcher(route.HeaderMatchConditions),
 		}
@@ -350,6 +350,6 @@ func containsMatch(s string) *envoy_api_v2_route.HeaderMatcher_SafeRegexMatch {
 	regex := fmt.Sprintf(".*%s.*", regexp.QuoteMeta(s))
 
 	return &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-		SafeRegexMatch: envoy.SafeRegexMatch(regex),
+		SafeRegexMatch: SafeRegexMatch(regex),
 	}
 }

--- a/internal/envoy/v2/route_test.go
+++ b/internal/envoy/v2/route_test.go
@@ -23,7 +23,6 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/projectcontour/contour/internal/dag"
-	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	"github.com/projectcontour/contour/internal/timeout"
@@ -961,7 +960,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: envoy.SafeRegexMatch(".*11-22-33-44.*"),
+						SafeRegexMatch: SafeRegexMatch(".*11-22-33-44.*"),
 					},
 				}},
 			},
@@ -980,7 +979,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: envoy.SafeRegexMatch(".*11\\.22\\.33\\.44.*"),
+						SafeRegexMatch: SafeRegexMatch(".*11\\.22\\.33\\.44.*"),
 					},
 				}},
 			},
@@ -999,7 +998,7 @@ func TestRouteMatch(t *testing.T) {
 					Name:        "x-header",
 					InvertMatch: false,
 					HeaderMatchSpecifier: &envoy_api_v2_route.HeaderMatcher_SafeRegexMatch{
-						SafeRegexMatch: envoy.SafeRegexMatch(".*11\\.\\[22\\]\\.\\*33\\.44.*"),
+						SafeRegexMatch: SafeRegexMatch(".*11\\.\\[22\\]\\.\\*33\\.44.*"),
 					},
 				}},
 			},
@@ -1027,7 +1026,7 @@ func TestRouteMatch(t *testing.T) {
 					// note, unlike header conditions this is not a quoted regex because
 					// the value comes directly from the Ingress.Paths.Path value which
 					// is permitted to be a bare regex.
-					SafeRegex: envoy.SafeRegexMatch("/v.1/*"),
+					SafeRegex: SafeRegexMatch("/v.1/*"),
 				},
 			},
 		},


### PR DESCRIPTION
The matcher package is for v2 xDS resource APIs, so needs to be in the internal/envoy/v2 package.

Signed-off-by: Steve Sloka <slokas@vmware.com>