### PR TITLE
internal/envoy: Enable xDS v3 Clusters

### DIFF
--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -1,0 +1,110 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// UpstreamTLSContext creates an envoy_tls_v3.UpstreamTlsContext. By default
+// UpstreamTLSContext returns a HTTP/1.1 TLS enabled context. A list of
+// additional ALPN protocols can be provided.
+func UpstreamTLSContext(peerValidationContext *dag.PeerValidationContext, sni string, clientSecret *dag.Secret, alpnProtocols ...string) *envoy_tls_v3.UpstreamTlsContext {
+	var clientSecretConfigs []*envoy_tls_v3.SdsSecretConfig
+	if clientSecret != nil {
+		clientSecretConfigs = []*envoy_tls_v3.SdsSecretConfig{{
+			Name:      envoy.Secretname(clientSecret),
+			SdsConfig: ConfigSource("contour"),
+		}}
+	}
+
+	context := &envoy_tls_v3.UpstreamTlsContext{
+		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+			AlpnProtocols:                  alpnProtocols,
+			TlsCertificateSdsSecretConfigs: clientSecretConfigs,
+		},
+		Sni: sni,
+	}
+
+	if peerValidationContext.GetCACertificate() != nil && len(peerValidationContext.GetSubjectName()) > 0 {
+		// We have to explicitly assign the value from validationContext
+		// to context.CommonTlsContext.ValidationContextType because the
+		// latter is an interface. Returning nil from validationContext
+		// directly into this field boxes the nil into the unexported
+		// type of this grpc OneOf field which causes proto marshaling
+		// to explode later on.
+		vc := validationContext(peerValidationContext.GetCACertificate(), peerValidationContext.GetSubjectName())
+		if vc != nil {
+			context.CommonTlsContext.ValidationContextType = vc
+		}
+	}
+
+	return context
+}
+
+func validationContext(ca []byte, subjectName string) *envoy_tls_v3.CommonTlsContext_ValidationContext {
+	vc := &envoy_tls_v3.CommonTlsContext_ValidationContext{
+		ValidationContext: &envoy_tls_v3.CertificateValidationContext{
+			TrustedCa: &envoy_core_v3.DataSource{
+				// TODO(dfc) update this for SDS
+				Specifier: &envoy_core_v3.DataSource_InlineBytes{
+					InlineBytes: ca,
+				},
+			},
+		},
+	}
+
+	if len(subjectName) > 0 {
+		vc.ValidationContext.MatchSubjectAltNames = []*matcher.StringMatcher{{
+			MatchPattern: &matcher.StringMatcher_Exact{
+				Exact: subjectName,
+			}},
+		}
+	}
+
+	return vc
+}
+
+// DownstreamTLSContext creates a new DownstreamTlsContext.
+func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_tls_v3.TlsParameters_TlsProtocol, peerValidationContext *dag.PeerValidationContext, alpnProtos ...string) *envoy_tls_v3.DownstreamTlsContext {
+	context := &envoy_tls_v3.DownstreamTlsContext{
+		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+			TlsParams: &envoy_tls_v3.TlsParameters{
+				TlsMinimumProtocolVersion: tlsMinProtoVersion,
+				TlsMaximumProtocolVersion: envoy_tls_v3.TlsParameters_TLSv1_3,
+				CipherSuites:              envoy.Ciphers,
+			},
+			TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
+				Name:      envoy.Secretname(serverSecret),
+				SdsConfig: ConfigSource("contour"),
+			}},
+			AlpnProtocols: alpnProtos,
+		},
+	}
+
+	if peerValidationContext.GetCACertificate() != nil {
+		vc := validationContext(peerValidationContext.GetCACertificate(), "")
+		if vc != nil {
+			context.CommonTlsContext.ValidationContextType = vc
+			context.RequireClientCertificate = protobuf.Bool(true)
+		}
+	}
+
+	return context
+}

