### PR TITLE
internal: Allow status on HTTPRoutes to be set

### DIFF
--- a/internal/contour/metrics_test.go
+++ b/internal/contour/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestHTTPProxyMetrics(t *testing.T) {
@@ -43,6 +44,10 @@ func TestHTTPProxyMetrics(t *testing.T) {
 				Source: dag.KubernetesCache{
 					RootNamespaces: tc.rootNamespaces,
 					FieldLogger:    fixture.NewTestLogger(t),
+					ConfiguredGateway: types.NamespacedName{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
 				},
 				Processors: []dag.Processor{
 					&dag.IngressProcessor{

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -47,7 +47,7 @@ type Builder struct {
 // configured DAG processors, in order.
 func (b *Builder) Build() *DAG {
 	dag := DAG{
-		StatusCache: status.NewCache(),
+		StatusCache: status.NewCache(b.Source.ConfiguredGateway),
 	}
 
 	for _, p := range b.Processors {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -218,7 +218,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 		}
 
 		if len(rule.ForwardTo) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegradedRoutes, "At least one Spec.Rules.ForwardTo must be specified.")
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "At least one Spec.Rules.ForwardTo must be specified.")
 			continue
 		}
 
@@ -226,13 +226,13 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 		for _, forward := range rule.ForwardTo {
 			// Verify the service is valid
 			if forward.ServiceName == nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegradedRoutes, "Spec.Rules.ForwardTo.ServiceName must be specified.")
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServiceName must be specified.")
 				continue
 			}
 
 			// TODO: Do not require port to be present (#3352).
 			if forward.Port == nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegradedRoutes, "Spec.Rules.ForwardTo.ServicePort must be specified.")
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServicePort must be specified.")
 				continue
 			}
 
@@ -241,14 +241,14 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 			// TODO: Refactor EnsureService to take an int32 so conversion to intstr is not needed.
 			service, err := p.dag.EnsureService(meta, intstr.FromInt(int(*forward.Port)), p.source)
 			if err != nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegradedRoutes, fmt.Sprintf("Service %q does not exist in namespace %q", meta.Name, meta.Namespace))
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, fmt.Sprintf("Service %q does not exist in namespace %q", meta.Name, meta.Namespace))
 				continue
 			}
 			services = append(services, service)
 		}
 
 		if len(services) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegradedRoutes, "All Spec.Rules.ForwardTos are invalid.")
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "All Spec.Rules.ForwardTos are invalid.")
 			continue
 		}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -218,7 +218,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 		}
 
 		if len(rule.ForwardTo) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "At least one Spec.Rules.ForwardTo must be specified.")
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.ForwardTo must be specified.")
 			continue
 		}
 
@@ -226,13 +226,13 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 		for _, forward := range rule.ForwardTo {
 			// Verify the service is valid
 			if forward.ServiceName == nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServiceName must be specified.")
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServiceName must be specified.")
 				continue
 			}
 
 			// TODO: Do not require port to be present (#3352).
 			if forward.Port == nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServicePort must be specified.")
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServicePort must be specified.")
 				continue
 			}
 
@@ -241,14 +241,14 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 			// TODO: Refactor EnsureService to take an int32 so conversion to intstr is not needed.
 			service, err := p.dag.EnsureService(meta, intstr.FromInt(int(*forward.Port)), p.source)
 			if err != nil {
-				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, fmt.Sprintf("Service %q does not exist in namespace %q", meta.Name, meta.Namespace))
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("Service %q does not exist in namespace %q", meta.Name, meta.Namespace))
 				continue
 			}
 			services = append(services, service)
 		}
 
 		if len(services) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionTrue, status.ReasonDegraded, "All Spec.Rules.ForwardTos are invalid.")
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "All Spec.Rules.ForwardTos are invalid.")
 			continue
 		}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -213,7 +213,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 			case gatewayapi_v1alpha1.PathMatchPrefix:
 				pathPrefixes = append(pathPrefixes, stringOrDefault(match.Path.Value, "/"))
 			default:
-				routeAccessor.AddCondition(status.ConditionInvalid, metav1.ConditionTrue, status.ReasonPathMatchType, "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.")
+				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonPathMatchType, "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.")
 			}
 		}
 
@@ -267,7 +267,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 	case 0:
 		routeAccessor.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionTrue, status.ReasonValid, "Valid HTTPRoute")
 	default:
