### PR TITLE
cmd/contour: Deprecate 'UseExperimentalServiceAPITypes' flag

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -147,7 +147,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 	serve.Flag("debug", "Enable debug logging.").Short('d').BoolVar(&ctx.Config.Debug)
 	serve.Flag("kubernetes-debug", "Enable Kubernetes client debug logging.").UintVar(&ctx.KubernetesDebug)
-	serve.Flag("experimental-service-apis", "Subscribe to the new service-apis types.").BoolVar(&ctx.UseExperimentalServiceAPITypes)
+	serve.Flag("experimental-service-apis", "DEPRECATED: Please configure the gateway.name & gateway.namespace in the configuration file.").BoolVar(&ctx.UseExperimentalServiceAPITypes)
 	return serve, ctx
 }
 

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -389,15 +389,16 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on service-apis types if they are present.
 	if ctx.UseExperimentalServiceAPITypes {
-		for _, r := range k8s.ServiceAPIResources() {
-			if !clients.ResourcesExist(r) {
-				log.WithField("resource", r).Warn("resource type not present on API server")
-				continue
-			}
+		log.Warn("DEPRECATED: The flag '--experimental-service-apis' is deprecated and should not be used. Please configure the gateway.name & gateway.namespace in the configuration file to specify which Gateway Contour will be watching.")
+	}
+	for _, r := range k8s.ServiceAPIResources() {
+		if !clients.ResourcesExist(r) {
+			log.WithField("resource", r).Warn("resource type not present on API server")
+			continue
+		}
 
-			if err := informOnResource(clients, r, &dynamicHandler); err != nil {
-				log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
-			}
+		if err := informOnResource(clients, r, &dynamicHandler); err != nil {
+			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
 

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -87,6 +87,8 @@ type serveContext struct {
 	// types.
 	// If the value is true, Contour will register for all the service-apis types
 	// (GatewayClass, Gateway, HTTPRoute, TCPRoute, and any more as they are added)
+	//
+	// DEPRECATED: Configure the Gateway.Name & Gateway.Namespace in the configuration file.
 	UseExperimentalServiceAPITypes bool `yaml:"-"`
 }
 


### PR DESCRIPTION
Deprecate the '--experimental-service-apis' flag to `contour serve` in favor of using the gateway.name & gateway.namespace config file options.

Follow up to #3310 to have a place to document the deprecations related to `contour serve` flags. 

Updates #3213

Signed-off-by: Steve Sloka <slokas@vmware.com>