### PR TITLE
_integration: fix externalname test

### DIFF
--- a/_integration/testsuite/httpproxy/018-external-name-service.yaml
+++ b/_integration/testsuite/httpproxy/018-external-name-service.yaml
@@ -18,7 +18,7 @@ metadata:
   name: external-name-svc
 spec:
   type: ExternalName
-  externalName: projectcontour.io
+  externalName: envoyproxy.io
   ports:
     - name: https
       port: 443
@@ -41,7 +41,7 @@ spec:
     requestHeadersPolicy:
       set:
       - name: Host
-        value: projectcontour.io
+        value: envoyproxy.io
 
 ---
 
@@ -71,6 +71,7 @@ Response := client.Get({
     "Host": "externalname.bar.com",
     "User-Agent": client.ua("external-name-test"),
   },
+  "enable_redirect": true,
 })
 
 check_for_status_code [msg] {


### PR DESCRIPTION
Allows redirects to be followed, and uses envoyproxy.io instead
of projectcontour.io as the target.

Closed #3320.

Signed-off-by: Steve Kriss <krisss@vmware.com>