### PR TITLE
internal/envoy/v3/bootstrap: Make configurable about keepalive settings.

### DIFF
--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -35,5 +35,8 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Flag("envoy-key-file", "Client key filename for Envoy secure xDS gRPC communication.").Envar("ENVOY_KEY_FILE").StringVar(&config.GrpcClientKey)
 	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&config.Namespace)
 	bootstrap.Flag("xds-resource-version", "The versions of the xDS resources to request from Contour.").Default("v3").StringVar((*string)(&config.XDSResourceVersion))
+	bootstrap.Flag("tcp-keepalive-probe", "Maximum number of keepalive probes to send without response.").Uint32Var(&config.KeepaliveProbe)
+	bootstrap.Flag("tcp-keepalive-time", "The number of seconds a connection needs to be idle before keep-alive probes start being sent.").Uint32Var(&config.KeepaliveTime)
+	bootstrap.Flag("tcp-keepalive-interval", "The number of seconds between keep-alive probes.").Uint32Var(&config.KeepaliveInterval)
 	return bootstrap, &config
 }

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -84,6 +84,15 @@ type BootstrapConfig struct {
 	// referenced in the configuration actually exist. This option is for
 	// testing only.
 	SkipFilePathCheck bool
+
+	// KeepaliveProbe is the maximum number of keepalive probes to send without response.
+	KeepaliveProbe uint32
+
+	// KeepaliveTime is the number of seconds a connection needs to be idle before keep-alive probes start being sent.
+	KeepaliveTime uint32
+
+	// KeepaliveInterval is the number of seconds between keep-alive probes.
+	KeepaliveInterval uint32
 }
 
 func (c *BootstrapConfig) GetXdsAddress() string { return stringOrDefault(c.XDSAddress, "127.0.0.1") }
@@ -95,6 +104,15 @@ func (c *BootstrapConfig) GetAdminPort() int { return intOrDefault(c.AdminPort, 
 func (c *BootstrapConfig) GetAdminAccessLogPath() string {
 	return stringOrDefault(c.AdminAccessLogPath, "/dev/null")
 }
+func (c *BootstrapConfig) GetKeepaliveProbe() uint32 {
+	return uint32OrDefault(c.KeepaliveProbe, 3)
+}
+func (c *BootstrapConfig) GetKeepaliveTime() uint32 {
+	return uint32OrDefault(c.KeepaliveTime, 30)
+}
+func (c *BootstrapConfig) GetKeepaliveInterval() uint32 {
+	return uint32OrDefault(c.KeepaliveInterval, 5)
+}
 
 func stringOrDefault(s, def string) string {
 	if s == "" {
@@ -104,6 +122,13 @@ func stringOrDefault(s, def string) string {
 }
 
 func intOrDefault(i, def int) int {
+	if i == 0 {
+		return def
+	}
+	return i
+}
+
+func uint32OrDefault(i, def uint32) uint32 {
 	if i == 0 {
 		return def
 	}

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -168,9 +168,9 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 				},
 				UpstreamConnectionOptions: &envoy_cluster_v3.UpstreamConnectionOptions{
 					TcpKeepalive: &envoy_core_v3.TcpKeepalive{
-						KeepaliveProbes:   protobuf.UInt32(3),
-						KeepaliveTime:     protobuf.UInt32(30),
-						KeepaliveInterval: protobuf.UInt32(5),
+						KeepaliveProbes:   protobuf.UInt32(c.GetKeepaliveProbe()),
+						KeepaliveTime:     protobuf.UInt32(c.GetKeepaliveTime()),
+						KeepaliveInterval: protobuf.UInt32(c.GetKeepaliveInterval()),
 					},
 				},
 				Http2ProtocolOptions: new(envoy_core_v3.Http2ProtocolOptions), // enables http2


### PR DESCRIPTION
This PR is an Implementation for allowing users to tune TCP keep alive settings.
I think this feature is already argued in #2652 and would help for #3214.

Fixes #2652
Fixes #3214

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>