### PR TITLE
Default header policy

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -279,6 +279,30 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		ctx.Config.Listener.ConnectionBalancer = ""
 	}
 
+	var requestHeadersPolicy dag.HeadersPolicy
+	if ctx.Config.Policy.RequestHeadersPolicy.Set != nil {
+		requestHeadersPolicy.Set = make(map[string]string)
+		for k, v := range ctx.Config.Policy.RequestHeadersPolicy.Set {
+			requestHeadersPolicy.Set[k] = v
+		}
+	}
+	if ctx.Config.Policy.RequestHeadersPolicy.Remove != nil {
+		requestHeadersPolicy.Remove = make([]string, len(ctx.Config.Policy.RequestHeadersPolicy.Remove))
+		requestHeadersPolicy.Remove = append(requestHeadersPolicy.Remove, ctx.Config.Policy.RequestHeadersPolicy.Remove...)
+	}
+
+	var responseHeadersPolicy dag.HeadersPolicy
+	if ctx.Config.Policy.ResponseHeadersPolicy.Set != nil {
+		responseHeadersPolicy.Set = make(map[string]string)
+		for k, v := range ctx.Config.Policy.RequestHeadersPolicy.Set {
+			responseHeadersPolicy.Set[k] = v
+		}
+	}
+	if ctx.Config.Policy.ResponseHeadersPolicy.Remove != nil {
+		responseHeadersPolicy.Remove = make([]string, len(ctx.Config.Policy.ResponseHeadersPolicy.Remove))
+		responseHeadersPolicy.Remove = append(responseHeadersPolicy.Remove, ctx.Config.Policy.ResponseHeadersPolicy.Remove...)
+	}
+
 	listenerConfig := xdscache_v3.ListenerConfig{
 		UseProxyProto:                 ctx.useProxyProto,
 		HTTPAddress:                   ctx.httpAddr,
@@ -413,6 +437,8 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 					FallbackCertificate:   fallbackCert,
 					DNSLookupFamily:       ctx.Config.Cluster.DNSLookupFamily,
 					ClientCertificate:     clientCert,
+					RequestHeadersPolicy:  &requestHeadersPolicy,
+					ResponseHeadersPolicy: &responseHeadersPolicy,
 				},
 				&dag.GatewayAPIProcessor{
 					FieldLogger: log.WithField("context", "GatewayAPIProcessor"),

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -120,3 +120,19 @@ data:
     #   service fails to respond with a valid rate limit decision within
     #   the timeout defined on the extension service.
     #   failOpen: false
+    #
+    # Global Policy settings.
+    # policy:
+    #   # Default headers to set on all requests (unless set/removed on the HTTPProxy object itself)
+    #   request-headers:
+    #     set:
+    #       # example: the hostname of the Envoy instance that proxied the request
+    #       X-Envoy-Hostname: %HOSTNAME%
+    #       # example: add a l5d-dst-override header to instruct Linkerd what service the request is destined for
+    #       l5d-dst-override: %CONTOUR_SERVICE_NAME%.%CONTOUR_NAMESPACE%.svc.cluster.local:%CONTOUR_SERVICE_PORT%
+    #   # default headers to set on all responses (unless set/removed on the HTTPProxy object itself)
+    #   response-headers:
+    #     set:
+    #       # example: Envoy flags that provide additional details about the response or connection
+    #       X-Envoy-Response-Flags: %RESPONSE_FLAGS%
+    #

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -154,6 +154,22 @@ data:
     #   service fails to respond with a valid rate limit decision within
     #   the timeout defined on the extension service.
     #   failOpen: false
+    #
+    # Global Policy settings.
+    # policy:
+    #   # Default headers to set on all requests (unless set/removed on the HTTPProxy object itself)
+    #   request-headers:
+    #     set:
+    #       # example: the hostname of the Envoy instance that proxied the request
+    #       X-Envoy-Hostname: %HOSTNAME%
+    #       # example: add a l5d-dst-override header to instruct Linkerd what service the request is destined for
+    #       l5d-dst-override: %CONTOUR_SERVICE_NAME%.%CONTOUR_NAMESPACE%.svc.cluster.local:%CONTOUR_SERVICE_PORT%
+    #   # default headers to set on all responses (unless set/removed on the HTTPProxy object itself)
+    #   response-headers:
+    #     set:
+    #       # example: Envoy flags that provide additional details about the response or connection
+    #       X-Envoy-Response-Flags: %RESPONSE_FLAGS%
+    #
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -8412,6 +8412,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		name    string
 		in      *contour_api_v1.HeadersPolicy
 		dyn     map[string]string
+		dhp     *HeadersPolicy
 		want    *HeadersPolicy
 		wantErr error
 	}{{
@@ -8431,6 +8432,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp: nil,
 		want: &HeadersPolicy{
 			Set: map[string]string{
 				"K-Foo": "bar",
@@ -8452,6 +8454,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp:     nil,
 		wantErr: errors.New(`duplicate header addition: "K-Foo"`),
 	}, {
 		name: "duplicate remove",
@@ -8461,6 +8464,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp:     nil,
 		wantErr: errors.New(`duplicate header removal: "K-Foo"`),
 	}, {
 		name: "invalid set header",
@@ -8473,6 +8477,21 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp:     nil,
+		wantErr: errors.New(`invalid set header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
+	}, {
+		name: "invalid set default header",
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{},
+		},
+		dyn: map[string]string{
+			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp: &HeadersPolicy{
+			Set: map[string]string{
+				"  K-Foo": "bar",
+			},
+		},
 		wantErr: errors.New(`invalid set header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
 	}, {
 		name: "invalid remove header",
@@ -8481,6 +8500,19 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		},
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp:     nil,
+		wantErr: errors.New(`invalid remove header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
+	}, {
+		name: "invalid remove default header",
+		in: &contour_api_v1.HeadersPolicy{
+			Remove: []string{"  K-Foo"},
+		},
+		dyn: map[string]string{
+			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp: &HeadersPolicy{
+			Remove: []string{"  K-Foo"},
 		},
 		wantErr: errors.New(`invalid remove header "  K-Foo": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')]`),
 	}, {
@@ -8493,6 +8525,24 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		},
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp:     nil,
+		wantErr: errors.New(`rewriting "Host" header is not supported`),
+	}, {
+		name: "invalid set default header (special headers)",
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "ook?",
+			}},
+		},
+		dyn: map[string]string{
+			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp: &HeadersPolicy{
+			Set: map[string]string{
+				"Host": "bar",
+			},
 		},
 		wantErr: errors.New(`rewriting "Host" header is not supported`),
 	}, {
@@ -8512,6 +8562,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp: nil,
 		want: &HeadersPolicy{
 			Set: map[string]string{
 				"K-Foo":           "100%%",
@@ -8532,6 +8583,7 @@ func TestValidateHeaderAlteration(t *testing.T) {
 			"CONTOUR_SERVICE_NAME": "myservice",
 			"CONTOUR_SERVICE_PORT": "80",
 		},
+		dhp: nil,
 		want: &HeadersPolicy{
 			Set: map[string]string{
 				"L5d-Dst-Override": "myservice.myns.svc.cluster.local:80",
@@ -8548,16 +8600,62 @@ func TestValidateHeaderAlteration(t *testing.T) {
 		dyn: map[string]string{
 			"CONTOUR_NAMESPACE": "myns",
 		},
+		dhp: nil,
 		want: &HeadersPolicy{
 			Set: map[string]string{
 				"L5d-Dst-Override": "%%CONTOUR_SERVICE_NAME%%.myns.svc.cluster.local:%%CONTOUR_SERVICE_PORT%%",
+			},
+		},
+	}, {
+		name: "default headers are combined with given headers and escaped",
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "100%",
+			}},
+		},
+		dyn: map[string]string{
+			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp: &HeadersPolicy{
+			Set: map[string]string{
+				"k-baz":           "%DOWNSTREAM_LOCAL_ADDRESS%", // This gets canonicalized
+				"Lot-Of-Percents": "%%%%%",
+			},
+		},
+		want: &HeadersPolicy{
+			Set: map[string]string{
+				"K-Foo":           "100%%",
+				"K-Baz":           "%DOWNSTREAM_LOCAL_ADDRESS%",
+				"Lot-Of-Percents": "%%%%%%%%%%",
+			},
+		},
+	}, {
+		name: "default headers do not replace given headers",
+		in: &contour_api_v1.HeadersPolicy{
+			Set: []contour_api_v1.HeaderValue{{
+				Name:  "K-Foo",
+				Value: "100%",
+			}},
+		},
+		dyn: map[string]string{
+			"CONTOUR_NAMESPACE": "myns",
+		},
+		dhp: &HeadersPolicy{
+			Set: map[string]string{
+				"K-Foo": "50%",
+			},
+		},
+		want: &HeadersPolicy{
+			Set: map[string]string{
+				"K-Foo": "100%%",
 			},
 		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, gotErr := headersPolicyService(test.in, test.dyn)
+			got, gotErr := headersPolicyService(test.dhp, test.in, test.dyn)
 			assert.Equal(t, test.want, got)
 			assert.Equal(t, test.wantErr, gotErr)
 		})

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -70,6 +70,12 @@ type HTTPProxyProcessor struct {
 	// ClientCertificate is the optional identifier of the TLS secret containing client certificate and
 	// private key to be used when establishing TLS connection to upstream cluster.
 	ClientCertificate *types.NamespacedName
+
+	// Request headers that will be set on all routes (optional).
+	RequestHeadersPolicy *HeadersPolicy
+
+	// Response headers that will be set on all routes (optional).
+	ResponseHeadersPolicy *HeadersPolicy
 }
 
 // Run translates HTTPProxies into DAG objects and
@@ -574,14 +580,13 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			dynamicHeaders["CONTOUR_SERVICE_NAME"] = service.Name
 			dynamicHeaders["CONTOUR_SERVICE_PORT"] = strconv.Itoa(service.Port)
 
-			reqHP, err := headersPolicyService(service.RequestHeadersPolicy, dynamicHeaders)
+			reqHP, err := headersPolicyService(p.RequestHeadersPolicy, service.RequestHeadersPolicy, dynamicHeaders)
 			if err != nil {
 				validCond.AddErrorf(contour_api_v1.ConditionTypeServiceError, "RequestHeadersPolicyInvalid",
 					"%s on request headers", err)
 				return nil
 			}
-
-			respHP, err := headersPolicyService(service.ResponseHeadersPolicy, dynamicHeaders)
+			respHP, err := headersPolicyService(p.ResponseHeadersPolicy, service.ResponseHeadersPolicy, dynamicHeaders)
 			if err != nil {
 				validCond.AddErrorf(contour_api_v1.ConditionTypeServiceError, "ResponseHeadersPolicyInvalid",
 					"%s on response headers", err)

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -117,6 +117,37 @@ func TestValidateClusterDNSFamilyType(t *testing.T) {
 	assert.NoError(t, IPv6ClusterDNSFamily.Validate())
 }
 
+func TestValidateHeadersPolicy(t *testing.T) {
+	assert.Error(t, HeadersPolicy{
+		Set: map[string]string{
+			"inv@lid-header": "ook",
+		},
+	}.Validate())
+	assert.Error(t, HeadersPolicy{
+		Remove: []string{"inv@lid-header"},
+	}.Validate())
+	assert.NoError(t, HeadersPolicy{
+		Set:    map[string]string{},
+		Remove: []string{},
+	}.Validate())
+	assert.NoError(t, HeadersPolicy{
+		Set: map[string]string{"X-Envoy-Host": "envoy-a12345"},
+	}.Validate())
+	assert.NoError(t, HeadersPolicy{
+		Set: map[string]string{
+			"X-Envoy-Host":     "envoy-s12345",
+			"l5d-dst-override": "kuard.default.svc.cluster.local:80",
+		},
+		Remove: []string{"Sensitive-Header"},
+	}.Validate())
+	assert.NoError(t, HeadersPolicy{
+		Set: map[string]string{
+			"X-Envoy-Host":     "%HOSTNAME%",
+			"l5d-dst-override": "%CONTOUR_SERVICE_NAME%.%CONTOUR_NAMESPACE%.svc.cluster.local:%CONTOUR_SERVICE_PORT%",
+		},
+	}.Validate())
+}
+
 func TestValidateNamespacedName(t *testing.T) {
 	assert.NoErrorf(t, NamespacedName{}.Validate(), "empty name should be OK")
 	assert.NoError(t, NamespacedName{Name: "name", Namespace: "ns"}.Validate())

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -78,6 +78,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | json-fields | string array | [fields][5]| This is the list the field names to include in the JSON [access log format][2]. |
 | kubeconfig | string | `$HOME/.kube/config` | Path to a Kubernetes [kubeconfig file][3] for when Contour is executed outside a cluster. |
 | leaderelection | leaderelection | | The [leader election configuration](#leader-election-configuration). |
+| policy | PolicyConfig | | The default [policy configuration](#policy-configuration). |
 | tls | TLS | | The default [TLS configuration](#tls-configuration). |
 | timeouts | TimeoutConfig | | The [timeout configuration](#timeout-configuration). |
 | cluster | ClusterConfig | | The [cluster configuration](#cluster-configuration). |
@@ -201,8 +202,35 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 |------------|-----|----------|-------------|
 | name | string | contour | This field specifies the name of a Gateway.  |
 | namespace | string | projectcontour | This field specifies the namespace of a Gateway.  |
+
+### Policy Configuration
+
+The Policy configuration block can be used to configure default policy values
+that are set if not overridden by the user.
+
+The `request-headers` field is used to rewrite headers on a HTTP request, and
+the `response-headers` field is used to rewrite headers on a HTTP response.
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| request-headers | HeaderPolicy | none | The default request headers set or removed on all service routes if not overridden in the object |
+| response-headers | HeaderPolicy | none | The default response headers set or removed on all service routes if not overridden in the object |
 {: class="table thead-dark table-bordered"}
 <br>
+
+#### HeaderPolicy
+
+The `set` field sets an HTTP header value, creating it if it doesn't already exist but not overwriting it if it does.
+The `remove` field removes an HTTP header.
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| set | map[string]string | none | Map of headers to set on all service routes if not overridden in the object |
+| remove | []string | none | List of headers to remove on all service routes if not overridden in the object |
+{: class="table thead-dark table-bordered"}
+<br>
+Note: the values of entries in the `set` and `remove` fields can be overridden in HTTPProxy objects but it it not possible to remove these entries.
+
 
 ### Rate Limit Service Configuration
 
@@ -331,6 +359,22 @@ data:
     #   extensionService: projectcontour/ratelimit
     #   domain: contour
     #   failOpen: false
+    #
+    # Global Policy settings.
+    # policy:
+    #   # Default headers to set on all requests (unless set/removed on the HTTPProxy object itself)
+    #   request-headers:
+    #     set:
+    #       # example: the hostname of the Envoy instance that proxied the request
+    #       X-Envoy-Hostname: %HOSTNAME%
+    #       # example: add a l5d-dst-override header to instruct Linkerd what service the request is destined for
+    #       l5d-dst-override: %CONTOUR_SERVICE_NAME%.%CONTOUR_NAMESPACE%.svc.cluster.local:%CONTOUR_SERVICE_PORT%
+    #   # default headers to set on all responses (unless set/removed on the HTTPProxy object itself)
+    #   response-headers:
+    #     set:
+    #       # example: Envoy flags that provide additional details about the response or connection
+    #       X-Envoy-Response-Flags: %RESPONSE_FLAGS%
+    #
 ```
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.


### PR DESCRIPTION
Second part of #3258

Add a policy section to the Contour configuration file with request-headers and response-headers fields that allow setting or removing default request and response headers unless overridden by users in their HTTPProxy objects.

Signed-off-by: Keith Burdis <keith.burdis@gs.com>