### PR TITLE
site: Update WeightedLeastRequestDescription in docs

### DIFF
--- a/site/docs/main/config/request-routing.md
+++ b/site/docs/main/config/request-routing.md
@@ -223,7 +223,7 @@ Each route can have a load balancing strategy applied to determine which of its 
 The following list are the options available to choose from:
 
 - `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
-- `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
+- `WeightedLeastRequest`:  The least request load balancer uses different algorithms depending on whether hosts have the same or different weights in an attempt to route traffic based upon the number of active requests or the load at the time of selection. 
 - `Random`: The random strategy selects a random healthy Endpoints.
 - `RequestHash`: The request hashing strategy allows for load balancing based on request attributes. An upstream Endpoint is selected based on the hash of an element of a request. Requests that contain a consistent value in a HTTP request header for example will be routed to the same upstream Endpoint. Currently only hashing of HTTP request headers is supported.
 - `Cookie`: The cookie load balancing strategy is similar to the request hash strategy and is a convenience feature to implement session affinity, as described below.

--- a/site/docs/v1.12.0/config/request-routing.md
+++ b/site/docs/v1.12.0/config/request-routing.md
@@ -223,7 +223,7 @@ Each route can have a load balancing strategy applied to determine which of its 
 The following list are the options available to choose from:
 
 - `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
-- `WeightedLeastRequest`: The least request strategy uses an O(1) algorithm which selects two random healthy Endpoints and picks the Endpoint which has fewer active requests. Note: This algorithm is simple and sufficient for load testing. It should not be used where true weighted least request behavior is desired.
+- `WeightedLeastRequest`: The least request load balancer uses different algorithms depending on whether hosts have the same or different weights in an attempt to route traffic based upon the number of active requests or the load at the time of selection.
 - `Random`: The random strategy selects a random healthy Endpoints.
 - `RequestHash`: The request hashing strategy allows for load balancing based on request attributes. An upstream Endpoint is selected based on the hash of an element of a request. Requests that contain a consistent value in a HTTP request header for example will be routed to the same upstream Endpoint. Currently only hashing of HTTP request headers is supported.
 - `Cookie`: The cookie load balancing strategy is similar to the request hash strategy and is a convenience feature to implement session affinity, as described below.


### PR DESCRIPTION
The 'WeightedLeastRequest' load balancer strategy in the docs outlined some text that it wasn't useful outside of just testing. This is due to copying from the Envoy docs (v1.5) when this algorithm was new and has evolved much since that time, we just never updated the docs to match.

This came up on the Community call today (@moderation). 

v1.17 docs: https://www.envoyproxy.io/docs/envoy/v1.17.0/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request
Old docs: https://www.envoyproxy.io/docs/envoy/v1.6.0/intro/arch_overview/load_balancing.html#weighted-least-request

Signed-off-by: Steve Sloka <slokas@vmware.com>