### PR TITLE
add CODEOWNERS file to make Github reviews work properly

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @maintainers will be requested for review when someone
+# opens a pull request.
+*       @projectcontour/maintainers


### PR DESCRIPTION
Currently we have Github configured to auto-request reviews from the @maintainers group, however, it's not working. I think this is because the PR's are opened against the `main` branch which is protected. Adding a `CODEOWNERS` file will allow the review to work properly: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

Signed-off-by: Steve Sloka <slokas@vmware.com>