### PR TITLE
internal: Add support for TLS on Gateway

### DIFF
--- a/_integration/testsuite/gatewayapi/004-tls-gateway.yaml
+++ b/_integration/testsuite/gatewayapi/004-tls-gateway.yaml
@@ -1,0 +1,237 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import data.contour.resources
+
+# Ensure that cert-manager is installed.
+# Version check the certificates resource.
+
+Group := "cert-manager.io"
+Version := "v1"
+
+have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+  sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+  "available versions:",
+  yaml.marshal(avail)
+  ])
+}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tlscert
+  namespace: projectcontour
+spec:
+  dnsNames:
+  - secure.projectcontour.io
+  secretName: tlscert
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-secure
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-secure
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: "All"
+        selector:
+          matchLabels:
+            type: insecure
+    - protocol: HTTPS
+      port: 443
+      tls:
+        certificateRef:
+          kind: Secret
+          group: core
+          name: tlscert
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: "All"
+        selector:
+          matchLabels:
+            type: secure
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    type: insecure
+spec:
+  hostnames:
+    - secure.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      forwardTo:
+      - serviceName: echo-slash-default
+        port: 80
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-2
+  labels:
+    type: secure
+spec:
+  hostnames:
+    - secure.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      forwardTo:
+      - serviceName: echo-slash-secure
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure http (insecure) request returns 200 status code.
+Response := client.Get({
+  "url": url.http("/"),
+    "headers": {
+      "Host": "secure.projectcontour.io",
+      "User-Agent": client.ua("insecure"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-slash-default")
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure https (secure) request returns 200 status code.
+Response := client.Get({
+  "url": url.https("/"),
+  "headers": {
+    "Host": "secure.projectcontour.io",
+    "User-Agent": client.ua("secure"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-slash-secure")
+}

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -1,0 +1,204 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dag
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/stretchr/testify/assert"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func TestComputeHosts(t *testing.T) {
+	tests := map[string]struct {
+		route     *gatewayapi_v1alpha1.HTTPRoute
+		want      []string
+		wantError []error
+	}{
+		"single host": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+					},
+				},
+			},
+			want:      []string{"test.projectcontour.io"},
+			wantError: []error(nil),
+		},
+		"single DNS label hostname": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"projectcontour",
+					},
+				},
+			},
+			want:      []string{"projectcontour"},
+			wantError: []error(nil),
+		},
+		"multiple hosts": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"test.projectcontour.io",
+						"test1.projectcontour.io",
+						"test2.projectcontour.io",
+						"test3.projectcontour.io",
+					},
+				},
+			},
+			want:      []string{"test.projectcontour.io", "test1.projectcontour.io", "test2.projectcontour.io", "test3.projectcontour.io"},
+			wantError: []error(nil),
+		},
+		"no host": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{},
+			},
+			want:      []string{"*"},
+			wantError: []error(nil),
+		},
+		"IP in host": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"1.2.3.4",
+					},
+				},
+			},
+			want: []string(nil),
+			wantError: []error{
+				fmt.Errorf("hostname \"1.2.3.4\" must be a DNS name, not an IP address"),
+			},
+		},
+		"valid wildcard hostname": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"*.projectcontour.io",
+					},
+				},
+			},
+			want:      []string{"*.projectcontour.io"},
+			wantError: []error(nil),
+		},
+		"invalid wildcard hostname": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"*.*.projectcontour.io",
+					},
+				},
+			},
+			want: []string(nil),
+			wantError: []error{
+				fmt.Errorf("invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
+			},
+		},
+		"invalid hostname": {
+			route: &gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "projectcontour",
+					Labels: map[string]string{
+						"app":  "contour",
+						"type": "controller",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"#projectcontour.io",
+					},
+				},
+			},
+			want: []string(nil),
+			wantError: []error{
+				fmt.Errorf("invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			processor := &GatewayAPIProcessor{
+				FieldLogger: fixture.NewTestLogger(t),
+			}
+
+			got, gotError := processor.computeHosts(tc.route)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantError, gotError)
+		})
+	}
+}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2899,4 +2899,121 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Message: "Errors found, check other Conditions for details.",
 		}},
 	})
