### PR TITLE
testsuite: standardize HTTP checks

### DIFF
--- a/_integration/testsuite/httpproxy/002-header-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/002-header-condition-match.yaml
@@ -194,7 +194,7 @@ error[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 random := sprintf("%d", [time.now_ns()])
 
@@ -236,25 +236,14 @@ requests[{ "req": req, "wanted_status": status, "wanted_service": service }] {
   service := case.service
 }
 
-error_if_wrong_status[msg] {
+check_for_status_code [msg] {
   req := requests[_]
   resp := http.send(req.req)
-
-  not response.status_is(resp, req.wanted_status)
-
-  msg := sprintf("got status %d, wanted %d", [
-    response.status_code(resp),
-    req.wanted_status,
-  ])
+  msg := expect.response_status_is(resp, req.wanted_status)
 }
 
-error_wrong_routing[msg] {
+check_for_service_routing [msg] {
   req := requests[_]
   resp := http.send(req.req)
-
-  not req.wanted_service == response.service(resp)
-
-  msg := sprintf("got service %s, wanted %q", [
-    response.service(resp), req.wanted_service,
-  ])
+  msg := expect.response_service_is(resp, req.wanted_service)
 }

--- a/_integration/testsuite/httpproxy/003-path-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/003-path-condition-match.yaml
@@ -123,7 +123,7 @@ error_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 cases := [
   [ "/", "echo-slash-default" ],
@@ -148,7 +148,7 @@ request_for_path[path] = request {
   }
 }
 
-response_for_path[path] = resp {
+response_for_path [path] = resp {
   path := cases[_][0]
   request := request_for_path[path]
   resp := http.send(request)
@@ -159,27 +159,17 @@ error_missing_responses {
   count(cases) != count(response_for_path)
 }
 
-error_non_200_response [msg] {
+check_for_status_code [msg] {
   path := cases[_][0]
   resp := response_for_path[path]
-
-  not response.status_is(resp, 200)
-
-  msg :=  sprintf("got status %d for path %q, wanted %d", [
-    response.status_code(resp), path, 200,
-  ])
+  msg := expect.response_status_is(resp, 200)
 }
 
-error_wrong_routing[msg] {
+check_for_service_routing [msg] {
   c := cases[_]
 
   path := c[0]
   svc := c[1]
   resp := response_for_path[path]
-
-  not svc == response.service(resp)
-
-  msg :=  sprintf("got wrong service %q for path %q, wanted %q", [
-    response.service(resp), path, svc,
-  ])
+  msg := expect.response_service_is(resp, svc)
 }

--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -241,7 +241,7 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 Service := "echo-two"
 
@@ -254,24 +254,12 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_no_response {
-  not Response
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-
-  msg :=  sprintf("got status %d, wanted %d", [
-    response.status_code(Response), 200
-  ])
-}
-
-error_wrong_routing[msg] {
-  not response.service(Response) == Service
-
-  msg :=  sprintf("got wrong service %q, wanted %q", [
-    response.service(Response), Service,
-  ])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, Service)
 }
 
 ---
@@ -317,7 +305,7 @@ Response := client.Get({
   "tls_server_name": "echo-one.projectcontour.io",
 })
 
-error_non_404_response [msg] {
+check_for_status_code [msg] {
   not response.is_4xx(Response)
   msg :=  sprintf("got status %d, wanted 4xx", [ Response.status_code ])
 }

--- a/_integration/testsuite/httpproxy/005-pod-restart.yaml
+++ b/_integration/testsuite/httpproxy/005-pod-restart.yaml
@@ -64,9 +64,7 @@ error_pod_unready [msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
-
-Service := "ingress-conformance-echo"
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.http(sprintf("/pre-delete/%d", [time.now_ns()])),
@@ -76,20 +74,13 @@ Response := client.Get({
   },
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-
-  msg := sprintf("got status %d, wanted %d", [
-    response.status_code(Response), 200,
-   ])
+check_for_response_status [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  not response.service(Response) == Service
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "ingress-conformance-echo")
 
-  msg := sprintf("got service %q, wanted %q", [
-    response.service(Response), Service,
-  ])
 }
 
 ---
@@ -117,9 +108,9 @@ error_pod_exists [msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.expect
 import data.contour.http.response
 
-Service := "ingress-conformance-echo"
 
 Response := client.Get({
   "url": url.http(sprintf("/post-delete/%d", [time.now_ns()])),
@@ -129,17 +120,12 @@ Response := client.Get({
   },
 })
 
-error_non_200_response [msg] {
-  Response.status_code != 200
-  msg :=  sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  not response.service(Response) == Service
-
-  msg := sprintf("got service %q, wanted %q", [
-    response.service(Response), Service,
-  ])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "ingress-conformance-echo")
 }
 
 error[msg] {

--- a/_integration/testsuite/httpproxy/006-merge-slash.yaml
+++ b/_integration/testsuite/httpproxy/006-merge-slash.yaml
@@ -60,9 +60,10 @@ fatal_proxy_is_not_valid[msg] {
 
 ---
 
-import data.contour.http.response
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.expect
+import data.contour.http.response
 
 Path := "this//has//lots////of/slashes"
 
@@ -74,9 +75,8 @@ Response := client.Get({
   },
 })
 
-error_non_200_response [msg] {
-  Response.status_code != 200
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 error_unexpected_path [msg] {

--- a/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
+++ b/_integration/testsuite/httpproxy/007-client-cert-auth.yaml
@@ -361,7 +361,7 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.contour.resources
 
 ServerSecret := resources.get("secrets", "007-client-cert-auth/echo-no-auth")
@@ -375,15 +375,12 @@ Response := client.Get({
   "tls_ca_cert": base64.decode(ServerSecret.data["ca.crt"]),
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  wanted := "echo-no-auth"
-  not response.service(Response) == wanted
-  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-no-auth")
 }
 
 ---
@@ -392,7 +389,7 @@ error_wrong_routing[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.contour.resources
 
 ServerSecret := resources.get("secrets", "007-client-cert-auth/echo-with-auth")
@@ -409,15 +406,12 @@ Response := client.Get({
   "tls_client_key": base64.decode(ClientSecret.data["tls.key"]),
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  wanted := "echo-with-auth"
-  not response.service(Response) == wanted
-  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-with-auth")
 }
 
 # TODO(jpeach): Need to test that requests without a client certificate

--- a/_integration/testsuite/httpproxy/008-tcproute-https-termination.yaml
+++ b/_integration/testsuite/httpproxy/008-tcproute-https-termination.yaml
@@ -121,7 +121,7 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.contour.resources
 
 Secret := resources.get("secrets", "echo-tcpproxy")
@@ -135,13 +135,10 @@ Response := client.Get({
   "tls_ca_cert": base64.decode(Secret.data["ca.crt"]),
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [response.status_code(Response), 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  wanted := "echo-tcpproxy"
-  not response.service(Response) == wanted
-  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
+check_for_routing_service [msg] {
+  msg := expect.response_service_is(Response, "echo-tcpproxy")
 }

--- a/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
+++ b/_integration/testsuite/httpproxy/009-https-misdirected-request.yaml
@@ -135,7 +135,7 @@ fatal_proxy_is_not_valid[msg] {
 import data.contour.http.client
 import data.contour.http.client.url
 import data.contour.http.request
-import data.contour.http.response
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.https(sprintf("/misdirected/%d", [time.now_ns()])),
@@ -146,22 +146,19 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing[msg] {
-  wanted := "echo"
-  not response.service(Response) == wanted
-  msg := sprintf("got service ID %q, wanted %q", [response.service(Response), wanted])
+check_for_service_routing [msg] {
+  msg:= expect.response_service_is(Response, "echo")
 }
 
 ---
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 # Send a request with a Host header that doesn't match the SNI name that
 # we have for the proxy document. We expect the mismatch will generate a
@@ -177,16 +174,15 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_421_response [msg] {
-  not response.status_is(Response, 421)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 421])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 421)
 }
 
 ---
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 # The virtual host name is port-insensitive, so verify that we can
 # stuff any old port number is and still succeed.
@@ -201,16 +197,15 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 ---
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 # Verify that the hostname match is case-insensitive.
 # The SNI server name match is still case sensitive,
@@ -226,7 +221,6 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }

--- a/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
+++ b/_integration/testsuite/httpproxy/010-include-prefix-condition.yaml
@@ -129,7 +129,7 @@ fatal_proxy_is_not_valid[msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 cases := {
   { "path": "/", "service": "echo-app" },
@@ -157,12 +157,8 @@ error_missing_response {
   count(responses) != count(cases)
 }
 
-error_misrouted_request[msg] {
+check_for_service_routing [msg] {
   r := responses[_]
 
-  not response.service(r.response) == r.service
-
-  msg := sprintf("got service %q, wanted %q", [
-    response.service(r.response), r.service
-  ])
+  msg := expect.response_service_is(r.response, r.service)
 }

--- a/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
+++ b/_integration/testsuite/httpproxy/012-https-fallback-certificate.yaml
@@ -92,7 +92,7 @@ spec:
 import data.contour.http.client
 import data.contour.http.client.url
 import data.contour.http.request
-import data.contour.http.response
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.https(sprintf("/fallback/%d", [time.now_ns()])),
@@ -101,17 +101,15 @@ Response := client.Get({
     "User-Agent": client.ua("fallback-certificate"),
   },
   "tls_insecure_skip_verify": true,
+  "tls_server_name": "echo.projectcontour.io",
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("SNI request got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing [msg] {
-  wanted := "echo"
-  not response.service(Response) == wanted
-  msg := sprintf("SNI request got test ID %q, wanted %q", [response.service(Response), wanted])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo")
 }
 
 ---
@@ -119,7 +117,7 @@ error_wrong_routing [msg] {
 import data.contour.http.client
 import data.contour.http.client.url
 import data.contour.http.request
-import data.contour.http.response
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.https(sprintf("/fallback/%d", [time.now_ns()])),
@@ -131,13 +129,10 @@ Response := client.Get({
   "tls_server_name": client.target_addr,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("fallback request got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
-error_wrong_routing [msg] {
-  wanted := "echo"
-  not response.service(Response) == wanted
-  msg := sprintf("SNI request got test ID %q, wanted %q", [response.service(Response), wanted])
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo")
 }

--- a/_integration/testsuite/httpproxy/013-backend-tls.yaml
+++ b/_integration/testsuite/httpproxy/013-backend-tls.yaml
@@ -243,6 +243,7 @@ error_secret_not_updated [msg] {
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.expect
 import data.contour.http.response
 import data.contour.resources
 
@@ -258,14 +259,8 @@ Response := client.Get({
 EnvoySecret := resources.get("secrets", "013-backend-tls/envoy-client-cert")
 EnvoyCert := base64.decode(EnvoySecret.data["tls.crt"])
 
-error_non_200_response [msg] {
-  not Response
-  msg := "no response"
-}
-
-error_non_200_response [msg] {
-  Response.status_code != 200
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 error_no_upstream_tls [msg] {
@@ -307,6 +302,7 @@ spec:
 
 import data.contour.http.client
 import data.contour.http.client.url
+import data.contour.http.expect
 import data.contour.http.response
 import data.contour.resources
 
@@ -322,14 +318,8 @@ Response := client.Get({
 EnvoySecret := resources.get("secrets", "013-backend-tls/envoy-client-cert")
 EnvoyCert := base64.decode(EnvoySecret.data["tls.crt"])
 
-error_non_200_response [msg] {
-  not Response
-  msg := "no response"
-}
-
-error_non_200_response [msg] {
-  Response.status_code != 200
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 error_no_upstream_tls [msg] {

--- a/_integration/testsuite/httpproxy/014-auth-basic-testserver.yaml
+++ b/_integration/testsuite/httpproxy/014-auth-basic-testserver.yaml
@@ -235,7 +235,7 @@ spec:
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.https(sprintf("/second/route/%d", [time.now_ns()])),
@@ -246,16 +246,15 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 ---
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 Response := client.Get({
   "url": url.https(sprintf("/first/route/%d", [time.now_ns()])),
@@ -266,16 +265,15 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_401_response [msg] {
-  not response.status_is(Response, 401)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 401])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 401)
 }
 
 ---
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 
 # The `testserver` authorization server will accept any request with
 # "allow" in the path, so this request should succeed. We can tell that
@@ -291,26 +289,16 @@ Response := client.Get({
   "tls_insecure_skip_verify": true,
 })
 
-error_non_200_response [msg] {
-  not response.status_is(Response, 200)
-  msg := sprintf("got status %d, wanted %d", [Response.status_code, 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 # Check route context key.
-error_missing_context [msg] {
-  not response.body_has_header_value(Response, "Auth-Context-Target", "first")
-  msg := sprintf("invalid global response context:\n%s", [
-    yaml.marshal(object.get(response.body(Response), "Headers", {}))
-  ])
+check_for_authorization_header [msg] {
+  msg := expect.response_header_is(Response, "Auth-Context-Target", "first")
 }
 
 # Check global context key.
-error_missing_context [msg] {
-  not response.body_has_header_value(Response, "Auth-Context-Hostname", "echo.projectcontour.io")
-  msg := sprintf("invalid global response context:\n%s", [
-    yaml.marshal(object.get(response.body(Response), "Headers", {}))
-  ])
+check_for_authorzation_header [msg] {
+  msg := expect.response_header_is(Response, "Auth-Context-Hostname", "echo.projectcontour.io")
 }
-
-
-

--- a/_integration/testsuite/httpproxy/015-http-health-checks.yaml
+++ b/_integration/testsuite/httpproxy/015-http-health-checks.yaml
@@ -44,7 +44,7 @@ spec:
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.builtin.result
 
 Response := client.Get({
@@ -55,14 +55,8 @@ Response := client.Get({
   },
 })
 
-check [r] {
-  response.status_is(Response, 200)
-  r := result.Pass("got status 200")
-}
-
-check [r] {
-  not response.status_is(Response, 200)
-  r := result.Errorf("got status %d, wanted %d", [response.status_code(Response), 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }
 
 ---
@@ -86,7 +80,7 @@ spec:
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.builtin.result
 
 Response := client.Get({
@@ -97,14 +91,8 @@ Response := client.Get({
   },
 })
 
-check [r] {
-  response.status_is(Response, 503)
-  r := result.Pass("got status 503")
-}
-
-check [r] {
-  not response.status_is(Response, 503)
-  r := result.Errorf("got status %d, wanted %d", [response.status_code(Response), 503])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 503)
 }
 
 ---
@@ -127,7 +115,7 @@ spec:
 
 import data.contour.http.client
 import data.contour.http.client.url
-import data.contour.http.response
+import data.contour.http.expect
 import data.builtin.result
 
 Response := client.Get({
@@ -138,12 +126,6 @@ Response := client.Get({
   },
 })
 
-check [r] {
-  response.status_is(Response, 200)
-  r := result.Pass("got status 200")
-}
-
-check [r] {
-  not response.status_is(Response, 200)
-  r := result.Errorf("got status %d, wanted %d", [response.status_code(Response), 200])
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
 }

--- a/_integration/testsuite/policies/contour-expect.rego
+++ b/_integration/testsuite/policies/contour-expect.rego
@@ -1,0 +1,81 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+package contour.http.expect
+
+import data.contour.http.response
+import data.builtin.result
+
+# response_status_is(response_object, status_code)
+#
+# Checks whether the response has the wanted HTTP status.
+response_status_is(response_object, wanted) = r {
+  response.status_code(response_object) == wanted
+  r := result.Passf("got expected status %d", [wanted])
+} else = r {
+  r := result.Errorf("got status %d, wanted %d", [response.status_code(response_object), wanted])
+}
+
+# response_status_not(response_object, status_code)
+#
+# Checks whether the response has the unwanted HTTP status.
+response_status_not(response_object, unwanted) = r {
+  response.status_code(response_object) == unwanted
+  r := result.Errorf("got status %d, wanted anything but %d",
+          [response.status_code(response_object), unwanted])
+} else = r {
+  r := result.Passf("got unwanted status %d", [unwanted])
+}
+
+# response_service_is(response_object, status_code)
+#
+# Checks whether the response has the wanted service name field.
+response_service_is(response_object, wanted) = r {
+  response.service(response_object) == wanted
+  r := result.Passf("got expected service name %q", [wanted])
+} else = r {
+  r := result.Errorf("got service name %q, wanted %q", [response.service(response_object), wanted])
+}
+
+# response_header_is(response_object, header_name, header_value)
+#
+# Checks whether the response body contains the matching header value.
+response_header_is(response_object, header_name, header_value) = r {
+  # Pass if the header is there and contains the wanted value.
+  response_body := response.body(response_object)
+  response_headers := object.get(response_body, "headers", {})
+  values := response_headers[header_name]
+
+  # Assert that there is some key v, which yields the value we want.
+  some v
+  values[v] == header_value
+
+  r := result.Passf("value of response header %q matches %q", [header_name, header_value])
+} else  = r {
+  # Error on any other values.
+  response_body := response.body(response_object)
+  response_headers := object.get(response_body, "headers", {})
+  values := response_headers[header_name]
+  r := result.Errorf("value of response header %q is %q, wanted %q", [header_name, values, header_value])
+} else  = r {
+  # Error if the header isn't present.
+  response_body := response.body(response_object)
+  response_headers := response_body["headers"]
+  r := result.Errorf("header %q is not present in the response body", [header_name])
+} else = r {
+  # Failsafe error.
+  r := result.Errorf("response header %q unmatched:\n%s", [
+    header_name, yaml.marshal(object.get(response.body(response_object), "Headers", {}))
+  ])
+}

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -7,7 +7,7 @@ set -o pipefail
 readonly KUSTOMIZE_VERS="v3.8.6"
 readonly KUBECTL_VERS="v1.19.2"
 readonly KIND_VERS="v0.9.0"
-readonly INTEGRATION_TESTER_VERS="5.0.0"
+readonly INTEGRATION_TESTER_VERS="6.0.0"
 
 readonly PROGNAME=$(basename $0)
 readonly CURL=${CURL:-curl}


### PR DESCRIPTION
Add a new `expect` policy module to make assertions on HTTP responses
from the conformance echo server. This lets us reduce the boilerplate
needed to check HTTP responses in test documents.

Signed-off-by: James Peach <jpeach@vmware.com>