### PR TITLE
change remaining v2 xDS references to v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,8 @@ Examples:
 ```
 contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-envoy_v2 "github.com/projectcontour/contour/internal/envoy/v2"
-xdscache_v2 "github.com/projectcontour/contour/internal/xdscache/v2"
+envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
+xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
 ```   
  
 ### Pre commit CI

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -129,12 +129,8 @@ type ExtensionServiceReference struct {
 }
 
 // AuthorizationServer configures an external server to authenticate
-// client requests. The external server must implement the Envoy
-// external authorization GRPC protocol. Currently, the
-// [v2](https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto)
-// protocol is always used, but authorization server authors should implement
-// the v3 protocol as well in the expectation that it will be supported
-// in future.
+// client requests. The external server must implement the v3 Envoy
+// external authorization GRPC protocol (https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto).
 type AuthorizationServer struct {
 	// ExtensionServiceRef specifies the extension resource that will authorize client requests.
 	//

--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -20,11 +20,19 @@ import (
 
 // ExtensionProtocolVersion is the version of the GRPC protocol used
 // to access extension services. The only version currently supported
-// is "v2".
+// is "v3".
 type ExtensionProtocolVersion string
 
-// SupportProtocolVersion2 requests the "v2" support protocol version.
-const SupportProtocolVersion2 ExtensionProtocolVersion = "v2"
+const (
+	// SupportProtocolVersion2 requests the "v2" support protocol version.
+	//
+	// Deprecated: this protocol version is no longer supported and the
+	// constant is retained for backwards compatibility only.
+	SupportProtocolVersion2 ExtensionProtocolVersion = "v2"
+
+	// SupportProtocolVersion3 requests the "v3" support protocol version.
+	SupportProtocolVersion3 ExtensionProtocolVersion = "v3"
+)
 
 // ExtensionServiceTarget defines an Kubernetes Service to target with
 // extension service traffic.
@@ -88,11 +96,11 @@ type ExtensionServiceSpec struct {
 
 	// This field sets the version of the GRPC protocol that Envoy uses to
 	// send requests to the extension service. Since Contour always uses the
-	// v2 Envoy API, this is currently fixed at "v2". However, other
+	// v3 Envoy API, this is currently fixed at "v3". However, other
 	// protocol options will be available in future.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=v2
+	// +kubebuilder:validation:Enum=v3
 	ProtocolVersion ExtensionProtocolVersion `json:"protocolVersion,omitempty"`
 }
 

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -49,9 +49,9 @@ spec:
                 - h2c
                 type: string
               protocolVersion:
-                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v3 Envoy API, this is currently fixed at "v3". However, other protocol options will be available in future.
                 enum:
-                - v2
+                - v3
                 type: string
               services:
                 description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -170,9 +170,9 @@ spec:
                 - h2c
                 type: string
               protocolVersion:
-                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v2 Envoy API, this is currently fixed at "v2". However, other protocol options will be available in future.
+                description: This field sets the version of the GRPC protocol that Envoy uses to send requests to the extension service. Since Contour always uses the v3 Envoy API, this is currently fixed at "v3". However, other protocol options will be available in future.
                 enum:
-                - v2
+                - v3
                 type: string
               services:
                 description: Services specifies the set of Kubernetes Service resources that receive GRPC extension API requests. If no weights are specified for any of the entries in this array, traffic will be spread evenly across all the services. Otherwise, traffic is balanced proportionally to the Weight field in each entry.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -359,7 +359,7 @@ func (v *VirtualHost) Valid() bool {
 type SecureVirtualHost struct {
 	VirtualHost
 
-	// TLS minimum protocol version. Defaults to envoy_api_v2_auth.TlsParameters_TLS_AUTO
+	// TLS minimum protocol version. Defaults to envoy_tls_v3.TlsParameters_TLS_AUTO
 	MinTLSVersion string
 
 	// The cert and key for this host.
@@ -508,7 +508,7 @@ type Cluster struct {
 	UpstreamValidation *PeerValidationContext
 
 	// The load balancer type to use when picking a host in the cluster.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#envoy-api-enum-cluster-lbpolicy
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-lbpolicy
 	LoadBalancerPolicy string
 
 	// Cluster http health check policy
@@ -710,7 +710,7 @@ type ExtensionCluster struct {
 	UpstreamValidation *PeerValidationContext
 
 	// The load balancer type to use when picking a host in the cluster.
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#envoy-api-enum-cluster-lbpolicy
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-lbpolicy
 	LoadBalancerPolicy string
 
 	// TimeoutPolicy specifies how to handle timeouts to this extension.

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -327,7 +327,7 @@ func (b *httpConnectionManagerBuilder) Validate() error {
 // Get returns a new http.HttpConnectionManager filter, constructed
 // from the builder settings.
 //
-// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto.html
+// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
 func (b *httpConnectionManagerBuilder) Get() *envoy_listener_v3.Filter {
 	// For now, failing validation is a programmer error that
 	// the caller can't reasonably recover from. A caller that can

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -584,10 +584,10 @@ func FilterExternalAuthz(authzClusterName string, failOpen bool, timeout timeout
 		},
 		MetadataContextNamespaces: []string{},
 		IncludePeerCertificate:    true,
+		// TODO(jpeach): When we move to the Envoy v4 API, propagate the
+		// `transport_api_version` from ExtensionServiceSpec ProtocolVersion.
+		TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 	}
-
-	// TODO(jpeach): When we move to the Envoy v3 API, propagate the
-	// `transport_api_version` from ExtensionServiceSpec ProtocolVersion.
 
 	return &http.HttpFilter{
 		Name: "envoy.filters.http.ext_authz",

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -101,6 +101,7 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 								StatusOnError: &envoy_type.HttpStatus{
 									Code: envoy_type.StatusCode_Forbidden,
 								},
+								TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 							},
 						),
 						nil, "h2", "http/1.1"),
@@ -189,6 +190,7 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 								StatusOnError: &envoy_type.HttpStatus{
 									Code: envoy_type.StatusCode_Forbidden,
 								},
+								TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 							},
 						),
 						nil, "h2", "http/1.1"),
@@ -505,6 +507,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 								StatusOnError: &envoy_type.HttpStatus{
 									Code: envoy_type.StatusCode_Forbidden,
 								},
+								TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 							},
 						),
 						nil, "h2", "http/1.1"),