-		routeAccessor.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors Found, check other Conditions for details.")
+		routeAccessor.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
 	}
 }
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2760,12 +2760,12 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			}},
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionTrue,
+			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
 		}, {
 			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionTrue,
+			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
@@ -2808,12 +2808,12 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			}},
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionTrue,
+			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
 		}, {
 			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionTrue,
+			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
@@ -2852,7 +2852,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			}},
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionTrue,
+			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "At least one Spec.Rules.ForwardTo must be specified.",
 		}, {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2477,6 +2477,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 							Listeners: []gatewayapi_v1alpha1.Listener{{
 								Port:     80,
 								Protocol: "HTTP",
+								Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+									Kind: KindHTTPRoute,
+								},
 							}},
 						},
 					},
@@ -2496,8 +2499,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				builder.Source.Insert(o)
 			}
 			dag := builder.Build()
-			t.Logf("%#v\n", dag.StatusCache)
-
 			updates := dag.StatusCache.GetHTTPRouteUpdates()
 
 			var gotConditions []metav1.Condition

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2585,9 +2585,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "Valid",
+			Reason:  string(status.ValidCondition),
 			Message: "Valid HTTPRoute",
 		}},
 	})
@@ -2623,14 +2623,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "PathMatchType",
+			Reason:  string(status.ReasonPathMatchType),
 			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
 		}, {
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
+			Reason:  string(status.ReasonErrorsExist),
 			Message: "Errors Found, check other Conditions for details.",
 		}},
 	})
@@ -2666,14 +2666,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "PathMatchType",
+			Reason:  string(status.ReasonPathMatchType),
 			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
 		}, {
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
+			Reason:  string(status.ReasonErrorsExist),
 			Message: "Errors Found, check other Conditions for details.",
 		}},
 	})
@@ -2716,14 +2716,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.NotImplemented),
+			Type:    string(status.ConditionNotImplemented),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "NotImplemented",
+			Reason:  string(status.ReasonNotImplemented),
 			Message: "HTTPRoute.Spec.TLS: Not yet implemented.",
 		}, {
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
+			Reason:  string(status.ReasonErrorsExist),
 			Message: "Errors Found, check other Conditions for details.",
 		}},
 	})
@@ -2759,14 +2759,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "ForwardTo",
+			Reason:  string(status.ReasonForwardTo),
 			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
 		}, {
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "ForwardTo",
+			Reason:  string(status.ReasonForwardTo),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    "Admitted",
@@ -2807,17 +2807,17 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "ForwardTo",
+			Reason:  string(status.ReasonForwardTo),
 			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
 		}, {
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "ForwardTo",
+			Reason:  string(status.ReasonForwardTo),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  "ErrorsExist",
 			Message: "Errors Found, check other Conditions for details.",
@@ -2851,9 +2851,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.Invalid),
+			Type:    string(status.ConditionInvalid),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  "ForwardTo",
+			Reason:  string(status.ReasonForwardTo),
 			Message: "At least one Spec.Rules.ForwardTo must be specified.",
 		}, {
 			Type:    "Admitted",

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -16,6 +16,8 @@ package dag
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/status"
@@ -25,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 func TestDAGStatus(t *testing.T) {
@@ -50,6 +54,9 @@ func TestDAGStatus(t *testing.T) {
 					},
 					&HTTPProxyProcessor{
 						FallbackCertificate: tc.fallbackCertificate,
+					},
+					&GatewayAPIProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
 					},
 					&ListenerProcessor{},
 				},
@@ -2439,5 +2446,419 @@ func TestDAGStatus(t *testing.T) {
 				WithGeneration(tlsPassthrough.Generation).
 				Valid(),
 		},
