### PR TITLE
.github: Update how deps are added to path in PR workflow

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: add deps to path
         run: |
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
-          echo "::add-path::$GITHUB_WORKSPACE/bin"
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: integration tests
         run: |
           make integration


### PR DESCRIPTION
Updates how paths are added when installing deps in Github Actions.

"The Error: The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files."

Signed-off-by: Steve Sloka <slokas@vmware.com>