--- a/internal/featuretests/v3/replaceprefix_test.go
+++ b/internal/featuretests/v3/replaceprefix_test.go
@@ -93,7 +93,7 @@ func basic(t *testing.T) {
 			vhost.Spec.Routes[0].PathRewritePolicy.ReplacePrefix =
 				[]contour_api_v1.ReplacePrefix{
 					{Replacement: "/api/v1"},
-					{Replacement: "/api/envoy_api_v2"},
+					{Replacement: "/api/v2"},
 				}
 		})
 
@@ -110,7 +110,7 @@ func basic(t *testing.T) {
 			vhost.Spec.Routes[0].PathRewritePolicy.ReplacePrefix =
 				[]contour_api_v1.ReplacePrefix{
 					{Prefix: "/foo", Replacement: "/api/v1"},
-					{Prefix: "/api", Replacement: "/api/envoy_api_v2"},
+					{Prefix: "/api", Replacement: "/api/v2"},
 				}
 		})
 
@@ -120,11 +120,11 @@ func basic(t *testing.T) {
 				envoy_v3.VirtualHost("kuard.projectcontour.io",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/api/"),
-						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/envoy_api_v2/"),
+						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/v2/"),
 					},
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/api"),
-						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/envoy_api_v2"),
+						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/v2"),
 					},
 				),
 			),
@@ -141,7 +141,7 @@ func basic(t *testing.T) {
 			vhost.Spec.Routes[0].PathRewritePolicy.ReplacePrefix =
 				[]contour_api_v1.ReplacePrefix{
 					{Prefix: "/foo", Replacement: "/api/v1"},
-					{Prefix: "/foo", Replacement: "/api/envoy_api_v2"},
+					{Prefix: "/foo", Replacement: "/api/v2"},
 				}
 		})
 
@@ -234,7 +234,7 @@ func multiInclude(t *testing.T) {
 			Includes: []contour_api_v1.Include{{
 				Name:       "app",
 				Namespace:  "default",
-				Conditions: matchconditions(prefixMatchCondition("/envoy_api_v2")),
+				Conditions: matchconditions(prefixMatchCondition("/v2")),
 			}},
 		})
 
@@ -247,7 +247,7 @@ func multiInclude(t *testing.T) {
 				}},
 				PathRewritePolicy: &contour_api_v1.PathRewritePolicy{
 					ReplacePrefix: []contour_api_v1.ReplacePrefix{
-						{Prefix: "/envoy_api_v2", Replacement: "/api/envoy_api_v2"},
+						{Prefix: "/v2", Replacement: "/api/v2"},
 						{Prefix: "/v1", Replacement: "/api/v1"},
 					},
 				},
