### PR TITLE
site: update quickstart redirect for 1.10

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
 # kubectl apply https://projectcontour.io/quickstart/contour.yaml
 [[redirects]]
   from = "/quickstart/contour.yaml"
-  to = "https://raw.githubusercontent.com/projectcontour/contour/release-1.9/examples/render/contour.yaml"
+  to = "https://raw.githubusercontent.com/projectcontour/contour/release-1.10/examples/render/contour.yaml"
   status = 302
 
 # Redirect versioned quickstarts so that they can easily be referenced by


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Holding as draft until after release is done.