### PR TITLE
internal/envoy: Move remaining methods from envoy v2 to v3 package

### DIFF
--- a/internal/envoy/v3/endpoint.go
+++ b/internal/envoy/v3/endpoint.go
@@ -16,6 +16,7 @@ package v3
 import (
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/projectcontour/contour/internal/protobuf"
 )
 
 // LBEndpoint creates a new LbEndpoint.
@@ -40,4 +41,22 @@ func Endpoints(addrs ...*envoy_core_v3.Address) []*envoy_endpoint_v3.LocalityLbE
 	return []*envoy_endpoint_v3.LocalityLbEndpoints{{
 		LbEndpoints: lbendpoints,
 	}}
+}
+
+func WeightedEndpoints(weight uint32, addrs ...*envoy_core_v3.Address) []*envoy_endpoint_v3.LocalityLbEndpoints {
+	lbendpoints := Endpoints(addrs...)
+	lbendpoints[0].LoadBalancingWeight = protobuf.UInt32(weight)
+	return lbendpoints
+}
+
+// ClusterLoadAssignment returns a *envoy_endpoint_v3.ClusterLoadAssignment with a single
+// LocalityLbEndpoints of the supplied addresses.
+func ClusterLoadAssignment(name string, addrs ...*envoy_core_v3.Address) *envoy_endpoint_v3.ClusterLoadAssignment {
+	if len(addrs) == 0 {
+		return &envoy_endpoint_v3.ClusterLoadAssignment{ClusterName: name}
+	}
+	return &envoy_endpoint_v3.ClusterLoadAssignment{
+		ClusterName: name,
+		Endpoints:   Endpoints(addrs...),
+	}
 }

--- a/internal/envoy/v3/endpoint_test.go
+++ b/internal/envoy/v3/endpoint_test.go
@@ -31,3 +31,57 @@ func TestLBEndpoint(t *testing.T) {
 	}
 	protobuf.ExpectEqual(t, want, got)
 }
+
+func TestEndpoints(t *testing.T) {
+	got := Endpoints(
+		SocketAddress("github.com", 443),
+		SocketAddress("microsoft.com", 80),
+	)
+	want := []*envoy_endpoint_v3.LocalityLbEndpoints{{
+		LbEndpoints: []*envoy_endpoint_v3.LbEndpoint{{
+			HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+				Endpoint: &envoy_endpoint_v3.Endpoint{
+					Address: SocketAddress("github.com", 443),
+				},
+			},
+		}, {
+			HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+				Endpoint: &envoy_endpoint_v3.Endpoint{
+					Address: SocketAddress("microsoft.com", 80),
+				},
+			},
+		}},
+	}}
+	protobuf.ExpectEqual(t, want, got)
+}
+
+func TestClusterLoadAssignment(t *testing.T) {
+	got := ClusterLoadAssignment("empty")
+	want := &envoy_endpoint_v3.ClusterLoadAssignment{
+		ClusterName: "empty",
+	}
+
+	protobuf.RequireEqual(t, want, got)
+
+	got = ClusterLoadAssignment("one addr", SocketAddress("microsoft.com", 81))
+	want = &envoy_endpoint_v3.ClusterLoadAssignment{
+		ClusterName: "one addr",
+		Endpoints:   Endpoints(SocketAddress("microsoft.com", 81)),
+	}
+
+	protobuf.RequireEqual(t, want, got)
+
+	got = ClusterLoadAssignment("two addrs",
+		SocketAddress("microsoft.com", 81),
+		SocketAddress("github.com", 443),
+	)
+	want = &envoy_endpoint_v3.ClusterLoadAssignment{
+		ClusterName: "two addrs",
+		Endpoints: Endpoints(
+			SocketAddress("microsoft.com", 81),
+			SocketAddress("github.com", 443),
+		),
+	}
+
+	protobuf.RequireEqual(t, want, got)
+}


### PR DESCRIPTION
Updates #1898

Signed-off-by: Steve Sloka <slokas@vmware.com>