### PR TITLE
ci: Add missing linters to CI runs

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -86,5 +86,5 @@ jobs:
           go-version: '1.15.8'
       - name: generate
         run: |
-          make generate
+          make generate lint-yamllint lint-flags
           ./hack/actions/check-uncommitted-codegen.sh

--- a/examples/ratelimit/02-ratelimit.yaml
+++ b/examples/ratelimit/02-ratelimit.yaml
@@ -44,7 +44,7 @@ spec:
             - name: REDIS_URL
               value: redis:6379
         - name: ratelimit
-          image: docker.io/envoyproxy/ratelimit:6f5de117 # latest a/o Jan 22 2021
+          image: docker.io/envoyproxy/ratelimit:6f5de117  # latest a/o Jan 22 2021
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
The CI job was missing the `yamllint` & `flags` tasks to verify the yaml format as well as flags.
This adds those back in as well as fixes the one issue found with the comment on the ratelimit example.

Signed-off-by: Steve Sloka <slokas@vmware.com>