### PR TITLE
ci: fix Github labels

### DIFF
--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -81,13 +81,6 @@ default:
         - name: Ingress
     - color: 0052cc
       description: Issues or PRs related to the Gateway (Gateway API working group) API.
-      name: gateway-api
-      target: both
-      addedBy: label
-      previously:
-        - name: service-apis
-    - color: 0052cc
-      description: Issues or PRs related to the Gateway (Gateway API working group) API.
       name: area/gateway-api
       target: both
       addedBy: label

--- a/site/_data/github-labels.yaml
+++ b/site/_data/github-labels.yaml
@@ -81,7 +81,7 @@ default:
         - name: Ingress
     - color: 0052cc
       description: Issues or PRs related to the Gateway (Gateway API working group) API.
-      name: area/gateway-api
+      name: gateway-api
       target: both
       addedBy: label
       previously:


### PR DESCRIPTION
In #3350, duplicate labels were added, this resolves that to make sure the labels are unique.

Fixes #3368

Signed-off-by: Steve Sloka <slokas@vmware.com>