### PR TITLE
cmd/contour: update CLI commands to use xDS v3

### DIFF
--- a/cmd/contour/cli.go
+++ b/cmd/contour/cli.go
@@ -20,7 +20,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_service_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_service_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	envoy_service_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
+	envoy_service_route_v3 "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -81,36 +85,36 @@ func (c *Client) dial() *grpc.ClientConn {
 }
 
 // ClusterStream returns a stream of Clusters using the config in the Client.
-func (c *Client) ClusterStream() v2.ClusterDiscoveryService_StreamClustersClient {
-	stream, err := v2.NewClusterDiscoveryServiceClient(c.dial()).StreamClusters(context.Background())
+func (c *Client) ClusterStream() envoy_service_cluster_v3.ClusterDiscoveryService_StreamClustersClient {
+	stream, err := envoy_service_cluster_v3.NewClusterDiscoveryServiceClient(c.dial()).StreamClusters(context.Background())
 	kingpin.FatalIfError(err, "failed to fetch stream of Clusters")
 	return stream
 }
 
 // EndpointStream returns a stream of Endpoints using the config in the Client.
-func (c *Client) EndpointStream() v2.ClusterDiscoveryService_StreamClustersClient {
-	stream, err := v2.NewEndpointDiscoveryServiceClient(c.dial()).StreamEndpoints(context.Background())
+func (c *Client) EndpointStream() envoy_service_endpoint_v3.EndpointDiscoveryService_StreamEndpointsClient {
+	stream, err := envoy_service_endpoint_v3.NewEndpointDiscoveryServiceClient(c.dial()).StreamEndpoints(context.Background())
 	kingpin.FatalIfError(err, "failed to fetch stream of Endpoints")
 	return stream
 }
 
 // ListenerStream returns a stream of Listeners using the config in the Client.
-func (c *Client) ListenerStream() v2.ClusterDiscoveryService_StreamClustersClient {
-	stream, err := v2.NewListenerDiscoveryServiceClient(c.dial()).StreamListeners(context.Background())
+func (c *Client) ListenerStream() envoy_service_listener_v3.ListenerDiscoveryService_StreamListenersClient {
+	stream, err := envoy_service_listener_v3.NewListenerDiscoveryServiceClient(c.dial()).StreamListeners(context.Background())
 	kingpin.FatalIfError(err, "failed to fetch stream of Listeners")
 	return stream
 }
 
 // RouteStream returns a stream of Routes using the config in the Client.
-func (c *Client) RouteStream() v2.ClusterDiscoveryService_StreamClustersClient {
-	stream, err := v2.NewRouteDiscoveryServiceClient(c.dial()).StreamRoutes(context.Background())
+func (c *Client) RouteStream() envoy_service_route_v3.RouteDiscoveryService_StreamRoutesClient {
+	stream, err := envoy_service_route_v3.NewRouteDiscoveryServiceClient(c.dial()).StreamRoutes(context.Background())
 	kingpin.FatalIfError(err, "failed to fetch stream of Routes")
 	return stream
 }
 
 type stream interface {
-	Send(*v2.DiscoveryRequest) error
-	Recv() (*v2.DiscoveryResponse, error)
+	Send(*envoy_discovery_v3.DiscoveryRequest) error
+	Recv() (*envoy_discovery_v3.DiscoveryResponse, error)
 }
 
 func watchstream(st stream, typeURL string, resources []string) {
@@ -119,7 +123,7 @@ func watchstream(st stream, typeURL string, resources []string) {
 		ExpandAny: true,
 	}
 	for {
-		req := &v2.DiscoveryRequest{
+		req := &envoy_discovery_v3.DiscoveryRequest{
 			TypeUrl:       typeURL,
 			ResourceNames: resources,
 		}

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -16,7 +16,7 @@ package main
 import (
 	"os"
 
-	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
+	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/projectcontour/contour/internal/build"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -80,19 +80,19 @@ func main() {
 		doCertgen(certgenConfig, log)
 	case cds.FullCommand():
 		stream := client.ClusterStream()
-		watchstream(stream, resource.ClusterType, resources)
+		watchstream(stream, resource_v3.ClusterType, resources)
 	case eds.FullCommand():
 		stream := client.EndpointStream()
-		watchstream(stream, resource.EndpointType, resources)
+		watchstream(stream, resource_v3.EndpointType, resources)
 	case lds.FullCommand():
 		stream := client.ListenerStream()
-		watchstream(stream, resource.ListenerType, resources)
+		watchstream(stream, resource_v3.ListenerType, resources)
 	case rds.FullCommand():
 		stream := client.RouteStream()
-		watchstream(stream, resource.RouteType, resources)
+		watchstream(stream, resource_v3.RouteType, resources)
 	case sds.FullCommand():
 		stream := client.RouteStream()
-		watchstream(stream, resource.SecretType, resources)
+		watchstream(stream, resource_v3.SecretType, resources)
 	case serve.FullCommand():
 		// Parse args a second time so cli flags are applied
 		// on top of any values sourced from -c's config file.

--- a/internal/xds/v3/callbacks.go
+++ b/internal/xds/v3/callbacks.go
@@ -40,7 +40,11 @@ func NewRequestLoggingCallbacks(log logrus.FieldLogger) envoy_server_v3.Callback
 func logDiscoveryRequestDetails(l logrus.FieldLogger, req *envoy_service_discovery_v3.DiscoveryRequest) *logrus.Entry {
 	log := l.WithField("version_info", req.VersionInfo).WithField("response_nonce", req.ResponseNonce)
 	if req.Node != nil {
-		log = log.WithField("node_id", req.Node.Id).WithField("node_version", fmt.Sprintf("v%d.%d.%d", req.Node.GetUserAgentBuildVersion().Version.MajorNumber, req.Node.GetUserAgentBuildVersion().Version.MinorNumber, req.Node.GetUserAgentBuildVersion().Version.Patch))
+		log = log.WithField("node_id", req.Node.Id)
+
+		if bv := req.Node.GetUserAgentBuildVersion(); bv != nil && bv.Version != nil {
+			log = log.WithField("node_version", fmt.Sprintf("v%d.%d.%d", bv.Version.MajorNumber, bv.Version.MinorNumber, bv.Version.Patch))
+		}
 	}
 
 	if status := req.ErrorDetail; status != nil {

--- a/internal/xds/v3/callbacks_test.go
+++ b/internal/xds/v3/callbacks_test.go
@@ -34,7 +34,7 @@ func TestLogDiscoveryRequestDetails(t *testing.T) {
 		expectedLogMsg  string
 		expectedLogData logrus.Fields
 	}{
-		"request with node info": {
+		"request with node info and node version": {
 			discoveryReq: &envoy_service_discovery_v3.DiscoveryRequest{
 				VersionInfo:   "req-version",
 				ResponseNonce: "resp-nonce",
@@ -61,6 +61,26 @@ func TestLogDiscoveryRequestDetails(t *testing.T) {
 				"type_url":       "some-type-url",
 				"node_id":        "node-id",
 				"node_version":   "v9.8.7",
+			},
+		},
+		"request with node info, without node version": {
+			discoveryReq: &envoy_service_discovery_v3.DiscoveryRequest{
+				VersionInfo:   "req-version",
+				ResponseNonce: "resp-nonce",
+				ResourceNames: []string{"some", "resources"},
+				TypeUrl:       "some-type-url",
+				Node: &envoy_config_core_v3.Node{
+					Id:                   "node-id",
+					UserAgentVersionType: nil,
+				},
+			},
+			expectedLogMsg: "handling v3 xDS resource request",
+			expectedLogData: logrus.Fields{
+				"version_info":   "req-version",
+				"response_nonce": "resp-nonce",
+				"resource_names": []string{"some", "resources"},
+				"type_url":       "some-type-url",
+				"node_id":        "node-id",
 			},
 		},
 		"request without node info": {


### PR DESCRIPTION
Updates the CLI commands to use xDS v3. Also fixes a panic
when no user agent build version is present.

Updates #3200.

Signed-off-by: Steve Kriss <krisss@vmware.com>