### PR TITLE
site: Add guide on upgrading from xDS v2-->v3

### DIFF
--- a/site/_guides/xds-migration.md
+++ b/site/_guides/xds-migration.md
@@ -1,0 +1,41 @@
+---
+title: Migrating from xDS v2 --> v3
+layout: page
+---
+
+This guide shows you how to migrate in-place instances of Envoy running xDS v2 to v3. 
+
+## Summary
+
+Envoy communicates with Contour over gRPC which allows for dynamic communication for Envoy configuration updates.
+Until Contour v1.10, this gRPC xDS communication utilized the v2 xDS for transport as well as resource version.
+
+In the beginning of Q1 20201, the Envoy community is [deprecating][0] the v2 xDS API in favor of the v3 which has been stable since Q1 2020.
+Contour offers support for the v3 xDS API in Contour v1.10.0. 
+
+Practically for users, this change has no effect on how Contour configures Envoy to route ingress traffic inside a Kubernetes cluster, however
+it's important to upgrade to this new version immediately since newer versions of Envoy won't support the `v2` api. 
+
+## Background
+
+Envoy gets configured with a boostrap configuration file which Contour provides via an `initContainer` on the Envoy daemonset.
+This file configures the dynamic xDS resources, Listener Discovery Service (LDS) and Cluster Discovery Service (CDS), to point to Contour's xDS gRPC server endpoint.
+
+The boostrap configuration file has two settings in the LDS/CDS entries which tell Contour what Resource & Transport version they would like to use. 
+In Contour v1.10.0, there's a new flag, `--xds-resource-version`, on the `contour boostrap` command which is used in the `initContainer` that allows users to specify the xDS resource version.
+
+Setting this flag to `v3` will configure Envoy to request the `v3` xDS Resource API version and will become the default in Contour v1.11.0.    
+
+## In-Place Upgrade
+
+When users have an existing Contour installation and wish to upgrade without dropping connections, they need only to change the Envoy Daemonset or deployment to include `--xds-resource-version=v3`.
+The usual rollout process will handle draining connections for you.
+Contour v1.10.0 will serve both v2 and v3 xDS versions from the same gRPC endpoint.
+This allows a fleet of Envoy instances to move from the `v2` xDS Resource API version gradually to the `v3` version. 
+
+## Redeploy Upgrade
+
+Redeploying Contour is a simple path for users who do not need to upgrade without dropping connections.
+The only change to remember is to set the `--xds-resource-version=v3` on the bootstrap `initContainer` to configure the new instances of Envoy to use the `v3` xDS Resource API. 
+
+[0]: https://www.envoyproxy.io/docs/envoy/latest/api/api_supported_versions


### PR DESCRIPTION
Add a small guide in the docs to discuss how xDS Resource API versions are implemented
and how to upgrade from v2 to v3.

Note: This should be referenced in the upgrade guide as well once we get to the release. 

Fixes #3047

Signed-off-by: Steve Sloka <slokas@vmware.com>