### PR TITLE
site/docs: update generated API docs

### DIFF
--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -9,7 +9,7 @@
 </ul>
 <h2 id="projectcontour.io/v1">projectcontour.io/v1</h2>
 <p>
-<p>This package holds the specification for the projectcontour.io Custom Resource Definitions (CRDs).</p>
+<p>Package v1 holds the specification for the projectcontour.io Custom Resource Definitions (CRDs).</p>
 <p>In building this CRD, we&rsquo;ve inadvertently overloaded the word &ldquo;Condition&rdquo;, so we&rsquo;ve tried to make
 this spec clear as to which types of condition are which.</p>
 <p><code>MatchConditions</code> are used by <code>Routes</code> and <code>Includes</code> to specify rules to match requests against for either


### PR DESCRIPTION
The generated API reference docs were slightly out-of-date,
this PR updates them.

Signed-off-by: Steve Kriss <krisss@vmware.com>