### PR TITLE
Remove James and Tong from the website

### DIFF
--- a/site/_contributors/02-james-peach.md
+++ b/site/_contributors/02-james-peach.md
@@ -1,7 +1,0 @@
----
-first_name: James
-last_name: Peach
-image: /img/contributors/jpeach.png
-github_handle: jpeach
----
-Maintainer

--- a/site/_contributors/03-tong-liu.md
+++ b/site/_contributors/03-tong-liu.md
@@ -1,7 +1,0 @@
----
-first_name: Tong
-last_name: Liu
-image: /img/contributors/tong-liu.png
-github_handle: tong101
----
-Engineering Manager


### PR DESCRIPTION
This will remove James Peach from the active maintainer list as he has moved to emeritus maintainer status, and also remove Tong Liu as he has moved to another role.

Signed-off-by: jonasrosland <jrosland@vmware.com>