### PR TITLE
internal/xds: convert xDS resources for the envoy xDS server

### DIFF
--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -15,9 +15,11 @@
 package protobuf
 
 import (
+	"fmt"
 	"reflect"
 	"time"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -100,4 +102,16 @@ func MustMarshalAny(pb proto.Message) *any.Any {
 func AnyMessageTypeOf(msg proto.Message) string {
 	a := MustMarshalAny(msg)
 	return a.TypeUrl
+}
+
+/// MustMarshalJSON marshals msg to indented JSON.
+func MustMarshalJSON(msg proto.Message) string {
+	m := jsonpb.Marshaler{Indent: "  "}
+
+	str, err := m.MarshalToString(msg)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal %T: %s", msg, err))
+	}
+
+	return str
 }

--- a/internal/xds/hash.go
+++ b/internal/xds/hash.go
@@ -14,23 +14,32 @@
 package xds
 
 import (
-	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	envoy_api_core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoy_config_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
-// ConstantHash is a specialized node ID hasher used to allow
+const CONSTANT_HASH_VALUE = "contour"
+
+// ConstantHashV2 is a specialized node ID hasher used to allow
 // any instance of Envoy to connect to Contour regardless of the
 // service-node flag configured on Envoy.
-type ConstantHash string
+type ConstantHashV2 struct{}
 
-func (c ConstantHash) ID(*envoy_api_v2_core.Node) string {
-	return string(c)
+func (c ConstantHashV2) ID(*envoy_api_core_v2.Node) string {
+	return CONSTANT_HASH_VALUE
 }
 
-func (c ConstantHash) String() string {
-	return string(c)
+func (c ConstantHashV2) String() string {
+	return CONSTANT_HASH_VALUE
 }
 
-var _ cache.NodeHash = ConstantHash("")
+// ConstantHashV3 is the same as ConstantHashV2 but for xDS v3.
+type ConstantHashV3 struct{}
 
-var DefaultHash = ConstantHash("contour")
+func (c ConstantHashV3) ID(*envoy_config_v3.Node) string {
+	return CONSTANT_HASH_VALUE
+}
+
+func (c ConstantHashV3) String() string {
+	return CONSTANT_HASH_VALUE
+}

--- a/internal/xds/v2/snapshotter.go
+++ b/internal/xds/v2/snapshotter.go
@@ -1,0 +1,55 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache_v2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	envoy_log "github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/projectcontour/contour/internal/xds"
+	"github.com/projectcontour/contour/internal/xdscache"
+)
+
+var Hash = xds.ConstantHashV2{}
+
+// Snapshotter is a v2 Snapshot cache that implements the xds.Snapshotter interface.
+type Snapshotter interface {
+	xdscache.Snapshotter
+	envoy_cache_v2.SnapshotCache
+}
+
+type snapshotter struct {
+	envoy_cache_v2.SnapshotCache
+}
+
+func (s *snapshotter) Generate(version string, resources map[envoy_types.ResponseType][]envoy_types.Resource) error {
+	// Create a snapshot with all xDS resources.
+	snapshot := envoy_cache_v2.NewSnapshot(
+		version,
+		resources[envoy_types.Endpoint],
+		resources[envoy_types.Cluster],
+		resources[envoy_types.Route],
+		resources[envoy_types.Listener],
+		nil,
+		resources[envoy_types.Secret],
+	)
+
+	return s.SetSnapshot(Hash.String(), snapshot)
+}
+
+func NewSnapshotCache(ads bool, logger envoy_log.Logger) Snapshotter {
+	return &snapshotter{
+		SnapshotCache: envoy_cache_v2.NewSnapshotCache(ads, &Hash, logger),
+	}
+}

--- a/internal/xds/v3/snapshotter.go
+++ b/internal/xds/v3/snapshotter.go
@@ -1,0 +1,77 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	envoy_cache_v2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	envoy_cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	envoy_log "github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/xds"
+	"github.com/projectcontour/contour/internal/xdscache"
+)
+
+var Hash = xds.ConstantHashV3{}
+
+// Snapshotter is a v3 Snapshot cache that implements the xds.Snapshotter interface.
+type Snapshotter interface {
+	xdscache.Snapshotter
+	envoy_cache_v3.SnapshotCache
+}
+
+type snapshotter struct {
+	envoy_cache_v3.SnapshotCache
+}
+
+func (s *snapshotter) Generate(version string, resources map[envoy_types.ResponseType][]envoy_types.Resource) error {
+	// Create a snapshot with all xDS resources.
+	snapshot := envoy_cache_v3.Snapshot{}
+
+	snapshot.Resources[envoy_types.Endpoint] = rewriteResources(version, resources[envoy_types.Endpoint])
+	snapshot.Resources[envoy_types.Cluster] = rewriteResources(version, resources[envoy_types.Cluster])
+	snapshot.Resources[envoy_types.Route] = rewriteResources(version, resources[envoy_types.Route])
+	snapshot.Resources[envoy_types.Listener] = rewriteResources(version, resources[envoy_types.Listener])
+	snapshot.Resources[envoy_types.Secret] = rewriteResources(version, resources[envoy_types.Secret])
+
+	return s.SetSnapshot(Hash.String(), snapshot)
+}
+
+func NewSnapshotCache(ads bool, logger envoy_log.Logger) Snapshotter {
+	return &snapshotter{
+		SnapshotCache: envoy_cache_v3.NewSnapshotCache(ads, &Hash, logger),
+	}
+}
+
+func rewriteResources(version string, items []envoy_types.Resource) envoy_cache_v3.Resources {
+	// Since we are using the xDS v2 types internally, create
+	// the resources with the v2 package so that it indexes them
+	// by name using the correct v2 type switch.
+	v2 := envoy_cache_v2.NewResources(version, rewrite(items))
+
+	return envoy_cache_v3.Resources{
+		Version: v2.Version,
+		Items:   v2.Items,
+	}
+}
+
+func rewrite(resources []envoy_types.Resource) []envoy_types.Resource {
+	rewritten := make([]envoy_types.Resource, len(resources))
+
+	for i, r := range resources {
+		rewritten[i] = xds.Rewrite(proto.Clone(r))
+	}
+
+	return rewritten
+}


### PR DESCRIPTION
Add a snapshotter interfact to paper over the go-control-plane API
bifurcation. Use this to populate v3 and v2 resources in the snapshot
cache.

This updates #1898.

Signed-off-by: James Peach <jpeach@vmware.com>