### PR TITLE
remove usages of vendor/ directory

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -38,7 +38,6 @@ jobs:
           go-version: '1.15.6'
       - name: test
         run: |
-          go mod vendor
           make install
           make check-coverage
       - name: codeCoverage
@@ -54,7 +53,6 @@ jobs:
           go-version: '1.15.6'
       - name: test
         run: |
-          go mod vendor
           make install
           make check-coverage
   lint:
@@ -88,6 +86,5 @@ jobs:
           go-version: '1.15.6'
       - name: generate
         run: |
-          go mod vendor
           make generate
           ./hack/actions/check-uncommitted-codegen.sh

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ export GO111MODULE=on
 check: install check-test check-test-race ## Install and run tests
 
 .PHONY: checkall
-checkall: vendor check lint check-generate
+checkall: check lint check-generate
 
 build: ## Build the contour binary
 	go build -mod=readonly -v -ldflags="$(GO_LDFLAGS)" $(GO_TAGS) $(MODULE)/cmd/contour
@@ -95,10 +95,6 @@ race:
 
 download: ## Download Go modules
 	go mod download
-
-## Vendor Go modules
-vendor:
-	go mod vendor
 
 multiarch-build-push: ## Build and push a multi-arch Contour container image to the Docker registry
 	docker buildx build \

--- a/hack/generate-crd-deepcopy.sh
+++ b/hack/generate-crd-deepcopy.sh
@@ -11,10 +11,8 @@ readonly YEAR=$(date +%Y)
 readonly PATHS="${1:-"./apis/..."}"
 
 readonly GO111MODULE=on
-readonly GOFLAGS=-mod=vendor
 
 export GO111MODULE
-export GOFLAGS
 
 boilerplate() {
     cat <<EOF

--- a/hack/generate-rbac.sh
+++ b/hack/generate-rbac.sh
@@ -8,10 +8,8 @@ readonly REPO=$(cd "$(dirname "$0")/.." && pwd)
 readonly PROGNAME=$(basename "$0")
 
 readonly GO111MODULE=on
-readonly GOFLAGS=-mod=vendor
 
 export GO111MODULE
-export GOFLAGS
 
 exec >"${REPO}/examples/contour/02-role-contour.yaml"
 

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -20,10 +20,6 @@ set -o pipefail
 
 readonly IMG="docker.io/projectcontour/contour:$NEWVERS"
 
-# If you are running this script, there's a good chance you switched
-# branches, do ensure the vendor cache is current.
-go mod vendor
-
 if [ -n "$(git tag --list "$NEWVERS")" ]; then
     printf "%s: tag '%s' already exists\n" "$PROGNAME" "$NEWVERS"
     exit 1


### PR DESCRIPTION
Removes unneeded setting of -mod=vendor from code-gen scripts
and calls to `go mod vendor` to remove requirement for a local
vendor/ directory.

Closes #3276.

Signed-off-by: Steve Kriss <krisss@vmware.com>