### PR TITLE
golangci-lint: ignore kubeconditions.go file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 10m
+  skip-files:
+    - apis/projectcontour/v1/kubeconditions.go # copy-pasted from k8s.io/apimachinery, has invalid header
 
 linters:
   enable:


### PR DESCRIPTION
Ignores apis/projectcontour/v1/kubeconditions.go when linting because
this file is copy-pasted from k8s.io/apimachinery and does not conform
to Contour's linting rules -- in particular, it has a different
copyright header.

Signed-off-by: Steve Kriss <krisss@vmware.com>

This will clear up the persistent lint failure on `main`.