### PR TITLE
internal/featuretests: use IsValid/IsInvalid helpers

### DIFF
--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
-	"github.com/projectcontour/contour/internal/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -110,9 +109,7 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 			},
 
 			staticListener()),
-	}).Status(p).Like(contour_api_v1.HTTPProxyStatus{
-		CurrentStatus: string(status.ProxyStatusValid),
-	})
+	}).Status(p).IsValid()
 }
 
 func authzInvalidResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
@@ -198,9 +195,7 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
 			staticListener()),
-	}).Status(p).Like(contour_api_v1.HTTPProxyStatus{
-		CurrentStatus: string(status.ProxyStatusValid),
-	})
+	}).Status(p).IsValid()
 }
 
 func authzFallbackIncompat(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
@@ -515,9 +510,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
 			staticListener()),
-	}).Status(invalid).Like(contour_api_v1.HTTPProxyStatus{
-		CurrentStatus: string(status.ProxyStatusValid),
-	})
+	}).Status(invalid).IsValid()
 }
 
 func TestAuthorization(t *testing.T) {

--- a/internal/featuretests/v3/corspolicy_test.go
+++ b/internal/featuretests/v3/corspolicy_test.go
@@ -23,7 +23,6 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -352,8 +351,6 @@ func TestCorsPolicy(t *testing.T) {
 		Resources: resources(t,
 			envoy_v3.RouteConfiguration("ingress_http")),
 		TypeUrl: routeType,
-	}).Status(invvhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusInvalid)},
-	)
+	}).Status(invvhost).IsInvalid()
 
 }

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -23,7 +23,6 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -115,8 +114,6 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			staticListener(),
 		),
 		TypeUrl: listenerType,
-	}).Status(proxy).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(proxy).IsValid()
 
 }

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -183,7 +183,9 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 }
 
 // resourceEventHandler composes a contour.EventHandler and a contour.EndpointsTranslator
-// into a single ResourceEventHandler type.
+// into a single ResourceEventHandler type. Its event handlers are *blocking* for non-Endpoints
+// resources: they wait until the DAG has been rebuilt and observed, and the sequence counter
+// has been incremented, before returning.
 type resourceEventHandler struct {
 	EventHandler     cache.ResourceEventHandler
 	EndpointsHandler cache.ResourceEventHandler
@@ -203,6 +205,9 @@ func (r *resourceEventHandler) OnAdd(obj interface{}) {
 		r.EndpointsHandler.OnAdd(obj)
 	default:
 		r.EventHandler.OnAdd(obj)
+
+		// Wait for the sequence counter to be incremented, which happens
+		// after the DAG has been rebuilt and observed.
 		<-r.Sequence
 	}
 }
@@ -222,6 +227,9 @@ func (r *resourceEventHandler) OnUpdate(oldObj, newObj interface{}) {
 		r.EndpointsHandler.OnUpdate(oldObj, newObj)
 	default:
 		r.EventHandler.OnUpdate(oldObj, newObj)
+
+		// Wait for the sequence counter to be incremented, which happens
+		// after the DAG has been rebuilt and observed.
 		<-r.Sequence
 	}
 }
@@ -238,6 +246,9 @@ func (r *resourceEventHandler) OnDelete(obj interface{}) {
 		r.EndpointsHandler.OnDelete(obj)
 	default:
 		r.EventHandler.OnDelete(obj)
+
+		// Wait for the sequence counter to be incremented, which happens
+		// after the DAG has been rebuilt and observed.
 		<-r.Sequence
 	}
 }
@@ -336,6 +347,15 @@ func (s *statusResult) IsValid() *Contour {
 	s.T.Helper()
 
 	assert.Equal(s.T, status.ProxyStatusValid, status.ProxyStatus(s.Have.CurrentStatus))
+
+	return s.Contour
+}
+
+// IsInvalid asserts that the proxy's CurrentStatus field is equal to "invalid".
+func (s *statusResult) IsInvalid() *Contour {
+	s.T.Helper()
+
+	assert.Equal(s.T, status.ProxyStatusInvalid, status.ProxyStatus(s.Have.CurrentStatus))
 
 	return s.Contour
 }

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -23,7 +23,6 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -545,9 +544,7 @@ func TestIngressClassUpdate(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost).IsValid()
 
 	// Updating to the non-configured ingress class should remove the
 	// vhost.

--- a/internal/featuretests/v3/replaceprefix_test.go
+++ b/internal/featuretests/v3/replaceprefix_test.go
@@ -21,7 +21,6 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/status"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
@@ -83,9 +82,7 @@ func basic(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost).IsValid()
 
 	// Update the vhost to make the replacement ambiguous. This should remove the generated config.
 	vhost = update(rh, vhost,
@@ -130,9 +127,7 @@ func basic(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost).IsValid()
 
 	// But having duplicate prefixes in the replacements makes
 	// it ambiguous again.
@@ -178,9 +173,7 @@ func basic(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost).IsValid()
 
 	// If we remove the prefix match condition, the implicit '/' prefix
 	// will be used. So we expect that the default replacement prefix
@@ -202,9 +195,7 @@ func basic(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost).IsValid()
 }
 
 func multiInclude(t *testing.T) {
@@ -284,11 +275,7 @@ func multiInclude(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost1).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	).Status(vhost2).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost1).IsValid().Status(vhost2).IsValid()
 
 	// Remove one of the replacements, and one cluster loses the rewrite.
 	update(rh, app,
@@ -321,11 +308,7 @@ func multiInclude(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost1).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	).Status(vhost2).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost1).IsValid().Status(vhost2).IsValid()
 }
 
 func replaceWithSlash(t *testing.T) {
@@ -405,11 +388,7 @@ func replaceWithSlash(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost1).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	).Status(vhost2).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost1).IsValid().Status(vhost2).IsValid()
 
 	// Not swap the routing and replacement prefixes. Because the routing
 	// prefix is '/', the replacement should just end up being prepended
@@ -446,11 +425,7 @@ func replaceWithSlash(t *testing.T) {
 			),
 		),
 		TypeUrl: routeType,
-	}).Status(vhost1).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	).Status(vhost2).Like(
-		contour_api_v1.HTTPProxyStatus{CurrentStatus: string(status.ProxyStatusValid)},
-	)
+	}).Status(vhost1).IsValid().Status(vhost2).IsValid()
 }
 
 // artifactoryDocker simulates an Artifactory Docker registry service.


### PR DESCRIPTION
Adds an IsInvalid() helper to match the existing IsValid() helper,
and uses them in all the feature tests to be more concise.

Also adds comments about the internal/featuretests event handler
being blocking.

Signed-off-by: Steve Kriss <krisss@vmware.com>