### PR TITLE
Fix bunch of typos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,7 @@ linters-settings:
 
 issues:
   exclude:
-  # TODO(jpeach): exclude unparam warnings about functions that always recieve
+  # TODO(jpeach): exclude unparam warnings about functions that always receive
   # the same arguments. We should clean those up some time.
   - always receives
   exclude-rules:

--- a/_integration/testsuite/httpproxy/003-path-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/003-path-condition-match.yaml
@@ -134,7 +134,7 @@ cases := [
   [ "/path/prefix/foo", "echo-slash-prefix" ],
 ]
 
-# NOTE(jpeach): the path formatting matters in the request contruction
+# NOTE(jpeach): the path formatting matters in the request construction
 # below, since we are testing for specific matches.
 request_for_path[path] = request {
   path := cases[_][0]

--- a/apis/projectcontour/v1/tlscertificatedelegation.go
+++ b/apis/projectcontour/v1/tlscertificatedelegation.go
@@ -63,7 +63,7 @@ type TLSCertificateDelegationStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+// TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 // See design/tls-certificate-delegation.md for details.
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Namespaced,path=tlscertificatedelegations,shortName=tlscerts,singular=tlscertificatedelegation

--- a/cmd/contour/certgen.go
+++ b/cmd/contour/certgen.go
@@ -49,7 +49,7 @@ func registerCertGen(app *kingpin.Application) (*kingpin.CmdClause, *certgenConf
 	return certgenApp, &certgenConfig
 }
 
-// certgenConfig holds the configuration for the certifcate generation process.
+// certgenConfig holds the configuration for the certificate generation process.
 type certgenConfig struct {
 
 	// KubeConfig is the path to the Kubeconfig file if we're not running in a cluster

--- a/design/delegation.md
+++ b/design/delegation.md
@@ -56,4 +56,4 @@ A counter-example of this is SQL injection, the text being included can contain 
 This is not possible in the DNS delegation model due to the implicit scope that surrounds the delegate.
 
 When considering how delegation works in Contour we must consider a blend of both the DNS delegation and file inclusion models.
-From the DNS delegation model we must take an idea of an enclosing scope; implicit restrictions which are overlayed on any configuration provided by the delegate.
+From the DNS delegation model we must take an idea of an enclosing scope; implicit restrictions which are overlaid on any configuration provided by the delegate.

--- a/design/external-authorization-design.md
+++ b/design/external-authorization-design.md
@@ -650,7 +650,7 @@ Adding support for the HTTP mechanism would increase configuration complexity, b
 There are few existing authorization servers that support the Envoy GRPC mechanism (most support HTTP).
 
 ***Decision:*** Maintainer consensus was that this trade-off is OK.
-We can help contribute Envoy GRPC support to existsing authorization servers.
+We can help contribute Envoy GRPC support to existing authorization servers.
 
 ## No Authorization Intermediaries
 

--- a/design/secure-communication.md
+++ b/design/secure-communication.md
@@ -24,7 +24,7 @@ Currently, the default deployment of Contour colocates the Envoy and Contour con
 
 In order to be able to split the deployment of Contour and Envoy, we must be able to provide an acceptable level of both transport security and authentication between the different pods.
 
-Currently, if you do split the deployment, Contour will assume that anything that talks to the xDS endpoints is authorized for all information in them. Notably, this includes any certificates used in any endpoint. Antyhing that can speak SDS can connect to contour and ask for all the certificates it knows about via SDS. This design is intended to mitigate this problem.
+Currently, if you do split the deployment, Contour will assume that anything that talks to the xDS endpoints is authorized for all information in them. Notably, this includes any certificates used in any endpoint. Anything that can speak SDS can connect to contour and ask for all the certificates it knows about via SDS. This design is intended to mitigate this problem.
 
 It's also important to note that the certificates talked about in this document are **only** the certificates used to secure the gRPC channel between Contour and Envoy, not any certificates used to serve TLS out of Envoy. As such, this design is wholly separate to any certificate functionality on either Ingress or IngressRoute.
 

--- a/design/session-affinity.md
+++ b/design/session-affinity.md
@@ -45,7 +45,7 @@ spec:
       strategy: Cookie
 ```
 As a route can specific multiple weighted backends, providing they choose `strategy: Cookie`, they will all be eligible for cookie based session affinity.
-Once a request has been served from service-a (or service-b) subsequent requests carrying Contour's session affinity cookie will always return to their nominated server reguardless of weightings.
+Once a request has been served from service-a (or service-b) subsequent requests carrying Contour's session affinity cookie will always return to their nominated server regardless of weightings.
 ```yaml
 apiVersion: contour.heptio.com/v1beta1
 kind: IngressRoute
@@ -160,7 +160,7 @@ For example consider two routes, `/cart` and `/checkout` are served by the same 
       port: 8080
       strategy: Cookie
 ```
-Given that both routes represent the same service with `static-content` overlayed to fill in the gaps, a session started on a backend of `ecommerce-pro` via `/cart` should land on the same `ecommerce-pro` backend when the request flow reaches `/checkout`.
+Given that both routes represent the same service with `static-content` overlaid to fill in the gaps, a session started on a backend of `ecommerce-pro` via `/cart` should land on the same `ecommerce-pro` backend when the request flow reaches `/checkout`.
 Placing the cookie at the `/` path permits this with few negative side effects.
 
  The session affinity cookie is _not_ a login cookie.
@@ -183,7 +183,7 @@ If the IngressRoute author wants to route _via_ a header, we are working on that
 #### Bootstrapping issues
 
 A related problem to Header based affinity is reusing a session cookie provided by the end user application.
-This is attractive as the application would normally be supplying its own cookie which we could treat as a input in the ring hash algorythm, however this suffers from two significant issues:
+This is attractive as the application would normally be supplying its own cookie which we could treat as a input in the ring hash algorithm, however this suffers from two significant issues:
 
 - Envoy consumes the whole cookie value, not part of it.
 If the application supplied session cookie contains unrelated date like previously selected page, shopping cart information, etc, then the hash of that cookie will change resulting in the request being directed to the incorrect server.

--- a/design/tls-certificate-delegation.md
+++ b/design/tls-certificate-delegation.md
@@ -25,7 +25,7 @@ This proposal introduces a specification, in the form of a simple CRD, whereby t
 ## High-Level Design
 
 - The definition of a Secret's name is extended to recognize a namespace prefix, ie. `secretName: kube-system/wildcard-tls` means the secret `wildcard-tls` in the `kube-system` namespace.
-- A `TLSCertificateDelegation` CRD grants the permission to reference the contents of a Secret in the owner's namespace to an Ingress controller operating in the context of an Ingress or IngressRoute object from a different namespace for the purpose of retrieving the TLS certicate.
+- A `TLSCertificateDelegation` CRD grants the permission to reference the contents of a Secret in the owner's namespace to an Ingress controller operating in the context of an Ingress or IngressRoute object from a different namespace for the purpose of retrieving the TLS certificate.
 
 ## Detailed Design
 

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1113,7 +1113,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation. See design/tls-certificate-delegation.md for details.
+        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specification. See design/tls-certificate-delegation.md for details.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1234,7 +1234,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation. See design/tls-certificate-delegation.md for details.
+        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD specification. See design/tls-certificate-delegation.md for details.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/hack/kind-dev-cluster.sh
+++ b/hack/kind-dev-cluster.sh
@@ -101,7 +101,7 @@ Host IP address(es): $(host::addresses | tr '\n' ' ')
 Next steps:
 
 * Edit the envoy daemonset to remove the contourcert and cacert secrets volume, and
-  update the boostrap container to point the xDS server to the host IP:
+  update the bootstrap container to point the xDS server to the host IP:
 
     ${KUBECTL} --context kind-${CLUSTER} --namespace projectcontour edit daemonset envoy
 

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -3,7 +3,7 @@
 # make-release-tag.sh: This script assumes that you are on a branch and have
 # otherwise prepared the release. It rewrites the Docker image version in
 # the deployment YAML, then created a tag with a message containing the
-# shortlog from the previous versio.
+# shortlog from the previous version.
 
 readonly PROGNAME=$(basename "$0")
 readonly OLDVERS="$1"

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -244,7 +244,7 @@ func MinTLSVersion(version string, defaultVal envoy_api_v2_auth.TlsParameters_Tl
 // 1. projectcontour.io/max-connections
 // 2. contour.heptio.com/max-connections
 //
-// '0' is returned if the annotation is absent or unparseable.
+// '0' is returned if the annotation is absent or unparsable.
 func MaxConnections(o metav1.ObjectMetaAccessor) uint32 {
 	return parseUInt32(CompatAnnotation(o, "max-connections"))
 }
@@ -254,7 +254,7 @@ func MaxConnections(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-pending-requests
 // 2. contour.heptio.com/max-pending-requests
 //
-// '0' is returned if the annotation is absent or unparseable.
+// '0' is returned if the annotation is absent or unparsable.
 func MaxPendingRequests(o metav1.ObjectMetaAccessor) uint32 {
 	return parseUInt32(CompatAnnotation(o, "max-pending-requests"))
 }
@@ -264,7 +264,7 @@ func MaxPendingRequests(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-requests
 // 2. contour.heptio.com/max-requests
 //
-// '0' is returned if the annotation is absent or unparseable.
+// '0' is returned if the annotation is absent or unparsable.
 func MaxRequests(o metav1.ObjectMetaAccessor) uint32 {
 	return parseUInt32(CompatAnnotation(o, "max-requests"))
 }
@@ -274,7 +274,7 @@ func MaxRequests(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-retries
 // 2. contour.heptio.com/max-retries
 //
-// '0' is returned if the annotation is absent or unparseable.
+// '0' is returned if the annotation is absent or unparsable.
 func MaxRetries(o metav1.ObjectMetaAccessor) uint32 {
 	return parseUInt32(CompatAnnotation(o, "max-retries"))
 }

--- a/internal/envoy/v2/listener.go
+++ b/internal/envoy/v2/listener.go
@@ -435,7 +435,7 @@ func Filters(filters ...*envoy_api_v2_listener.Filter) []*envoy_api_v2_listener.
 	return filters
 }
 
-// FilterChain retruns a *envoy_api_v2_listener.FilterChain for the supplied filters.
+// FilterChain returns a *envoy_api_v2_listener.FilterChain for the supplied filters.
 func FilterChain(filters ...*envoy_api_v2_listener.Filter) *envoy_api_v2_listener.FilterChain {
 	return &envoy_api_v2_listener.FilterChain{
 		Filters: filters,

--- a/internal/featuretests/v2/replaceprefix_test.go
+++ b/internal/featuretests/v2/replaceprefix_test.go
@@ -135,7 +135,7 @@ func basic(t *testing.T) {
 	)
 
 	// But having duplicate prefixes in the replacements makes
-	// it ambigious again.
+	// it ambiguous again.
 	vhost = update(rh, vhost,
 		func(vhost *contour_api_v1.HTTPProxy) {
 			vhost.Spec.Routes[0].PathRewritePolicy.ReplacePrefix =

--- a/internal/featuretests/v2/timeoutpolicy_test.go
+++ b/internal/featuretests/v2/timeoutpolicy_test.go
@@ -79,7 +79,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(i1, i2)
 
-	// check annotation with infinite timeout is propogated
+	// check annotation with infinite timeout is propagated
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http",
@@ -171,7 +171,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnAdd(p1)
 
-	// check timeout policy with malformed response timeout is not propogated
+	// check timeout policy with malformed response timeout is not propagated
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http"),
@@ -197,7 +197,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(p1, p2)
 
-	// check timeout policy with response timeout is propogated correctly
+	// check timeout policy with response timeout is propagated correctly
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http",
@@ -230,7 +230,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(p2, p3)
 
-	// check timeout policy with explicit infine response timeout is propogated as infinity
+	// check timeout policy with explicit infine response timeout is propagated as infinity
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http",
@@ -275,7 +275,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 	}
 	rh.OnAdd(p1)
 
-	// check timeout policy with malformed response timeout is not propogated
+	// check timeout policy with malformed response timeout is not propagated
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http"),
@@ -301,7 +301,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(p1, p2)
 
-	// check timeout policy with response timeout is propogated correctly
+	// check timeout policy with response timeout is propagated correctly
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http",
@@ -334,7 +334,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 	}
 	rh.OnUpdate(p2, p3)
 
-	// check timeout policy with explicit infine response timeout is propogated as infinity
+	// check timeout policy with explicit infine response timeout is propagated as infinity
 	c.Request(routeType).Equals(&envoy_api_v2.DiscoveryResponse{
 		Resources: resources(t,
 			envoyv2.RouteConfiguration("ingress_http",

--- a/internal/httpsvc/http.go
+++ b/internal/httpsvc/http.go
@@ -60,7 +60,7 @@ func (svc *Service) Start(stop <-chan struct{}) (err error) {
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		_ = s.Shutdown(ctx) // ignored, will always be a cancelation error
+		_ = s.Shutdown(ctx) // ignored, will always be a cancellation error
 	}()
 
 	svc.WithField("address", s.Addr).Info("started HTTP server")

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -87,7 +87,7 @@ func AsMessages(messages interface{}) []proto.Message {
 	return protos
 }
 
-// MustMarshalAny marshals a protobug into an any.Any type, panicing
+// MustMarshalAny marshals a protobug into an any.Any type, panicking
 // if that operation fails.
 func MustMarshalAny(pb proto.Message) *any.Any {
 	a, err := ptypes.MarshalAny(pb)

--- a/internal/xdscache/v2/endpointstranslator.go
+++ b/internal/xdscache/v2/endpointstranslator.go
@@ -102,7 +102,7 @@ type EndpointsCache struct {
 // cached Endpoints and stale ServiceClusters. A ClusterLoadAssignment
 // will be generated for every stale ServerCluster, however, if there
 // are no endpoints for the Services in the ServiceCluster, the
-// ClusterLoadAssignment wil be empty.
+// ClusterLoadAssignment will be empty.
 func (c *EndpointsCache) Recalculate() map[string]*envoy_api_v2.ClusterLoadAssignment {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/xdscache/v2/route_test.go
+++ b/internal/xdscache/v2/route_test.go
@@ -3053,7 +3053,7 @@ func TestSortLongestRouteFirst(t *testing.T) {
 
 		// Verify that we always order the headers, even if
 		// we don't need to compare the header conditions to
-		// order multple routes with the same prefix.
+		// order multiple routes with the same prefix.
 		"headers order in single route": {
 			routes: []*envoy_api_v2_route.Route{{
 				Match: routePrefix("/",

--- a/site/_guides/xds-migration.md
+++ b/site/_guides/xds-migration.md
@@ -18,10 +18,10 @@ it's important to upgrade to this new version immediately since newer versions o
 
 ## Background
 
-Envoy gets configured with a boostrap configuration file which Contour provides via an `initContainer` on the Envoy daemonset.
+Envoy gets configured with a bootstrap configuration file which Contour provides via an `initContainer` on the Envoy daemonset.
 This file configures the dynamic xDS resources, Listener Discovery Service (LDS) and Cluster Discovery Service (CDS), to point to Contour's xDS gRPC server endpoint.
 
-The boostrap configuration file has two settings in the LDS/CDS entries which tell Contour what Resource & Transport version they would like to use. 
+The bootstrap configuration file has two settings in the LDS/CDS entries which tell Contour what Resource & Transport version they would like to use. 
 In Contour v1.10.0, there's a new flag, `--xds-resource-version`, on the `contour boostrap` command which is used in the `initContainer` that allows users to specify the xDS resource version.
 
 Setting this flag to `v3` will configure Envoy to request the `v3` xDS Resource API version and will become the default in Contour v1.11.0.    

--- a/site/_plugins/youtube.rb
+++ b/site/_plugins/youtube.rb
@@ -84,7 +84,7 @@ module Jekyll
     end
 
     def render(context)
-      ouptut = super
+      output = super
 
       if !@video_id
         @video_id = "#{context[@content.strip]}"

--- a/site/_posts/2019-09-17-projectcontour.md
+++ b/site/_posts/2019-09-17-projectcontour.md
@@ -12,4 +12,4 @@ Times change. Summer turns to autumn, leaves fall from their branches, brands di
 
 Yes, it's time to wish the Heptio brand a fond farewell. As we gather on the shores to watch the pyre burn it is a time for happiness because Contour isn't dead, we've just moved house.
 
-You might have noticed the cheery 301 redirect that GitHub sent your browswer to inform it that Contour's new home is https://github.com/projectcontour/contour.
+You might have noticed the cheery 301 redirect that GitHub sent your browser to inform it that Contour's new home is https://github.com/projectcontour/contour.

--- a/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
+++ b/site/_posts/2019-09-27-from-ingressroute-to-httpproxy.md
@@ -19,7 +19,7 @@ Fast forward to July of this year where plans to move Contour out of the _0.what
 We knew that stamping a 1.0 release on Contour required us to do the same for IngressRoute, which had at that point been in beta for a period of time that would make a Google product blush.
 Bringing IngressRoute, as it was known at the time, to 1.0 status would involve three things.
 
-The first was addressing, which in retrospect seemed like an inspired piece of guerilla marketing, the fact that I had plastered not just the name of the product but the name of the sponsoring company throughout annotation names, CRD groups, repository image hosting, and namespace objects.
+The first was addressing, which in retrospect seemed like an inspired piece of guerrilla marketing, the fact that I had plastered not just the name of the product but the name of the sponsoring company throughout annotation names, CRD groups, repository image hosting, and namespace objects.
 Taking the necessary hit to _rename all the things_ is the focus of the beta.1 and upcoming rc.1 releases.
 
 Once these procedural issues were in hand the second issue was to consider the name _IngressRoute_ itself.
@@ -27,7 +27,7 @@ The name, to the best of my recollection chosen without any particular deliberat
 
 With a year's experience developing and supporting IngressRoute, a few problems with the name had become evident.
 As a name, IngressRoute was lengthy.
-Abreviating it introduced confusion with another Kubernetes object--also in beta--which we didn't want to be confused with.
+Abbreviating it introduced confusion with another Kubernetes object--also in beta--which we didn't want to be confused with.
 If you wanted to be precise, you had to type, and _say aloud_, the entire thing.
 But there are more problems than verbosity.
 

--- a/site/about.md
+++ b/site/about.md
@@ -42,7 +42,7 @@ CDS is most like a Kubernetes Service resource in that a Service is an abstract 
 
 SDS is most like a Kubernetes Endpoint resource, and is probably the simplest to implement. It presents itself to Contour with an identifier we control, which maps to an Endpoint resource. Contour then transforms the Endpoint response objects into a `{ hosts: [] }` json fragment.
 
-The identifier presented to SDS is the CDS clusters `service_name`, which we set as Service.ObjectMeta.Namespace + "/" + Sevice.ObjectMeta.Name.
+The identifier presented to SDS is the CDS clusters `service_name`, which we set as Service.ObjectMeta.Namespace + "/" + Service.ObjectMeta.Name.
 
 ### RDS
 

--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -170,7 +170,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/main/config/upstream-tls.md
+++ b/site/docs/main/config/upstream-tls.md
@@ -5,7 +5,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _**Note:**
 If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -209,7 +209,7 @@ connects to Contour:
 | <nobr>--envoy-cafile</nobr> | "" | CA filename for Envoy secure xDS gRPC communication.  |
 | <nobr>--envoy-cert-file</nobr> | "" | Client certificate filename for Envoy secure xDS gRPC communication.  |
 | <nobr>--envoy-key-file</nobr> | "" | Client key filename for Envoy secure xDS gRPC communication.  |
-| <nobr>--namespace</nobr> | projectcontour | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the boostrap configuration file.    |
+| <nobr>--namespace</nobr> | projectcontour | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the bootstrap configuration file.    |
 | <nobr>--xds-resource-version</nobr> | v2 | Specify the xDS API resource version to use. Options are `v2` or `v3`.  |
 {: class="table thead-dark table-bordered"}
 <br>

--- a/site/docs/v1.0.0/httpproxy.md
+++ b/site/docs/v1.0.0/httpproxy.md
@@ -589,7 +589,7 @@ spec:
 
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.0.0/ingressroute.md
+++ b/site/docs/v1.0.0/ingressroute.md
@@ -525,7 +525,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.0.1/httpproxy.md
+++ b/site/docs/v1.0.1/httpproxy.md
@@ -589,7 +589,7 @@ spec:
 
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity on a per route basis with `loadBalancerPolocy` `strategy: Cookie`.
 
 ```yaml

--- a/site/docs/v1.0.1/ingressroute.md
+++ b/site/docs/v1.0.1/ingressroute.md
@@ -525,7 +525,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.1.0/api-reference.html
+++ b/site/docs/v1.1.0/api-reference.html
@@ -149,7 +149,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.1.0/ingressroute.md
+++ b/site/docs/v1.1.0/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.10.0/config/api-reference.html
+++ b/site/docs/v1.10.0/config/api-reference.html
@@ -170,7 +170,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.10.0/config/upstream-tls.md
+++ b/site/docs/v1.10.0/config/upstream-tls.md
@@ -5,7 +5,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _**Note:**
 If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._

--- a/site/docs/v1.10.0/configuration.md
+++ b/site/docs/v1.10.0/configuration.md
@@ -209,7 +209,7 @@ connects to Contour:
 | <nobr>--envoy-cafile</nobr> | "" | CA filename for Envoy secure xDS gRPC communication.  |
 | <nobr>--envoy-cert-file</nobr> | "" | Client certificate filename for Envoy secure xDS gRPC communication.  |
 | <nobr>--envoy-key-file</nobr> | "" | Client key filename for Envoy secure xDS gRPC communication.  |
-| <nobr>--namespace</nobr> | projectcontour | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the boostrap configuration file.    |
+| <nobr>--namespace</nobr> | projectcontour | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the bootstrap configuration file.    |
 | <nobr>--xds-resource-version</nobr> | v2 | Specify the xDS API resource version to use. Options are `v2` or `v3`.  |
 {: class="table thead-dark table-bordered"}
 <br>

--- a/site/docs/v1.2.0/api-reference.html
+++ b/site/docs/v1.2.0/api-reference.html
@@ -149,7 +149,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.2.0/ingressroute.md
+++ b/site/docs/v1.2.0/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.2.1/api-reference.html
+++ b/site/docs/v1.2.1/api-reference.html
@@ -149,7 +149,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.2.1/ingressroute.md
+++ b/site/docs/v1.2.1/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.3.0/api-reference.html
+++ b/site/docs/v1.3.0/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.3.0/ingressroute.md
+++ b/site/docs/v1.3.0/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.4.0/api-reference.html
+++ b/site/docs/v1.4.0/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.4.0/ingressroute.md
+++ b/site/docs/v1.4.0/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.5.0/api-reference.html
+++ b/site/docs/v1.5.0/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.5.0/httpproxy.md
+++ b/site/docs/v1.5.0/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.5.0/ingressroute.md
+++ b/site/docs/v1.5.0/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.5.1/api-reference.html
+++ b/site/docs/v1.5.1/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.5.1/httpproxy.md
+++ b/site/docs/v1.5.1/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.5.1/ingressroute.md
+++ b/site/docs/v1.5.1/ingressroute.md
@@ -527,7 +527,7 @@ spec:
 ```
 #### Session Affinity
 
-Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consitently routed to the same application backend.
+Session affinity, also known as _sticky sessions_, is a load balancing strategy whereby a sequence of requests from a single client are consistently routed to the same application backend.
 Contour supports session affinity with the `strategy: Cookie` key on a per service basis.
 
 ```yaml

--- a/site/docs/v1.6.0/api-reference.html
+++ b/site/docs/v1.6.0/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.6.0/httpproxy.md
+++ b/site/docs/v1.6.0/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.6.1/api-reference.html
+++ b/site/docs/v1.6.1/api-reference.html
@@ -158,7 +158,7 @@ Status
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.6.1/httpproxy.md
+++ b/site/docs/v1.6.1/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.7.0/api-reference.html
+++ b/site/docs/v1.7.0/api-reference.html
@@ -167,7 +167,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.7.0/httpproxy.md
+++ b/site/docs/v1.7.0/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.8.0/api-reference.html
+++ b/site/docs/v1.8.0/api-reference.html
@@ -167,7 +167,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.8.0/httpproxy.md
+++ b/site/docs/v1.8.0/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.8.1/api-reference.html
+++ b/site/docs/v1.8.1/api-reference.html
@@ -167,7 +167,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.8.1/httpproxy.md
+++ b/site/docs/v1.8.1/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.8.2/api-reference.html
+++ b/site/docs/v1.8.2/api-reference.html
@@ -170,7 +170,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.8.2/httpproxy.md
+++ b/site/docs/v1.8.2/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 

--- a/site/docs/v1.9.0/api-reference.html
+++ b/site/docs/v1.9.0/api-reference.html
@@ -170,7 +170,7 @@ HTTPProxyStatus
 <h3 id="projectcontour.io/v1.TLSCertificateDelegation">TLSCertificateDelegation
 </h3>
 <p>
-<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specificiation.
+<p>TLSCertificateDelegation is an TLS Certificate Delegation CRD specification.
 See design/tls-certificate-delegation.md for details.</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">

--- a/site/docs/v1.9.0/httpproxy.md
+++ b/site/docs/v1.9.0/httpproxy.md
@@ -308,7 +308,7 @@ Applying the `projectcontour.io/upstream-protocol.tls` annotation to a Service o
 The same configuration can be specified by setting the protocol name in the `spec.routes.services[].protocol` field on the HTTPProxy object.
 If both the annotation and the protocol field are specified, the protocol field takes precedence.
 By default, the upstream TLS server certificate will not be validated, but validation can be requested by setting the `spec.routes.services[].validation` field.
-This field has mandatory `caSecret` and `subjectName` fields, which specfy the trusted root certificates with which to validate the server certificate and the expected server name.
+This field has mandatory `caSecret` and `subjectName` fields, which specify the trusted root certificates with which to validate the server certificate and the expected server name.
 
 _Note: If `spec.routes.services[].validation` is present, `spec.routes.services[].{name,port}` must point to a Service with a matching `projectcontour.io/upstream-protocol.tls` Service annotation._
 


### PR DESCRIPTION
Found using Codespell with the following command:

codespell -S .git,*.png,*.woff,*.ttf,*.jpg,*.ico -L \
keypair,keypairs,nd,suh,od,rouge,als,wit

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>