### PR TITLE
Bump build image and CI to go 1.15.6

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.2'
+          go-version: '1.15.6'
       - name: test
         run: |
           go mod vendor
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.2'
+          go-version: '1.15.6'
       - name: test
         run: |
           go mod vendor
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.2'
+          go-version: '1.15.6'
       - name: generate
         run: |
           go mod vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM golang:1.15.2 AS build
+FROM --platform=$BUILDPLATFORM golang:1.15.6 AS build
 WORKDIR /contour
 
 ENV GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Gives us security fixes and general tool/compiler/etc. fixes: https://golang.org/doc/devel/release.html#go1.15