### PR TITLE
 grpc httpProxy example added

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,3 +29,7 @@ If you have your own Grafana and Prometheus deployment already, the supplied [Co
 ## `kind`, `root-rbac`
 
 Both of these examples are fragments used in other documentation ([deploy-options](https://projectcontour.io/docs/main/deploy-options))
+
+## `grpc`
+
+GRPC configuration with HTTPProxy.

--- a/examples/grpc/01-example-service.yaml
+++ b/examples/grpc/01-example-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+  labels:
+    app: example-service
+spec:
+  ports:
+    - port: 50001
+      protocol: TCP
+      targetPort: 50001
+  selector:
+    app: example
+  type: ClusterIP
+  sessionAffinity: None

--- a/examples/grpc/01-example-service.yaml
+++ b/examples/grpc/01-example-service.yaml
@@ -13,3 +13,4 @@ spec:
     app: example
   type: ClusterIP
   sessionAffinity: None
+  

--- a/examples/grpc/02-example-httpproxy.yaml
+++ b/examples/grpc/02-example-httpproxy.yaml
@@ -1,0 +1,15 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: example-httpproxy
+  namespace: default
+spec:
+  routes:
+    - services:
+      - name: example-service
+        port: 50001
+        protocol: h2c
+  virtualhost:
+    fqdn: app.example.com
+    tls:
+      secretName: letsencrypt-example

--- a/examples/grpc/02-example-httpproxy.yaml
+++ b/examples/grpc/02-example-httpproxy.yaml
@@ -13,3 +13,4 @@ spec:
     fqdn: app.example.com
     tls:
       secretName: letsencrypt-example
+      

--- a/examples/grpc/02-example-httpproxy.yaml
+++ b/examples/grpc/02-example-httpproxy.yaml
@@ -8,7 +8,7 @@ spec:
     - services:
       - name: example-service
         port: 50001
-        protocol: h2c # If backend service doesnot support tls otherwise use h2 if backend service support/configured tls
+        protocol: h2c # If backend service does not support tls otherwise use h2 if backend service support/configured tls
   virtualhost:
     fqdn: app.example.com
     tls:

--- a/examples/grpc/02-example-httpproxy.yaml
+++ b/examples/grpc/02-example-httpproxy.yaml
@@ -8,7 +8,7 @@ spec:
     - services:
       - name: example-service
         port: 50001
-        protocol: h2c
+        protocol: h2c # If backend service doesnot support tls otherwise use h2 if backend service support/configured tls
   virtualhost:
     fqdn: app.example.com
     tls:


### PR DESCRIPTION
this is an example of how HttpProxy can be configured to access GRPC backed service #3432