### PR TITLE
_integration: disable flaky test

### DIFF
--- a/_integration/testsuite/httpproxy/018-external-name-service.yaml
+++ b/_integration/testsuite/httpproxy/018-external-name-service.yaml
@@ -12,6 +12,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+skip[msg] {
+  msg := "018-external-name-service is flaky, skipping until it's fixed"
+}
+
+---
+
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
The ExternalName integration test has turned out to be
flaky. This PR skips it for now until a more robust test
can be implemented.

Signed-off-by: Steve Kriss <krisss@vmware.com>