### PR TITLE
Ignore tools.ietf.org in site proof check

### DIFF
--- a/hack/site-proofing/cibuild
+++ b/hack/site-proofing/cibuild
@@ -18,4 +18,4 @@ htmlproofer ./_site \
     --allow-hash-href \
     --http-status-ignore 429 \
     --typhoeus-config '{"headers": {"User-Agent": "Mozilla/5.0 (Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0"}}' \
-    --url-ignore /www.haproxy.org/ # gives false positive timeouts
+    --url-ignore "/www.haproxy.org/,/tools.ietf.org/" # gives false positive timeouts

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -128,6 +128,7 @@ metadata:
   namespace: projectcontour
 data:
   contour.yaml: |
+    #
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
     #   xds-server-type: contour
@@ -138,32 +139,70 @@ data:
     # path to kubeconfig (if not running inside a k8s cluster)
     # kubeconfig: /path/to/.kube/config
     #
-    # disable httpproxy permitInsecure field
-    # disablePermitInsecure: false
+    # Disable RFC-compliant behavior to strip "Content-Length" header if
+    # "Tranfer-Encoding: chunked" is also set.
+    # disableAllowChunkedLength: false
+    # Disable HTTPProxy permitInsecure field
+    disablePermitInsecure: false
     tls:
-      # minimum TLS version that Contour will negotiate
-      # minimumProtocolVersion: "1.2"
+    # minimum TLS version that Contour will negotiate
+    # minimum-protocol-version: "1.2"
+    # Defines the Kubernetes name/namespace matching a secret to use
+    # as the fallback certificate when requests which don't match the
+    # SNI defined for a vhost.
       fallback-certificate:
-      # name: fallback-secret-name
-      # namespace: projectcontour
+    #   name: fallback-secret-name
+    #   namespace: projectcontour
       envoy-client-certificate:
-      # name: envoy-client-cert-secret-name
-      # namespace: projectcontour
+    #   name: envoy-client-cert-secret-name
+    #   namespace: projectcontour
     # The following config shows the defaults for the leader election.
     # leaderelection:
-      # configmap-name: leader-elect
-      # configmap-namespace: projectcontour
-    # Default HTTP versions.
+    #   configmap-name: leader-elect
+    #   configmap-namespace: projectcontour
+    ### Logging options
+    # Default setting
+    accesslog-format: envoy
+    # To enable JSON logging in Envoy
+    # accesslog-format: json
+    # The default fields that will be logged are specified below.
+    # To customise this list, just add or remove entries.
+    # The canonical list is available at
+    # https://godoc.org/github.com/projectcontour/contour/internal/envoy#JSONFields
+    # json-fields:
+    #   - "@timestamp"
+    #   - "authority"
+    #   - "bytes_received"
+    #   - "bytes_sent"
+    #   - "downstream_local_address"
+    #   - "downstream_remote_address"
+    #   - "duration"
+    #   - "method"
+    #   - "path"
+    #   - "protocol"
+    #   - "request_id"
+    #   - "requested_server_name"
+    #   - "response_code"
+    #   - "response_flags"
+    #   - "uber_trace_id"
+    #   - "upstream_cluster"
+    #   - "upstream_host"
+    #   - "upstream_local_address"
+    #   - "upstream_service_time"
+    #   - "user_agent"
+    #   - "x_forwarded_for"
+    #
     # default-http-versions:
-    # - "HTTP/1.1"
     # - "HTTP/2"
+    # - "HTTP/1.1"
+    #
     # The following shows the default proxy timeout settings.
     # timeouts:
-    #  request-timeout: infinity
-    #  connection-idle-timeout: 60s
-    #  stream-idle-timeout: 5m
-    #  max-connection-duration: infinity
-    #  connection-shutdown-grace-period: 5s
+    #   request-timeout: infinity
+    #   connection-idle-timeout: 60s
+    #   stream-idle-timeout: 5m
+    #   max-connection-duration: infinity
+    #   connection-shutdown-grace-period: 5s
     #
     # Envoy cluster settings.
     # cluster:


### PR DESCRIPTION
Returns frequent false positive timeouts

See https://github.com/projectcontour/contour/pull/3292/checks?check_run_id=1809735846, checking for https://tools.ietf.org/html/rfc7540#section-9.1.1

Also syncs the example contour configmap with the actual file to ensure the siteproof check reruns in CI