### PR TITLE
internal: update HTTP/2 protocol options config

### DIFF
--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -173,7 +173,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 						KeepaliveInterval: protobuf.UInt32(5),
 					},
 				},
-				Http2ProtocolOptions: new(envoy_core_v3.Http2ProtocolOptions), // enables http2
+				TypedExtensionProtocolOptions: http2ProtocolOptions(),
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
 					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
 						Priority:           envoy_core_v3.RoutingPriority_HIGH,

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -82,7 +82,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -210,7 +217,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -337,7 +351,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -465,7 +486,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -591,7 +619,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -721,7 +756,14 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "http2_protocol_options": {},
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -880,7 +922,14 @@ func TestBootstrap(t *testing.T) {
                   }
                 ]
               },
-              "http2_protocol_options": {},
+              "typed_extension_protocol_options": {
+                "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+                  "explicit_http_config": {
+                    "http2_protocol_options": {}
+                  }
+                }
+              },
               "transport_socket": {
                 "name": "envoy.transport_sockets.tls",
                 "typed_config": {

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -20,7 +20,9 @@ import (
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -84,7 +86,7 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2":
-		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				c.UpstreamValidation,
@@ -94,10 +96,23 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
 	}
 
 	return cluster
+}
+
+func http2ProtocolOptions() map[string]*any.Any {
+	return map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+					},
+				},
+			}),
+	}
 }
 
 // ExtensionCluster builds a envoy_cluster_v3.Cluster struct for the given extension service.
@@ -129,7 +144,7 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 
 	switch ext.Protocol {
 	case "h2":
-		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				ext.UpstreamValidation,
@@ -139,7 +154,7 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
 	}
 
 	return cluster

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -19,8 +19,10 @@ import (
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -137,7 +139,16 @@ func TestCluster(t *testing.T) {
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
 				},
-				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+				TypedExtensionProtocolOptions: map[string]*any.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+						&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+							UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+								ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+									ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+								},
+							},
+						}),
+				},
 			},
 		},
 		"h2 upstream": {
@@ -156,7 +167,16 @@ func TestCluster(t *testing.T) {
 				TransportSocket: UpstreamTLSTransportSocket(
 					UpstreamTLSContext(nil, "", nil, "h2"),
 				),
-				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+				TypedExtensionProtocolOptions: map[string]*any.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+						&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+							UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+								ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+									ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+								},
+							},
+						}),
+				},
 			},
 		},
 		"externalName service": {

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -28,6 +28,7 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -180,7 +181,16 @@ func tlsClusterWithoutValidation(c *envoy_cluster_v3.Cluster, sni string, client
 }
 
 func h2cCluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
-	c.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
+	c.TypedExtensionProtocolOptions = map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+					},
+				},
+			}),
+	}
 	return c
 }
 

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -17,12 +17,14 @@ import (
 	"testing"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/golang/protobuf/ptypes/any"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -203,7 +205,16 @@ func TestExternalNameService(t *testing.T) {
 			DefaultCluster(
 				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
-					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+					TypedExtensionProtocolOptions: map[string]*any.Any{
+						"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+							&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+								UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+									ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+										ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+									},
+								},
+							}),
+					},
 				},
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(

--- a/internal/xdscache/v3/cluster_test.go
+++ b/internal/xdscache/v3/cluster_test.go
@@ -19,7 +19,9 @@ import (
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
@@ -263,7 +265,16 @@ func TestClusterVisit(t *testing.T) {
 						EdsConfig:   envoy_v3.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
-					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
+					TypedExtensionProtocolOptions: map[string]*any.Any{
+						"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+							&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+								UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+									ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+										ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+									},
+								},
+							}),
+					},
 				},
 			),
 		},


### PR DESCRIPTION
Replaces the deprecated cluster Http2ProtocolOptions field
with TypedExtensionProtocolOptions.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Fixes the lint errors that came up on `main` after upgrading go-control-plane to v0.9.8 (these didn't show up on the PR lint run, that's a separate issue).

https://github.com/projectcontour/contour/runs/1703439466

ref. https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/upstreams/http/v3/http_protocol_options.proto#envoy-v3-api-msg-extensions-upstreams-http-v3-httpprotocoloptions