@@ -273,12 +273,12 @@ func multiInclude(t *testing.T) {
 				),
 				envoy_v3.VirtualHost("host2.projectcontour.io",
 					&envoy_route_v3.Route{
-						Match:  routePrefix("/envoy_api_v2/"),
-						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/envoy_api_v2/"),
+						Match:  routePrefix("/v2/"),
+						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/v2/"),
 					},
 					&envoy_route_v3.Route{
-						Match:  routePrefix("/envoy_api_v2"),
-						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/envoy_api_v2"),
+						Match:  routePrefix("/v2"),
+						Action: withPrefixRewrite(routeCluster("default/kuard/8080/da39a3ee5e"), "/api/v2"),
 					},
 				),
 			),
@@ -314,7 +314,7 @@ func multiInclude(t *testing.T) {
 				),
 				envoy_v3.VirtualHost("host2.projectcontour.io",
 					&envoy_route_v3.Route{
-						Match:  routePrefix("/envoy_api_v2"),
+						Match:  routePrefix("/v2"),
 						Action: routeCluster("default/kuard/8080/da39a3ee5e"),
 					},
 				),
@@ -475,10 +475,10 @@ func artifactoryDocker(t *testing.T) {
 				}},
 				PathRewritePolicy: &contour_api_v1.PathRewritePolicy{
 					ReplacePrefix: []contour_api_v1.ReplacePrefix{
-						{Prefix: "/envoy_api_v2/container-sandbox", Replacement: "/artifactory/api/docker/container-sandbox/envoy_api_v2"},
-						{Prefix: "/envoy_api_v2/container-release", Replacement: "/artifactory/api/docker/container-release/envoy_api_v2"},
-						{Prefix: "/envoy_api_v2/container-external", Replacement: "/artifactory/api/docker/container-external/envoy_api_v2"},
-						{Prefix: "/envoy_api_v2/container-public", Replacement: "/artifactory/api/docker/container-public/envoy_api_v2"},
+						{Prefix: "/v2/container-sandbox", Replacement: "/artifactory/api/docker/container-sandbox/v2"},
+						{Prefix: "/v2/container-release", Replacement: "/artifactory/api/docker/container-release/v2"},
+						{Prefix: "/v2/container-external", Replacement: "/artifactory/api/docker/container-external/v2"},
+						{Prefix: "/v2/container-public", Replacement: "/artifactory/api/docker/container-public/v2"},
 					},
 				},
 			}},
@@ -491,10 +491,10 @@ func artifactoryDocker(t *testing.T) {
 				Fqdn: "artifactory.projectcontour.io",
 			},
 			Includes: []contour_api_v1.Include{
-				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/envoy_api_v2/container-sandbox"))},
-				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/envoy_api_v2/container-release"))},
-				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/envoy_api_v2/container-external"))},
-				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/envoy_api_v2/container-public"))},
+				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/v2/container-sandbox"))},
+				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/v2/container-release"))},
+				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/v2/container-external"))},
+				{Name: "routes", Conditions: matchconditions(prefixMatchCondition("/v2/container-public"))},
 			},
 		}),
 	)
