### PR TITLE
site: Fix typo in HTTPProxy reference

### DIFF
--- a/site/docs/main/config/tls-termination.md
+++ b/site/docs/main/config/tls-termination.md
@@ -137,7 +137,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.4.0/httpproxy.md
+++ b/site/docs/v1.4.0/httpproxy.md
@@ -1269,7 +1269,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.5.0/httpproxy.md
+++ b/site/docs/v1.5.0/httpproxy.md
@@ -1344,7 +1344,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.5.1/httpproxy.md
+++ b/site/docs/v1.5.1/httpproxy.md
@@ -1344,7 +1344,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.6.0/httpproxy.md
+++ b/site/docs/v1.6.0/httpproxy.md
@@ -1342,7 +1342,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.6.1/httpproxy.md
+++ b/site/docs/v1.6.1/httpproxy.md
@@ -1342,7 +1342,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.7.0/httpproxy.md
+++ b/site/docs/v1.7.0/httpproxy.md
@@ -1342,7 +1342,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.8.0/httpproxy.md
+++ b/site/docs/v1.8.0/httpproxy.md
@@ -1342,7 +1342,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.8.1/httpproxy.md
+++ b/site/docs/v1.8.1/httpproxy.md
@@ -1342,7 +1342,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.8.2/httpproxy.md
+++ b/site/docs/v1.8.2/httpproxy.md
@@ -1348,7 +1348,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml

--- a/site/docs/v1.9.0/httpproxy.md
+++ b/site/docs/v1.9.0/httpproxy.md
@@ -1416,7 +1416,7 @@ spec:
 ## Client Certificate Validation
 
 It is possible to protect the backend service from unauthorized external clients by requiring the client to present a valid TLS certificate.
-Envoy will validate the client certificate by verifying that it is not expired and that a a chain of trust can be established to the configured trusted root CA certificate.
+Envoy will validate the client certificate by verifying that it is not expired and that a chain of trust can be established to the configured trusted root CA certificate.
 Only those requests with a valid client certificate will be accepted and forwarded to the backend service.
 
 ```yaml


### PR DESCRIPTION
Fix a typo in HTTPProxy Client Certificate Validation.
[Link](https://projectcontour.io/docs/v1.9.0/httpproxy/#client-certificate-validation) to the current HTTPProxy Reference which contains the typo.

Signed-off-by: jwenz723 <jwenz723@gmail.com>