### PR TITLE
internal/xds: respond with rewritten v3 xDS resources

### DIFF
--- a/internal/xds/v3/contour.go
+++ b/internal/xds/v3/contour.go
@@ -150,15 +150,16 @@ func (s *contourServer) stream(st grpcStream) error {
 			}
 
 			// Rewrite the embedded message types to v3.
+			var rewritten []proto.Message
 			for _, r := range resources {
 				// Note that the resource cache
 				// gave us a pointer to its internal
 				// object, so we should rewrite a copy.
-				xds.Rewrite(proto.Clone(r))
+				rewritten = append(rewritten, xds.Rewrite(proto.Clone(r)))
 			}
 
-			any := make([]*any.Any, 0, len(resources))
-			for _, r := range resources {
+			any := make([]*any.Any, 0, len(rewritten))
+			for _, r := range rewritten {
 				a, err := ptypes.MarshalAny(r)
 				if err != nil {
 					return done(log, err)


### PR DESCRIPTION
Fixes bug where rewritten resources were not being used in the
discovery responses.

Updates #3096.
Updates #1898.

Signed-off-by: Steve Kriss <krisss@vmware.com>