### PR TITLE
admin: Updates the PR template so that the text is visible

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -6,15 +6,15 @@ about: Tell us about your contribution
 ---
 ## Thanks for contributing to Contour!
 
-Please delete this text between the lines (and the lines) before submitting your PR.
+Please delete this text between the `---` strings (and the strings themselves) before submitting your PR.
 
 Before submitting a pull request, make sure you read about our Contribution Workflow here: https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#contribution-workflow
 
 Some notable call outs from our Contribution Workflow:
-1. All PR's must have a `Fixes #NNN` or `Updates #NNN` line in the pull request description.
-Contour operates according to the talk, then code rule.
-If you plan to submit a pull request for anything more than a typo or small bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
-We generally won't merge a PR without an associated issue.
-2. Large changes must have an associated design document, raising an issue with your proposed change will give us a chance to determin
-3. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#dco-sign-off
+- All PR's must have a `Fixes #NNN` or `Updates #NNN` line in the pull request description.
+- Contour operates according to the talk, then code rule.
+- If you plan to submit a pull request for anything more than a typo or small bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
+- We generally won't merge a PR without an associated issue.
+- Large changes must have an associated design document, raising an issue with your proposed change will give us a chance to determine if the change needs a design doc.
+- All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#dco-sign-off
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -3,13 +3,18 @@ name: Pull request
 about: Tell us about your contribution
 ---
 
-<!--  Thanks for contributing to Contour!
+---
+## Thanks for contributing to Contour!
+
+Please delete this text between the lines (and the lines) before submitting your PR.
 
 Before submitting a pull request, make sure you read about our Contribution Workflow here: https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#contribution-workflow
 
 Some notable call outs from our Contribution Workflow:
-
-1. All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request description. Contour operates according to the talk, then code rule. If you plan to submit a pull request for anything more than a typo or obvious bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
-2. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#dco-sign-off
-
--->
+1. All PR's must have a `Fixes #NNN` or `Updates #NNN` line in the pull request description.
+Contour operates according to the talk, then code rule.
+If you plan to submit a pull request for anything more than a typo or small bug fix, first you should raise an issue to discuss your proposal, before submitting any code.
+We generally won't merge a PR without an associated issue.
+2. Large changes must have an associated design document, raising an issue with your proposed change will give us a chance to determin
+3. All commits to Contour must have a Developer Certificate of Origin (DCO) sign off. More about that here https://github.com/projectcontour/contour/blob/main/CONTRIBUTING.md#dco-sign-off
+---


### PR DESCRIPTION
The PR template had some explanatory text, but it was commented out, meaning that
it wouldn't be visible when you create your PR.

This uncomments the text, and makes some small updates to th template to make it
clearer for new contributors.

Signed-off-by: Nick Young <ynick@vmware.com>