### PR TITLE
internal/dag: Remove GetProxyStatusesTesting function

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/projectcontour/contour/internal/xds"
@@ -77,19 +76,6 @@ func (d *DAG) Visit(fn func(Vertex)) {
 	for _, r := range d.roots {
 		fn(r)
 	}
-}
-
-// GetProxyStatusesTesting returns a slice of Status objects associated with
-// the computation of this DAG, for testing status output.
-// TODO(youngnick)#2967: This should be removed, see the linked issue for details.
-func (d *DAG) GetProxyStatusesTesting() map[types.NamespacedName]contour_api_v1.DetailedCondition {
-	validConds := make(map[types.NamespacedName]contour_api_v1.DetailedCondition)
-
-	for _, pu := range d.StatusCache.GetProxyUpdates() {
-		validConds[pu.Fullname] = *pu.Conditions[status.ValidCondition]
-	}
-
-	return validConds
 }
 
 // AddRoot appends the given root to the DAG's roots.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -18,6 +18,7 @@ import (
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/status"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
@@ -58,7 +59,12 @@ func TestDAGStatus(t *testing.T) {
 			}
 			dag := builder.Build()
 			t.Logf("%#v\n", dag.StatusCache)
-			got := dag.GetProxyStatusesTesting()
+
+			got := make(map[types.NamespacedName]contour_api_v1.DetailedCondition)
+			for _, pu := range dag.StatusCache.GetProxyUpdates() {
+				got[pu.Fullname] = *pu.Conditions[status.ValidCondition]
+			}
+
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
The GetProxyStatusesTesting() was left in the dag package to allow for an easy way to mutate
values stored in the status.Cache into an easier format to consume. This removes the helper
function, leaving the work to implement a different pattern to #2969.

Fixes #2967

Signed-off-by: Steve Sloka <slokas@vmware.com>