### PR TITLE
internal/xdscache: include global rate limits for secure vhosts

### DIFF
--- a/_integration/testsuite/httpproxy/020-global-rate-limiting.yaml
+++ b/_integration/testsuite/httpproxy/020-global-rate-limiting.yaml
@@ -37,6 +37,8 @@ $apply:
 
 ---
 
+# Test Case 1: non-TLS virtual hosts
+
 # Create the HTTPProxy without rate limits first
 # and wait until we get a 200 from it before applying
 # rate limits and counting responses. This ensures
@@ -224,6 +226,211 @@ Response := client.Get({
     "Host": "routeratelimit.projectcontour.io",
     "User-Agent": client.ua("global-rate-limit"),
   },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+---
+
+# Test Case 2: TLS virtual hosts
+
+# Create a self-signed issuer to give us secrets.
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tlsvhostratelimit
+spec:
+  dnsNames:
+  - tls.vhostratelimit.projectcontour.io
+  secretName: tlsvhostratelimit
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+# TLS vhost with a global rate limit policy on the virtual host.
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: tlsvhostratelimit
+spec:
+  virtualhost:
+    fqdn: tls.vhostratelimit.projectcontour.io
+    tls:
+      secretName: tlsvhostratelimit
+    rateLimitPolicy:
+      global:
+        descriptors:
+          - entries:
+              - genericKey:
+                  value: tlsvhostlimit
+  routes:
+  - services:
+    - name: echo
+      port: 80
+---
+
+# Make a request against the proxy, confirm a 200 response
+# is returned since we're allowed one request per hour.
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.https("/"),
+  "headers": {
+    "Host": "tls.vhostratelimit.projectcontour.io",
+    "User-Agent": client.ua("global-rate-limit"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+---
+
+# Make another request against the proxy, confirm a 429
+# response is now gotten since we've exceeded the rate
+# limit.
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.https("/"),
+  "headers": {
+    "Host": "tls.vhostratelimit.projectcontour.io",
+    "User-Agent": client.ua("global-rate-limit"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 429)
+}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tlsrouteratelimit
+spec:
+  dnsNames:
+  - tls.routeratelimit.projectcontour.io
+  secretName: tlsrouteratelimit
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+# TLS vhost with a global rate limit policy on the route.
+
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: tlsrouteratelimit
+spec:
+  virtualhost:
+    fqdn: tls.routeratelimit.projectcontour.io
+    tls:
+      secretName: tlsrouteratelimit
+  routes:
+  - services:
+    - name: echo
+      port: 80
+    rateLimitPolicy:
+      global:
+        descriptors:
+          - entries:
+              - genericKey:
+                  value: tlsroutelimit
+  - conditions:
+      - prefix: /unlimited
+    services:
+    - name: echo
+      port: 80
+---
+
+# Make a request against the proxy, confirm a 200 response
+# is returned since we're allowed one request per hour.
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.https("/"),
+  "headers": {
+    "Host": "tls.routeratelimit.projectcontour.io",
+    "User-Agent": client.ua("global-rate-limit"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+---
+
+# Make another request against the proxy, confirm a 429
+# response is now gotten since we've exceeded the rate
+# limit.
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.https("/"),
+  "headers": {
+    "Host": "tls.routeratelimit.projectcontour.io",
+    "User-Agent": client.ua("global-rate-limit"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 429)
+}
+
+---
+
+# Make a request against the route that doesn't have
+# rate limiting to confirm we still get a 200 for that
+# route.
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.https("/unlimited"),
+  "headers": {
+    "Host": "tls.routeratelimit.projectcontour.io",
+    "User-Agent": client.ua("global-rate-limit"),
+  },
+  "tls_insecure_skip_verify": true,
 })
 
 check_for_status_code [msg] {

--- a/_integration/testsuite/install-ratelimit-service.sh
+++ b/_integration/testsuite/install-ratelimit-service.sh
@@ -51,6 +51,16 @@ data:
         rate_limit:
           unit: hour
           requests_per_unit: 1
+      - key: generic_key
+        value: tlsvhostlimit
+        rate_limit:
+          unit: hour
+          requests_per_unit: 1
+      - key: generic_key
+        value: tlsroutelimit
+        rate_limit:
+          unit: hour
+          requests_per_unit: 1
 EOF
 
 # Create the ratelimit deployment, service and extension service.

--- a/internal/featuretests/v3/globalratelimit_test.go
+++ b/internal/featuretests/v3/globalratelimit_test.go
@@ -25,6 +25,7 @@ import (
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
@@ -34,6 +35,7 @@ import (
 	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -100,7 +102,7 @@ func globalRateLimitFilterExists(t *testing.T, rh cache.ResourceEventHandler, c 
 	}).Status(p).IsValid()
 }
 
-func globalRateLimitNoRateLimitsDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls bool) {
+func globalRateLimitNoRateLimitsDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls tlsConfig) {
 	p := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -123,16 +125,17 @@ func globalRateLimitNoRateLimitsDefined(t *testing.T, rh cache.ResourceEventHand
 		},
 	}
 
-	if tls {
+	if tls.enabled {
 		p.Spec.VirtualHost.TLS = &contour_api_v1.TLS{
-			SecretName: "tls-cert",
+			SecretName:                "tls-cert",
+			EnableFallbackCertificate: tls.fallbackEnabled,
 		}
 	}
 
 	rh.OnAdd(p)
 	c.Status(p).IsValid()
 
-	switch tls {
+	switch tls.enabled {
 	case true:
 		c.Request(routeType, "https/foo.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl: routeType,
@@ -148,6 +151,22 @@ func globalRateLimitNoRateLimitsDefined(t *testing.T, rh cache.ResourceEventHand
 				),
 			),
 		})
+		if tls.fallbackEnabled {
+			c.Request(routeType, "ingress_fallbackcert").Equals(&envoy_discovery_v3.DiscoveryResponse{
+				TypeUrl: routeType,
+				Resources: resources(t,
+					envoy_v3.RouteConfiguration(
+						"ingress_fallbackcert",
+						envoy_v3.VirtualHost("foo.com",
+							&envoy_route_v3.Route{
+								Match:  routePrefix("/"),
+								Action: routeCluster("default/s1/80/da39a3ee5e"),
+							},
+						),
+					),
+				),
+			})
+		}
 	default:
 		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl: routeType,
@@ -167,7 +186,7 @@ func globalRateLimitNoRateLimitsDefined(t *testing.T, rh cache.ResourceEventHand
 
 }
 
-func globalRateLimitVhostRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls bool) {
+func globalRateLimitVhostRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls tlsConfig) {
 	p := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -206,9 +225,10 @@ func globalRateLimitVhostRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 		},
 	}
 
-	if tls {
+	if tls.enabled {
 		p.Spec.VirtualHost.TLS = &contour_api_v1.TLS{
-			SecretName: "tls-cert",
+			SecretName:                "tls-cert",
+			EnableFallbackCertificate: tls.fallbackEnabled,
 		}
 	}
 
@@ -238,12 +258,18 @@ func globalRateLimitVhostRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 		},
 	}
 
-	switch tls {
+	switch tls.enabled {
 	case true:
 		c.Request(routeType, "https/foo.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
 			Resources: resources(t, envoy_v3.RouteConfiguration("https/foo.com", vhost)),
 		})
+		if tls.fallbackEnabled {
+			c.Request(routeType, "ingress_fallbackcert").Equals(&envoy_discovery_v3.DiscoveryResponse{
+				TypeUrl:   routeType,
+				Resources: resources(t, envoy_v3.RouteConfiguration("ingress_fallbackcert", vhost)),
+			})
+		}
 	default:
 		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
@@ -252,7 +278,7 @@ func globalRateLimitVhostRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 	}
 }
 
