### PR TITLE
examples: update Envoy to 1.16.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
 PHONY = gencerts
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.16.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.16.2
 
 # The version of Jekyll is pinned in site/Gemfile.lock.
 # https://docs.netlify.com/configure-builds/common-configurations/#jekyll

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -53,7 +53,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.16.1
+        image: docker.io/envoyproxy/envoy:v1.16.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1805,7 +1805,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.16.1
+        image: docker.io/envoyproxy/envoy:v1.16.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

The compatibility matrix will need to be updated when 1.10.1 and 1.11 are cut.