@@ -505,44 +505,44 @@ func artifactoryDocker(t *testing.T) {
 				envoy_v3.VirtualHost("artifactory.projectcontour.io",
 
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-sandbox/"),
+						Match: routePrefix("/v2/container-sandbox/"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-sandbox/envoy_api_v2/"),
+							"/artifactory/api/docker/container-sandbox/v2/"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-sandbox"),
+						Match: routePrefix("/v2/container-sandbox"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-sandbox/envoy_api_v2"),
+							"/artifactory/api/docker/container-sandbox/v2"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-release/"),
+						Match: routePrefix("/v2/container-release/"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-release/envoy_api_v2/"),
+							"/artifactory/api/docker/container-release/v2/"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-release"),
+						Match: routePrefix("/v2/container-release"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-release/envoy_api_v2"),
+							"/artifactory/api/docker/container-release/v2"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-public/"),
+						Match: routePrefix("/v2/container-public/"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-public/envoy_api_v2/"),
+							"/artifactory/api/docker/container-public/v2/"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-public"),
+						Match: routePrefix("/v2/container-public"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-public/envoy_api_v2"),
+							"/artifactory/api/docker/container-public/v2"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-external/"),
+						Match: routePrefix("/v2/container-external/"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-external/envoy_api_v2/"),
+							"/artifactory/api/docker/container-external/v2/"),
 					},
 					&envoy_route_v3.Route{
-						Match: routePrefix("/envoy_api_v2/container-external"),
+						Match: routePrefix("/v2/container-external"),
 						Action: withPrefixRewrite(routeCluster("artifactory/service/8080/da39a3ee5e"),
-							"/artifactory/api/docker/container-external/envoy_api_v2"),
+							"/artifactory/api/docker/container-external/v2"),
 					},
 				),
 			),

--- a/internal/xds/hash.go
+++ b/internal/xds/hash.go
@@ -19,7 +19,9 @@ import (
 
 const CONSTANT_HASH_VALUE = "contour"
 
-// ConstantHashV3 is the same as ConstantHashV2 but for xDS v3.
+// ConstantHashV3 is a specialized node ID hasher used to allow
+// any instance of Envoy to connect to Contour regardless of the
+// service-node flag configured on Envoy.
 type ConstantHashV3 struct{}
 
 func (c ConstantHashV3) ID(*envoy_config_v3.Node) string {

--- a/internal/xds/v3/contour_test.go
+++ b/internal/xds/v3/contour_test.go
@@ -20,9 +20,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
-	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/sirupsen/logrus"
@@ -93,7 +92,7 @@ func TestXDSHandlerStream(t *testing.T) {
 							ch <- i + 1
 						},
 						contents: func() []proto.Message {
-							return []proto.Message{new(envoy_api_v2.ClusterLoadAssignment)}
+							return []proto.Message{new(envoy_endpoint_v3.ClusterLoadAssignment)}
 						},
 						typeurl: func() string { return "io.projectcontour.potato" },
 					},

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -250,7 +250,7 @@ type TimeoutParameters struct {
 	// this is a timeout for the entire request, not an idle timeout. Omit or set to
 	// "infinity" to disable the timeout entirely.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-request-timeout
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
 	// for more information.
 	RequestTimeout string `yaml:"request-timeout,omitempty"`
 
@@ -258,7 +258,7 @@ type TimeoutParameters struct {
 	// no active requests (for HTTP/1.1) or streams (for HTTP/2) before terminating
 	// an HTTP connection. Set to "infinity" to disable the timeout entirely.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 	// for more information.
 	ConnectionIdleTimeout string `yaml:"connection-idle-timeout,omitempty"`
 
@@ -267,7 +267,7 @@ type TimeoutParameters struct {
 	// terminating the HTTP request or stream. Set to "infinity" to disable the
 	// timeout entirely.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 	// for more information.
 	StreamIdleTimeout string `yaml:"stream-idle-timeout,omitempty"`
 
@@ -276,7 +276,7 @@ type TimeoutParameters struct {
 	// regardless of whether there has been activity or not. Omit or set to "infinity" for
 	// no max duration.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
 	// for more information.
 	MaxConnectionDuration string `yaml:"max-connection-duration,omitempty"`
 
@@ -285,7 +285,7 @@ type TimeoutParameters struct {
 	// During this grace period, the proxy will continue to respond to new streams. After the final
 	// GOAWAY frame has been sent, the proxy will refuse new streams.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-drain-timeout
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
 	// for more information.
 	ConnectionShutdownGracePeriod string `yaml:"connection-shutdown-grace-period,omitempty"`
 }
@@ -339,7 +339,7 @@ type ClusterParameters struct {
 	// in the IPv4 family.
 	// Note: This only applies to externalName clusters.
 	//
-	// See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cluster.proto#enum-cluster-dnslookupfamily
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
 	// for more information.
 	DNSLookupFamily ClusterDNSFamilyType `yaml:"dns-lookup-family"`
 }

--- a/site/_guides/external-authorization.md
+++ b/site/_guides/external-authorization.md
@@ -372,7 +372,7 @@ authorization:
 
 [1]: https://github.com/projectcontour/contour-authserver
 [2]: https://httpd.apache.org/docs/current/misc/password_encryptions.html
-[3]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto
+[3]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
 [4]: /docs/{{site.latest}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
 [5]: /docs/{{site.latest}}/config/api/#projectcontour.io/v1.HTTPProxy
 [6]: https://cert-manager.io/

--- a/site/docs/main/config/annotations.md
+++ b/site/docs/main/config/annotations.md
@@ -70,20 +70,20 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 ## Contour specific HTTPProxy annotations
 - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the HTTPProxy. See the [main Ingress class annotation section](#ingress-class) for more details.
 
-[1]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-max-retries
-[2]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
-[3]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
+[1]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-max-retries
+[2]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-retry-on
+[3]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout
 [4]: https://golang.org/pkg/time/#ParseDuration
-[5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-retrypolicy-retry-on
-[6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/configuration/http_filters/router_filter.html#config-http-filters-router-x-envoy-retry-on
-[7]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/auth/cert.proto#envoy-api-msg-auth-tlsparameters
-[8]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto#envoy-api-field-route-routeaction-use-websocket
+[5]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-retrypolicy-retry-on
+[6]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on
+[7]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html#extensions-transport-sockets-tls-v3-tlsparameters
+[8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-upgrade-configs
 [9]: https://kubernetes.io/docs/concepts/services-networking/service/
-[10]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/intro/terminology.html
-[11]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-connections
-[12]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-pending-requests
-[13]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-requests
-[14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
+[10]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/terminology
+[11]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-connections
+[12]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-pending-requests
+[13]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-requests
+[14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: {% link docs/{{page.version}}/config/fundamentals.md %}
-[16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
+[16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
 [17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -320,12 +320,8 @@ outer scope.</p>
 </p>
 <p>
 <p>AuthorizationServer configures an external server to authenticate
-client requests. The external server must implement the Envoy
-external authorization GRPC protocol. Currently, the
-<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto">v2</a>
-protocol is always used, but authorization server authors should implement
-the v3 protocol as well in the expectation that it will be supported
-in future.</p>
+client requests. The external server must implement the v3 Envoy
+external authorization GRPC protocol (<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto">https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto</a>).</p>
 </p>
 <table class="table table-striped table-borderless" style="border:none">
 <thead class="border-bottom">
@@ -2703,7 +2699,7 @@ ExtensionProtocolVersion
 <em>(Optional)</em>
 <p>This field sets the version of the GRPC protocol that Envoy uses to
 send requests to the extension service. Since Contour always uses the
-v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+v3 Envoy API, this is currently fixed at &ldquo;v3&rdquo;. However, other
 protocol options will be available in future.</p>
 </td>
 </tr>
@@ -2734,7 +2730,7 @@ ExtensionServiceStatus
 <p>
 <p>ExtensionProtocolVersion is the version of the GRPC protocol used
 to access extension services. The only version currently supported
-is &ldquo;v2&rdquo;.</p>
+is &ldquo;v3&rdquo;.</p>
 </p>
 <h3 id="projectcontour.io/v1alpha1.ExtensionServiceSpec">ExtensionServiceSpec
 </h3>
@@ -2847,7 +2843,7 @@ ExtensionProtocolVersion
 <em>(Optional)</em>
 <p>This field sets the version of the GRPC protocol that Envoy uses to
 send requests to the extension service. Since Contour always uses the
-v2 Envoy API, this is currently fixed at &ldquo;v2&rdquo;. However, other
+v3 Envoy API, this is currently fixed at &ldquo;v3&rdquo;. However, other
 protocol options will be available in future.</p>
 </td>
 </tr>

--- a/site/docs/main/config/client-authorization.md
+++ b/site/docs/main/config/client-authorization.md
@@ -27,7 +27,7 @@ In principle, the Envoy cluster can be used for any purpose, but in this
 document we are concerned only with how to use it as an authorization service.
 
 An authorization service is a gRPC service that implements the Envoy [`CheckRequest`][3] protocol.
-Note that Contour requires the extension to implement the "v2" version of the protocol.
+Note that Contour requires the extension to implement the "v3" version of the protocol.
 Contour is compatible with any authorization server that implements this protocol.
 
 The primary field of interest in the `ExtensionService` CRD is the
@@ -116,7 +116,7 @@ context field of authorization policy for the route.
 
 [1]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter
 [2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
-[3]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto
+[3]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
 [4]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
 [5]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationServer
 [6]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationPolicy

--- a/site/docs/main/config/request-routing.md
+++ b/site/docs/main/config/request-routing.md
@@ -280,7 +280,7 @@ None of these properties are guaranteed by a Kubernetes cluster and will be visi
 
 Any perturbation in the set of pods backing a service risks redistributing backends around the hash ring.
 
-[4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
+[4]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout
 [5]: https://godoc.org/time#ParseDuration
-[6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
-[7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
+[6]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-idle-timeout
+[7]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/overview

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -222,8 +222,8 @@ connects to Contour:
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 [7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
-[8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
-[9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
-[10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration
-[11]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-drain-timeout
-[12]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-request-timeout
+[8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
+[9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
+[10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
+[11]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
+[12]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout


### PR DESCRIPTION
Updates comments, documentation, etc. to exclusively reference
xDS v3.

Closes #3200.

Signed-off-by: Steve Kriss <krisss@vmware.com>