### PR TITLE
site/docs: update links to point to current docs version

### DIFF
--- a/site/docs/main/config/annotations.md
+++ b/site/docs/main/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.5.0/annotations.md
+++ b/site/docs/v1.5.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: ingressroute.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.5.0/httpproxy.md
+++ b/site/docs/v1.5.0/httpproxy.md
@@ -1415,5 +1415,5 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate

--- a/site/docs/v1.5.1/annotations.md
+++ b/site/docs/v1.5.1/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: ingressroute.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.5.1/httpproxy.md
+++ b/site/docs/v1.5.1/httpproxy.md
@@ -1415,5 +1415,5 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate

--- a/site/docs/v1.6.0/annotations.md
+++ b/site/docs/v1.6.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.6.0/httpproxy.md
+++ b/site/docs/v1.6.0/httpproxy.md
@@ -1414,6 +1414,6 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
 

--- a/site/docs/v1.6.1/annotations.md
+++ b/site/docs/v1.6.1/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.6.1/httpproxy.md
+++ b/site/docs/v1.6.1/httpproxy.md
@@ -1414,6 +1414,6 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
 

--- a/site/docs/v1.7.0/annotations.md
+++ b/site/docs/v1.7.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.7.0/httpproxy.md
+++ b/site/docs/v1.7.0/httpproxy.md
@@ -1414,7 +1414,7 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
  [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/docs/v1.8.0/annotations.md
+++ b/site/docs/v1.8.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.8.0/httpproxy.md
+++ b/site/docs/v1.8.0/httpproxy.md
@@ -1414,7 +1414,7 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
  [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/docs/v1.8.1/annotations.md
+++ b/site/docs/v1.8.1/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.8.1/httpproxy.md
+++ b/site/docs/v1.8.1/httpproxy.md
@@ -1414,7 +1414,7 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
  [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/docs/v1.8.2/annotations.md
+++ b/site/docs/v1.8.2/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.8.2/httpproxy.md
+++ b/site/docs/v1.8.2/httpproxy.md
@@ -1420,6 +1420,6 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
  [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac

--- a/site/docs/v1.9.0/annotations.md
+++ b/site/docs/v1.9.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{site.latest}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/v1.9.0/httpproxy.md
+++ b/site/docs/v1.9.0/httpproxy.md
@@ -1488,6 +1488,6 @@ Some examples of invalid configurations that Contour provides statuses for:
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
  [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{site.latest}}/api/#projectcontour.io/v1.Service
+ [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
  [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac


### PR DESCRIPTION
Changes several versioned docs links from using site.latest to
page.version, so that the links remain within the same docs
version as the source page.

Signed-off-by: Steve Kriss <krisss@vmware.com>