### PR TITLE
site: Remove extra references to xds-server-version

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -10,7 +10,6 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
-    #   specify the xDS versions to use when serving resources to Envoy.
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -44,7 +44,6 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
-    #   specify the xDS versions to use when serving resources to Envoy.
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -111,7 +111,6 @@ The server configuration block can be used to configure various settings for the
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | xds-server-type | string | contour | This field specifies the xDS Server to use. Options are `contour` or `envoy`.  |
-| xds-server-versions | []string | [v2] | This field specifies the xDS Server versions to use. Options are `v2` & `v3`.  |
 {: class="table thead-dark table-bordered"}
 <br>
 
@@ -130,9 +129,6 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
-    #   specify the xDS versions to use when serving resources to Envoy.
-    #   xds-server-versions:
-    #   - v2
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true


### PR DESCRIPTION
Following up to #3078, remove references to xds-server-version from docs and examples.

Signed-off-by: Steve Sloka <slokas@vmware.com>