### PR TITLE
HTTPProxy: Add validation check

### DIFF
--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -144,6 +144,10 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 
 	var tlsEnabled bool
 	if tls := proxy.Spec.VirtualHost.TLS; tls != nil {
+		if tls.Passthrough && tls.EnableFallbackCertificate {
+			validCond.AddError(contour_api_v1.ConditionTypeTLSError, "TLSIncompatibleFeatures",
+				"Spec.VirtualHost.TLS: both Passthrough and enableFallbackCertificate were specified")
+		}
 		if !isBlank(tls.SecretName) && tls.Passthrough {
 			validCond.AddError(contour_api_v1.ConditionTypeTLSError, "TLSConfigNotValid",
 				"Spec.VirtualHost.TLS: both Passthrough and SecretName were specified")


### PR DESCRIPTION
Add validation to ensure that Passthrough and Fallback aren't specified
at the same time.

Fixes: #3197
Signed-off-by: Amey Bhide <amey15@gmail.com>