### PR TITLE
internal: Add support for exact path match type

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -107,6 +107,15 @@ type PrefixMatchCondition struct {
 	Prefix string
 }
 
+func (pc *ExactMatchCondition) String() string {
+	return "exact: " + pc.Path
+}
+
+// ExactMatchCondition matches the entire path of a URL.
+type ExactMatchCondition struct {
+	Path string
+}
+
 func (pc *PrefixMatchCondition) String() string {
 	return "prefix: " + pc.Prefix
 }

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -73,6 +73,13 @@ func RouteMatch(route *dag.Route) *envoy_route_v3.RouteMatch {
 			},
 			Headers: headerMatcher(route.HeaderMatchConditions),
 		}
+	case *dag.ExactMatchCondition:
+		return &envoy_route_v3.RouteMatch{
+			PathSpecifier: &envoy_route_v3.RouteMatch_Path{
+				Path: c.Path,
+			},
+			Headers: headerMatcher(route.HeaderMatchConditions),
+		}
 	default:
 		return &envoy_route_v3.RouteMatch{
 			Headers: headerMatcher(route.HeaderMatchConditions),

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1052,6 +1052,18 @@ func TestRouteMatch(t *testing.T) {
 				},
 			},
 		},
+		"path exact": {
+			route: &dag.Route{
+				PathMatchCondition: &dag.ExactMatchCondition{
+					Path: "/foo",
+				},
+			},
+			want: &envoy_route_v3.RouteMatch{
+				PathSpecifier: &envoy_route_v3.RouteMatch_Path{
+					Path: "/foo",
+				},
+			},
+		},
 		"path regex": {
 			route: &dag.Route{
 				PathMatchCondition: &dag.RegexMatchCondition{


### PR DESCRIPTION
Adds support for exact match type which will be used by IngressV1 & GatewayAPI.

Signed-off-by: Steve Sloka <slokas@vmware.com>