### PR TITLE
internal/dag: fix debug printout for client cert secret

### DIFF
--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -124,7 +124,7 @@ func (p *IngressProcessor) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1
 			p.WithError(err).
 				WithField("name", ing.GetName()).
 				WithField("namespace", ing.GetNamespace()).
-				WithField("secret", clientCertSecret).
+				WithField("secret", p.ClientCertificate).
 				Error("tls.envoy-client-certificate contains unresolved secret reference")
 			return
 		}


### PR DESCRIPTION
This change corrects the debug message when mutual authentication is
misconfigured with a missing secret.  When Ingress was being processed,
the error was printed with empty field secret="<nil>" while the intention
was to print the secret name: secret="namespace/secretname".

Signed-off-by: Tero Saarni <tero.saarni@est.tech>