### PR TITLE
internal/xdscache: change default global TLS minimum to 1.2

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -50,10 +49,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 	corev1 "k8s.io/api/core/v1"
-	networking_api_v1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
@@ -190,84 +187,6 @@ func validateCRDs(dynamicClient dynamic.Interface, log logrus.FieldLogger) {
 	}
 }
 
-// warnTLS logs a warning for HTTPProxies/Ingresses that specify a minimum protocol
-// version of 1.1, but the config file isn't explicitly allowing 1.1, since in a
-// future release the config file default will bump to 1.2 which will change the behavior
-// for these proxies.
-//
-// TODO(#3010): remove this function after the config file default has switched to 1.2.
-func warnTLS(log logrus.FieldLogger, client dynamic.Interface, ctx *serveContext) {
-	// if the config file specifies a valid minimum protocol version, behavior
-	// won't change, so there's nothing to warn on.
-	switch ctx.Config.TLS.MinimumProtocolVersion {
-	case "1.1", "1.2", "1.3":
-		return
-	}
-
-	getWarning := func(kindPlural string, items []string) string {
-		template := "In an upcoming Contour release, TLS 1.1 will be globally disabled by default since it's end-of-life. The following %s currently allow " +
-			"TLS 1.1: [%s]. You must either update the %s to have a minimum TLS protocol version of 1.2 (which is now the Contour default), or explicitly " +
-			"allow TLS 1.1 to be used in Contour by setting \"tls.minimum-protocol-version\" to \"1.1\" in the Contour config file."
-
-		return fmt.Sprintf(template, kindPlural, strings.Join(items, ", "), kindPlural)
-	}
-
-	// Check for & warn on HTTPProxies that have a minimum protocol version of 1.1.
-	proxyList, err := client.Resource(contour_api_v1.HTTPProxyGVR).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		log.Warnf("error listing HTTPProxies: %v", err)
-	} else {
-		var warn []string
-		for _, p := range proxyList.Items {
-			var proxy contour_api_v1.HTTPProxy
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(p.Object, &proxy); err != nil {
-				log.Warnf("error converting HTTPProxy %s/%s from unstructured: %v", p.GetNamespace(), p.GetName(), err)
-				continue
-			}
-
-			if proxy.Spec.VirtualHost == nil || proxy.Spec.VirtualHost.TLS == nil || proxy.Spec.VirtualHost.TLS.MinimumProtocolVersion != "1.1" {
-				continue
-			}
-
-			warn = append(warn, k8s.NamespacedNameOf(&proxy).String())
-		}
-
-		if len(warn) > 0 {
-			log.Warn(getWarning("HTTPProxies", warn))
-		}
-	}
-
-	// Check for & warn on Ingresses that have a minimum protocol version of 1.1.
-	ingressGVR := networking_api_v1beta1.SchemeGroupVersion.WithResource("ingresses")
-	ingressList, err := client.Resource(ingressGVR).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		log.Warnf("error listing Ingresses: %v", err)
-	} else {
-		var warn []string
-		for _, ing := range ingressList.Items {
-			var ingress networking_api_v1beta1.Ingress
-			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ing.Object, &ingress); err != nil {
-				log.Warnf("error converting Ingress %s/%s from unstructured: %v", ing.GetNamespace(), ing.GetName(), err)
-				continue
-			}
-
-			if !annotation.MatchesIngressClass(&ingress, ctx.ingressClass) {
-				continue
-			}
-
-			if annotation.CompatAnnotation(&ingress, "tls-minimum-protocol-version") != "1.1" {
-				continue
-			}
-
-			warn = append(warn, k8s.NamespacedNameOf(&ingress).String())
-		}
-
-		if len(warn) > 0 {
-			log.Warn(getWarning("Ingresses", warn))
-		}
-	}
-}
-
 // doServe runs the contour serve subcommand.
 func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// Establish k8s core & dynamic client connections.
@@ -278,12 +197,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Validate that Contour CRDs have been updated to v1.
 	validateCRDs(clients.DynamicClient(), log)
-
-	// Warn on proxies/ingresses using TLS 1.1 without it being
-	// explicitly allowed via the config file, since in an
-	// upcoming Contour release, TLS 1.1 will be disallowed by
-	// default.
-	warnTLS(log, clients.DynamicClient(), ctx)
 
 	// informerNamespaces is a list of namespaces that we should start informers for.
 	var informerNamespaces []string

