### PR TITLE
site: Update gateway-api guide

### DIFF
--- a/examples/gatewayapi/01-common.yaml
+++ b/examples/gatewayapi/01-common.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: projectcontour-roots
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rootapp
+  namespace: projectcontour-roots
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rootapp
+  template:
+    metadata:
+      labels:
+        app: rootapp
+    spec:
+      containers:
+        - name: echo
+          image: stevesloka/echo-server
+          command: ["echo-server"]
+          args:
+            - --echotext=This is the default app site [rootapp]!
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rootapp
+  name: rootapp
+  namespace: projectcontour-roots
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: rootapp
+  type: ClusterIP
+

--- a/examples/gatewayapi/02-gateway.yaml
+++ b/examples/gatewayapi/02-gateway.yaml
@@ -1,0 +1,44 @@
+kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        selector:
+          matchLabels:
+            app: http
+        namespaces:
+          from: "All"
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: default-route
+  namespace: projectcontour-roots
+  labels:
+    app: http
+spec:
+  tls:
+  hostnames:
+    - local.projectcontour.io
+  rules:
+    - matches:
+        - path:
+            type: Prefix
+            value: /
+      forwardTo:
+        - serviceName: rootapp
+          port: 80

--- a/site/_guides/gateway-api.md
+++ b/site/_guides/gateway-api.md
@@ -35,9 +35,51 @@ The following prerequisites must be met before using Gateway API with Contour:
 - A working [Kubernetes][2] cluster. Refer to the [compatibility matrix][3] for cluster version requirements.
 - The [kubectl][4] command-line tool, installed and configured to access your cluster.
 
-### Using Gateway API with Contour Operator
+### Deploy
 
-The preferred method for using Gateway API is with [Contour Operator][5]. This is because the GatewayClass and Gateway
+#### Option 1: kubectl apply
+
+Gateway API is a set of CRDs that need to be applied to your cluster first before deploying Contour.
+This getting started guide is perfect to be used with [Kind configuration](https://projectcontour.io/docs/v1.13.1/deploy-options/#kind).
+
+Apply the Gateway API CRDs:
+```shell
+$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0" | kubectl apply -f -
+```
+
+Deploy Contour:
+```shell
+$ kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+```
+
+Create some sample resources:
+```shell
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/main/examples/contour/01-common.yaml
+```
+
+Create some sample Gateway API resources:
+```shell
+$ kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/main/examples/contour/02-gateway.yaml
+```
+
+This creates:
+
+- Namespace `projectcontour` to run Contour & Envoy.
+- Namespace `projectcontour-roots` to run sample apps.
+- Sample Deployment/Service sample apps.
+- A GatewayClass named `contour-class` that abstracts the infrastructure-specific configuration from Gateways.
+- A Gateway named `contour` in namespace `projectcontour`.
+
+Test it out!
+
+Use `curl` to test access to the application:
+```shell
+$ curl -i http://local.projectcontour.io
+```
+
+### Option 2: Contour Operator
+
+Another method for using Gateway API is with [Contour Operator][5]. This is because the GatewayClass and Gateway
 resources should be managed by active controllers that are implemented by the operator. Refer to the [contour][6] and
 [operator][7] designs for additional background on the gateway API implementation.
 


### PR DESCRIPTION
Updates the guide to show how to run sample gateway-apis resources without the operator.

Signed-off-by: Steve Sloka <slokas@vmware.com>