--- a/internal/envoy/v3/auth_test.go
+++ b/internal/envoy/v3/auth_test.go
@@ -1,0 +1,114 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/protobuf"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpstreamTLSContext(t *testing.T) {
+	secret := &dag.Secret{
+		Object: &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "default",
+			},
+			Type: v1.SecretTypeTLS,
+			Data: map[string][]byte{dag.CACertificateKey: []byte("ca")},
+		},
+	}
+
+	tests := map[string]struct {
+		validation    *dag.PeerValidationContext
+		alpnProtocols []string
+		externalName  string
+		want          *envoy_tls_v3.UpstreamTlsContext
+	}{
+		"no alpn, no validation": {
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
+			},
+		},
+		"h2, no validation": {
+			alpnProtocols: []string{"h2c"},
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+					AlpnProtocols: []string{"h2c"},
+				},
+			},
+		},
+		"no alpn, missing altname": {
+			validation: &dag.PeerValidationContext{
+				CACertificate: secret,
+			},
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
+			},
+		},
+		"no alpn, missing ca": {
+			validation: &dag.PeerValidationContext{
+				SubjectName: "www.example.com",
+			},
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
+			},
+		},
+		"no alpn, ca and altname": {
+			validation: &dag.PeerValidationContext{
+				CACertificate: secret,
+				SubjectName:   "www.example.com",
+			},
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+					ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContext{
+						ValidationContext: &envoy_tls_v3.CertificateValidationContext{
+							TrustedCa: &envoy_core_v3.DataSource{
+								Specifier: &envoy_core_v3.DataSource_InlineBytes{
+									InlineBytes: []byte("ca"),
+								},
+							},
+							MatchSubjectAltNames: []*matcher.StringMatcher{{
+								MatchPattern: &matcher.StringMatcher_Exact{
+									Exact: "www.example.com",
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"external name sni": {
+			externalName: "projectcontour.local",
+			want: &envoy_tls_v3.UpstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
+				Sni:              "projectcontour.local",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := UpstreamTLSContext(tc.validation, tc.externalName, nil, tc.alpnProtocols...)
+			protobuf.ExpectEqual(t, tc.want, got)
+		})
+	}
+}

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -14,9 +14,196 @@
 package v3
 
 import (
+	"strings"
+	"time"
+
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/xds"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+func clusterDefaults() *envoy_cluster_v3.Cluster {
+	return &envoy_cluster_v3.Cluster{
+		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
+		CommonLbConfig: ClusterCommonLBConfig(),
+		LbPolicy:       lbPolicy(""),
+	}
+}
+
+// Cluster creates new envoy_cluster_v3.Cluster from dag.Cluster.
+func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
+	service := c.Upstream
+	cluster := clusterDefaults()
+
+	cluster.Name = envoy.Clustername(c)
+	cluster.AltStatName = envoy.AltStatName(service)
+	cluster.LbPolicy = lbPolicy(c.LoadBalancerPolicy)
+	cluster.HealthChecks = edshealthcheck(c)
+	cluster.DnsLookupFamily = parseDNSLookupFamily(c.DNSLookupFamily)
+
+	switch len(service.ExternalName) {
+	case 0:
+		// external name not set, cluster will be discovered via EDS
+		cluster.ClusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS)
+		cluster.EdsClusterConfig = edsconfig("contour", service)
+	default:
+		// external name set, use hard coded DNS name
+		cluster.ClusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS)
+		cluster.LoadAssignment = StaticClusterLoadAssignment(service)
+	}
+
+	// Drain connections immediately if using healthchecks and the endpoint is known to be removed
+	if c.HTTPHealthCheckPolicy != nil || c.TCPHealthCheckPolicy != nil {
+		cluster.IgnoreHealthOnHostRemoval = true
+	}
+
+	if envoy.AnyPositive(service.MaxConnections, service.MaxPendingRequests, service.MaxRequests, service.MaxRetries) {
+		cluster.CircuitBreakers = &envoy_cluster_v3.CircuitBreakers{
+			Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+				MaxConnections:     protobuf.UInt32OrNil(service.MaxConnections),
+				MaxPendingRequests: protobuf.UInt32OrNil(service.MaxPendingRequests),
+				MaxRequests:        protobuf.UInt32OrNil(service.MaxRequests),
+				MaxRetries:         protobuf.UInt32OrNil(service.MaxRetries),
+			}},
+		}
+	}
+
+	switch c.Protocol {
+	case "tls":
+		cluster.TransportSocket = UpstreamTLSTransportSocket(
+			UpstreamTLSContext(
+				c.UpstreamValidation,
+				c.SNI,
+				c.ClientCertificate,
+			),
+		)
+	case "h2":
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TransportSocket = UpstreamTLSTransportSocket(
+			UpstreamTLSContext(
+				c.UpstreamValidation,
+				c.SNI,
+				c.ClientCertificate,
+				"h2",
+			),
+		)
+	case "h2c":
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+	}
+
+	return cluster
+}
+
+// ExtensionCluster builds a envoy_cluster_v3.Cluster struct for the given extension service.
+func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
+	cluster := clusterDefaults()
+
+	// The Envoy cluster name has already been set.
+	cluster.Name = ext.Name
+
+	// The AltStatName was added to make a more readable alternative
+	// to the cluster name for metrics (see #827). For extension
+	// services, we can have multiple ports, so it doesn't make
+	// sense to build this the same way we build it for HTTPProxy
+	// service clusters. However, we know the namespaced name for
+	// the ExtensionCluster is globally unique, so we can use that
+	// to produce a stable, readable name.
+	cluster.AltStatName = strings.ReplaceAll(cluster.Name, "/", "_")
+
+	cluster.LbPolicy = lbPolicy(ext.LoadBalancerPolicy)
+
+	// Cluster will be discovered via EDS.
+	cluster.ClusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS)
+	cluster.EdsClusterConfig = &envoy_cluster_v3.Cluster_EdsClusterConfig{
+		EdsConfig:   ConfigSource("contour"),
+		ServiceName: ext.Upstream.ClusterName,
+	}
+
+	// TODO(jpeach): Externalname service support in https://github.com/projectcontour/contour/issues/2875
+
+	switch ext.Protocol {
+	case "h2":
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TransportSocket = UpstreamTLSTransportSocket(
+			UpstreamTLSContext(
+				ext.UpstreamValidation,
+				ext.SNI,
+				ext.ClientCertificate,
+				"h2",
+			),
+		)
+	case "h2c":
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+	}
+
+	return cluster
+}
+
+// StaticClusterLoadAssignment creates a *v2.ClusterLoadAssignment pointing to the external DNS address of the service
+func StaticClusterLoadAssignment(service *dag.Service) *envoy_endpoint_v3.ClusterLoadAssignment {
+	addr := SocketAddress(service.ExternalName, int(service.Weighted.ServicePort.Port))
+	return &envoy_endpoint_v3.ClusterLoadAssignment{
+		Endpoints: Endpoints(addr),
+		ClusterName: xds.ClusterLoadAssignmentName(
+			types.NamespacedName{Name: service.Weighted.ServiceName, Namespace: service.Weighted.ServiceNamespace},
+			service.Weighted.ServicePort.Name,
+		),
+	}
+}
+
+func edsconfig(cluster string, service *dag.Service) *envoy_cluster_v3.Cluster_EdsClusterConfig {
+	return &envoy_cluster_v3.Cluster_EdsClusterConfig{
+		EdsConfig: ConfigSource(cluster),
+		ServiceName: xds.ClusterLoadAssignmentName(
+			types.NamespacedName{Name: service.Weighted.ServiceName, Namespace: service.Weighted.ServiceNamespace},
+			service.Weighted.ServicePort.Name,
+		),
+	}
+}
+
+func lbPolicy(strategy string) envoy_cluster_v3.Cluster_LbPolicy {
+	switch strategy {
+	case "WeightedLeastRequest":
+		return envoy_cluster_v3.Cluster_LEAST_REQUEST
+	case "Random":
+		return envoy_cluster_v3.Cluster_RANDOM
+	case "Cookie":
+		return envoy_cluster_v3.Cluster_RING_HASH
+	default:
+		return envoy_cluster_v3.Cluster_ROUND_ROBIN
+	}
+}
+
+func edshealthcheck(c *dag.Cluster) []*envoy_core_v3.HealthCheck {
+	if c.HTTPHealthCheckPolicy == nil && c.TCPHealthCheckPolicy == nil {
+		return nil
+	}
+
+	if c.HTTPHealthCheckPolicy != nil {
+		return []*envoy_core_v3.HealthCheck{
+			httpHealthCheck(c),
+		}
+	}
+
+	return []*envoy_core_v3.HealthCheck{
+		tcpHealthCheck(c),
+	}
+}
+
+// ClusterCommonLBConfig creates a *v2.Cluster_CommonLbConfig with HealthyPanicThreshold disabled.
+func ClusterCommonLBConfig() *envoy_cluster_v3.Cluster_CommonLbConfig {
+	return &envoy_cluster_v3.Cluster_CommonLbConfig{
+		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+			Value: 0,
+		},
+	}
+}
 
 // ConfigSource returns a *envoy_core_v3.ConfigSource for cluster.
 func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
