### PR TITLE
drop all TLS 1.1 references

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -216,7 +216,9 @@ type TLS struct {
 	// If specified, the named secret must contain a matching certificate
 	// for the virtual host's FQDN.
 	SecretName string `json:"secretName,omitempty"`
-	// Minimum TLS version this vhost should negotiate
+	// MinimumProtocolVersion is the minimum TLS version this vhost should
+	// negotiate. Valid options are `1.2` (default) and `1.3`. Any other value
+	// defaults to TLS 1.2.
 	// +optional
 	MinimumProtocolVersion string `json:"minimumProtocolVersion,omitempty"`
 	// Passthrough defines whether the encrypted TLS handshake will be

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -21,7 +21,7 @@ data:
     disablePermitInsecure: false
     tls:
     # minimum TLS version that Contour will negotiate
-    # minimum-protocol-version: "1.1"
+    # minimum-protocol-version: "1.2"
     # Defines the Kubernetes name/namespace matching a secret to use
     # as the fallback certificate when requests which don't match the
     # SNI defined for a vhost.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -923,7 +923,7 @@ spec:
                         description: EnableFallbackCertificate defines if the vhost should allow a default certificate to be applied which handles all requests which don't match the SNI defined in this vhost.
                         type: boolean
                       minimumProtocolVersion:
-                        description: Minimum TLS version this vhost should negotiate
+                        description: MinimumProtocolVersion is the minimum TLS version this vhost should negotiate. Valid options are `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2.
                         type: string
                       passthrough:
                         description: Passthrough defines whether the encrypted TLS handshake will be passed through to the backing cluster. Either Passthrough or SecretName must be specified, but not both.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -55,7 +55,7 @@ data:
     disablePermitInsecure: false
     tls:
     # minimum TLS version that Contour will negotiate
-    # minimum-protocol-version: "1.1"
+    # minimum-protocol-version: "1.2"
     # Defines the Kubernetes name/namespace matching a secret to use
     # as the fallback certificate when requests which don't match the
     # SNI defined for a vhost.
@@ -1044,7 +1044,7 @@ spec:
                         description: EnableFallbackCertificate defines if the vhost should allow a default certificate to be applied which handles all requests which don't match the SNI defined in this vhost.
                         type: boolean
                       minimumProtocolVersion:
-                        description: Minimum TLS version this vhost should negotiate
+                        description: MinimumProtocolVersion is the minimum TLS version this vhost should negotiate. Valid options are `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2.
                         type: string
                       passthrough:
                         description: Passthrough defines whether the encrypted TLS handshake will be passed through to the backing cluster. Either Passthrough or SecretName must be specified, but not both.

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -202,7 +202,7 @@ func MatchesIngressClass(o metav1.ObjectMetaAccessor, ic string) bool {
 // or default if non present.
 func MinTLSVersion(version string, defaultVal string) string {
 	switch version {
-	case "1.1", "1.2", "1.3":
+	case "1.2", "1.3":
 		return version
 	default:
 		return defaultVal

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -196,7 +196,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 	}
 
 	tlsParams := &envoy_tls_v3.TlsParameters{
-		TlsMinimumProtocolVersion: envoy_tls_v3.TlsParameters_TLSv1_1,
+		TlsMinimumProtocolVersion: envoy_tls_v3.TlsParameters_TLSv1_2,
 		TlsMaximumProtocolVersion: envoy_tls_v3.TlsParameters_TLSv1_3,
 		CipherSuites: []string{
 			"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
@@ -272,7 +272,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 		want *envoy_tls_v3.DownstreamTlsContext
 	}{
 		"TLS context without client authentication": {
-			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_1, nil, "h2", "http/1.1"),
+			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
 			&envoy_tls_v3.DownstreamTlsContext{
 				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 					TlsParams:                      tlsParams,
@@ -282,7 +282,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 			},
 		},
 		"TLS context with client authentication": {
-			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_1, peerValidationContext, "h2", "http/1.1"),
+			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, peerValidationContext, "h2", "http/1.1"),
 			&envoy_tls_v3.DownstreamTlsContext{
 				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 					TlsParams:                      tlsParams,
@@ -294,7 +294,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 			},
 		},
 		"Downstream validation shall not support subjectName validation": {
-			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_1, peerValidationContextWithSubjectName, "h2", "http/1.1"),
+			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, peerValidationContextWithSubjectName, "h2", "http/1.1"),
 			&envoy_tls_v3.DownstreamTlsContext{
 				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
 					TlsParams:                      tlsParams,

--- a/internal/envoy/v3/socket_test.go
+++ b/internal/envoy/v3/socket_test.go
@@ -66,11 +66,11 @@ func TestDownstreamTLSTransportSocket(t *testing.T) {
 		want *envoy_core_v3.TransportSocket
 	}{
 		"default/tls": {
-			ctxt: DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_1, nil, "client-subject-name", "h2", "http/1.1"),
+			ctxt: DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, "client-subject-name", "h2", "http/1.1"),
 			want: &envoy_core_v3.TransportSocket{
 				Name: "envoy.transport_sockets.tls",
 				ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
-					TypedConfig: protobuf.MustMarshalAny(DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_1, nil, "client-subject-name", "h2", "http/1.1")),
+					TypedConfig: protobuf.MustMarshalAny(DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, "client-subject-name", "h2", "http/1.1")),
 				},
 			},
 		},

