### PR TITLE
internal/xds: clone xDS protobufs before rewriting them

### DIFF
--- a/internal/xds/v3/contour.go
+++ b/internal/xds/v3/contour.go
@@ -151,7 +151,10 @@ func (s *contourServer) stream(st grpcStream) error {
 
 			// Rewrite the embedded message types to v3.
 			for _, r := range resources {
-				xds.Rewrite(r)
+				// Note that the resource cache
+				// gave us a pointer to its internal
+				// object, so we should rewrite a copy.
+				xds.Rewrite(proto.Clone(r))
 			}
 
 			any := make([]*any.Any, 0, len(resources))


### PR DESCRIPTION
Each xDS resource caches the protoufs that it generates from DAG updates
and hands them out to the xDS consumers via a pointer reference. When
we rewrite these to xDS v3, we were modifying the cached values, which
would cause errors if we had to rewrite them again.

This updates #1898.

Signed-off-by: James Peach <jpeach@vmware.com>