### PR TITLE
internal/dag: Add informers for TLSRoute & BackendPolicy

### DIFF
--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -50,17 +50,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  - httproutes
-  - tcproutes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get
@@ -74,6 +63,17 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies
+  - gateways
+  - httproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - projectcontour.io
   resources:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1647,17 +1647,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  - httproutes
-  - tcproutes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get
@@ -1671,6 +1660,17 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies
+  - gateways
+  - httproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - projectcontour.io
   resources:

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -53,6 +53,8 @@ type KubernetesCache struct {
 	services             map[types.NamespacedName]*v1.Service
 	gateways             map[types.NamespacedName]*serviceapis.Gateway
 	httproutes           map[types.NamespacedName]*serviceapis.HTTPRoute
+	tlsroutes            map[types.NamespacedName]*serviceapis.TLSRoute
+	backendpolicies      map[types.NamespacedName]*serviceapis.BackendPolicy
 	extensions           map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
@@ -69,6 +71,8 @@ func (kc *KubernetesCache) init() {
 	kc.services = make(map[types.NamespacedName]*v1.Service)
 	kc.gateways = make(map[types.NamespacedName]*serviceapis.Gateway)
 	kc.httproutes = make(map[types.NamespacedName]*serviceapis.HTTPRoute)
+	kc.tlsroutes = make(map[types.NamespacedName]*serviceapis.TLSRoute)
+	kc.backendpolicies = make(map[types.NamespacedName]*serviceapis.BackendPolicy)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
 
@@ -169,6 +173,20 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding HTTPRoute")
 		kc.httproutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
+	case *serviceapis.TLSRoute:
+		m := k8s.NamespacedNameOf(obj)
+		// TODO(youngnick): Remove this once service-apis actually have behavior
+		// other than being added to the cache.
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding TLSRoute")
+		kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
+		return true
+	case *serviceapis.BackendPolicy:
+		m := k8s.NamespacedNameOf(obj)
+		// TODO(youngnick): Remove this once service-apis actually have behavior
+		// other than being added to the cache.
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding BackendPolicy")
+		kc.backendpolicies[k8s.NamespacedNameOf(obj)] = obj
+		return true
 	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 		return true
@@ -237,6 +255,22 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		// other than being removed from the cache.
 		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing HTTPRoute")
 		delete(kc.httproutes, m)
+		return ok
+	case *serviceapis.TLSRoute:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.tlsroutes[m]
+		// TODO(youngnick): Remove this once service-apis actually have behavior
+		// other than being removed from the cache.
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing TLSRoute")
+		delete(kc.tlsroutes, m)
+		return ok
+	case *serviceapis.BackendPolicy:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.backendpolicies[m]
+		// TODO(youngnick): Remove this once service-apis actually have behavior
+		// other than being removed from the cache.
+		kc.WithField("experimental", "service-apis").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing BackendPolicy")
+		delete(kc.backendpolicies, m)
 		return ok
 	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -664,6 +664,24 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert service-apis TLSRoute": {
+			obj: &serviceapis.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tlsroute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert service-apis BackendPolicy": {
+			obj: &serviceapis.BackendPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendpolicy",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
 		"insert extension service": {
 			obj: &contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
@@ -848,6 +866,36 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &serviceapis.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove service-apis TLSRoute": {
+			cache: cache(&serviceapis.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tlsroute",
+					Namespace: "default",
+				},
+			}),
+			obj: &serviceapis.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tlsroute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove service-apis BackendPolicy": {
+			cache: cache(&serviceapis.BackendPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendpolicy",
+					Namespace: "default",
+				},
+			}),
+			obj: &serviceapis.BackendPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendpolicy",
 					Namespace: "default",
 				},
 			},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -41,7 +41,7 @@ func DefaultResources() []schema.GroupVersionResource {
 	}
 }
 
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tcproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gateways;httproutes;backendpolicies;tlsroutes,verbs=get;list;watch
 
 // ServiceAPIResources ...
 func ServiceAPIResources() []schema.GroupVersionResource {
@@ -53,6 +53,14 @@ func ServiceAPIResources() []schema.GroupVersionResource {
 		Group:    serviceapis.GroupVersion.Group,
 		Version:  serviceapis.GroupVersion.Version,
 		Resource: "httproutes",
+	}, {
+		Group:    serviceapis.GroupVersion.Group,
+		Version:  serviceapis.GroupVersion.Version,
+		Resource: "backendpolicies",
+	}, {
+		Group:    serviceapis.GroupVersion.Group,
+		Version:  serviceapis.GroupVersion.Version,
+		Resource: "tlsroutes",
 	},
 	}
 }


### PR DESCRIPTION
Adds informers for service-apis TLSRoute & BackendPolicy
which were missing from Contour.

Signed-off-by: Steve Sloka <slokas@vmware.com>