--- a/internal/envoy/v3/tls.go
+++ b/internal/envoy/v3/tls.go
@@ -19,8 +19,6 @@ import (
 
 func ParseTLSVersion(version string) envoy_tls_v3.TlsParameters_TlsProtocol {
 	switch version {
-	case "1.1":
-		return envoy_tls_v3.TlsParameters_TLSv1_1
 	case "1.2":
 		return envoy_tls_v3.TlsParameters_TLSv1_2
 	case "1.3":

--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -2217,7 +2217,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Minimum TLS version this vhost should negotiate</p>
+<p>MinimumProtocolVersion is the minimum TLS version this vhost should
+negotiate. Valid options are <code>1.2</code> (default) and <code>1.3</code>. Any other value
+defaults to TLS 1.2.</p>
 </td>
 </tr>
 <tr>

--- a/site/docs/main/config/tls-termination.md
+++ b/site/docs/main/config/tls-termination.md
@@ -55,7 +55,6 @@ The TLS **Minimum Protocol Version** a virtual host should negotiate can be spec
 
 - 1.3
 - 1.2  (Default)
-- 1.1
 
 ## Fallback Certificate
 

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -40,7 +40,7 @@ Contour should provision TLS hosts.
 
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
-| minimum-protocol-version| string | `1.2` | This field specifies the minimum TLS protocol version that is allowed. Valid options are `1.1`, `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2. |
+| minimum-protocol-version| string | `1.2` | This field specifies the minimum TLS protocol version that is allowed. Valid options are `1.2` (default) and `1.3`. Any other value defaults to TLS 1.2. |
 | fallback-certificate | | | [Fallback certificate configuration](#fallback-certificate). |
 | envoy-client-certificate | | | [Client certificate configuration for Envoy](#envoy-client-certificate). |
 {: class="table thead-dark table-bordered"}
@@ -141,7 +141,7 @@ data:
     # disablePermitInsecure: false
     tls:
       # minimum TLS version that Contour will negotiate
-      # minimumProtocolVersion: "1.1"
+      # minimumProtocolVersion: "1.2"
       fallback-certificate:
       # name: fallback-secret-name
       # namespace: projectcontour


### PR DESCRIPTION
Support for TLS 1.1 has been officially dropped from Contour.
This PR updates all code, documentation and examples to indicate
that 1.2 is now the minimum/default.

Closes #3246.
Updates #2777.
    
Signed-off-by: Steve Kriss <krisss@vmware.com>