### PR TITLE
internal/dag: Remove processing of service-apis GatewayClass/TCPRoute

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -51,10 +51,8 @@ type KubernetesCache struct {
 	secrets              map[types.NamespacedName]*v1.Secret
 	httpproxydelegations map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation
 	services             map[types.NamespacedName]*v1.Service
-	gatewayclasses       map[types.NamespacedName]*serviceapis.GatewayClass
 	gateways             map[types.NamespacedName]*serviceapis.Gateway
 	httproutes           map[types.NamespacedName]*serviceapis.HTTPRoute
-	tcproutes            map[types.NamespacedName]*serviceapis.TCPRoute
 	extensions           map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
@@ -69,10 +67,8 @@ func (kc *KubernetesCache) init() {
 	kc.secrets = make(map[types.NamespacedName]*v1.Secret)
 	kc.httpproxydelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
 	kc.services = make(map[types.NamespacedName]*v1.Service)
-	kc.gatewayclasses = make(map[types.NamespacedName]*serviceapis.GatewayClass)
 	kc.gateways = make(map[types.NamespacedName]*serviceapis.Gateway)
 	kc.httproutes = make(map[types.NamespacedName]*serviceapis.HTTPRoute)
-	kc.tcproutes = make(map[types.NamespacedName]*serviceapis.TCPRoute)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
 
@@ -159,13 +155,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *contour_api_v1.TLSCertificateDelegation:
 		kc.httpproxydelegations[k8s.NamespacedNameOf(obj)] = obj
 		return true
-	case *serviceapis.GatewayClass:
-		m := k8s.NamespacedNameOf(obj)
-		// TODO(youngnick): Remove this once service-apis actually have behavior
-		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding GatewayClass")
-		kc.gatewayclasses[k8s.NamespacedNameOf(obj)] = obj
-		return true
 	case *serviceapis.Gateway:
 		m := k8s.NamespacedNameOf(obj)
 		// TODO(youngnick): Remove this once service-apis actually have behavior
@@ -179,13 +168,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		// other than being added to the cache.
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding HTTPRoute")
 		kc.httproutes[k8s.NamespacedNameOf(obj)] = obj
-		return true
-	case *serviceapis.TCPRoute:
-		m := k8s.NamespacedNameOf(obj)
-		// TODO(youngnick): Remove this once service-apis actually have behavior
-		// other than being added to the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding TcpRoute")
-		kc.tcproutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
 	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
@@ -240,14 +222,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		_, ok := kc.httpproxydelegations[m]
 		delete(kc.httpproxydelegations, m)
 		return ok
-	case *serviceapis.GatewayClass:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.gatewayclasses[m]
-		// TODO(youngnick): Remove this once service-apis actually have behavior
-		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing GatewayClass")
-		delete(kc.gatewayclasses, m)
-		return ok
 	case *serviceapis.Gateway:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.gateways[m]
@@ -263,14 +237,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		// other than being removed from the cache.
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing HTTPRoute")
 		delete(kc.httproutes, m)
-		return ok
-	case *serviceapis.TCPRoute:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.tcproutes[m]
-		// TODO(youngnick): Remove this once service-apis actually have behavior
-		// other than being removed from the cache.
-		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing TcpRoute")
-		delete(kc.tcproutes, m)
 		return ok
 	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -646,15 +646,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert service-apis Gatewayclass": {
-			obj: &serviceapis.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gatewayclass",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
 		"insert service-apis Gateway": {
 			obj: &serviceapis.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -668,15 +659,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			obj: &serviceapis.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"insert service-apis TcPRoute": {
-			obj: &serviceapis.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
 					Namespace: "default",
 				},
 			},
@@ -841,21 +823,6 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			},
 			want: false,
 		},
-		"remove service-apis Gatewayclass": {
-			cache: cache(&serviceapis.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gatewayclass",
-					Namespace: "default",
-				},
-			}),
-			obj: &serviceapis.GatewayClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gatewayclass",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
 		"remove service-apis Gateway": {
 			cache: cache(&serviceapis.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -881,21 +848,6 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &serviceapis.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"remove service-apis TcpRoute": {
-			cache: cache(&serviceapis.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
-					Namespace: "default",
-				},
-			}),
-			obj: &serviceapis.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
 					Namespace: "default",
 				},
 			},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -48,19 +48,11 @@ func ServiceAPIResources() []schema.GroupVersionResource {
 	return []schema.GroupVersionResource{{
 		Group:    serviceapis.GroupVersion.Group,
 		Version:  serviceapis.GroupVersion.Version,
-		Resource: "gatewayclasses",
-	}, {
-		Group:    serviceapis.GroupVersion.Group,
-		Version:  serviceapis.GroupVersion.Version,
 		Resource: "gateways",
 	}, {
 		Group:    serviceapis.GroupVersion.Group,
 		Version:  serviceapis.GroupVersion.Version,
 		Resource: "httproutes",
-	}, {
-		Group:    serviceapis.GroupVersion.Group,
-		Version:  serviceapis.GroupVersion.Version,
-		Resource: "tcproutes",
 	},
 	}
 }


### PR DESCRIPTION
The service-apis design calls out that GatewayClasses & TCPRoutes won't be watched
or processed by Contour the controller, so this removes them from processing since
they won't be used.

Updates #3213

Signed-off-by: Steve Sloka <slokas@vmware.com>