### PR TITLE
Ingress: Default backend overridden by Ingress rule and add some additional tests

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -5850,6 +5850,30 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
+		"insert ingress overlay reverse order": {
+			objs: []interface{}{
+				i13b, i13a, sec13, s13a, s13b,
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("example.com",
+							routeUpgrade("/", service(s13a)),
+							prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
+						),
+					),
+				}, &Listener{
+					Port: 443,
+					VirtualHosts: virtualhosts(
+						securevirtualhost("example.com", sec13,
+							routeUpgrade("/", service(s13a)),
+							prefixroute("/.well-known/acme-challenge/gVJl5NWL2owUqZekjHkt_bo3OHYC2XNDURRRgLI5JTk", service(s13b)),
+						),
+					),
+				},
+			),
+		},
 		"h2c service annotation": {
 			objs: []interface{}{
 				i3a, s3a,

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -241,7 +241,6 @@ func toV1Ingress(obj *v1beta1.Ingress) *networking_v1.Ingress {
 
 	var convertedTLS []networking_v1.IngressTLS
 	var convertedIngressRules []networking_v1.IngressRule
-	var paths []networking_v1.HTTPIngressPath
 	var convertedDefaultBackend *networking_v1.IngressBackend
 
 	for _, tls := range obj.Spec.TLS {
@@ -260,6 +259,7 @@ func toV1Ingress(obj *v1beta1.Ingress) *networking_v1.Ingress {
 		}
 
 		if r.HTTP != nil {
+			var paths []networking_v1.HTTPIngressPath
 
 			for _, p := range r.HTTP.Paths {
 				var pathType networking_v1.PathType

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -214,11 +214,12 @@ func route(ingress *networking_v1.Ingress, path string, service *Service, client
 
 // rulesFromSpec merges the IngressSpec's Rules with a synthetic
 // rule representing the default backend.
+// Prepend the default backend so it can be overriden by later rules.
 func rulesFromSpec(spec networking_v1.IngressSpec) []networking_v1.IngressRule {
 	rules := spec.Rules
 	if backend := spec.DefaultBackend; backend != nil {
 		rule := defaultBackendRule(backend)
-		rules = append(rules, rule)
+		rules = append([]networking_v1.IngressRule{rule}, rules...)
 	}
 	return rules
 }

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -214,7 +214,7 @@ func route(ingress *networking_v1.Ingress, path string, service *Service, client
 
 // rulesFromSpec merges the IngressSpec's Rules with a synthetic
 // rule representing the default backend.
-// Prepend the default backend so it can be overriden by later rules.
+// Prepend the default backend so it can be overridden by later rules.
 func rulesFromSpec(spec networking_v1.IngressSpec) []networking_v1.IngressRule {
 	rules := spec.Rules
 	if backend := spec.DefaultBackend; backend != nil {

--- a/internal/featuretests/v3/route_test.go
+++ b/internal/featuretests/v3/route_test.go
@@ -894,7 +894,7 @@ func TestDefaultBackendDoesNotOverwriteNamedHost(t *testing.T) {
 	})
 }
 
-func TestDefaultBackendIsOverridenByNoHostIngressRule(t *testing.T) {
+func TestDefaultBackendIsOverriddenByNoHostIngressRule(t *testing.T) {
 	rh, c, done := setup(t)
 	defer done()
 


### PR DESCRIPTION
- Overlaying Ingresses in reverse order
- A default backend is overriden by a no-host prefix '/' rule
  - default backend is prepended to list of Ingress Rules to make this
    work

Updates https://github.com/projectcontour/contour/issues/3461