-func globalRateLimitRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls bool) {
+func globalRateLimitRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls tlsConfig) {
 	p := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -291,9 +317,10 @@ func globalRateLimitRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 		},
 	}
 
-	if tls {
+	if tls.enabled {
 		p.Spec.VirtualHost.TLS = &contour_api_v1.TLS{
-			SecretName: "tls-cert",
+			SecretName:                "tls-cert",
+			EnableFallbackCertificate: tls.fallbackEnabled,
 		}
 	}
 
@@ -324,12 +351,18 @@ func globalRateLimitRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 
 	vhost := envoy_v3.VirtualHost("foo.com", route)
 
-	switch tls {
+	switch tls.enabled {
 	case true:
 		c.Request(routeType, "https/foo.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
 			Resources: resources(t, envoy_v3.RouteConfiguration("https/foo.com", vhost)),
 		})
+		if tls.fallbackEnabled {
+			c.Request(routeType, "ingress_fallbackcert").Equals(&envoy_discovery_v3.DiscoveryResponse{
+				TypeUrl:   routeType,
+				Resources: resources(t, envoy_v3.RouteConfiguration("ingress_fallbackcert", vhost)),
+			})
+		}
 	default:
 		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
@@ -338,7 +371,7 @@ func globalRateLimitRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHa
 	}
 }
 
-func globalRateLimitVhostAndRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls bool) {
+func globalRateLimitVhostAndRouteRateLimitDefined(t *testing.T, rh cache.ResourceEventHandler, c *Contour, tls tlsConfig) {
 	p := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -393,9 +426,10 @@ func globalRateLimitVhostAndRouteRateLimitDefined(t *testing.T, rh cache.Resourc
 		},
 	}
 
-	if tls {
+	if tls.enabled {
 		p.Spec.VirtualHost.TLS = &contour_api_v1.TLS{
-			SecretName: "tls-cert",
+			SecretName:                "tls-cert",
+			EnableFallbackCertificate: tls.fallbackEnabled,
 		}
 	}
 
@@ -442,12 +476,18 @@ func globalRateLimitVhostAndRouteRateLimitDefined(t *testing.T, rh cache.Resourc
 		},
 	}
 
-	switch tls {
+	switch tls.enabled {
 	case true:
 		c.Request(routeType, "https/foo.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
 			Resources: resources(t, envoy_v3.RouteConfiguration("https/foo.com", vhost)),
 		})
+		if tls.fallbackEnabled {
+			c.Request(routeType, "ingress_fallbackcert").Equals(&envoy_discovery_v3.DiscoveryResponse{
+				TypeUrl:   routeType,
+				Resources: resources(t, envoy_v3.RouteConfiguration("ingress_fallbackcert", vhost)),
+			})
+		}
 	default:
 		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 			TypeUrl:   routeType,
@@ -456,48 +496,87 @@ func globalRateLimitVhostAndRouteRateLimitDefined(t *testing.T, rh cache.Resourc
 	}
 }
 
+type tlsConfig struct {
+	enabled         bool
+	fallbackEnabled bool
+}
+
 func TestGlobalRateLimiting(t *testing.T) {
+	var (
+		tlsDisabled     = tlsConfig{}
+		tlsEnabled      = tlsConfig{enabled: true}
+		fallbackEnabled = tlsConfig{enabled: true, fallbackEnabled: true}
+	)
+
 	subtests := map[string]func(*testing.T, cache.ResourceEventHandler, *Contour){
 		"GlobalRateLimitFilterExists": globalRateLimitFilterExists,
 
 		// test cases for insecure/non-TLS vhosts
 		"NoRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitNoRateLimitsDefined(t, rh, c, false)
+			globalRateLimitNoRateLimitsDefined(t, rh, c, tlsDisabled)
 		},
 		"VirtualHostRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitVhostRateLimitDefined(t, rh, c, false)
+			globalRateLimitVhostRateLimitDefined(t, rh, c, tlsDisabled)
 		},
 		"RouteRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitRouteRateLimitDefined(t, rh, c, false)
+			globalRateLimitRouteRateLimitDefined(t, rh, c, tlsDisabled)
 		},
 		"VirtualHostAndRouteRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitVhostAndRouteRateLimitDefined(t, rh, c, false)
+			globalRateLimitVhostAndRouteRateLimitDefined(t, rh, c, tlsDisabled)
 		},
 
 		// test cases for secure/TLS vhosts
 		"TLSNoRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitNoRateLimitsDefined(t, rh, c, true)
+			globalRateLimitNoRateLimitsDefined(t, rh, c, tlsEnabled)
 		},
 		"TLSVirtualHostRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitVhostRateLimitDefined(t, rh, c, true)
+			globalRateLimitVhostRateLimitDefined(t, rh, c, tlsEnabled)
 		},
 		"TLSRouteRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitRouteRateLimitDefined(t, rh, c, true)
