### PR TITLE
site/docs: fix rate limiting docs bugs

### DIFF
--- a/site/docs/main/config/rate-limiting.md
+++ b/site/docs/main/config/rate-limiting.md
@@ -103,8 +103,7 @@ spec:
 
 #### Headers
 
-By default, Envoy sets the `x-envoy-ratelimited` header on rate limited responses.
-Additional headers can optionally be added to rate limited responses, by configuring the `responseHeadersToAdd` field.
+Headers can optionally be added to rate limited responses, by configuring the `responseHeadersToAdd` field.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -127,5 +126,5 @@ spec:
         unit: minute
         responseHeadersToAdd:
         - name: x-contour-ratelimited
-          value: true
+          value: "true"
 ```

--- a/site/docs/v1.12.0/config/rate-limiting.md
+++ b/site/docs/v1.12.0/config/rate-limiting.md
@@ -103,8 +103,7 @@ spec:
 
 #### Headers
 
-By default, Envoy sets the `x-envoy-ratelimited` header on rate limited responses.
-Additional headers can optionally be added to rate limited responses, by configuring the `responseHeadersToAdd` field.
+Headers can optionally be added to rate limited responses, by configuring the `responseHeadersToAdd` field.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -127,5 +126,5 @@ spec:
         unit: minute
         responseHeadersToAdd:
         - name: x-contour-ratelimited
-          value: true
+          value: "true"
 ```


### PR DESCRIPTION
Properly quotes the header value in the rate limiting example YAML.
Also removes statement about x-envoy-ratelimited header being added
by Envoy since it's not true.

Closes #3318.

Signed-off-by: Steve Kriss <krisss@vmware.com>