### PR TITLE
ci: Add envoyproxy.io to ignore list for site-proof check

### DIFF
--- a/hack/site-proofing/cibuild
+++ b/hack/site-proofing/cibuild
@@ -18,4 +18,4 @@ htmlproofer ./_site \
     --allow-hash-href \
     --http-status-ignore 429 \
     --typhoeus-config '{"headers": {"User-Agent": "Mozilla/5.0 (Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0"}}' \
-    --url-ignore "/www.haproxy.org/,/tools.ietf.org/" # gives false positive timeouts
+    --url-ignore "/www.haproxy.org/,/tools.ietf.org/,/www.envoyproxy.io/,/envoyproxy.io/" # gives false positive timeouts


### PR DESCRIPTION
The site proof check which runs on each run checks for invalid links, however, the links
to envoyproxy.io seem to fail the site check. This adds the envoyproxy.io site to the ignore
list which will skip this site from getting checked.

Signed-off-by: Steve Sloka <slokas@vmware.com>