+			globalRateLimitRouteRateLimitDefined(t, rh, c, tlsEnabled)
 		},
 		"TLSVirtualHostAndRouteRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
-			globalRateLimitVhostAndRouteRateLimitDefined(t, rh, c, false)
+			globalRateLimitVhostAndRouteRateLimitDefined(t, rh, c, tlsEnabled)
+		},
+
+		// test cases for secure/TLS vhosts with fallback cert enabled
+		"FallbackNoRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+			globalRateLimitNoRateLimitsDefined(t, rh, c, fallbackEnabled)
+		},
+		"FallbackVirtualHostRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+			globalRateLimitVhostRateLimitDefined(t, rh, c, fallbackEnabled)
+		},
+		"FallbackRouteRateLimitDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+			globalRateLimitRouteRateLimitDefined(t, rh, c, fallbackEnabled)
+		},
+		"FallbackVirtualHostAndRouteRateLimitsDefined": func(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+			globalRateLimitVhostAndRouteRateLimitDefined(t, rh, c, fallbackEnabled)
 		},
 	}
 
 	for n, f := range subtests {
 		f := f
 		t.Run(n, func(t *testing.T) {
-			rh, c, done := setup(t, func(cfg *xdscache_v3.ListenerConfig) {
-				cfg.RateLimitConfig = &xdscache_v3.RateLimitConfig{
-					ExtensionService: k8s.NamespacedNameFrom("projectcontour/ratelimit"),
-					Domain:           "contour",
-				}
-			})
+			rh, c, done := setup(t,
+				func(cfg *xdscache_v3.ListenerConfig) {
+					cfg.RateLimitConfig = &xdscache_v3.RateLimitConfig{
+						ExtensionService: k8s.NamespacedNameFrom("projectcontour/ratelimit"),
+						Domain:           "contour",
+					}
+				},
+				func(eh *contour.EventHandler) {
+					eh.Builder.Processors = []dag.Processor{
+						&dag.HTTPProxyProcessor{
+							FallbackCertificate: &types.NamespacedName{
+								Name:      "fallback-cert",
+								Namespace: "default",
+							},
+						},
+						&dag.ListenerProcessor{},
+					}
+				},
+			)
+
 			defer done()
 
 			// Add common test fixtures.
@@ -505,6 +584,11 @@ func TestGlobalRateLimiting(t *testing.T) {
 			rh.OnAdd(fixture.NewService("s2").WithPorts(corev1.ServicePort{Port: 80}))
 			rh.OnAdd(&corev1.Secret{
 				ObjectMeta: fixture.ObjectMeta("tls-cert"),
+				Type:       "kubernetes.io/tls",
+				Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+			})
+			rh.OnAdd(&corev1.Secret{
+				ObjectMeta: fixture.ObjectMeta("fallback-cert"),
 				Type:       "kubernetes.io/tls",
 				Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 			})

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -248,6 +248,9 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 			}
 			evh.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"] = envoy_v3.LocalRateLimitConfig(svh.RateLimitPolicy.Local, "vhost."+svh.Name)
 		}
+		if svh.RateLimitPolicy != nil && svh.RateLimitPolicy.Global != nil {
+			evh.RateLimits = envoy_v3.GlobalRateLimits(svh.RateLimitPolicy.Global.Descriptors)
+		}
 
 		v.routes[name].VirtualHosts = append(v.routes[name].VirtualHosts, evh)
 
@@ -269,6 +272,9 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 					fvh.TypedPerFilterConfig = map[string]*any.Any{}
 				}
 				fvh.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"] = envoy_v3.LocalRateLimitConfig(svh.RateLimitPolicy.Local, "vhost."+svh.Name)
+			}
+			if svh.RateLimitPolicy != nil && svh.RateLimitPolicy.Global != nil {
+				fvh.RateLimits = envoy_v3.GlobalRateLimits(svh.RateLimitPolicy.Global.Descriptors)
 			}
 
 			v.routes[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts = append(v.routes[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts, fvh)


### PR DESCRIPTION
Fixes a bug where global rate limit policies were being ignored
when defined at the virtual host level on secure vhosts.

Fixes #3409.

Signed-off-by: Steve Kriss <krisss@vmware.com>