--- a/internal/featuretests/v2/envoy.go
+++ b/internal/featuretests/v2/envoy.go
@@ -308,7 +308,7 @@ func filterchaintlsfallback(fallbackSecret *v1.Secret, peerValidationContext *da
 	return envoy_v2.FilterChainTLSFallback(
 		envoy_v2.DownstreamTLSContext(
 			&dag.Secret{Object: fallbackSecret},
-			envoy_api_v2_auth.TlsParameters_TLSv1_1,
+			envoy_api_v2_auth.TlsParameters_TLSv1_2,
 			peerValidationContext,
 			alpn...),
 		envoy_v2.Filters(

--- a/internal/xdscache/v2/listener.go
+++ b/internal/xdscache/v2/listener.go
@@ -207,12 +207,12 @@ func (lvc *ListenerConfig) newSecureAccessLog() []*envoy_api_v2_accesslog.Access
 }
 
 // minTLSVersion returns the requested minimum TLS protocol
-// version or envoy_api_v2_auth.TlsParameters_TLSv1_1 if not configured.
+// version or envoy_api_v2_auth.TlsParameters_TLSv1_2 if not configured.
 func (lvc *ListenerConfig) minTLSVersion() envoy_api_v2_auth.TlsParameters_TlsProtocol {
-	if lvc.MinimumTLSVersion > envoy_api_v2_auth.TlsParameters_TLSv1_1 {
+	if lvc.MinimumTLSVersion > envoy_api_v2_auth.TlsParameters_TLSv1_2 {
 		return lvc.MinimumTLSVersion
 	}
-	return envoy_api_v2_auth.TlsParameters_TLSv1_1
+	return envoy_api_v2_auth.TlsParameters_TLSv1_2
 }
 
 // ListenerCache manages the contents of the gRPC LDS cache.

--- a/internal/xdscache/v2/listener_test.go
+++ b/internal/xdscache/v2/listener_test.go
@@ -1186,7 +1186,7 @@ func TestListenerVisit(t *testing.T) {
 					FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 						TransportProtocol: "tls",
 					},
-					TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+					TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 					Filters:         envoy_v2.Filters(fallbackCertFilter),
 					Name:            "fallback-certificate",
 				}},
@@ -1309,7 +1309,7 @@ func TestListenerVisit(t *testing.T) {
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							TransportProtocol: "tls",
 						},
-						TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_1, "h2", "http/1.1"),
+						TransportSocket: transportSocket("fallbacksecret", envoy_api_v2_auth.TlsParameters_TLSv1_2, "h2", "http/1.1"),
 						Filters:         envoy_v2.Filters(fallbackCertFilter),
 						Name:            "fallback-certificate",
 					}},

--- a/internal/xdscache/v2/visitor_test.go
+++ b/internal/xdscache/v2/visitor_test.go
@@ -123,7 +123,7 @@ func TestVisitListeners(t *testing.T) {
 								Data: secretdata(CERTIFICATE, RSA_PRIVATE_KEY),
 							},
 						},
-						MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_1,
+						MinTLSVersion: envoy_api_v2_auth.TlsParameters_TLSv1_2,
 					},
 				),
 			},
@@ -135,7 +135,7 @@ func TestVisitListeners(t *testing.T) {
 						FilterChainMatch: &envoy_api_v2_listener.FilterChainMatch{
 							ServerNames: []string{"tcpproxy.example.com"},
 						},
-						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_1),
+						TransportSocket: transportSocket("secret", envoy_api_v2_auth.TlsParameters_TLSv1_2),
 						Filters:         envoy_v2.Filters(envoy_v2.TCPProxy(ENVOY_HTTPS_LISTENER, p1, envoy_v2.FileAccessLogEnvoy(DEFAULT_HTTPS_ACCESS_LOG))),
 					}},
 					ListenerFilters: envoy_v2.ListenerFilters(

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -40,7 +40,7 @@ Contour should provision TLS hosts.
 
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
-| minimum-protocol-version| string | `""` | This field specifies the minimum TLS protocol version that is allowed. Valid options are `1.2` and `1.3`. Any other value defaults to TLS 1.1. |
+| minimum-protocol-version| string | `1.2` | This field specifies the minimum TLS protocol version that is allowed. Valid options are `1.1`, `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2. |
 | fallback-certificate | | | [Fallback certificate configuration](#fallback-certificate). |
 | envoy-client-certificate | | | [Client certificate configuration for Envoy](#envoy-client-certificate). |
 {: class="table thead-dark table-bordered"}


### PR DESCRIPTION
Updates the default global minimum TLS version to 1.2 from 1.1.
This forces *all* HTTPProxies and Ingresses to use at least 1.2.

Closes #3010.

Signed-off-by: Steve Kriss <krisss@vmware.com>