@@ -41,4 +228,16 @@ func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
 // ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
 func ClusterDiscoveryType(t envoy_cluster_v3.Cluster_DiscoveryType) *envoy_cluster_v3.Cluster_Type {
 	return &envoy_cluster_v3.Cluster_Type{Type: t}
+}
+
+// parseDNSLookupFamily parses the dnsLookupFamily string into a v2.Cluster_DnsLookupFamily
+func parseDNSLookupFamily(value string) envoy_cluster_v3.Cluster_DnsLookupFamily {
+
+	switch value {
+	case "v4":
+		return envoy_cluster_v3.Cluster_V4_ONLY
+	case "v6":
+		return envoy_cluster_v3.Cluster_V6_ONLY
+	}
+	return envoy_cluster_v3.Cluster_AUTO
 }

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -1,0 +1,669 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+	"time"
+
+	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/xds"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestCluster(t *testing.T) {
+	s1 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
+	s2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			ExternalName: "foo.io",
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
+	svcExternal := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			ExternalName: "projectcontour.local",
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       443,
+				TargetPort: intstr.FromInt(8080),
+			}},
+			Type: v1.ServiceTypeExternalName,
+		},
+	}
+
+	secret := &dag.Secret{
+		Object: &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret",
+				Namespace: "default",
+			},
+			Type: v1.SecretTypeTLS,
+			Data: map[string][]byte{dag.CACertificateKey: []byte("cacert")},
+		},
+	}
+
+	clientSecret := &dag.Secret{
+		Object: &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "clientcertsecret",
+				Namespace: "default",
+			},
+			Type: v1.SecretTypeTLS,
+			Data: map[string][]byte{
+				v1.TLSCertKey:       []byte("cert"),
+				v1.TLSPrivateKeyKey: []byte("key"),
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		cluster *dag.Cluster
+		want    *envoy_cluster_v3.Cluster
+	}{
+		"simple service": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1),
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+			},
+		},
+		"h2c upstream": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1, "h2c"),
+				Protocol: "h2c",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+			},
+		},
+		"h2 upstream": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1, "h2"),
+				Protocol: "h2",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, "", nil, "h2"),
+				),
+				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+			},
+		},
+		"externalName service": {
+			cluster: &dag.Cluster{
+				Upstream: service(s2),
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+			},
+		},
+		"externalName service - dns-lookup-family v4": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "v4",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      envoy_cluster_v3.Cluster_V4_ONLY,
+			},
+		},
+		"externalName service - dns-lookup-family v6": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "v6",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      envoy_cluster_v3.Cluster_V6_ONLY,
+			},
+		},
+		"externalName service - dns-lookup-family auto": {
+			cluster: &dag.Cluster{
+				Upstream:        service(s2),
+				DNSLookupFamily: "auto",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      envoy_cluster_v3.Cluster_AUTO,
+			},
+		},
+		"externalName service - dns-lookup-family not defined": {
+			cluster: &dag.Cluster{
+				Upstream: service(s2),
+				//DNSLookupFamily: "auto",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(s2)),
+				DnsLookupFamily:      envoy_cluster_v3.Cluster_AUTO,
+			},
+		},
+		"tls upstream": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1, "tls"),
+				Protocol: "tls",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, "", nil),
+				),
+			},
+		},
+		"tls upstream - external name": {
+			cluster: &dag.Cluster{
+				Upstream: service(svcExternal, "tls"),
+				Protocol: "tls",
+				SNI:      "projectcontour.local",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				LoadAssignment:       StaticClusterLoadAssignment(service(svcExternal, "tls")),
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, "projectcontour.local", nil),
+				),
+			},
+		},
+		"verify tls upstream with san": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1, "tls"),
+				Protocol: "tls",
+				UpstreamValidation: &dag.PeerValidationContext{
+					CACertificate: secret,
+					SubjectName:   "foo.bar.io",
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/3ac4e90987",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(
+						&dag.PeerValidationContext{
+							CACertificate: secret,
+							SubjectName:   "foo.bar.io",
+						},
+						"",
+						nil),
+				),
+			},
+		},
+		"projectcontour.io/max-connections": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					MaxConnections: 9000,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      s1.Name,
+						ServiceNamespace: s1.Namespace,
+						ServicePort:      s1.Spec.Ports[0],
+					},
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
+					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+						MaxConnections: protobuf.UInt32(9000),
+					}},
+				},
+			},
+		},
+		"projectcontour.io/max-pending-requests": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					MaxPendingRequests: 4096,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      s1.Name,
+						ServiceNamespace: s1.Namespace,
+						ServicePort:      s1.Spec.Ports[0],
+					},
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
+					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+						MaxPendingRequests: protobuf.UInt32(4096),
+					}},
+				},
+			},
+		},
+		"projectcontour.io/max-requests": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					MaxRequests: 404,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      s1.Name,
+						ServiceNamespace: s1.Namespace,
+						ServicePort:      s1.Spec.Ports[0],
+					},
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
+					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+						MaxRequests: protobuf.UInt32(404),
+					}},
+				},
+			},
+		},
+		"projectcontour.io/max-retries": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					MaxRetries: 7,
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      s1.Name,
+						ServiceNamespace: s1.Namespace,
+						ServicePort:      s1.Spec.Ports[0],
+					},
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
+					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
+						MaxRetries: protobuf.UInt32(7),
+					}},
+				},
+			},
+		},
+		"cluster with random load balancer policy": {
+			cluster: &dag.Cluster{
+				Upstream:           service(s1),
+				LoadBalancerPolicy: "Random",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/58d888c08a",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				LbPolicy: envoy_cluster_v3.Cluster_RANDOM,
+			},
+		},
+		"cluster with cookie policy": {
+			cluster: &dag.Cluster{
+				Upstream:           service(s1),
+				LoadBalancerPolicy: "Cookie",
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/e4f81994fe",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
+			},
+		},
+
+		"tcp service": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1),
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+			},
+		},
+		"tcp service with healthcheck": {
+			cluster: &dag.Cluster{
+				Upstream: service(s1),
+				TCPHealthCheckPolicy: &dag.TCPHealthCheckPolicy{
+					Timeout:            2,
+					Interval:           10,
+					UnhealthyThreshold: 3,
+					HealthyThreshold:   2,
+				},
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				IgnoreHealthOnHostRemoval: true,
+				HealthChecks: []*envoy_core_v3.HealthCheck{{
+					Timeout:            durationOrDefault(2, envoy.HCTimeout),
+					Interval:           durationOrDefault(10, envoy.HCInterval),
+					UnhealthyThreshold: protobuf.UInt32OrDefault(3, envoy.HCUnhealthyThreshold),
+					HealthyThreshold:   protobuf.UInt32OrDefault(2, envoy.HCHealthyThreshold),
+					HealthChecker: &envoy_core_v3.HealthCheck_TcpHealthCheck_{
+						TcpHealthCheck: &envoy_core_v3.HealthCheck_TcpHealthCheck{},
+					},
+				}},
+			},
+		},
+		"use client certificate to authentication towards backend": {
+			cluster: &dag.Cluster{
+				Upstream:          service(s1, "tls"),
+				Protocol:          "tls",
+				ClientCertificate: clientSecret,
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/da39a3ee5e",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				TransportSocket: UpstreamTLSTransportSocket(
+					UpstreamTLSContext(nil, "", clientSecret),
+				),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Cluster(tc.cluster)
+			want := clusterDefaults()
+
+			proto.Merge(want, tc.want)
+
+			protobuf.ExpectEqual(t, want, got)
+		})
+	}
+}
+
+func TestClusterLoadAssignmentName(t *testing.T) {
+	assert.Equal(t, xds.ClusterLoadAssignmentName(types.NamespacedName{Namespace: "ns", Name: "svc"}, "port"), "ns/svc/port")
+	assert.Equal(t, xds.ClusterLoadAssignmentName(types.NamespacedName{Namespace: "ns", Name: "svc"}, ""), "ns/svc")
+	assert.Equal(t, xds.ClusterLoadAssignmentName(types.NamespacedName{}, ""), "/")
+}
+
+func TestClustername(t *testing.T) {
+	tests := map[string]struct {
+		cluster *dag.Cluster
+		want    string
+	}{
+		"simple": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "backend",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(6502),
+						},
+					},
+				},
+			},
+			want: "default/backend/80/da39a3ee5e",
+		},
+		"far too long": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "must-be-in-want-of-a-wife",
+						ServiceNamespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
+						ServicePort: v1.ServicePort{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       9999,
+							TargetPort: intstr.FromString("http-alt"),
+						},
+					},
+				},
+			},
+			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
+		},
+		"various healthcheck params": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "backend",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(6502),
+						},
+					},
+				},
+				LoadBalancerPolicy: "Random",
+				HTTPHealthCheckPolicy: &dag.HTTPHealthCheckPolicy{
+					Path:               "/healthz",
+					Interval:           5 * time.Second,
+					Timeout:            30 * time.Second,
+					UnhealthyThreshold: 3,
+					HealthyThreshold:   1,
+				},
+			},
+			want: "default/backend/80/5c26077e1d",
+		},
+		"upstream tls validation with subject alt name": {
+			cluster: &dag.Cluster{
+				Upstream: &dag.Service{
+					Weighted: dag.WeightedService{
+						Weight:           1,
+						ServiceName:      "backend",
+						ServiceNamespace: "default",
+						ServicePort: v1.ServicePort{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(6502),
+						},
+					},
+				},
+				LoadBalancerPolicy: "Random",
+				UpstreamValidation: &dag.PeerValidationContext{
+					CACertificate: &dag.Secret{
+						Object: &v1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "secret",
+								Namespace: "default",
+							},
+							Data: map[string][]byte{
+								dag.CACertificateKey: []byte("somethingsecret"),
+							},
+						},
+					},
+					SubjectName: "foo.com",
+				},
+			},
+			want: "default/backend/80/6bf46b7b3a",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := envoy.Clustername(tc.cluster)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestLBPolicy(t *testing.T) {
+	tests := map[string]envoy_cluster_v3.Cluster_LbPolicy{
+		"WeightedLeastRequest": envoy_cluster_v3.Cluster_LEAST_REQUEST,
+		"Random":               envoy_cluster_v3.Cluster_RANDOM,
+		"RoundRobin":           envoy_cluster_v3.Cluster_ROUND_ROBIN,
+		"":                     envoy_cluster_v3.Cluster_ROUND_ROBIN,
+		"unknown":              envoy_cluster_v3.Cluster_ROUND_ROBIN,
+		"Cookie":               envoy_cluster_v3.Cluster_RING_HASH,
+
+		// RingHash and Maglev were removed as options in 0.13.
+		// See #1150
+		"RingHash": envoy_cluster_v3.Cluster_ROUND_ROBIN,
+		"Maglev":   envoy_cluster_v3.Cluster_ROUND_ROBIN,
+	}
+
+	for policy, want := range tests {
+		t.Run(policy, func(t *testing.T) {
+			got := lbPolicy(policy)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestClusterCommonLBConfig(t *testing.T) {
+	got := ClusterCommonLBConfig()
+	want := &envoy_cluster_v3.Cluster_CommonLbConfig{
+		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+			Value: 0,
+		},
+	}
+	assert.Equal(t, want, got)
+}
+
+func service(s *v1.Service, protocols ...string) *dag.Service {
+	protocol := ""
+	if len(protocols) > 0 {
+		protocol = protocols[0]
+	}
+	return &dag.Service{
+		Weighted: dag.WeightedService{
+			Weight:           1,
+			ServiceName:      s.Name,
+			ServiceNamespace: s.Namespace,
+			ServicePort:      s.Spec.Ports[0],
+		},
+		ExternalName: s.Spec.ExternalName,
+		Protocol:     protocol,
+	}
+}

--- a/internal/envoy/v3/healthcheck.go
+++ b/internal/envoy/v3/healthcheck.go
@@ -1,0 +1,70 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"time"
+
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+// httpHealthCheck returns a *envoy_core_v3.HealthCheck value for HTTP Routes
+func httpHealthCheck(cluster *dag.Cluster) *envoy_core_v3.HealthCheck {
+	hc := cluster.HTTPHealthCheckPolicy
+	host := envoy.HCHost
+	if hc.Host != "" {
+		host = hc.Host
+	}
+
+	// TODO(dfc) why do we need to specify our own default, what is the default
+	// that envoy applies if these fields are left nil?
+	return &envoy_core_v3.HealthCheck{
+		Timeout:            durationOrDefault(hc.Timeout, envoy.HCTimeout),
+		Interval:           durationOrDefault(hc.Interval, envoy.HCInterval),
+		UnhealthyThreshold: protobuf.UInt32OrDefault(hc.UnhealthyThreshold, envoy.HCUnhealthyThreshold),
+		HealthyThreshold:   protobuf.UInt32OrDefault(hc.HealthyThreshold, envoy.HCHealthyThreshold),
+		HealthChecker: &envoy_core_v3.HealthCheck_HttpHealthCheck_{
+			HttpHealthCheck: &envoy_core_v3.HealthCheck_HttpHealthCheck{
+				Path: hc.Path,
+				Host: host,
+			},
+		},
+	}
+}
+
+// tcpHealthCheck returns a *envoy_core_v3.HealthCheck value for TCPProxies
+func tcpHealthCheck(cluster *dag.Cluster) *envoy_core_v3.HealthCheck {
+	hc := cluster.TCPHealthCheckPolicy
+
+	return &envoy_core_v3.HealthCheck{
+		Timeout:            durationOrDefault(hc.Timeout, envoy.HCTimeout),
+		Interval:           durationOrDefault(hc.Interval, envoy.HCInterval),
+		UnhealthyThreshold: protobuf.UInt32OrDefault(hc.UnhealthyThreshold, envoy.HCUnhealthyThreshold),
+		HealthyThreshold:   protobuf.UInt32OrDefault(hc.HealthyThreshold, envoy.HCHealthyThreshold),
+		HealthChecker: &envoy_core_v3.HealthCheck_TcpHealthCheck_{
+			TcpHealthCheck: &envoy_core_v3.HealthCheck_TcpHealthCheck{},
+		},
+	}
+}
+
+func durationOrDefault(d, def time.Duration) *duration.Duration {
+	if d != 0 {
+		return protobuf.Duration(d)
+	}
+	return protobuf.Duration(def)
+}

--- a/internal/envoy/v3/healthcheck_test.go
+++ b/internal/envoy/v3/healthcheck_test.go
@@ -1,0 +1,102 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+	"time"
+
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/envoy"
+	"github.com/projectcontour/contour/internal/protobuf"
+)
+
+func TestHealthCheck(t *testing.T) {
+	tests := map[string]struct {
+		cluster *dag.Cluster
+		want    *envoy_core_v3.HealthCheck
+	}{
+		// this is an odd case because contour.edshealthcheck will not call envoy.HealthCheck
+		// when hc is nil, so if hc is not nil, at least one of the parameters on it must be set.
+		"blank healthcheck": {
+			cluster: &dag.Cluster{
+				HTTPHealthCheckPolicy: new(dag.HTTPHealthCheckPolicy),
+			},
+			want: &envoy_core_v3.HealthCheck{
+				Timeout:            protobuf.Duration(envoy.HCTimeout),
+				Interval:           protobuf.Duration(envoy.HCInterval),
+				UnhealthyThreshold: protobuf.UInt32(3),
+				HealthyThreshold:   protobuf.UInt32(2),
+				HealthChecker: &envoy_core_v3.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &envoy_core_v3.HealthCheck_HttpHealthCheck{
+						// TODO(dfc) this doesn't seem right
+						Host: "contour-envoy-healthcheck",
+					},
+				},
+			},
+		},
+		"healthcheck path only": {
+			cluster: &dag.Cluster{
+				HTTPHealthCheckPolicy: &dag.HTTPHealthCheckPolicy{
+					Path: "/healthy",
+				},
+			},
+			want: &envoy_core_v3.HealthCheck{
+				Timeout:            protobuf.Duration(envoy.HCTimeout),
+				Interval:           protobuf.Duration(envoy.HCInterval),
+				UnhealthyThreshold: protobuf.UInt32(3),
+				HealthyThreshold:   protobuf.UInt32(2),
+				HealthChecker: &envoy_core_v3.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &envoy_core_v3.HealthCheck_HttpHealthCheck{
+						Path: "/healthy",
+						Host: "contour-envoy-healthcheck",
+					},
+				},
+			},
+		},
+		"explicit healthcheck": {
+			cluster: &dag.Cluster{
+				HTTPHealthCheckPolicy: &dag.HTTPHealthCheckPolicy{
+					Host:               "foo-bar-host",
+					Path:               "/healthy",
+					Timeout:            99 * time.Second,
+					Interval:           98 * time.Second,
+					UnhealthyThreshold: 97,
+					HealthyThreshold:   96,
+				},
+			},
+			want: &envoy_core_v3.HealthCheck{
+				Timeout:            protobuf.Duration(99 * time.Second),
+				Interval:           protobuf.Duration(98 * time.Second),
+				UnhealthyThreshold: protobuf.UInt32(97),
+				HealthyThreshold:   protobuf.UInt32(96),
+				HealthChecker: &envoy_core_v3.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &envoy_core_v3.HealthCheck_HttpHealthCheck{
+						Path: "/healthy",
+						Host: "foo-bar-host",
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := httpHealthCheck(tc.cluster)
+			protobuf.ExpectEqual(t, tc.want, got)
+
+		})
+	}
+}


### PR DESCRIPTION
Enables v3 xDS Clusters as well as supporting structs.

Updates #1898

Signed-off-by: Steve Sloka <slokas@vmware.com>