### PR TITLE
fix broken troubleshooting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See the [Getting Started](https://projectcontour.io/getting-started) document.
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting docs](/site/docs/main/troubleshooting.md), [file an issue](https://github.com/projectcontour/contour/issue), or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
+If you encounter issues, review the Troubleshooting section of [the docs](https://projectcontour.io/docs), [file an issue](https://github.com/projectcontour/contour/issue), or talk to us on the [#contour channel](https://kubernetes.slack.com/messages/contour) on the Kubernetes Slack server.
 
 ## Contributing
 

--- a/site/getting-started.md
+++ b/site/getting-started.md
@@ -84,14 +84,13 @@ We've also got [a FAQ][4] for short-answer questions and conceptual stuff that d
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting docs][5], [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
+If you encounter issues, review the Troubleshooting section of [the docs][3], [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
 
 [0]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes
 [1]: /docs/{{site.latest}}/deploy-options
 [2]: /docs/{{site.latest}}/config/fundamentals
 [3]: /docs/{{site.latest}}
 [4]: {% link _resources/faq.md %}
-[5]: /docs/{{site.latest}}/troubleshooting
 [6]: {{site.github.repository_url}}/issues
 [9]: https://github.com/kubernetes-up-and-running/kuard
 [10]: https://kubernetes.io/docs/concepts/services-networking/service


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

We don't have a main Troubleshooting page anymore, so just link to the docs home page. I think this is fine for now; we could also add back a landing page for Troubleshooting but then we'd have to keep it up to date with an index.