### PR TITLE
internal: Add support for watching ingress/v1 resources

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -373,6 +373,20 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		inf.AddEventHandler(&dynamicHandler)
 	}
 
+	// If Ingress v1 resource exist, then add informers to watch, otherwise
+	// add Ingress v1beta1 informers.
+	if clients.ResourcesExist(k8s.IngressV1Resources()...) {
+		for _, r := range k8s.IngressV1Resources() {
+			if err := informOnResource(clients, r, &dynamicHandler); err != nil {
+				log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
+			}
+		}
+	} else {
+		if err := informOnResource(clients, k8s.IngressV1Beta1Resource(), &dynamicHandler); err != nil {
+			log.WithError(err).WithField("resource", k8s.IngressV1Beta1Resource()).Fatal("failed to create informer")
+		}
+	}
+
 	// Inform on service-apis types if they are present.
 	if ctx.UseExperimentalServiceAPITypes {
 		for _, r := range k8s.ServiceAPIResources() {

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -50,6 +50,14 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1707,6 +1707,14 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"github.com/projectcontour/contour/internal/timeout"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -130,19 +130,19 @@ func ParseUpstreamProtocols(m map[string]string) map[string]string {
 
 // HTTPAllowed returns true unless the kubernetes.io/ingress.allow-http annotation is
 // present and set to false.
-func HTTPAllowed(i *v1beta1.Ingress) bool {
+func HTTPAllowed(i *networking_v1.Ingress) bool {
 	return !(i.Annotations["kubernetes.io/ingress.allow-http"] == "false")
 }
 
 // TLSRequired returns true if the ingress.kubernetes.io/force-ssl-redirect annotation is
 // present and set to true.
-func TLSRequired(i *v1beta1.Ingress) bool {
+func TLSRequired(i *networking_v1.Ingress) bool {
 	return i.Annotations["ingress.kubernetes.io/force-ssl-redirect"] == "true"
 }
 
 // WebsocketRoutes retrieves the details of routes that should have websockets enabled from the
 // associated websocket-routes annotation.
-func WebsocketRoutes(i *v1beta1.Ingress) map[string]bool {
+func WebsocketRoutes(i *networking_v1.Ingress) map[string]bool {
 	routes := make(map[string]bool)
 	for _, v := range strings.Split(i.Annotations["projectcontour.io/websocket-routes"], ",") {
 		route := strings.TrimSpace(v)
@@ -155,12 +155,12 @@ func WebsocketRoutes(i *v1beta1.Ingress) map[string]bool {
 
 // NumRetries returns the number of retries specified by the
 // "projectcontour.io/num-retries" annotation.
-func NumRetries(i *v1beta1.Ingress) uint32 {
+func NumRetries(i *networking_v1.Ingress) uint32 {
 	return parseUInt32(ContourAnnotation(i, "num-retries"))
 }
 
 // PerTryTimeout returns the duration envoy will wait per retry cycle.
-func PerTryTimeout(i *v1beta1.Ingress) (timeout.Setting, error) {
+func PerTryTimeout(i *networking_v1.Ingress) (timeout.Setting, error) {
 	return timeout.Parse(ContourAnnotation(i, "per-try-timeout"))
 }
 

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	networking_v1 "k8s.io/api/networking/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +48,8 @@ type KubernetesCache struct {
 	// Secrets that are referred from the configuration file.
 	ConfiguredSecretRefs []*types.NamespacedName
 
-	ingresses            map[types.NamespacedName]*v1beta1.Ingress
+	ingresses            map[types.NamespacedName]*networking_v1.Ingress
+	ingressclasses       map[string]*networking_v1.IngressClass
 	httpproxies          map[types.NamespacedName]*contour_api_v1.HTTPProxy
 	secrets              map[types.NamespacedName]*v1.Secret
 	httpproxydelegations map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation
@@ -65,7 +67,8 @@ type KubernetesCache struct {
 
 // init creates the internal cache storage. It is called implicitly from the public API.
 func (kc *KubernetesCache) init() {
-	kc.ingresses = make(map[types.NamespacedName]*v1beta1.Ingress)
+	kc.ingresses = make(map[types.NamespacedName]*networking_v1.Ingress)
+	kc.ingressclasses = make(map[string]*networking_v1.IngressClass)
 	kc.httpproxies = make(map[types.NamespacedName]*contour_api_v1.HTTPProxy)
 	kc.secrets = make(map[types.NamespacedName]*v1.Secret)
 	kc.httpproxydelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
@@ -146,9 +149,19 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		return kc.serviceTriggersRebuild(obj)
 	case *v1beta1.Ingress:
 		if kc.matchesIngressClass(obj) {
+			// Convert the v1beta1 object to v1 before adding to the
+			// local ingress cache for easier processing later on.
+			kc.ingresses[k8s.NamespacedNameOf(obj)] = toV1Ingress(obj)
+			return true
+		}
+	case *networking_v1.Ingress:
+		if kc.matchesIngressClass(obj) {
 			kc.ingresses[k8s.NamespacedNameOf(obj)] = obj
 			return true
 		}
+	case *networking_v1.IngressClass:
+		kc.ingressclasses[obj.Name] = obj
+		return true
 	case *contour_api_v1.HTTPProxy:
 		if kc.matchesIngressClass(obj) {
 			kc.httpproxies[k8s.NamespacedNameOf(obj)] = obj
@@ -198,6 +211,99 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	return false
 }
 
+func toV1Ingress(obj *v1beta1.Ingress) *networking_v1.Ingress {
+
+	if obj == nil {
+		return nil
+	}
+
+	var convertedTLS []networking_v1.IngressTLS
+	var convertedIngressRules []networking_v1.IngressRule
+	var paths []networking_v1.HTTPIngressPath
+	var convertedDefaultBackend *networking_v1.IngressBackend
+
+	for _, tls := range obj.Spec.TLS {
+		convertedTLS = append(convertedTLS, networking_v1.IngressTLS{
+			Hosts:      tls.Hosts,
+			SecretName: tls.SecretName,
+		})
+	}
+
+	for _, r := range obj.Spec.Rules {
+
+		rule := networking_v1.IngressRule{}
+
+		if r.Host != "" {
+			rule.Host = r.Host
+		}
+
+		if r.HTTP != nil {
+
+			for _, p := range r.HTTP.Paths {
+				var pathType networking_v1.PathType
+				if p.PathType != nil {
+					switch *p.PathType {
+					case v1beta1.PathTypePrefix:
+						pathType = networking_v1.PathTypePrefix
+					case v1beta1.PathTypeExact:
+						pathType = networking_v1.PathTypeExact
+					case v1beta1.PathTypeImplementationSpecific:
+						pathType = networking_v1.PathTypeImplementationSpecific
+					}
+				}
+
+				paths = append(paths, networking_v1.HTTPIngressPath{
+					Path:     p.Path,
+					PathType: &pathType,
+					Backend: networking_v1.IngressBackend{
+						Service: &networking_v1.IngressServiceBackend{
+							Name: p.Backend.ServiceName,
+							Port: serviceBackendPort(p.Backend.ServicePort),
+						},
+					},
+				})
+			}
+
+			rule.IngressRuleValue = networking_v1.IngressRuleValue{
+				HTTP: &networking_v1.HTTPIngressRuleValue{
+					Paths: paths,
+				},
+			}
+		}
+
+		convertedIngressRules = append(convertedIngressRules, rule)
+	}
+
+	if obj.Spec.Backend != nil {
+		convertedDefaultBackend = &networking_v1.IngressBackend{
+			Service: &networking_v1.IngressServiceBackend{
+				Name: obj.Spec.Backend.ServiceName,
+				Port: serviceBackendPort(obj.Spec.Backend.ServicePort),
+			},
+		}
+	}
+
+	return &networking_v1.Ingress{
+		ObjectMeta: obj.ObjectMeta,
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: convertedDefaultBackend,
+			TLS:            convertedTLS,
+			Rules:          convertedIngressRules,
+		},
+	}
+}
+
+func serviceBackendPort(port intstr.IntOrString) networking_v1.ServiceBackendPort {
+	if port.Type == intstr.String {
+		return networking_v1.ServiceBackendPort{
+			Name: port.StrVal,
+		}
+	}
+	return networking_v1.ServiceBackendPort{
+		Number: port.IntVal,
+	}
+}
+
 // Remove removes obj from the KubernetesCache.
 // Remove returns a boolean indicating if the cache changed after the remove operation.
 func (kc *KubernetesCache) Remove(obj interface{}) bool {
@@ -227,6 +333,15 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.ingresses[m]
 		delete(kc.ingresses, m)
+		return ok
+	case *networking_v1.Ingress:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.ingresses[m]
+		delete(kc.ingresses, m)
+		return ok
+	case *networking_v1.IngressClass:
+		_, ok := kc.ingressclasses[obj.Name]
+		delete(kc.ingressclasses, obj.Name)
 		return ok
 	case *contour_api_v1.HTTPProxy:
 		m := k8s.NamespacedNameOf(obj)
@@ -290,8 +405,8 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 		if ingress.Namespace != service.Namespace {
 			continue
 		}
-		if backend := ingress.Spec.Backend; backend != nil {
-			if backend.ServiceName == service.Name {
+		if backend := ingress.Spec.DefaultBackend; backend != nil {
+			if backend.Service.Name == service.Name {
 				return true
 			}
 		}
@@ -302,7 +417,7 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 				continue
 			}
 			for _, path := range http.Paths {
-				if path.Backend.ServiceName == service.Name {
+				if path.Backend.Service.Name == service.Name {
 					return true
 				}
 			}

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -17,6 +17,8 @@ import (
 	"errors"
 	"testing"
 
+	networking_v1 "k8s.io/api/networking/v1"
+
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/annotation"
@@ -777,6 +779,21 @@ func TestKubernetesCacheRemove(t *testing.T) {
 				},
 			}),
 			obj: &v1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove ingressv1": {
+			cache: cache(&networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress",
+					Namespace: "default",
+				},
+			}),
+			obj: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress",
 					Namespace: "default",

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -16,10 +16,12 @@ package dag
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -105,7 +107,7 @@ func (p *IngressProcessor) computeIngresses() {
 	}
 }
 
-func (p *IngressProcessor) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1.IngressRule) {
+func (p *IngressProcessor) computeIngressRule(ing *networking_v1.Ingress, rule networking_v1.IngressRule) {
 	host := rule.Host
 	if strings.Contains(host, "*") {
 		// reject hosts with wildcard characters.
@@ -133,8 +135,16 @@ func (p *IngressProcessor) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1
 	for _, httppath := range httppaths(rule) {
 		path := stringOrDefault(httppath.Path, "/")
 		be := httppath.Backend
-		m := types.NamespacedName{Name: be.ServiceName, Namespace: ing.Namespace}
-		s, err := p.dag.EnsureService(m, be.ServicePort, p.source)
+		m := types.NamespacedName{Name: be.Service.Name, Namespace: ing.Namespace}
+
+		var port intstr.IntOrString
+		if len(be.Service.Port.Name) > 0 {
+			port = intstr.FromString(be.Service.Port.Name)
+		} else {
+			port = intstr.FromInt(int(be.Service.Port.Number))
+		}
+
+		s, err := p.dag.EnsureService(m, port, p.source)
 		if err != nil {
 			continue
 		}
@@ -165,7 +175,7 @@ func (p *IngressProcessor) computeIngressRule(ing *v1beta1.Ingress, rule v1beta1
 }
 
 // route builds a dag.Route for the supplied Ingress.
-func route(ingress *v1beta1.Ingress, path string, service *Service, clientCertSecret *Secret, log logrus.FieldLogger) (*Route, error) {
+func route(ingress *networking_v1.Ingress, path string, service *Service, clientCertSecret *Secret, log logrus.FieldLogger) (*Route, error) {
 	log = log.WithFields(logrus.Fields{
 		"name":      ingress.Name,
 		"namespace": ingress.Namespace,
@@ -199,9 +209,9 @@ func route(ingress *v1beta1.Ingress, path string, service *Service, clientCertSe
 
 // rulesFromSpec merges the IngressSpec's Rules with a synthetic
 // rule representing the default backend.
-func rulesFromSpec(spec v1beta1.IngressSpec) []v1beta1.IngressRule {
+func rulesFromSpec(spec networking_v1.IngressSpec) []networking_v1.IngressRule {
 	rules := spec.Rules
-	if backend := spec.Backend; backend != nil {
+	if backend := spec.DefaultBackend; backend != nil {
 		rule := defaultBackendRule(backend)
 		rules = append(rules, rule)
 	}
@@ -209,14 +219,16 @@ func rulesFromSpec(spec v1beta1.IngressSpec) []v1beta1.IngressRule {
 }
 
 // defaultBackendRule returns an IngressRule that represents the IngressBackend.
-func defaultBackendRule(be *v1beta1.IngressBackend) v1beta1.IngressRule {
-	return v1beta1.IngressRule{
-		IngressRuleValue: v1beta1.IngressRuleValue{
-			HTTP: &v1beta1.HTTPIngressRuleValue{
-				Paths: []v1beta1.HTTPIngressPath{{
-					Backend: v1beta1.IngressBackend{
-						ServiceName: be.ServiceName,
-						ServicePort: be.ServicePort,
+func defaultBackendRule(be *networking_v1.IngressBackend) networking_v1.IngressRule {
+	return networking_v1.IngressRule{
+		IngressRuleValue: networking_v1.IngressRuleValue{
+			HTTP: &networking_v1.HTTPIngressRuleValue{
+				Paths: []networking_v1.HTTPIngressPath{{
+					Backend: networking_v1.IngressBackend{
+						Service: &networking_v1.IngressServiceBackend{
+							Name: be.Service.Name,
+							Port: be.Service.Port,
+						},
 					},
 				}},
 			},
@@ -234,7 +246,7 @@ func stringOrDefault(s, def string) string {
 // httppaths returns a slice of HTTPIngressPath values for a given IngressRule.
 // In the case that the IngressRule contains no valid HTTPIngressPaths, a
 // nil slice is returned.
-func httppaths(rule v1beta1.IngressRule) []v1beta1.HTTPIngressPath {
+func httppaths(rule networking_v1.IngressRule) []networking_v1.HTTPIngressPath {
 	if rule.IngressRuleValue.HTTP == nil {
 		// rule.IngressRuleValue.HTTP value is optional.
 		return nil

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -20,11 +20,12 @@ import (
 	"strings"
 	"time"
 
+	networking_v1 "k8s.io/api/networking/v1"
+
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -190,7 +191,7 @@ func escapeHeaderValue(value string, dynamicHeaders map[string]string) string {
 }
 
 // ingressRetryPolicy builds a RetryPolicy from ingress annotations.
-func ingressRetryPolicy(ingress *v1beta1.Ingress, log logrus.FieldLogger) *RetryPolicy {
+func ingressRetryPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger) *RetryPolicy {
 	retryOn := annotation.ContourAnnotation(ingress, "retry-on")
 	if len(retryOn) < 1 {
 		return nil
@@ -215,7 +216,7 @@ func ingressRetryPolicy(ingress *v1beta1.Ingress, log logrus.FieldLogger) *Retry
 	return rp
 }
 
-func ingressTimeoutPolicy(ingress *v1beta1.Ingress, log logrus.FieldLogger) TimeoutPolicy {
+func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger) TimeoutPolicy {
 	response := annotation.ContourAnnotation(ingress, "response-timeout")
 	if len(response) == 0 {
 		// Note: due to a misunderstanding the name of the annotation is

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -22,21 +22,21 @@ import (
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestRetryPolicyIngress(t *testing.T) {
 	tests := map[string]struct {
-		i    *v1beta1.Ingress
+		i    *networking_v1.Ingress
 		want *RetryPolicy
 	}{
 		"no anotations": {
-			i:    &v1beta1.Ingress{},
+			i:    &networking_v1.Ingress{},
 			want: nil,
 		},
 		"retry-on": {
-			i: &v1beta1.Ingress{
+			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on": "5xx",
@@ -48,7 +48,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 		},
 		"explicitly zero retries": {
-			i: &v1beta1.Ingress{
+			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on":    "5xx",
@@ -62,7 +62,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 		},
 		"num-retries": {
-			i: &v1beta1.Ingress{
+			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on":    "5xx",
@@ -76,7 +76,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 		},
 		"no retry count, per try timeout": {
-			i: &v1beta1.Ingress{
+			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on":        "5xx",
@@ -91,7 +91,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 		},
 		"explicit 0s timeout": {
-			i: &v1beta1.Ingress{
+			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on":        "5xx",

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -17,12 +17,14 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
+	networking_v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serviceapis "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.k8s.io",resources=ingressclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses/status,verbs=create;get;update
 
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies;tlscertificatedelegations,verbs=get;list;watch
@@ -37,7 +39,17 @@ func DefaultResources() []schema.GroupVersionResource {
 		contour_api_v1.TLSCertificateDelegationGVR,
 		contour_api_v1alpha1.ExtensionServiceGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
-		v1beta1.SchemeGroupVersion.WithResource("ingresses"),
+	}
+}
+
+func IngressV1Beta1Resource() schema.GroupVersionResource {
+	return networking_v1beta1.SchemeGroupVersion.WithResource("ingresses")
+}
+
+func IngressV1Resources() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		networking_v1.SchemeGroupVersion.WithResource("ingresses"),
+		networking_v1.SchemeGroupVersion.WithResource("ingressclasses"),
 	}
 }
 


### PR DESCRIPTION
Add support for watching networking.k8s.io/v1 Ingress resources and add/remove
from internal Cache later allowing these objects to be implemented.

Signed-off-by: Steve Sloka <slokas@vmware.com>