### PR TITLE
internal/envoy/v3: Strip port from hostname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
-	github.com/envoyproxy/go-control-plane v0.9.8
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210111201334-f1f47757da33
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
-github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210111201334-f1f47757da33 h1:U16cYLyGghDDNddBIk9+PwCIwkyqGnt+W29t8JmYfnk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210111201334-f1f47757da33/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -389,6 +389,14 @@ func (b *httpConnectionManagerBuilder) Get() *envoy_listener_v3.Filter {
 		UseRemoteAddress: protobuf.Bool(true),
 		NormalizePath:    protobuf.Bool(true),
 
+		// We can ignore any port number supplied in the Host/:authority header
+		// before processing by filters or routing.
+		// Note that the port a listener is bound to will already be selected
+		// and that the port is stripped from the header sent upstream as well.
+		StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+			StripAnyHostPort: true,
+		},
+
 		// issue #1487 pass through X-Request-Id if provided.
 		PreserveExternalRequestId: true,
 		MergeSlashes:              true,
@@ -568,17 +576,10 @@ function envoy_on_request(request_handle)
 	local target = "%s"
 
 	if host ~= target then
-		s, e = string.find(host, ":", 1, true)
-		if s ~= nil then
-			host = string.sub(host, 1, s - 1)
-		end
-
-		if host ~= target then
-			request_handle:respond(
-				{[":status"] = "421"},
-				string.format("misdirected request to %%q", headers:get(":authority"))
-			)
-		end
+		request_handle:respond(
+			{[":status"] = "421"},
+			string.format("misdirected request to %%q", headers:get(":authority"))
+		)
 	end
 end
 	`

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -578,7 +578,7 @@ function envoy_on_request(request_handle)
 	if host ~= target then
 		request_handle:respond(
 			{[":status"] = "421"},
-			string.format("misdirected request to %%q", headers:get(":authority"))
+			string.format("misdirected request to %%q", host)
 		)
 	end
 end

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -410,6 +410,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -498,6 +501,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						RequestTimeout:            protobuf.Duration(10 * time.Second),
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
@@ -586,9 +592,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 						CommonHttpProtocolOptions: &envoy_core_v3.HttpProtocolOptions{
 							IdleTimeout: protobuf.Duration(90 * time.Second),
 						},
-						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
-						UseRemoteAddress:          protobuf.Bool(true),
-						NormalizePath:             protobuf.Bool(true),
+						AccessLog:        FileAccessLogEnvoy("/dev/stdout"),
+						UseRemoteAddress: protobuf.Bool(true),
+						NormalizePath:    protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -677,6 +686,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						StreamIdleTimeout:         protobuf.Duration(90 * time.Second),
@@ -765,9 +777,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 						CommonHttpProtocolOptions: &envoy_core_v3.HttpProtocolOptions{
 							MaxConnectionDuration: protobuf.Duration(90 * time.Second),
 						},
-						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
-						UseRemoteAddress:          protobuf.Bool(true),
-						NormalizePath:             protobuf.Bool(true),
+						AccessLog:        FileAccessLogEnvoy("/dev/stdout"),
+						UseRemoteAddress: protobuf.Bool(true),
+						NormalizePath:    protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -856,6 +871,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 					}),
@@ -944,6 +962,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						DelayedCloseTimeout:       protobuf.Duration(90 * time.Second),
@@ -1033,6 +1054,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						DrainTimeout:              protobuf.Duration(90 * time.Second),
@@ -1124,6 +1148,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						DrainTimeout:              protobuf.Duration(90 * time.Second),
@@ -1214,6 +1241,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 						AccessLog:                 FileAccessLogEnvoy("/dev/stdout"),
 						UseRemoteAddress:          protobuf.Bool(true),
 						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
 						PreserveExternalRequestId: true,
 						MergeSlashes:              true,
 						DrainTimeout:              protobuf.Duration(90 * time.Second),

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -259,15 +259,9 @@ func weightedClusters(clusters []*dag.Cluster) *envoy_route_v3.WeightedCluster {
 
 // VirtualHost creates a new route.VirtualHost.
 func VirtualHost(hostname string, routes ...*envoy_route_v3.Route) *envoy_route_v3.VirtualHost {
-	domains := []string{hostname}
-	if hostname != "*" {
-		// NOTE(jpeach) see also envoy.FilterMisdirectedRequests().
-		domains = append(domains, hostname+":*")
-	}
-
 	return &envoy_route_v3.VirtualHost{
 		Name:    envoy.Hashname(60, hostname),
-		Domains: domains,
+		Domains: []string{hostname},
 		Routes:  routes,
 	}
 }

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -760,7 +760,7 @@ func TestVirtualHost(t *testing.T) {
 			port:     9999,
 			want: &envoy_route_v3.VirtualHost{
 				Name:    "www.example.com",
-				Domains: []string{"www.example.com", "www.example.com:*"},
+				Domains: []string{"www.example.com"},
 			},
 		},
 	}
@@ -783,7 +783,7 @@ func TestCORSVirtualHost(t *testing.T) {
 			cp:       nil,
 			want: &envoy_route_v3.VirtualHost{
 				Name:    "www.example.com",
-				Domains: []string{"www.example.com", "www.example.com:*"},
+				Domains: []string{"www.example.com"},
 			},
 		},
 		"cors policy": {
@@ -800,7 +800,7 @@ func TestCORSVirtualHost(t *testing.T) {
 			},
 			want: &envoy_route_v3.VirtualHost{
 				Name:    "www.example.com",
-				Domains: []string{"www.example.com", "www.example.com:*"},
+				Domains: []string{"www.example.com"},
 				Cors: &envoy_route_v3.CorsPolicy{
 					AllowOriginStringMatch: []*matcher.StringMatcher{
 						{


### PR DESCRIPTION
- Strips host port using the strip_any_host_port field on HTTP connection manager
- All filter/router processing will be done internally without the port number attached
- Ensures <HOST>:<PORT_NUM> is accepted and treated the same as the plain <HOST>
- Removes Lua logic to check port number as it is no longer needed, the filter will never see the port on the :authority header
- Removes <HOST>:* wildcard domain match in router, the router will never see the port on the domain to match
- Note that this will strip the port from the Host/:authority header sent to upstreams
- Bumps go-control-plane as latest tagged release is not new enough and does not include the field used
- Will be useful in implementing wildcard host matching, makes internal logic simpler

See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-strip-any-host-port