### PR TITLE
Replace misspell with codespell

### DIFF
--- a/.codespell.ignorewords
+++ b/.codespell.ignorewords
@@ -1,0 +1,7 @@
+keypair
+keypairs
+nd
+suh
+od
+als
+wit

--- a/.codespell.skip
+++ b/.codespell.skip
@@ -1,0 +1,8 @@
+.git
+*.png
+*.woff
+*.ttf
+*.jpg
+*.ico
+./site/Gemfile.lock
+./site/_config.yml

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -54,6 +54,19 @@ jobs:
         with:
           version: v1.31
           only-new-issues: true
+  codespell:
+    name: Codespell
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Codespell
+        uses: codespell-project/actions-codespell@master
+        with:
+          skip: .git,*.png,*.woff,*.ttf,*.jpg,*.ico,./site/Gemfile.lock,./site/_config.yml
+          ignore_words_file: './.codespell.ignorewords'
+          check_filenames: true
+          check_hidden: true
   codegen:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -150,17 +150,14 @@ check-coverage: ## Run tests to generate code coverage
 
 .PHONY: lint
 lint: ## Run lint checks
-lint: lint-golint lint-yamllint lint-flags lint-misspell
+lint: lint-golint lint-yamllint lint-flags lint-codespell
 
-.PHONY: check-misspell
-lint-misspell:
-	@echo Running spell checker ...
-	@go run github.com/client9/misspell/cmd/misspell \
-		-locale US \
-		-error \
-		-i mitre,Mitre,cancelled \
-		-source=text \
-		$$(git ls-files | grep -E '(md|html)$$')
+.PHONY: lint-codespell
+lint-codespell: CODESPELL_SKIP := $(shell cat .codespell.skip | tr \\n ',')
+lint-codespell: CODESPELL_BIN := codespell
+lint-codespell:
+	which $(CODESPELL_BIN) >/dev/null 2>&1 || (echo "$(CODESPELL_BIN) binary not found, skipping spell checking"; exit 0)
+	$(CODESPELL_BIN) --skip $(CODESPELL_SKIP) --ignore-words .codespell.ignorewords --check-filenames --check-hidden
 
 .PHONY: check-golint
 lint-golint:

--- a/tools.go
+++ b/tools.go
@@ -4,7 +4,6 @@ package tools
 
 import (
 	_ "github.com/ahmetb/gen-crd-api-reference-docs"
-	_ "github.com/client9/misspell/cmd/misspell"
 
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kustomize/kyaml"


### PR DESCRIPTION
**This PR includes commits from PR #3098**

As discussed in #3098, creating a PR which replaces `misspell` with `codespell`. IMO `misspell` can stay enabled in `golangci-lint`, as it may still catch some typos which won't be covered by `codespell`.