### PR TITLE
internal/envoy/v3: Add required ConfigSource fields for Envoy 1.17.0

### DIFF
--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -277,6 +277,7 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 // including paths to TLS certificates and key
 func tlsCertificateSdsSecretConfig(c *envoy.BootstrapConfig) *envoy_service_discovery_v3.DiscoveryResponse {
 	secret := &envoy_tls_v3.Secret{
+		Name: "contour_xds_tls_certificate",
 		Type: &envoy_tls_v3.Secret_TlsCertificate{
 			TlsCertificate: &envoy_tls_v3.TlsCertificate{
 				CertificateChain: &envoy_core_v3.DataSource{
@@ -302,6 +303,7 @@ func tlsCertificateSdsSecretConfig(c *envoy.BootstrapConfig) *envoy_service_disc
 // including path to CA certificate bundle
 func validationContextSdsSecretConfig(c *envoy.BootstrapConfig) *envoy_service_discovery_v3.DiscoveryResponse {
 	secret := &envoy_tls_v3.Secret{
+		Name: "contour_xds_tls_validation_context",
 		Type: &envoy_tls_v3.Secret_ValidationContext{
 			ValidationContext: &envoy_tls_v3.CertificateValidationContext{
 				TrustedCa: &envoy_core_v3.DataSource{

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -249,6 +249,7 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 	context := &envoy_tls_v3.UpstreamTlsContext{
 		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 			TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
+				Name: "contour_xds_tls_certificate",
 				SdsConfig: &envoy_core_v3.ConfigSource{
 					ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
 					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{
@@ -258,6 +259,7 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 			}},
 			ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &envoy_tls_v3.SdsSecretConfig{
+					Name: "contour_xds_tls_validation_context",
 					SdsConfig: &envoy_core_v3.ConfigSource{
 						ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
 						ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -250,6 +250,7 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 		CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 			TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
 				SdsConfig: &envoy_core_v3.ConfigSource{
+					ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
 					ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{
 						Path: certificateSdsFile,
 					},
@@ -258,6 +259,7 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 			ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &envoy_tls_v3.SdsSecretConfig{
 					SdsConfig: &envoy_core_v3.ConfigSource{
+						ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
 						ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_Path{
 							Path: validationSdsFile,
 						},

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -888,6 +888,7 @@ func TestBootstrap(t *testing.T) {
                   "common_tls_context": {
                     "tls_certificate_sds_secret_configs": [
                       {
+                        "name": "contour_xds_tls_certificate",
                         "sds_config": {
                           "resource_api_version": "V3",
                           "path": "resources/sds/xds-tls-certificate.json"
@@ -895,6 +896,7 @@ func TestBootstrap(t *testing.T) {
                       }
                     ],
                     "validation_context_sds_secret_config": {
+                      "name": "contour_xds_tls_validation_context",
                       "sds_config": {
                         "resource_api_version": "V3",
                         "path": "resources/sds/xds-validation-context.json"

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -984,6 +984,7 @@ func TestBootstrap(t *testing.T) {
       "resources": [
         {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+          "name": "contour_xds_tls_certificate",
           "tls_certificate": {
             "certificate_chain": {
               "filename": "client.cert"
@@ -999,6 +1000,7 @@ func TestBootstrap(t *testing.T) {
       "resources": [
         {
           "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret",
+          "name": "contour_xds_tls_validation_context",
           "validation_context": {
             "trusted_ca": {
               "filename": "CA.cert"

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -889,12 +889,14 @@ func TestBootstrap(t *testing.T) {
                     "tls_certificate_sds_secret_configs": [
                       {
                         "sds_config": {
+                          "resource_api_version": "V3",
                           "path": "resources/sds/xds-tls-certificate.json"
                         }
                       }
                     ],
                     "validation_context_sds_secret_config": {
                       "sds_config": {
+                        "resource_api_version": "V3",
                         "path": "resources/sds/xds-validation-context.json"
                       }
                     }


### PR DESCRIPTION
Adds required fields that are now validated in Envoy 1.17.0

Merge before https://github.com/projectcontour/contour/pull/3245 to ensure upgrade on Envoy 1.16.2 is validated with this change