### PR TITLE
ci: Enable service-apis when running integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ site-check: ## Test the site's links
 
 integration: ## Run integration tests against a real k8s cluster
 	./_integration/testsuite/make-kind-cluster.sh
+	./_integration/testsuite/install-service-apis.sh
 	./_integration/testsuite/install-contour-working.sh
 	./_integration/testsuite/install-fallback-certificate.sh
 	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml

--- a/_integration/testsuite/install-service-apis.sh
+++ b/_integration/testsuite/install-service-apis.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# install-service-apiss.sh: Install the service-apis CRDs.
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+readonly KUBECTL=${KUBECTL:-kubectl}
+readonly VERSION=v0.1.0
+
+${KUBECTL} kustomize "github.com/kubernetes-sigs/service-apis/config/crd?ref=${VERSION}" | ${KUBECTL} apply -f -


### PR DESCRIPTION
Add service-apis to CI tests which will enable integration tests to be built as
the service-apis work is merged into Contour.

- Install the v0.1.0 service-apis CRDs

Signed-off-by: Steve Sloka <slokas@vmware.com>