+	})
+}
+
+func TestGatewayAPIDAGStatus(t *testing.T) {
+
+	type testcase struct {
+		objs []interface{}
+		want []metav1.Condition
+	}
+
+	run := func(t *testing.T, desc string, tc testcase) {
+		t.Helper()
+		t.Run(desc, func(t *testing.T) {
+			t.Helper()
+			builder := Builder{
+				Source: KubernetesCache{
+					RootNamespaces: []string{"roots", "marketing"},
+					FieldLogger:    fixture.NewTestLogger(t),
+					ConfiguredGateway: types.NamespacedName{
+						Namespace: "contour",
+						Name:      "projectcontour",
+					},
+					gateway: &gatewayapi_v1alpha1.Gateway{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "contour",
+							Namespace: "projectcontour",
+						},
+						Spec: gatewayapi_v1alpha1.GatewaySpec{
+							Listeners: []gatewayapi_v1alpha1.Listener{{
+								Port:     80,
+								Protocol: "HTTP",
+							}},
+						},
+					},
+				},
+				Processors: []Processor{
+					&IngressProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
+					&HTTPProxyProcessor{},
+					&GatewayAPIProcessor{
+						FieldLogger: fixture.NewTestLogger(t),
+					},
+					&ListenerProcessor{},
+				},
+			}
+			for _, o := range tc.objs {
+				builder.Source.Insert(o)
+			}
+			dag := builder.Build()
+			t.Logf("%#v\n", dag.StatusCache)
+
+			updates := dag.StatusCache.GetHTTPRouteUpdates()
+
+			var gotConditions []metav1.Condition
+			for _, u := range updates {
+				gotConditions = append(gotConditions, u.Conditions...)
+			}
+
+			ops := []cmp.Option{
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+				cmpopts.SortSlices(func(i, j int) bool {
+					return tc.want[i].Message < tc.want[j].Message
+				}),
+			}
+
+			if diff := cmp.Diff(tc.want, gotConditions, ops...); diff != "" {
+				t.Fatalf("expected: %v, got %v", tc.want, diff)
+			}
+		})
+	}
+
+	gateway := &gatewayapi_v1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "contour",
+			Namespace: "projectcontour",
+		},
+		Spec: gatewayapi_v1alpha1.GatewaySpec{
+			Listeners: []gatewayapi_v1alpha1.Listener{{
+				Port:     80,
+				Protocol: "HTTP",
+				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "contour",
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	kuardService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard",
+			Namespace: "default",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
+	run(t, "simple httproute", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "Valid",
+			Message: "Valid HTTPRoute",
+		}},
+	})
+
+	run(t, "invalid prefix match for httproute", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "UNKNOWN", // <---- unknown type to break the test
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "PathMatchType",
+			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "exact prefix match not yet supported for httproute", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Exact", // <---- exact type not yet supported
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "PathMatchType",
+			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.tls not yet supported for httproute", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					TLS: &gatewayapi_v1alpha1.RouteTLSConfig{
+						CertificateRef: gatewayapi_v1alpha1.LocalObjectReference{
+							Group: "core",
+							Kind:  "secret",
+							Name:  "someSecret",
+						},
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.NotImplemented),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "NotImplemented",
+			Message: "HTTPRoute.Spec.TLS: Not yet implemented.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.rules.forwardTo.serviceName not specified", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: nil,
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "ForwardTo",
+			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
+		}, {
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "ForwardTo",
+			Message: "All Spec.Rules.ForwardTos are invalid.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.rules.forwardTo.servicePort not specified", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        nil,
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "ForwardTo",
+			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
+		}, {
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "ForwardTo",
+			Message: "All Spec.Rules.ForwardTos are invalid.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.rules.forwardTo not specified", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.Invalid),
+			Status:  contour_api_v1.ConditionTrue,
+			Reason:  "ForwardTo",
+			Message: "At least one Spec.Rules.ForwardTo must be specified.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors Found, check other Conditions for details.",
+		}},
 	})
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2759,14 +2759,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonForwardTo),
+			Reason:  string(status.ReasonDegradedRoutes),
 			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
 		}, {
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonForwardTo),
+			Reason:  string(status.ReasonDegradedRoutes),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    "Admitted",
@@ -2807,14 +2807,14 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonForwardTo),
+			Reason:  string(status.ReasonDegradedRoutes),
 			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
 		}, {
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonForwardTo),
+			Reason:  string(status.ReasonDegradedRoutes),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -2851,9 +2851,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonForwardTo),
+			Reason:  string(status.ReasonDegradedRoutes),
 			Message: "At least one Spec.Rules.ForwardTo must be specified.",
 		}, {
 			Type:    "Admitted",

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2623,7 +2623,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionNotImplemented),
 			Status:  contour_api_v1.ConditionTrue,
 			Reason:  string(status.ReasonPathMatchType),
 			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
