### PR TITLE
contour: Linter errors not showing #3227

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,3 +59,9 @@ issues:
   - linters:
     - golint
     text: "don't use ALL_CAPS in Go names; use CamelCase"
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  # Default value for this option is true.
+  exclude-use-default: false


### PR DESCRIPTION
There are a number of linter errors that golangci-lint is excluding by default.
By including EXC0002, linter errors of the following form should be shown.

warning: exported ... should have comment or be unexported

Updates #3227

Signed-off-by: Nicholas Seemiller <seemiller@gmail.com>