### PR TITLE
_integration: re-enable SNI test

### DIFF
--- a/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
+++ b/_integration/testsuite/httpproxy/004-https-sni-enforcement.yaml
@@ -14,10 +14,6 @@
 
 import data.contour.resources
 
-skip[msg] {
-  msg := "004-https-sni-enforcement is flaky, skipping until it's fixed"
-}
-
 # Ensure that cert-manager is installed.
 # Version check the certificates resource.
 


### PR DESCRIPTION
The SNI integration test was disabled in #3163
due to unexplained sporadic failures. The failures
have not been reproducible in recent testing. It's
possible that a change made to Contour since #3163
has eliminated the source of the test flake, but
also possible that the test is still flaky and just
did not reproduce during testing.

Signed-off-by: Steve Kriss <krisss@vmware.com>