### PR TITLE
internal/envoy: use generic key descriptor's key

### DIFF
--- a/_integration/testsuite/httpproxy/020-global-rate-limiting.yaml
+++ b/_integration/testsuite/httpproxy/020-global-rate-limiting.yaml
@@ -161,6 +161,9 @@ spec:
         descriptors:
           - entries:
               - genericKey:
+                  # specify a custom key here as an added test
+                  # that this is configured with Envoy if specified.
+                  key: route_limit_key
                   value: routelimit
   - conditions:
       - prefix: /unlimited

--- a/_integration/testsuite/install-ratelimit-service.sh
+++ b/_integration/testsuite/install-ratelimit-service.sh
@@ -46,7 +46,7 @@ data:
         rate_limit:
           unit: hour
           requests_per_unit: 1
-      - key: generic_key
+      - key: route_limit_key
         value: routelimit
         rate_limit:
           unit: hour

--- a/internal/envoy/v3/ratelimit.go
+++ b/internal/envoy/v3/ratelimit.go
@@ -79,6 +79,7 @@ func GlobalRateLimits(descriptors []*dag.RateLimitDescriptor) []*envoy_route_v3.
 				rl.Actions = append(rl.Actions, &envoy_route_v3.RateLimit_Action{
 					ActionSpecifier: &envoy_route_v3.RateLimit_Action_GenericKey_{
 						GenericKey: &envoy_route_v3.RateLimit_Action_GenericKey{
+							DescriptorKey:   entry.GenericKeyKey,
 							DescriptorValue: entry.GenericKeyValue,
 						},
 					},

--- a/internal/envoy/v3/ratelimit_test.go
+++ b/internal/envoy/v3/ratelimit_test.go
@@ -107,6 +107,7 @@ func TestGlobalRateLimits(t *testing.T) {
 					Entries: []dag.RateLimitDescriptorEntry{
 						{RemoteAddress: true},
 						{GenericKeyValue: "generic-key-val"},
+						{GenericKeyKey: "generic-key-custom-key", GenericKeyValue: "generic-key-val"},
 					},
 				},
 				{
@@ -128,6 +129,14 @@ func TestGlobalRateLimits(t *testing.T) {
 						{
 							ActionSpecifier: &envoy_route_v3.RateLimit_Action_GenericKey_{
 								GenericKey: &envoy_route_v3.RateLimit_Action_GenericKey{
+									DescriptorValue: "generic-key-val",
+								},
+							},
+						},
+						{
+							ActionSpecifier: &envoy_route_v3.RateLimit_Action_GenericKey_{
+								GenericKey: &envoy_route_v3.RateLimit_Action_GenericKey{
+									DescriptorKey:   "generic-key-custom-key",
 									DescriptorValue: "generic-key-val",
 								},
 							},


### PR DESCRIPTION
Fixes a bug where a generic key descriptor's key
was not being configured in the Envoy descriptor
if it was specified, resulting in Envoy always
generating the default key of "generic_key".

Fixes #3443.

Signed-off-by: Steve Kriss <krisss@vmware.com>