### PR TITLE
internal: fix issue with duplicate DAG services & clusters

### DIFF
--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -49,9 +49,8 @@ func (dag *DAG) GetService(meta types.NamespacedName, port int32) *Service {
 }
 
 // EnsureService looks for a Kubernetes service in the cache matching the provided
-// namespace, name and port, adds it to the DAG if it does not already exist, and
-/// returns it. If a matching service cannot be found in the cache, an error is
-// returned.
+// namespace, name and port, and returns a DAG service for it. If a matching service
+// cannot be found in the cache, an error is returned.
 func (dag *DAG) EnsureService(meta types.NamespacedName, port intstr.IntOrString, cache *KubernetesCache) (*Service, error) {
 	svc, svcPort, err := cache.LookupService(meta, port)
 	if err != nil {
@@ -76,7 +75,6 @@ func (dag *DAG) EnsureService(meta types.NamespacedName, port intstr.IntOrString
 		MaxRetries:         annotation.MaxRetries(svc),
 		ExternalName:       externalName(svc),
 	}
-	dag.AddRoot(dagSvc)
 	return dagSvc, nil
 }
 

--- a/internal/xdscache/v2/endpointstranslator.go
+++ b/internal/xdscache/v2/endpointstranslator.go
@@ -272,11 +272,11 @@ func (e *EndpointsTranslator) OnChange(d *dag.DAG) {
 			if err := svc.Validate(); err != nil {
 				e.WithError(err).Errorf("dropping invalid service cluster %q", svc.ClusterName)
 			} else if _, ok := names[svc.ClusterName]; ok {
-				e.Errorf("dropping service cluster with duplicate name %q", svc.ClusterName)
+				e.Debugf("dropping service cluster with duplicate name %q", svc.ClusterName)
 			} else {
-
 				e.Debugf("added ServiceCluster %q from DAG", svc.ClusterName)
 				clusters = append(clusters, svc.DeepCopy())
+				names[svc.ClusterName] = true
 			}
 		}
 


### PR DESCRIPTION
Fixes an issue where services were being added as DAG roots, even
though they're always children of a route, so by definition not
roots. Also fixes a bug in the endpoints translator that did not
properly track already-visited service clusters to avoid processing
them twice.

Signed-off-by: Steve Kriss <krisss@vmware.com>