### PR TITLE
internal: use metav1.Object for metadata access

### DIFF
--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -94,8 +94,8 @@ func ValidForKind(kind string, key string) bool {
 
 // ContourAnnotation checks the Object for the given annotation with the
 // "projectcontour.io/" prefix.
-func ContourAnnotation(o metav1.ObjectMetaAccessor, key string) string {
-	a := o.GetObjectMeta().GetAnnotations()
+func ContourAnnotation(o metav1.Object, key string) string {
+	a := o.GetAnnotations()
 
 	return a["projectcontour.io/"+key]
 }
@@ -168,8 +168,8 @@ func PerTryTimeout(i *v1beta1.Ingress) (timeout.Setting, error) {
 // annotations:
 // 1. projectcontour.io/ingress.class
 // 2. kubernetes.io/ingress.class
-func IngressClass(o metav1.ObjectMetaAccessor) string {
-	a := o.GetObjectMeta().GetAnnotations()
+func IngressClass(o metav1.Object) string {
+	a := o.GetAnnotations()
 	if class, ok := a["projectcontour.io/ingress.class"]; ok {
 		return class
 	}
@@ -181,7 +181,7 @@ func IngressClass(o metav1.ObjectMetaAccessor) string {
 
 // MatchesIngressClass checks that the passed object has an ingress class that matches
 // either the passed ingress-class string, or DEFAULT_INGRESS_CLASS if it's empty.
-func MatchesIngressClass(o metav1.ObjectMetaAccessor, ic string) bool {
+func MatchesIngressClass(o metav1.Object, ic string) bool {
 
 	switch IngressClass(o) {
 	case ic:
@@ -214,7 +214,7 @@ func MinTLSVersion(version string, defaultVal string) string {
 // 1. projectcontour.io/max-connections
 //
 // '0' is returned if the annotation is absent or unparsable.
-func MaxConnections(o metav1.ObjectMetaAccessor) uint32 {
+func MaxConnections(o metav1.Object) uint32 {
 	return parseUInt32(ContourAnnotation(o, "max-connections"))
 }
 
@@ -223,7 +223,7 @@ func MaxConnections(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-pending-requests
 //
 // '0' is returned if the annotation is absent or unparsable.
-func MaxPendingRequests(o metav1.ObjectMetaAccessor) uint32 {
+func MaxPendingRequests(o metav1.Object) uint32 {
 	return parseUInt32(ContourAnnotation(o, "max-pending-requests"))
 }
 
@@ -232,7 +232,7 @@ func MaxPendingRequests(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-requests
 //
 // '0' is returned if the annotation is absent or unparsable.
-func MaxRequests(o metav1.ObjectMetaAccessor) uint32 {
+func MaxRequests(o metav1.Object) uint32 {
 	return parseUInt32(ContourAnnotation(o, "max-requests"))
 }
 
@@ -241,6 +241,6 @@ func MaxRequests(o metav1.ObjectMetaAccessor) uint32 {
 // 1. projectcontour.io/max-retries
 //
 // '0' is returned if the annotation is absent or unparsable.
-func MaxRetries(o metav1.ObjectMetaAccessor) uint32 {
+func MaxRetries(o metav1.Object) uint32 {
 	return parseUInt32(ContourAnnotation(o, "max-retries"))
 }

--- a/internal/annotation/annotations_test.go
+++ b/internal/annotation/annotations_test.go
@@ -279,7 +279,7 @@ func TestAnnotationKindValidation(t *testing.T) {
 		valid bool
 	}
 	tests := map[string]struct {
-		obj         metav1.ObjectMetaAccessor
+		obj         metav1.Object
 		annotations map[string]status
 	}{
 		"service": {
@@ -355,7 +355,7 @@ func TestMatchIngressClass(t *testing.T) {
 	// ingress class is empty
 	// ingress class is not empty.
 	tests := map[string]struct {
-		fixture metav1.ObjectMetaAccessor
+		fixture metav1.Object
 		// these are results for empty and "contour" ingress class
 		// respectively.
 		want []bool

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -110,7 +110,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 
 	if proxy.Spec.VirtualHost == nil {
 		// mark HTTPProxy as orphaned.
-		p.setOrphaned(proxy)
+		p.orphaned[k8s.NamespacedNameOf(proxy)] = true
 		return
 	}
 
@@ -792,15 +792,6 @@ func (p *HTTPProxyProcessor) rootAllowed(namespace string) bool {
 		}
 	}
 	return false
-}
-
-// setOrphaned records an HTTPProxy resource as orphaned.
-func (p *HTTPProxyProcessor) setOrphaned(obj k8s.Object) {
-	m := types.NamespacedName{
-		Name:      obj.GetObjectMeta().GetName(),
-		Namespace: obj.GetObjectMeta().GetNamespace(),
-	}
-	p.orphaned[m] = true
 }
 
 // expandPrefixMatches adds new Routes to account for the difference

--- a/internal/dag/status.go
+++ b/internal/dag/status.go
@@ -17,14 +17,14 @@ import (
 	"fmt"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 // Status contains the status for an HTTPProxy (valid / invalid / orphan, etc)
 type Status struct {
-	Object      k8s.Object
+	Object      metav1.Object
 	Status      string
 	Description string
 	Vhost       string
@@ -36,7 +36,7 @@ type StatusWriter struct {
 
 type ObjectStatusWriter struct {
 	sw     *StatusWriter
-	obj    k8s.Object
+	obj    metav1.Object
 	values map[string]string
 }
 
@@ -47,7 +47,7 @@ type ObjectStatusWriter struct {
 // but keep the commit function for itself. The commit function should be either called
 // via a defer, or directly if statuses are being set in a loop (as defers will not fire
 // until the end of the function).
-func (sw *StatusWriter) WithObject(obj k8s.Object) (_ *ObjectStatusWriter, commit func()) {
+func (sw *StatusWriter) WithObject(obj metav1.Object) (_ *ObjectStatusWriter, commit func()) {
 	osw := &ObjectStatusWriter{
 		sw:     sw,
 		obj:    obj,
@@ -65,8 +65,8 @@ func (sw *StatusWriter) commit(osw *ObjectStatusWriter) {
 	}
 
 	m := types.NamespacedName{
-		Name:      osw.obj.GetObjectMeta().GetName(),
-		Namespace: osw.obj.GetObjectMeta().GetNamespace(),
+		Name:      osw.obj.GetName(),
+		Namespace: osw.obj.GetNamespace(),
 	}
 	if _, ok := sw.statuses[m]; !ok {
 		// only record the first status event
@@ -100,7 +100,7 @@ func (osw *ObjectStatusWriter) SetValid() {
 // ObjectStatusWriter's values, including its status if set. This is convenient if
 // the object shares a relationship with its parent. The caller should arrange for
 // the commit function to be called to write the final status of the object.
-func (osw *ObjectStatusWriter) WithObject(obj k8s.Object) (_ *ObjectStatusWriter, commit func()) {
+func (osw *ObjectStatusWriter) WithObject(obj metav1.Object) (_ *ObjectStatusWriter, commit func()) {
 	m := make(map[string]string)
 	for k, v := range osw.values {
 		m[k] = v

--- a/internal/k8s/objectmeta.go
+++ b/internal/k8s/objectmeta.go
@@ -20,19 +20,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Object is any Kubernetes object that has an ObjectMeta.
-// TODO(youngnick): Review references to this and replace them
-// with straight metav1.ObjectMetaAccessor calls if we can.
-type Object interface {
-	metav1.ObjectMetaAccessor
-}
-
 // NamespacedNameOf returns the NamespacedName of any given Kubernetes object.
-func NamespacedNameOf(obj Object) types.NamespacedName {
-	m := obj.GetObjectMeta()
+func NamespacedNameOf(obj metav1.Object) types.NamespacedName {
 	name := types.NamespacedName{
-		Name:      m.GetName(),
-		Namespace: m.GetNamespace(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}
 
 	if name.Namespace == "" {

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -70,7 +71,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		return
 	}
 
-	var typed Object
+	var typed metav1.Object
 	var gvr schema.GroupVersionResource
 	var kind string
 
@@ -93,8 +94,8 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 
 	if !annotation.MatchesIngressClass(typed, s.IngressClass) {
 		s.Logger.
-			WithField("name", typed.GetObjectMeta().GetName()).
-			WithField("namespace", typed.GetObjectMeta().GetNamespace()).
+			WithField("name", typed.GetName()).
+			WithField("namespace", typed.GetNamespace()).
 			WithField("ingress-class", annotation.IngressClass(typed)).
 			WithField("target-ingress-class", s.IngressClass).
 			WithField("kind", kind).
@@ -103,16 +104,16 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 	}
 
 	s.Logger.
-		WithField("name", typed.GetObjectMeta().GetName()).
-		WithField("namespace", typed.GetObjectMeta().GetNamespace()).
+		WithField("name", typed.GetName()).
+		WithField("namespace", typed.GetNamespace()).
 		WithField("ingress-class", annotation.IngressClass(typed)).
 		WithField("kind", kind).
 		WithField("defined-ingress-class", s.IngressClass).
 		Debug("received an object, sending status address update")
 
 	s.StatusUpdater.Send(NewStatusUpdate(
-		typed.GetObjectMeta().GetName(),
-		typed.GetObjectMeta().GetNamespace(),
+		typed.GetName(),
+		typed.GetNamespace(),
 		gvr,
 		StatusMutatorFunc(func(obj interface{}) interface{} {
 			switch o := obj.(type) {
@@ -126,7 +127,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 				return dco
 			default:
 				panic(fmt.Sprintf("Unsupported object %s/%s in status Address mutator",
-					typed.GetObjectMeta().GetName(), typed.GetObjectMeta().GetNamespace(),
+					typed.GetName(), typed.GetNamespace(),
 				))
 			}
 		}),

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -20,7 +20,7 @@ import (
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -58,7 +58,7 @@ type Cache struct {
 // Get returns a pointer to a the cache entry if it exists, nil
 // otherwise. The return value is shared between all callers, who
 // should take care to cooperate.
-func (c *Cache) Get(obj k8s.Object) CacheEntry {
+func (c *Cache) Get(obj metav1.Object) CacheEntry {
 	kind := k8s.KindOf(obj)
 
 	if _, ok := c.entries[kind]; !ok {
@@ -69,7 +69,7 @@ func (c *Cache) Get(obj k8s.Object) CacheEntry {
 }
 
 // Put returns an entry to the cache.
-func (c *Cache) Put(obj k8s.Object, e CacheEntry) {
+func (c *Cache) Put(obj metav1.Object, e CacheEntry) {
 	kind := k8s.KindOf(obj)
 
 	if _, ok := c.entries[kind]; !ok {
@@ -88,7 +88,7 @@ func (c *Cache) ProxyAccessor(proxy *contour_api_v1.HTTPProxy) (*ProxyUpdate, fu
 	pu := &ProxyUpdate{
 		Fullname:       k8s.NamespacedNameOf(proxy),
 		Generation:     proxy.Generation,
-		TransitionTime: v1.NewTime(time.Now()),
+		TransitionTime: metav1.NewTime(time.Now()),
 		Conditions:     make(map[ConditionType]*contour_api_v1.DetailedCondition),
 	}
 


### PR DESCRIPTION
Replaces k8s.Object and metav1.ObjectMetaAccessor with metav1.Object
usage, which all API objects implement and allows direct access to
metadata fields.

Signed-off-by: Steve Kriss <krisss@vmware.com>