### PR TITLE
internal/featuretests: use helper for default HTTP listener

### DIFF
--- a/internal/featuretests/v3/backendcavalidation_test.go
+++ b/internal/featuretests/v3/backendcavalidation_test.go
@@ -16,12 +16,9 @@ package v3
 import (
 	"testing"
 
-	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
-	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
@@ -72,14 +69,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the insecure listener and the stats listener are present in LDS.
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			&envoy_listener_v3.Listener{
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
+			defaultHTTPListener(),
 			staticListener(),
 		),
 		TypeUrl: listenerType,
@@ -120,14 +110,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the insecure listener and the stats listener are present in LDS.
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			&envoy_listener_v3.Listener{
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
+			defaultHTTPListener(),
 			staticListener(),
 		),
 		TypeUrl: listenerType,
@@ -177,14 +160,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the insecure listener and the stats listener are present in LDS.
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			&envoy_listener_v3.Listener{
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
+			defaultHTTPListener(),
 			staticListener(),
 		),
 		TypeUrl: listenerType,

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -78,15 +78,6 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 
 	rh.OnAdd(proxy)
 
-	ingressHTTP := &envoy_listener_v3.Listener{
-		Name:    "ingress_http",
-		Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-		FilterChains: envoy_v3.FilterChains(
-			envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-		),
-		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-	}
-
 	ingressHTTPS := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
 		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -109,7 +100,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			ingressHTTP,
+			defaultHTTPListener(),
 			ingressHTTPS,
 			staticListener(),
 		),

--- a/internal/featuretests/v3/localratelimit_test.go
+++ b/internal/featuretests/v3/localratelimit_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_config_filter_http_local_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -60,13 +59,7 @@ func filterExists(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: listenerType,
 		Resources: resources(t,
-			&envoy_listener_v3.Listener{
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				// TODO since this uses the same helper as the actual Contour code, this is not a very good test.
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
+			defaultHTTPListener(),
 			staticListener()),
 	}).Status(p).IsValid()
 }

--- a/internal/featuretests/v3/rootnamespaces_test.go
+++ b/internal/featuretests/v3/rootnamespaces_test.go
@@ -16,7 +16,6 @@ package v3
 import (
 	"testing"
 
-	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -119,14 +118,7 @@ func TestRootNamespaces(t *testing.T) {
 	// assert that hp2 creates port 80 listener.
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			&envoy_listener_v3.Listener{
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
+			defaultHTTPListener(),
 			staticListener(),
 		),
 		TypeUrl: listenerType,

--- a/internal/featuretests/v3/tcpproxy_test.go
+++ b/internal/featuretests/v3/tcpproxy_test.go
@@ -394,19 +394,13 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			// ingress_http is present for
+			// http://kuard-tcp.example.com/ -> default/backend:80
+			defaultHTTPListener(),
+
+			// ingress_https is present for
+			// kuard-tcp.example.com:443 terminated at envoy then forwarded to default/backend:80
 			&envoy_listener_v3.Listener{
-				// ingress_http is present for
-				// http://kuard-tcp.example.com/ -> default/backend:80
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
-			&envoy_listener_v3.Listener{
-				// ingress_https is present for
-				// kuard-tcp.example.com:443 terminated at envoy then forwarded to default/backend:80
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
 				FilterChains: appendFilterChains(
@@ -490,19 +484,13 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			// ingress_http is present for
+			// http://kuard-tcp.example.com/ -> default/backend:80
+			defaultHTTPListener(),
+
+			// ingress_https is present for
+			// kuard-tcp.example.com:443 terminated at envoy then tcpproxied to default/backend:80
 			&envoy_listener_v3.Listener{
-				// ingress_http is present for
-				// http://kuard-tcp.example.com/ -> default/backend:80
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
-			&envoy_listener_v3.Listener{
-				// ingress_https is present for
-				// kuard-tcp.example.com:443 terminated at envoy then tcpproxied to default/backend:80
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
 				FilterChains: appendFilterChains(
@@ -579,19 +567,13 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			// ingress_http is present for
+			// http://kuard-tcp.example.com/ -> default/backend:80
+			defaultHTTPListener(),
+
+			// ingress_https is present for
+			// kuard-tcp.example.com:443 direct to default/backend:80
 			&envoy_listener_v3.Listener{
-				// ingress_http is present for
-				// http://kuard-tcp.example.com/ -> default/backend:80
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
-			&envoy_listener_v3.Listener{
-				// ingress_https is present for
-				// kuard-tcp.example.com:443 direct to default/backend:80
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_listener_v3.FilterChain{{
@@ -672,21 +654,15 @@ func TestTCPProxyTLSPassthroughAndHTTPServicePermitInsecure(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			// ingress_http is present for
+			// http://kuard-tcp.example.com/ -> default/backend:80, this is not 301 upgraded
+			// because permitInsecure: true is in use.
+			defaultHTTPListener(),
+
+			// ingress_https is present for
+			// kuard-tcp.example.com:443 direct to default/backend:80, envoy does not handle
+			// the TLS handshake beyond SNI demux because passthrough: true is in use.
 			&envoy_listener_v3.Listener{
-				// ingress_http is present for
-				// http://kuard-tcp.example.com/ -> default/backend:80, this is not 301 upgraded
-				// because permitInsecure: true is in use.
-				Name:    "ingress_http",
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			},
-			&envoy_listener_v3.Listener{
-				// ingress_https is present for
-				// kuard-tcp.example.com:443 direct to default/backend:80, envoy does not handle
-				// the TLS handshake beyond SNI demux because passthrough: true is in use.
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
 				FilterChains: []*envoy_listener_v3.FilterChain{{

--- a/internal/featuretests/v3/tlscertificatedelegation_test.go
+++ b/internal/featuretests/v3/tlscertificatedelegation_test.go
@@ -105,15 +105,6 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	}
 	rh.OnAdd(t1)
 
-	ingressHTTP := &envoy_listener_v3.Listener{
-		Name:    "ingress_http",
-		Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-		FilterChains: envoy_v3.FilterChains(
-			envoy_v3.HTTPConnectionManager("ingress_http", envoy_v3.FileAccessLogEnvoy("/dev/stdout"), 0, 0),
-		),
-		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-	}
-
 	ingressHTTPS := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
 		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -130,7 +121,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			ingressHTTP,
+			defaultHTTPListener(),
 			ingressHTTPS,
 			staticListener(),
 		),
@@ -156,7 +147,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			ingressHTTP,
+			defaultHTTPListener(),
 			ingressHTTPS,
 			staticListener(),
 		),
@@ -264,7 +255,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			ingressHTTP,
+			defaultHTTPListener(),
 			ingressHTTPS,
 			staticListener(),
 		),


### PR DESCRIPTION
Replaces the many repeated definitions of the default HTTP listener
with calls to defaultHTTPListener(). In places where a non-default
HTTP listener is needed, uses the default as a starting point and
applies modifications to it. This reduces copy-pasted boilerplate.

Signed-off-by: Steve Kriss <krisss@vmware.com>