### PR TITLE
chore: update Envoy to v1.16.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
 PHONY = gencerts
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.16.0
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.16.1
 
 # The version of Jekyll is pinned in site/Gemfile.lock.
 # https://docs.netlify.com/configure-builds/common-configurations/#jekyll

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -53,7 +53,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.16.0
+        image: docker.io/envoyproxy/envoy:v1.16.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1805,7 +1805,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.16.0
+        image: docker.io/envoyproxy/envoy:v1.16.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/_resources/envoy.md
+++ b/site/_resources/envoy.md
@@ -11,6 +11,7 @@ This page describes the compatibility matrix of Contour and Envoy versions.
 
 | Contour Version | Envoy Version        |
 | --------------- | :------------------- |
+| 1.10.1          | 1.16.1               |
 | 1.10.0          | 1.16.0               |
 | 1.9.0           | 1.15.1<sup>7</sup>   |
 | 1.8.2           | 1.15.1<sup>7</sup>   |


### PR DESCRIPTION
Updates Envoy to the latest minor version.

Contains the changes listed here: https://www.envoyproxy.io/docs/envoy/v1.16.1/version_history/current