### PR TITLE
examples: Make xds-resource-version default to v2

### DIFF
--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -99,7 +99,7 @@ spec:
         - /config/envoy.json
         - --xds-address=contour
         - --xds-port=8001
-        - --xds-resource-version=v3
+        - --xds-resource-version=v2
         - --resources-dir=/config/resources
         - --envoy-cafile=/certs/ca.crt
         - --envoy-cert-file=/certs/tls.crt

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1848,7 +1848,7 @@ spec:
         - /config/envoy.json
         - --xds-address=contour
         - --xds-port=8001
-        - --xds-resource-version=v3
+        - --xds-resource-version=v2
         - --resources-dir=/config/resources
         - --envoy-cafile=/certs/ca.crt
         - --envoy-cert-file=/certs/tls.crt


### PR DESCRIPTION
Support for xDS v3 has been added, however, Contour shouldn't default to that version
until v1.11.0. This gives users a chance to upgrade during the v1.10.0 cycle at their own pace.

Signed-off-by: Steve Sloka <slokas@vmware.com>