### PR TITLE
Revert "internal: update HTTP/2 protocol options config (#3260)"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,11 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: package github.com/golang/protobuf"
+  # Disable deprecation warnings for Http2ProtocolOptions, which we're still using for compatibility
+  # with Envoy 1.16 to allow no-downtime upgrades, and which we can't nolint by line (see above).
+  - linters:
+    - staticcheck
+    text: "Http2ProtocolOptions is deprecated: Do not use."
   - linters:
     - golint
     text: "var `ingress_https` should be `ingressHTTPS`"

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -173,7 +173,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 						KeepaliveInterval: protobuf.UInt32(5),
 					},
 				},
-				TypedExtensionProtocolOptions: http2ProtocolOptions(),
+				Http2ProtocolOptions: new(envoy_core_v3.Http2ProtocolOptions), // enables http2
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
 					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
 						Priority:           envoy_core_v3.RoutingPriority_HIGH,

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -82,14 +82,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -217,14 +210,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -351,14 +337,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -486,14 +465,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -619,14 +591,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -756,14 +721,7 @@ func TestBootstrap(t *testing.T) {
             }
           ]
         },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
+        "http2_protocol_options": {},
         "upstream_connection_options": {
           "tcp_keepalive": {
             "keepalive_probes": 3,
@@ -922,14 +880,7 @@ func TestBootstrap(t *testing.T) {
                   }
                 ]
               },
-              "typed_extension_protocol_options": {
-                "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-                  "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-                  "explicit_http_config": {
-                    "http2_protocol_options": {}
-                  }
-                }
-              },
+              "http2_protocol_options": {},
               "transport_socket": {
                 "name": "envoy.transport_sockets.tls",
                 "typed_config": {

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -20,9 +20,7 @@ import (
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -86,7 +84,7 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				c.UpstreamValidation,
@@ -96,23 +94,10 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
 	}
 
 	return cluster
-}
-
-func http2ProtocolOptions() map[string]*any.Any {
-	return map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-					},
-				},
-			}),
-	}
 }
 
 // ExtensionCluster builds a envoy_cluster_v3.Cluster struct for the given extension service.
@@ -144,7 +129,7 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 
 	switch ext.Protocol {
 	case "h2":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				ext.UpstreamValidation,
@@ -154,7 +139,7 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		cluster.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
 	}
 
 	return cluster

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -19,10 +19,8 @@ import (
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -139,16 +137,7 @@ func TestCluster(t *testing.T) {
 					EdsConfig:   ConfigSource("contour"),
 					ServiceName: "default/kuard/http",
 				},
-				TypedExtensionProtocolOptions: map[string]*any.Any{
-					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-						&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-							UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-								ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-									ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-								},
-							},
-						}),
-				},
+				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 			},
 		},
 		"h2 upstream": {
@@ -167,16 +156,7 @@ func TestCluster(t *testing.T) {
 				TransportSocket: UpstreamTLSTransportSocket(
 					UpstreamTLSContext(nil, "", nil, "h2"),
 				),
-				TypedExtensionProtocolOptions: map[string]*any.Any{
-					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-						&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-							UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-								ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-									ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-								},
-							},
-						}),
-				},
+				Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 			},
 		},
 		"externalName service": {

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -28,7 +28,6 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -181,16 +180,7 @@ func tlsClusterWithoutValidation(c *envoy_cluster_v3.Cluster, sni string, client
 }
 
 func h2cCluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
-	c.TypedExtensionProtocolOptions = map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-					},
-				},
-			}),
-	}
+	c.Http2ProtocolOptions = &envoy_core_v3.Http2ProtocolOptions{}
 	return c
 }
 

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -17,14 +17,12 @@ import (
 	"testing"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes/any"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +30,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// Assert that services of type v1.ServiceTypeExternalName can be
 // referenced by an Ingress, or HTTPProxy document.
 func TestExternalNameService(t *testing.T) {
 	rh, c, done := setup(t)
@@ -205,16 +202,7 @@ func TestExternalNameService(t *testing.T) {
 			DefaultCluster(
 				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
-					TypedExtensionProtocolOptions: map[string]*any.Any{
-						"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-							&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-								UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-									ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-										ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-									},
-								},
-							}),
-					},
+					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 				},
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(

--- a/internal/xdscache/v3/cluster_test.go
+++ b/internal/xdscache/v3/cluster_test.go
@@ -19,9 +19,7 @@ import (
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
@@ -265,16 +263,7 @@ func TestClusterVisit(t *testing.T) {
 						EdsConfig:   envoy_v3.ConfigSource("contour"),
 						ServiceName: "default/kuard/http",
 					},
-					TypedExtensionProtocolOptions: map[string]*any.Any{
-						"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-							&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-								UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-									ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-										ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-									},
-								},
-							}),
-					},
+					Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{},
 				},
 			),
 		},


### PR DESCRIPTION
Reverts commit 78c434fcd9aa8e08f12ee5def7c0e215c0c805c5, which made
a Contour change that was not backwards-compatible with Envoy 1.16.
Also ignores lint errors which were the original motivation for #3260.

Signed-off-by: Steve Kriss <krisss@vmware.com>