### PR TITLE
hack: check API ref docs for uncommitted codegen

### DIFF
--- a/hack/actions/check-uncommitted-codegen.sh
+++ b/hack/actions/check-uncommitted-codegen.sh
@@ -7,16 +7,17 @@ set -o pipefail
 readonly HERE=$(cd $(dirname $0) && pwd)
 readonly REPO=$(cd ${HERE}/../.. && pwd)
 
-declare -r -a DIRS=(
+declare -r -a TARGETS=(
 	${REPO}/apis
 	${REPO}/site/_metrics
 	${REPO}/examples/render
 	${REPO}/examples/contour
+	${REPO}/site/docs/main/config/api-reference.html
 )
 
-if git status -s ${DIRS[@]} 2>&1 | grep -E -q '^\s+[MADRCU]'
+if git status -s ${TARGETS[@]} 2>&1 | grep -E -q '^\s+[MADRCU]'
 then
 	echo Uncommitted changes in generated sources:
-	git status -s ${DIRS[@]}
+	git status -s ${TARGETS[@]}
 	exit 1
 fi


### PR DESCRIPTION
Adds the API reference docs file to the list of targets
to check for uncommitted codegen.

Closes #3344.

Signed-off-by: Steve Kriss <krisss@vmware.com>