@@ -2631,7 +2631,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonErrorsExist),
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 
@@ -2666,7 +2666,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 				},
 			}},
 		want: []metav1.Condition{{
-			Type:    string(status.ConditionInvalid),
+			Type:    string(status.ConditionNotImplemented),
 			Status:  contour_api_v1.ConditionTrue,
 			Reason:  string(status.ReasonPathMatchType),
 			Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type is supported.",
@@ -2674,7 +2674,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonErrorsExist),
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 
@@ -2724,7 +2724,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonErrorsExist),
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 
@@ -2772,7 +2772,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    "Admitted",
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  "ErrorsExist",
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 
@@ -2820,7 +2820,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  "ErrorsExist",
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 
@@ -2859,7 +2859,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Type:    "Admitted",
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  "ErrorsExist",
-			Message: "Errors Found, check other Conditions for details.",
+			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2761,12 +2761,12 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonDegradedRoutes),
+			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
 		}, {
 			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonDegradedRoutes),
+			Reason:  string(status.ReasonDegraded),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    "Admitted",
@@ -2809,12 +2809,12 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonDegradedRoutes),
+			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
 		}, {
 			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonDegradedRoutes),
+			Reason:  string(status.ReasonDegraded),
 			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -2853,7 +2853,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 		want: []metav1.Condition{{
 			Type:    string(status.ConditionResolvedRefs),
 			Status:  contour_api_v1.ConditionTrue,
-			Reason:  string(status.ReasonDegradedRoutes),
+			Reason:  string(status.ReasonDegraded),
 			Message: "At least one Spec.Rules.ForwardTo must be specified.",
 		}, {
 			Type:    "Admitted",

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // KindOf returns the kind string for the given Kubernetes object.
@@ -48,6 +49,8 @@ func KindOf(obj interface{}) string {
 			return "ExtensionService"
 		case *unstructured.Unstructured:
 			return obj.GetKind()
+		case *gatewayapi_v1alpha1.HTTPRoute:
+			return "HTTPRoute"
 		default:
 			return ""
 		}

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -43,14 +43,14 @@ func KindOf(obj interface{}) string {
 			return "Ingress"
 		case *contour_api_v1.HTTPProxy:
 			return "HTTPProxy"
+		case *gatewayapi_v1alpha1.HTTPRoute:
+			return "HTTPRoute"
 		case *contour_api_v1.TLSCertificateDelegation:
 			return "TLSCertificateDelegation"
 		case *v1alpha1.ExtensionService:
 			return "ExtensionService"
 		case *unstructured.Unstructured:
 			return obj.GetKind()
-		case *gatewayapi_v1alpha1.HTTPRoute:
-			return "HTTPRoute"
 		default:
 			return ""
 		}

--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -73,6 +73,7 @@ type StatusUpdateHandler struct {
 
 func (suh *StatusUpdateHandler) apply(upd StatusUpdate) {
 	gvk, err := suh.Clients.KindFor(upd.Resource)
+
 	if err != nil {
 		suh.Log.WithError(err).
 			WithField("name", upd.NamespacedName.Name).

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -100,7 +100,7 @@ func (c *Cache) GetStatusUpdates() []k8s.StatusUpdate {
 		flattened = append(flattened, update)
 	}
 
-	for fullname, pu := range c.httpRouteUpdates {
+	for fullname, routeUpdate := range c.httpRouteUpdates {
 		update := k8s.StatusUpdate{
 			NamespacedName: fullname,
 			Resource: schema.GroupVersionResource{
@@ -108,7 +108,7 @@ func (c *Cache) GetStatusUpdates() []k8s.StatusUpdate {
 				Version:  gatewayapi_v1alpha1.GroupVersion.Version,
 				Resource: "httproutes",
 			},
-			Mutator: pu,
+			Mutator: routeUpdate,
 		}
 
 		flattened = append(flattened, update)

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -16,27 +16,41 @@
 package status
 
 import (
-	"time"
-
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-type ProxyStatus string
+// ConditionType is used to ensure we only use a limited set of possible values
+// for DetailedCondition types. It's cast back to a string before sending off to
+// HTTPProxy structs, as those use upstream types which we can't alias easily.
+type ConditionType string
 
-const (
-	ProxyStatusValid    ProxyStatus = "valid"
-	ProxyStatusInvalid  ProxyStatus = "invalid"
-	ProxyStatusOrphaned ProxyStatus = "orphaned"
-)
+// ValidCondition is the ConditionType for Valid.
+const ValidCondition ConditionType = "Valid"
+
+// AdmittedConditionValid is the valid ConditionType for Admitted.
+const AdmittedConditionValid ConditionType = "AdmittedValid"
+
+// AdmittedConditionInValid is the invalid ConditionType for Admitted.
+const AdmittedConditionInvalid ConditionType = "AdmittedInvalid"
+
+// NotImplemented is the ConditionType for NotImplemented.
+const NotImplemented ConditionType = "NotImplemented"
+
+// Invalid is the ConditionType for Invalid.
+const Invalid ConditionType = "Invalid"
 
 // NewCache creates a new Cache for holding status updates.
-func NewCache() Cache {
+func NewCache(gateway types.NamespacedName) Cache {
 	return Cache{
-		proxyUpdates: make(map[types.NamespacedName]*ProxyUpdate),
-		entries:      make(map[string]map[types.NamespacedName]CacheEntry),
+		proxyUpdates:     make(map[types.NamespacedName]*ProxyUpdate),
+		gatewayRef:       gateway,
+		httpRouteUpdates: make(map[types.NamespacedName]*HTTPRouteUpdate),
+		entries:          make(map[string]map[types.NamespacedName]CacheEntry),
 	}
 }
 
@@ -50,6 +64,9 @@ type CacheEntry interface {
 // KindAccessor.
 type Cache struct {
 	proxyUpdates map[types.NamespacedName]*ProxyUpdate
+
+	gatewayRef       types.NamespacedName
+	httpRouteUpdates map[types.NamespacedName]*HTTPRouteUpdate
 
 	// Map of cache entry maps, keyed on Kind.
 	entries map[string]map[types.NamespacedName]CacheEntry
@@ -79,45 +96,6 @@ func (c *Cache) Put(obj metav1.Object, e CacheEntry) {
 	c.entries[kind][k8s.NamespacedNameOf(obj)] = e
 }
 
-// ProxyAccessor returns a ProxyUpdate that allows a client to build up a list of
-// errors and warnings to go onto the proxy as conditions, and a function to commit the change
-// back to the cache when everything is done.
-// The commit function pattern is used so that the ProxyUpdate does not need to know anything
-// the cache internals.
-func (c *Cache) ProxyAccessor(proxy *contour_api_v1.HTTPProxy) (*ProxyUpdate, func()) {
-	pu := &ProxyUpdate{
-		Fullname:       k8s.NamespacedNameOf(proxy),
-		Generation:     proxy.Generation,
-		TransitionTime: metav1.NewTime(time.Now()),
-		Conditions:     make(map[ConditionType]*contour_api_v1.DetailedCondition),
-	}
-
-	return pu, func() {
-		c.commitProxy(pu)
-	}
-}
-
-func (c *Cache) commitProxy(pu *ProxyUpdate) {
-	if len(pu.Conditions) == 0 {
-		return
-	}
-
-	_, ok := c.proxyUpdates[pu.Fullname]
-	if ok {
-		// When we're committing, if we already have a Valid Condition with an error, and we're trying to
-		// set the object back to Valid, skip the commit, as we've visited too far down.
-		// If this is removed, the status reporting for when a parent delegates to a child that delegates to itself
-		// will not work. Yes, I know, problems everywhere. I'm sorry.
-		// TODO(youngnick)#2968: This issue has more details.
-		if c.proxyUpdates[pu.Fullname].Conditions[ValidCondition].Status == contour_api_v1.ConditionFalse {
-			if pu.Conditions[ValidCondition].Status == contour_api_v1.ConditionTrue {
-				return
-			}
-		}
-	}
-	c.proxyUpdates[pu.Fullname] = pu
-}
-
 // GetStatusUpdates returns a slice of StatusUpdates, ready to be sent off
 // to the StatusUpdater by the event handler.
 // As more kinds are handled by Cache, we'll update this method.
@@ -129,6 +107,20 @@ func (c *Cache) GetStatusUpdates() []k8s.StatusUpdate {
 			NamespacedName: fullname,
 			Resource:       contour_api_v1.HTTPProxyGVR,
 			Mutator:        pu,
+		}
+
+		flattened = append(flattened, update)
+	}
+
+	for fullname, pu := range c.httpRouteUpdates {
+		update := k8s.StatusUpdate{
+			NamespacedName: fullname,
+			Resource: schema.GroupVersionResource{
+				Group:    gatewayapi_v1alpha1.GroupVersion.Group,
+				Version:  gatewayapi_v1alpha1.GroupVersion.Version,
+				Resource: "httproutes",
+			},
+			Mutator: pu,
 		}
 
 		flattened = append(flattened, update)
@@ -151,6 +143,16 @@ func (c *Cache) GetProxyUpdates() []*ProxyUpdate {
 	var allUpdates []*ProxyUpdate
 	for _, pu := range c.proxyUpdates {
 		allUpdates = append(allUpdates, pu)
+	}
+	return allUpdates
+}
+
+// GetHTTPRouteUpdates gets the underlying HTTPRouteUpdate objects
+// from the cache.
+func (c *Cache) GetHTTPRouteUpdates() []*HTTPRouteUpdate {
+	var allUpdates []*HTTPRouteUpdate
+	for _, httpRouteUpdate := range c.httpRouteUpdates {
+		allUpdates = append(allUpdates, httpRouteUpdate)
 	}
 	return allUpdates
 }

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -32,18 +32,6 @@ type ConditionType string
 // ValidCondition is the ConditionType for Valid.
 const ValidCondition ConditionType = "Valid"
 
-// AdmittedConditionValid is the valid ConditionType for Admitted.
-const AdmittedConditionValid ConditionType = "AdmittedValid"
-
-// AdmittedConditionInValid is the invalid ConditionType for Admitted.
-const AdmittedConditionInvalid ConditionType = "AdmittedInvalid"
-
-// NotImplemented is the ConditionType for NotImplemented.
-const NotImplemented ConditionType = "NotImplemented"
-
-// Invalid is the ConditionType for Invalid.
-const Invalid ConditionType = "Invalid"
-
 // NewCache creates a new Cache for holding status updates.
 func NewCache(gateway types.NamespacedName) Cache {
 	return Cache{

--- a/internal/status/cache_test.go
+++ b/internal/status/cache_test.go
@@ -15,8 +15,6 @@ package status
 import (
 	"testing"
 
-	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
-
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -24,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 type testCacheEntry struct {

--- a/internal/status/httproutestatus.go
+++ b/internal/status/httproutestatus.go
@@ -1,0 +1,143 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"fmt"
+	"time"
+
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+type HTTPRouteUpdate struct {
+	Fullname           types.NamespacedName
+	Conditions         []metav1.Condition
+	ExistingConditions []metav1.Condition
+	GatewayRef         types.NamespacedName
+}
+
+// ConditionFor returns a v1.Condition for a given ConditionType.
+func (pu *HTTPRouteUpdate) ConditionFor(cond ConditionType, reason string, message string) metav1.Condition {
+	newDc := v1.Condition{}
+	newDc.Reason = reason
+	newDc.Status = contour_api_v1.ConditionTrue
+	newDc.Type = string(cond)
+
+	switch cond {
+	case AdmittedConditionValid:
+		newDc.Type = "Admitted"
+	case AdmittedConditionInvalid:
+		newDc.Status = contour_api_v1.ConditionFalse
+		newDc.Type = "Admitted"
+	}
+	newDc.Message = message
+	newDc.LastTransitionTime = metav1.NewTime(time.Now())
+	pu.Conditions = append(pu.Conditions, newDc)
+	return newDc
+}
+
+// HTTPRouteAccessor returns a HTTPRouteUpdate that allows a client to build up a list of
+// v1.Conditions as well as a function to commit the change back to the cache when everything
+// is done. The commit function pattern is used so that the HTTPRouteUpdate does not need
+// to know anything the cache internals.
+func (c *Cache) HTTPRouteAccessor(route *gatewayapi_v1alpha1.HTTPRoute) (*HTTPRouteUpdate, func()) {
+	pu := &HTTPRouteUpdate{
+		Fullname:           k8s.NamespacedNameOf(route),
+		Conditions:         []metav1.Condition{},
+		ExistingConditions: c.getGatewayConditions(route.Status.Gateways),
+		GatewayRef:         c.gatewayRef,
+	}
+
+	return pu, func() {
+		c.commitHTTPRoute(pu)
+	}
+}
+
+func (c *Cache) commitHTTPRoute(pu *HTTPRouteUpdate) {
+	if len(pu.Conditions) == 0 {
+		return
+	}
+	c.httpRouteUpdates[pu.Fullname] = pu
+}
+
+func (pu *HTTPRouteUpdate) Mutate(obj interface{}) interface{} {
+	o, ok := obj.(*gatewayapi_v1alpha1.HTTPRoute)
+	if !ok {
+		panic(fmt.Sprintf("Unsupported %T object %s/%s in HTTPRouteUpdate status mutator",
+			obj, pu.Fullname.Namespace, pu.Fullname.Name,
+		))
+	}
+
+	httpRoute := o.DeepCopy()
+
+	var gatewayStatuses []gatewayapi_v1alpha1.RouteGatewayStatus
+	var conditionsToWrite []metav1.Condition
+
+	for _, cond := range pu.Conditions {
+
+		// Look through the newly calculated conditions, if they already exist
+		// on the object then leave them be, otherwise add them to the list
+		// to be written back to the API.
+		for _, existingCond := range pu.ExistingConditions {
+			if cond.Status == existingCond.Status &&
+				cond.Reason == existingCond.Reason &&
+				cond.Message == existingCond.Message &&
+				cond.Type == existingCond.Type {
+
+				cond.ObservedGeneration = existingCond.ObservedGeneration
+				cond.LastTransitionTime = existingCond.LastTransitionTime
+			}
+		}
+
+		conditionsToWrite = append(conditionsToWrite, cond)
+	}
+
+	gatewayStatuses = append(gatewayStatuses, gatewayapi_v1alpha1.RouteGatewayStatus{
+		GatewayRef: gatewayapi_v1alpha1.GatewayReference{
+			Name:      pu.GatewayRef.Name,
+			Namespace: pu.GatewayRef.Namespace,
+		},
+		Conditions: conditionsToWrite,
+	})
+
+	// Now that we have all the conditions, add them back to the object
+	// to get written out.
+	for _, rgs := range httpRoute.Status.Gateways {
+		if rgs.GatewayRef.Name == pu.GatewayRef.Name && rgs.GatewayRef.Namespace == pu.GatewayRef.Namespace {
+			continue
+		} else {
+			gatewayStatuses = append(gatewayStatuses, rgs)
+		}
+	}
+
+	// Set the GatewayStatuses.
+	httpRoute.Status.RouteStatus.Gateways = gatewayStatuses
+
+	return httpRoute
+}
+
+func (c *Cache) getGatewayConditions(gatewayStatus []gatewayapi_v1alpha1.RouteGatewayStatus) []metav1.Condition {
+	for _, gs := range gatewayStatus {
+		if c.gatewayRef.Name == gs.GatewayRef.Name &&
+			c.gatewayRef.Namespace == gs.GatewayRef.Namespace {
+			return gs.Conditions
+		}
+	}
+	return []metav1.Condition{}
+}

--- a/internal/status/httproutestatus.go
+++ b/internal/status/httproutestatus.go
@@ -30,7 +30,7 @@ type RouteReasonType string
 
 const ReasonNotImplemented RouteReasonType = "NotImplemented"
 const ReasonPathMatchType RouteReasonType = "PathMatchType"
-const ReasonDegradedRoutes RouteReasonType = "DegradedRoute"
+const ReasonDegraded RouteReasonType = "Degraded"
 const ReasonValid RouteReasonType = "Valid"
 const ReasonErrorsExist RouteReasonType = "ErrorsExist"
 

--- a/internal/status/httproutestatus.go
+++ b/internal/status/httproutestatus.go
@@ -99,13 +99,14 @@ func (routeUpdate *HTTPRouteUpdate) Mutate(obj interface{}) interface{} {
 	for _, cond := range routeUpdate.Conditions {
 
 		// Look through the newly calculated conditions, if they already exist
-		// on the object then leave them be, otherwise add them to the list
-		// to be written back to the API.
+		// on the object or if our obervation is stale, then leave them be,
+		// otherwise add them to the list to be written back to the API.
 		for _, existingCond := range routeUpdate.ExistingConditions {
-			if cond.Status == existingCond.Status &&
+			if (cond.Status == existingCond.Status &&
 				cond.Reason == existingCond.Reason &&
 				cond.Message == existingCond.Message &&
-				cond.Type == existingCond.Type {
+				cond.Type == existingCond.Type) ||
+				existingCond.ObservedGeneration > cond.ObservedGeneration {
 
 				cond.ObservedGeneration = existingCond.ObservedGeneration
 				cond.LastTransitionTime = existingCond.LastTransitionTime

--- a/internal/status/httproutestatus_test.go
+++ b/internal/status/httproutestatus_test.go
@@ -20,30 +20,37 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func TestHTTPRouteConditionFor(t *testing.T) {
+func TestHTTPRouteAddCondition(t *testing.T) {
+
+	var testGeneration int64 = 7
+
 	simpleValidCondition := metav1.Condition{
-		Type:    "Admitted",
-		Status:  projectcontour.ConditionTrue,
-		Reason:  "Valid",
-		Message: "Valid HTTPRoute",
+		Type:               string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+		Status:             projectcontour.ConditionTrue,
+		Reason:             "Valid",
+		Message:            "Valid HTTPRoute",
+		ObservedGeneration: testGeneration,
 	}
 
-	pu := HTTPRouteUpdate{
-		Fullname: k8s.NamespacedNameFrom("test/test"),
+	httpRouteUpdate := HTTPRouteUpdate{
+		Fullname:   k8s.NamespacedNameFrom("test/test"),
+		Generation: testGeneration,
 		Conditions: []metav1.Condition{{
-			Type:    "Admitted",
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  projectcontour.ConditionTrue,
 			Reason:  "Valid",
 			Message: "Valid HTTPRoute",
 		}},
 	}
 
-	got := pu.ConditionFor(AdmittedConditionValid, "Valid", "Valid HTTPRoute")
+	got := httpRouteUpdate.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionTrue, "Valid", "Valid HTTPRoute")
 
 	assert.Equal(t, simpleValidCondition.Message, got.Message)
 	assert.Equal(t, simpleValidCondition.Reason, got.Reason)
 	assert.Equal(t, simpleValidCondition.Type, got.Type)
 	assert.Equal(t, simpleValidCondition.Status, got.Status)
+	assert.Equal(t, simpleValidCondition.ObservedGeneration, got.ObservedGeneration)
 }

--- a/internal/status/httproutestatus_test.go
+++ b/internal/status/httproutestatus_test.go
@@ -1,0 +1,49 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+
+	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHTTPRouteConditionFor(t *testing.T) {
+	simpleValidCondition := metav1.Condition{
+		Type:    "Admitted",
+		Status:  projectcontour.ConditionTrue,
+		Reason:  "Valid",
+		Message: "Valid HTTPRoute",
+	}
+
+	pu := HTTPRouteUpdate{
+		Fullname: k8s.NamespacedNameFrom("test/test"),
+		Conditions: []metav1.Condition{{
+			Type:    "Admitted",
+			Status:  projectcontour.ConditionTrue,
+			Reason:  "Valid",
+			Message: "Valid HTTPRoute",
+		}},
+	}
+
+	got := pu.ConditionFor(AdmittedConditionValid, "Valid", "Valid HTTPRoute")
+
+	assert.Equal(t, simpleValidCondition.Message, got.Message)
+	assert.Equal(t, simpleValidCondition.Reason, got.Reason)
+	assert.Equal(t, simpleValidCondition.Type, got.Type)
+	assert.Equal(t, simpleValidCondition.Status, got.Status)
+}

--- a/internal/status/httproutestatus_test.go
+++ b/internal/status/httproutestatus_test.go
@@ -36,7 +36,7 @@ func TestHTTPRouteAddCondition(t *testing.T) {
 	}
 
 	httpRouteUpdate := HTTPRouteUpdate{
-		Fullname:   k8s.NamespacedNameFrom("test/test"),
+		FullName:   k8s.NamespacedNameFrom("test/test"),
 		Generation: testGeneration,
 		Conditions: []metav1.Condition{{
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),

--- a/internal/status/proxystatus_test.go
+++ b/internal/status/proxystatus_test.go
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package status
 
 import (

--- a/internal/status/proxystatus_test.go
+++ b/internal/status/proxystatus_test.go
@@ -80,7 +80,7 @@ func TestStatusMutator(t *testing.T) {
 			assert.Equal(t, tc.wantCurrentStatus, o.Status.CurrentStatus, desc)
 			assert.Equal(t, tc.wantDescription, o.Status.Description, desc)
 		default:
-			t.Fatal("Got a non-HTTPProxy object, wow, impressive.")
+			t.Fatal("Got a non-HTTPProxy object.")
 		}
 	}
 


### PR DESCRIPTION
- Update the status package to process GatewayAPI HTTPRoutes.
- Update the dag.GatewayAPIProcessor to set status.

Fixes #3436

Signed-off-by: Steve Sloka <slokas@vmware.com>