+
+	run(t, "spec.rules.hostname: invalid wildcard", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"*.*.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.rules.hostname: invalid hostname", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"#projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "spec.rules.hostname: invalid hostname, ip address", testcase{
+		objs: []interface{}{
+			gateway,
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"1.2.3.4",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+							Path: gatewayapi_v1alpha1.HTTPPathMatch{
+								Type:  "Prefix",
+								Value: "/",
+							},
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "hostname \"1.2.3.4\" must be a DNS name, not an IP address",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
 }

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_service_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -110,6 +112,10 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 		Builder: dag.Builder{
 			Source: dag.KubernetesCache{
 				FieldLogger: log,
+				ConfiguredGateway: types.NamespacedName{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
 			},
 		},
 	}
@@ -122,6 +128,9 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 			FieldLogger: log.WithField("context", "ExtensionServiceProcessor"),
 		},
 		&dag.HTTPProxyProcessor{},
+		&dag.GatewayAPIProcessor{
+			FieldLogger: log.WithField("context", "GatewayAPIProcessor"),
+		},
 		&dag.ListenerProcessor{},
 	}
 

--- a/internal/featuretests/v3/gatewayapi_test.go
+++ b/internal/featuretests/v3/gatewayapi_test.go
@@ -1,0 +1,183 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+
+	"github.com/projectcontour/contour/internal/dag"
+
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
+	"github.com/projectcontour/contour/internal/featuretests"
+	"github.com/projectcontour/contour/internal/fixture"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func TestGateway_TLS(t *testing.T) {
+	rh, c, done := setup(t)
+	defer done()
+
+	rh.OnAdd(fixture.NewService("svc1").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
+
+	rh.OnAdd(fixture.NewService("svc2").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}),
+	)
+
+	sec1 := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tlscert",
+			Namespace: "projectcontour",
+		},
+		Type: v1.SecretTypeTLS,
+		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+	}
+
+	rh.OnAdd(sec1)
+
+	rh.OnAdd(&gatewayapi_v1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "contour",
+			Namespace: "projectcontour",
+		},
+		Spec: gatewayapi_v1alpha1.GatewaySpec{
+			Listeners: []gatewayapi_v1alpha1.Listener{{
+				Port:     80,
+				Protocol: "HTTP",
+				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+						From: gatewayapi_v1alpha1.RouteSelectAll,
+					},
+					Kind: dag.KindHTTPRoute,
+				},
+			}, {
+				Port:     443,
+				Protocol: "HTTPS",
+				TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+					CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
+						Group: "core",
+						Kind:  "Secret",
+						Name:  "tlscert",
+					},
+				},
+				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+						From: gatewayapi_v1alpha1.RouteSelectAll,
+					},
+					Kind: dag.KindHTTPRoute,
+				},
+			}},
+		},
+	})
+
+	rh.OnAdd(&gatewayapi_v1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":  "contour",
+				"type": "controller",
+			},
+		},
+		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayapi_v1alpha1.Hostname{
+				"test.projectcontour.io",
+			},
+			Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+				Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+					Path: gatewayapi_v1alpha1.HTTPPathMatch{
+						Type:  "Prefix",
+						Value: "/blog",
+					},
+				}},
+				ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+					ServiceName: pointer.StringPtr("svc2"),
+					Port:        gatewayPort(80),
+				}},
+			}, {
+				Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
+					Path: gatewayapi_v1alpha1.HTTPPathMatch{
+						Type:  "Prefix",
+						Value: "/",
+					},
+				}},
+				ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+					ServiceName: pointer.StringPtr("svc1"),
+					Port:        gatewayPort(80),
+				}},
+			}},
+		},
+	})
+
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration("https/test.projectcontour.io",
+				envoy_v3.VirtualHost("test.projectcontour.io",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/blog"),
+						Action: routeCluster("default/svc2/80/da39a3ee5e"),
+					}, &envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: routeCluster("default/svc1/80/da39a3ee5e"),
+					},
+				),
+			),
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("test.projectcontour.io",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/blog"),
+						Action: routeCluster("default/svc2/80/da39a3ee5e"),
+					}, &envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: routeCluster("default/svc1/80/da39a3ee5e"),
+					},
+				),
+			),
+		),
+		TypeUrl: routeType,
+	})
+
+	c.Request(listenerType, "ingress_https").Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				FilterChains: appendFilterChains(
+					filterchaintls("test.projectcontour.io", sec1,
+						httpsFilterFor("test.projectcontour.io"),
+						nil, "h2", "http/1.1"),
+				),
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+		),
+	})
+}
+
+func gatewayPort(port int) *gatewayapi_v1alpha1.PortNumber {
+	p := gatewayapi_v1alpha1.PortNumber(port)
+	return &p
+}


### PR DESCRIPTION
Gateways can now supply certificateRefs which allow the Gateway & it's selected HTTPRoutes to
terminate TLS at the Envoy listener.

Updates #3438

Signed-off-by: Steve Sloka <slokas@vmware.com>