### PR TITLE
internal/dag: trigger rebuild for configured secrets

### DIFF
--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -688,11 +688,24 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert secret that is referred by configuration file": {
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secretReferredByConfigFile",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeTLS,
+				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			cache := KubernetesCache{
+				ConfiguredSecretRefs: []*types.NamespacedName{
+					{Name: "secretReferredByConfigFile", Namespace: "default"}},
 				FieldLogger: fixture.NewTestLogger(t),
 			}
 			for _, p := range tc.pre {


### PR DESCRIPTION
This change adds secret references from the configuration file to the list of
secrets that will trigger DAG rebuild.  Previously only secrets referred by
HTTPProxy and Ingress resources were considered.  The result was that secrets
referred by fallback-certificate and envoy-client-certificate config file entries 
were not picked up correctly if they were created after HTTPProxy or Ingress.

Fixes #3190 

Signed-off-by: Tero Saarni <tero.saarni@est.tech>