### PR TITLE
CI: run integration tests against all supported Kubernetes versions

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -8,6 +8,22 @@ env:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # use stable kubernetes_version values since they're included
+        # in the name of the GitHub Actions job, and we don't want to
+        # have to update branch protection rules every time we change
+        # a Kubernetes version number.
+        kubernetes_version: ["kubernetes:latest", "kubernetes:n-1", "kubernetes:n-2"]
+        # include defines an additional variable (the specific node
+        # image to use) for each kubernetes_version value.
+        include:
+          - kubernetes_version: "kubernetes:latest"
+            node_image: "docker.io/kindest/node:v1.20.2"
+          - kubernetes_version: "kubernetes:n-1"
+            node_image: "docker.io/kindest/node:v1.19.7"
+          - kubernetes_version: "kubernetes:n-2"
+            node_image: "docker.io/kindest/node:v1.18.15"
     steps:
       - uses: actions/checkout@v2
       - name: add deps to path
@@ -15,6 +31,8 @@ jobs:
           ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: integration tests
+        env:
+          NODEIMAGE: ${{ matrix.node_image }}
         run: |
           make integration
   # TODO: re-enable once Ingress v1 support is complete

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -24,6 +24,7 @@ set -o nounset
 readonly KIND=${KIND:-kind}
 readonly KUBECTL=${KUBECTL:-kubectl}
 
+readonly NODEIMAGE=${NODEIMAGE:-"docker.io/kindest/node:v1.20.2"}
 readonly CLUSTERNAME=${CLUSTERNAME:-contour-integration}
 readonly WAITTIME=${WAITTIME:-5m}
 
@@ -37,6 +38,7 @@ kind::cluster::exists() {
 kind::cluster::create() {
     ${KIND} create cluster \
         --name "${CLUSTERNAME}" \
+        --image "${NODEIMAGE}" \
         --wait "${WAITTIME}" \
         --config "${REPO}/_integration/testsuite/kind-expose-port.yaml"
 }


### PR DESCRIPTION
Runs integration tests against the three supported minor versions
of Kubernetes.

Closes #3396.

Signed-off-by: Steve Kriss <krisss@vmware.com>