### PR TITLE
Updates Netlify Quickstart Links for v1.13.0 Release

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
 # kubectl apply https://projectcontour.io/quickstart/contour.yaml
 [[redirects]]
   from = "/quickstart/contour.yaml"
-  to = "https://raw.githubusercontent.com/projectcontour/contour/release-1.12/examples/render/contour.yaml"
+  to = "https://raw.githubusercontent.com/projectcontour/contour/release-1.13/examples/render/contour.yaml"
   status = 302
 
 # Redirect versioned quickstarts so that they can easily be referenced by
@@ -39,7 +39,7 @@
 # kubectl apply https://projectcontour.io/quickstart/operator.yaml
 [[redirects]]
 from = "/quickstart/operator.yaml"
-to = "https://raw.githubusercontent.com/projectcontour/contour-operator/release-1.12/examples/operator/operator.yaml"
+to = "https://raw.githubusercontent.com/projectcontour/contour-operator/release-1.13/examples/operator/operator.yaml"
 status = 302
 
 # Redirect versioned quickstarts so that they can easily be referenced by
@@ -56,7 +56,7 @@ status = 302
 # kubectl apply https://projectcontour.io/quickstart/contour-custom-resource.yaml
 [[redirects]]
 from = "/quickstart/contour-custom-resource.yaml"
-to = "https://raw.githubusercontent.com/projectcontour/contour-operator/release-1.12/examples/contour/contour.yaml"
+to = "https://raw.githubusercontent.com/projectcontour/contour-operator/release-1.13/examples/contour/contour.yaml"
 status = 302
 
 # Redirect versioned quickstarts so that they can easily be referenced by


### PR DESCRIPTION
Updates Netlify quickstart links for the v1.13.0 release.

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>