### PR TITLE
Fix codespell errors causing CI failure

### DIFF
--- a/design/httpproxy-prefix-rewrite.md
+++ b/design/httpproxy-prefix-rewrite.md
@@ -45,7 +45,7 @@ In other words, it doesn't make sense to want to rewrite a path prefix unless yo
 This implies that even if the owner of a leaf HTTPProxy doesn't control the root or intermediate documents, they still have fairly concrete expectations around the full URL path to expect.
 
 Although there are a number of ways to conceptualize path prefix rewriting, path regex rewriting requires knowledge of the full request path at the time of writing the regex.
-This is because a regex rewrite can be used to re-order arbitratry portions of the URL path, and this can't be done unless the regex is defined as being applied to the complete path.
+This is because a regex rewrite can be used to re-order arbitrary portions of the URL path, and this can't be done unless the regex is defined as being applied to the complete path.
 
 ## High Level Design
 

--- a/design/tls-certificate-delegation.md
+++ b/design/tls-certificate-delegation.md
@@ -18,7 +18,7 @@ This document outlines a specification to allow an Ingress Controller to referen
 
 Currently the Secret containing the TLS certificate must be co-located in the same namespace as the Ingress or root IngressRoute object referencing that secret.
 This requirement complicates deployment patterns where wildcard TLS certificates are used, specifically the use of a wildcard certificate to secure a number of subdomains where the Ingress/IngressRoute records for those subdomains do not share the same namespace as the wildcard TLS certificate.
-For example, presenting foo.example.com using the certifiate for \*.example.com when the Ingress/IngressRoute object for foo.example.com does not share the same namespace as the Secret containing \*.example.com.
+For example, presenting foo.example.com using the certificate for \*.example.com when the Ingress/IngressRoute object for foo.example.com does not share the same namespace as the Secret containing \*.example.com.
 
 This proposal introduces a specification, in the form of a simple CRD, whereby the permission to access the contents of a secret containing a TLS certificate is delegated from the owning namespace to one or more other namespaces.
 


### PR DESCRIPTION
Signed-off-by: Nick Young <ynick@vmware.com>