### PR TITLE
integration: Add simple integration test for GatewayAPIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ integration: ## Run integration tests against a real k8s cluster
 	./_integration/testsuite/install-contour-working.sh
 	./_integration/testsuite/install-fallback-certificate.sh
 	./_integration/testsuite/install-ratelimit-service.sh
-	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml
+	./_integration/testsuite/run-test-case.sh ./_integration/testsuite/httpproxy/*.yaml ./_integration/testsuite/gatewayapi/*.yaml
 	./_integration/testsuite/cleanup.sh
 
 check-ingress-conformance: ## Run Ingress controller conformance

--- a/_integration/testsuite/gatewayapi/001-path-condition-match.yaml
+++ b/_integration/testsuite/gatewayapi/001-path-condition-match.yaml
@@ -1,0 +1,186 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour-gateway
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        selector:
+          matchLabels:
+            app: filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    app: filter
+spec:
+  hostnames:
+    - conditions.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /path/prefix/
+      forwardTo:
+      - serviceName: echo-slash-prefix
+        port: 80
+    - matches:
+      - path:
+          type: Prefix
+          value: /path/prefix
+      forwardTo:
+      - serviceName: echo-slash-noprefix
+        port: 80
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      forwardTo:
+      - serviceName: echo-slash-default
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+cases := [
+  [ "/", "echo-slash-default" ],
+  [ "/foo", "echo-slash-default" ],
+  [ "/path/prefix", "echo-slash-noprefix" ],
+  [ "/path/prefixfoo", "echo-slash-noprefix" ],
+  [ "/path/prefix/", "echo-slash-prefix" ],
+  [ "/path/prefix/foo", "echo-slash-prefix" ],
+]
+
+# NOTE(jpeach): the path formatting matters in the request construction
+# below, since we are testing for specific matches.
+request_for_path[path] = request {
+  path := cases[_][0]
+  request := {
+    "method": "GET",
+    "url": url.http(path),
+    "headers": {
+      "Host": "conditions.projectcontour.io",
+      "User-Agent": client.ua("path-condition-match"),
+    }
+  }
+}
+
+response_for_path [path] = resp {
+  path := cases[_][0]
+  request := request_for_path[path]
+  resp := http.send(request)
+}
+
+# Ensure that we get a response for each test case.
+error_missing_responses {
+  count(cases) != count(response_for_path)
+}
+
+check_for_status_code [msg] {
+  path := cases[_][0]
+  resp := response_for_path[path]
+  msg := expect.response_status_is(resp, 200)
+}
+
+check_for_service_routing [msg] {
+  c := cases[_]
+
+  path := c[0]
+  svc := c[1]
+  resp := response_for_path[path]
+  msg := expect.response_service_is(resp, svc)
+}


### PR DESCRIPTION
Adds a simple integration test based upon the httpproxy/003-path-condition-match.yaml test that already
exists for HTTPProxy resources, but aligns to GatewayAPI.

Updates #2287

Signed-off-by: Steve Sloka <slokas@vmware.com>