### PR TITLE
internal/dag: Watch namespaces from k8s api

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -477,9 +477,8 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		if !clients.ResourcesExist(r) {
 			log.WithField("resource", r).Warn("resource type not present on API server")
 			continue
-		} else {
-			foundGatewayAPI = true
 		}
+		foundGatewayAPI = true
 
 		if err := informOnResource(clients, r, &dynamicHandler); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -471,14 +471,25 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	if ctx.UseExperimentalServiceAPITypes {
 		log.Warn("DEPRECATED: The flag '--experimental-service-apis' is deprecated and should not be used. Please configure the gateway.name & gateway.namespace in the configuration file to specify which Gateway Contour will be watching.")
 	}
+
+	foundGatewayAPI := false
 	for _, r := range k8s.GatewayAPIResources() {
 		if !clients.ResourcesExist(r) {
 			log.WithField("resource", r).Warn("resource type not present on API server")
 			continue
+		} else {
+			foundGatewayAPI = true
 		}
 
 		if err := informOnResource(clients, r, &dynamicHandler); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
+		}
+	}
+
+	// Only watch namespaces if Gateway API is found.
+	if foundGatewayAPI {
+		if err := informOnResource(clients, k8s.NamespacesResource(), &dynamicHandler); err != nil {
+			log.WithError(err).WithField("resource", k8s.NamespacesResource()).Fatal("failed to create informer")
 		}
 	}
 

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -28,6 +28,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1827,6 +1827,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -57,6 +57,7 @@ type KubernetesCache struct {
 	secrets              map[types.NamespacedName]*v1.Secret
 	httpproxydelegations map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation
 	services             map[types.NamespacedName]*v1.Service
+	namespaces           map[types.NamespacedName]*v1.Namespace
 	gateway              *gatewayapi_v1alpha1.Gateway
 	httproutes           map[types.NamespacedName]*gatewayapi_v1alpha1.HTTPRoute
 	tlsroutes            map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute
@@ -76,6 +77,7 @@ func (kc *KubernetesCache) init() {
 	kc.secrets = make(map[types.NamespacedName]*v1.Secret)
 	kc.httpproxydelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
 	kc.services = make(map[types.NamespacedName]*v1.Service)
+	kc.namespaces = make(map[types.NamespacedName]*v1.Namespace)
 	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.HTTPRoute)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute)
 	kc.backendpolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha1.BackendPolicy)
@@ -167,6 +169,9 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *v1.Service:
 		kc.services[k8s.NamespacedNameOf(obj)] = obj
 		return kc.serviceTriggersRebuild(obj)
+	case *v1.Namespace:
+		kc.namespaces[k8s.NamespacedNameOf(obj)] = obj
+		return true
 	case *v1beta1.Ingress:
 		if kc.matchesIngressClass(obj) {
 			// Convert the v1beta1 object to v1 before adding to the
@@ -345,6 +350,11 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.services[m]
 		delete(kc.services, m)
+		return ok
+	case *v1.Namespace:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.namespaces[m]
+		delete(kc.namespaces, m)
 		return ok
 	case *v1beta1.Ingress:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -647,6 +647,15 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert namespace": {
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "namespace",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
 		"insert gateway-api Gateway": {
 			obj: &gatewayapi_v1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -782,6 +791,21 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove namespace": {
+			cache: cache(&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "namespace",
+					Namespace: "default",
+				},
+			}),
+			obj: &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "namespace",
 					Namespace: "default",
 				},
 			},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -103,3 +103,10 @@ func ServicesResources() []schema.GroupVersionResource {
 		corev1.SchemeGroupVersion.WithResource("services"),
 	}
 }
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
+// NamespacesResource ...
+func NamespacesResource() schema.GroupVersionResource {
+	return corev1.SchemeGroupVersion.WithResource("namespaces")
+}


### PR DESCRIPTION
The RouteBindingSelector in Gateway API has an option to only process routes which exist
in a namespace based upon a selector defined in the Gateway.

When "Selector" is chosen then only Routes in namespaces selected by the selector may be used by this Gateway (https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.RouteSelectType).

_Added release note action label since this updates RBAC permissions, but only needed if Gateway APIs are present._ 

Updates #3401

Signed-off-by: Steve Sloka <slokas@vmware.com>