### PR TITLE
Restore 'ValidConditionType' to follow api versioning rules

### DIFF
--- a/apis/projectcontour/v1/detailedconditions.go
+++ b/apis/projectcontour/v1/detailedconditions.go
@@ -114,6 +114,9 @@ type DetailedCondition struct {
 }
 
 const (
+	// ValidConditionType describes an valid condition.
+	ValidConditionType = "Valid"
+
 	// ConditionTypeAuthError describes an error condition related to Auth.
 	ConditionTypeAuthError = "AuthError"
 
@@ -159,9 +162,6 @@ const (
 	// ConditionTypeTLSError describes an error condition relating
 	// to TLS configuration.
 	ConditionTypeTLSError = "TLSError"
-
-	// ConditionTypeValid describes an valid condition.
-	ConditionTypeValid = "Valid"
 
 	// ConditionTypeVirtualHostError describes an error condition relating
 	// to the VirtualHost configuration section of an HTTPProxy resource.

--- a/apis/projectcontour/v1/helpers.go
+++ b/apis/projectcontour/v1/helpers.go
@@ -169,7 +169,7 @@ func (dc *DetailedCondition) GetWarning(warnType string) (SubCondition, bool) {
 // condition like `Valid` or `Ready`, and false otherwise.
 func (dc *DetailedCondition) IsPositivePolarity() bool {
 	switch dc.Type {
-	case ConditionTypeValid:
+	case ValidConditionType:
 		return true
 	default:
 		return false

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -318,7 +318,7 @@ func (s *statusResult) Like(want contour_api_v1.HTTPProxyStatus) *Contour {
 func (s *statusResult) HasError(condType string, reason, message string) *Contour {
 	assert.Equal(s.T, s.Have.CurrentStatus, string(status.ProxyStatusInvalid))
 	assert.Equal(s.T, s.Have.Description, `At least one error present, see Errors for details`)
-	validCond := s.Have.GetConditionFor(contour_api_v1.ConditionTypeValid)
+	validCond := s.Have.GetConditionFor(contour_api_v1.ValidConditionType)
 	assert.NotNil(s.T, validCond)
 
 	subCond, ok := validCond.GetError(condType)

--- a/internal/fixture/detailedcondition.go
+++ b/internal/fixture/detailedcondition.go
@@ -24,7 +24,7 @@ type DetailedConditionBuilder v1.DetailedCondition
 func NewValidCondition() *DetailedConditionBuilder {
 	b := &DetailedConditionBuilder{
 		Condition: v1.Condition{
-			Type: v1.ConditionTypeValid,
+			Type: v1.ValidConditionType,
 		},
 	}
 

--- a/internal/status/proxystatus.go
+++ b/internal/status/proxystatus.go
@@ -94,7 +94,7 @@ func (pu *ProxyUpdate) Mutate(obj interface{}) interface{} {
 
 	// Set the old status fields using the Valid DetailedCondition's details.
 	// Other conditions are not relevant for these two fields.
-	validCond := proxy.Status.GetConditionFor(projectcontour.ConditionTypeValid)
+	validCond := proxy.Status.GetConditionFor(projectcontour.ValidConditionType)
 
 	switch validCond.Status {
 	case projectcontour.ConditionTrue:


### PR DESCRIPTION
Following up to https://github.com/projectcontour/contour/pull/3148#discussion_r534281248 I clicked merge before seeing this comment come in. 

This restores the variable `ValidConditionType` which was renamed in #3148 to keep the api stable and not require a new version. 

Updates: #2988

Signed-off-by: Steve Sloka <slokas@vmware.com>