### PR TITLE
codespell: Add more exceptions to .codespell.skip and move binary check

### DIFF
--- a/.codespell.skip
+++ b/.codespell.skip
@@ -6,3 +6,7 @@
 *.ico
 ./site/Gemfile.lock
 ./site/_config.yml
+./site/bundler
+./site/.jekyll-cache
+./site/_site
+./vendor

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,7 @@ lint: lint-golint lint-yamllint lint-flags lint-codespell
 lint-codespell: CODESPELL_SKIP := $(shell cat .codespell.skip | tr \\n ',')
 lint-codespell: CODESPELL_BIN := codespell
 lint-codespell:
-	which $(CODESPELL_BIN) >/dev/null 2>&1 || (echo "$(CODESPELL_BIN) binary not found, skipping spell checking"; exit 0)
-	$(CODESPELL_BIN) --skip $(CODESPELL_SKIP) --ignore-words .codespell.ignorewords --check-filenames --check-hidden
+	@./hack/codespell.sh --skip $(CODESPELL_SKIP) --ignore-words .codespell.ignorewords --check-filenames --check-hidden -q2
 
 .PHONY: check-golint
 lint-golint:

--- a/hack/codespell.sh
+++ b/hack/codespell.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+readonly PROGNAME="codespell"
+
+if command -v ${PROGNAME} >/dev/null; then
+	# TODO(jpeach): check this won't self-exec ...
+	exec ${PROGNAME} "$@"
+fi
+
+cat <<EOF
+Unable to run codespell. Please check installation instructions:
+	https://github.com/codespell-project/codespell#installation
+EOF
+
+exit 69 # EX_UNAVAILABLE


### PR DESCRIPTION
Adds additional exceptions to the code spell check list as well as move the check for the binary to hack scripts mirroring how other checks are done. 

Signed-off-by: Steve Sloka <slokas@vmware.com>