### PR TITLE
internal/xdscache: fix concurrent map access bug

### DIFF
--- a/internal/xdscache/v2/endpointstranslator.go
+++ b/internal/xdscache/v2/endpointstranslator.go
@@ -299,13 +299,18 @@ func (e *EndpointsTranslator) OnChange(d *dag.DAG) {
 	entries := e.cache.Recalculate()
 
 	// Only update and notify if entries has changed.
+	changed := false
+
+	e.mu.Lock()
 	if !equal(e.entries, entries) {
-		e.Debug("cluster load assignments changed, notifying waiters")
-
-		e.mu.Lock()
 		e.entries = entries
-		e.mu.Unlock()
+		changed = true
+	}
+	e.mu.Unlock()
 
+
+	if changed {
+		e.Debug("cluster load assignments changed, notifying waiters")
 		e.Notify()
 	} else {
 		e.Debug("cluster load assignments did not change")


### PR DESCRIPTION
Fixes a bug where the `entries` map was not correctly being
guarded by its mutex against concurrent reads/writes.

Fixes #3193.

Signed-off-by: Steve Kriss <krisss@vmware.com>


**Note** this PR is for the `release-1.10` branch, assuming we're going to ship a v1.10.1 patch release.