### PR TITLE
cmd/contour: pass pointers to StatusAddressUpdater

### DIFF
--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -116,16 +116,16 @@ func (isw *loadBalancerStatusWriter) Start(stop <-chan struct{}) error {
 			if err := isw.clients.Cache().List(context.Background(), &ingressList); err != nil {
 				isw.log.WithError(err).WithField("kind", "Ingress").Error("failed to list objects")
 			} else {
-				for _, i := range ingressList.Items {
-					u.OnAdd(i)
+				for i := range ingressList.Items {
+					u.OnAdd(&ingressList.Items[i])
 				}
 			}
 
 			if err := isw.clients.Cache().List(context.Background(), &proxyList); err != nil {
 				isw.log.WithError(err).WithField("kind", "HTTPProxy").Error("failed to list objects")
 			} else {
-				for _, i := range proxyList.Items {
-					u.OnAdd(i)
+				for i := range proxyList.Items {
+					u.OnAdd(&proxyList.Items[i])
 				}
 			}
 		}

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -87,8 +87,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		gvr = contour_api_v1.SchemeGroupVersion.WithResource("httpproxies")
 		kind = "httpproxy"
 	default:
-		s.Logger.
-			Debug("unsupported type received")
+		s.Logger.Debugf("unsupported type %T received", o)
 		return
 	}
 


### PR DESCRIPTION
Fixes an issue where non-pointers were being passed to
the StatusAddressUpdater when the load balancer address
changed, which was resulting in HTTPProxies/Ingresses
not immediately getting updated with the new address.

Fixes #3411.

Signed-off-by: Steve Kriss <krisss@vmware.com>