### PR TITLE
pkg/config: Add Gateway reference parameters to config file

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -11,6 +11,11 @@ data:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
     #
+    # Specify the service-apis Gateway Contour should watch.
+    # gateway:
+    #   name: contour
+    #   namespace: projectcontour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -45,6 +45,11 @@ data:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
     #
+    # Specify the service-apis Gateway Contour should watch.
+    # gateway:
+    #   name: contour
+    #   namespace: projectcontour
+    #
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -49,6 +49,9 @@ debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
   xds-server-type: contour
+gateway:
+  name: contour
+  namespace: projectcontour
 accesslog-format: envoy
 json-fields:
 - '@timestamp'
@@ -128,6 +131,12 @@ func TestValidateServerType(t *testing.T) {
 
 	assert.NoError(t, EnvoyServerType.Validate())
 	assert.NoError(t, ContourServerType.Validate())
+}
+
+func TestValidateGatewayParameters(t *testing.T) {
+	assert.EqualError(t, GatewayParameters{Name: "gwname", Namespace: ""}.Validate(), "invalid Gateway parameters specified: namespace required")
+	assert.EqualError(t, GatewayParameters{Name: "", Namespace: "ns"}.Validate(), "invalid Gateway parameters specified: name required")
+	assert.EqualError(t, GatewayParameters{Name: "", Namespace: ""}.Validate(), "invalid Gateway parameters specified: name required, namespace required")
 }
 
 func TestValidateAccessLogType(t *testing.T) {

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -32,6 +32,7 @@ Where Contour settings can also be specified with command-line flags, the comman
 | cluster | ClusterConfig | | The [cluster configuration](#cluster-configuration). |
 | network | NetworkConfig | | The [network configuration](#network-configuration). |
 | server | ServerConfig |  | The [server configuration](#server-configuration) for `contour serve` command. |
+| gateway | GatewayConfig |  | The [service-apis Gateway configuration](#gateway-configuration). |
 {: class="table thead-dark table-bordered"}
 <br>
 
@@ -127,6 +128,17 @@ The server configuration block can be used to configure various settings for the
 {: class="table thead-dark table-bordered"}
 <br>
 
+### Gateway Configuration
+
+The gateway configuration block is used to configure which service-apis Gateway Contour should configure:
+
+| Field Name | Type| Default  | Description |
+|------------|-----|----------|-------------|
+| name | string | contour | This field specifies the name of a Gateway.  |
+| namespace | string | projectcontour | This field specifies the namespace of a Gateway.  |
+{: class="table thead-dark table-bordered"}
+<br>
+
 ### Configuration Example
 
 The following is an example ConfigMap with configuration file included:
@@ -143,6 +155,11 @@ data:
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
+    #
+    # specify the service-apis Gateway Contour should configure
+    # gateway:
+    #   name: contour
+    #   namespace: projectcontour
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true


### PR DESCRIPTION
Adds a gateway reference name/namespace parameter to the config file so that when using service-apis, users are able to define which Gateway this instance of Contour should configure.

Updates #3213

Signed-off-by: Steve Sloka <slokas@vmware.com>