### PR TITLE
cmd/contour: remove duplicated block of code

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -357,36 +357,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		}
 	}
 
-	if ctx.Config.RateLimitService.ExtensionService != "" {
-		namespacedName := k8s.NamespacedNameFrom(ctx.Config.RateLimitService.ExtensionService)
-		client := clients.DynamicClient().Resource(contour_api_v1alpha1.ExtensionServiceGVR).Namespace(namespacedName.Namespace)
-
-		// ensure the specified ExtensionService exists
-		res, err := client.Get(context.Background(), namespacedName.Name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("error getting rate limit extension service %s: %v", namespacedName, err)
-		}
-		var extensionSvc contour_api_v1alpha1.ExtensionService
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(res.Object, &extensionSvc); err != nil {
-			return fmt.Errorf("error converting rate limit extension service %s: %v", namespacedName, err)
-		}
-		// get the response timeout from the ExtensionService
-		var responseTimeout timeout.Setting
-		if tp := extensionSvc.Spec.TimeoutPolicy; tp != nil {
-			responseTimeout, err = timeout.Parse(tp.Response)
-			if err != nil {
-				return fmt.Errorf("error parsing rate limit extension service %s response timeout: %v", namespacedName, err)
-			}
-		}
-
-		listenerConfig.RateLimitConfig = &xdscache_v3.RateLimitConfig{
-			ExtensionService: namespacedName,
-			Domain:           ctx.Config.RateLimitService.Domain,
-			Timeout:          responseTimeout,
-			FailOpen:         ctx.Config.RateLimitService.FailOpen,
-		}
-	}
-
 	contourMetrics := metrics.NewMetrics(registry)
 
 	// Endpoints updates are handled directly by the EndpointsTranslator


### PR DESCRIPTION
A previous PR inadvertently duplicated a block of
code. This PR removes the duplicate.

Signed-off-by: Steve Kriss <krisss@vmware.com>