### PR TITLE
_integration: temporarily disable flaky SNI test

### DIFF
--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -14,6 +14,10 @@
 
 import data.contour.resources
 
+skip[msg] {
+  msg := "004-https-sni-enforcement is flaky, skipping until it's fixed"
+}
+
 # Ensure that cert-manager is installed.
 # Version check the certificates resource.
 


### PR DESCRIPTION
Disables 004-https-sni-enforcement until the cause for the flaky
behavior can be found and fixed.

Signed-off-by: Steve Kriss <krisss@vmware.com>