### PR TITLE
internal/dag: Change key for namespaces cache to be string

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -57,7 +57,7 @@ type KubernetesCache struct {
 	secrets              map[types.NamespacedName]*v1.Secret
 	httpproxydelegations map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation
 	services             map[types.NamespacedName]*v1.Service
-	namespaces           map[types.NamespacedName]*v1.Namespace
+	namespaces           map[string]*v1.Namespace
 	gateway              *gatewayapi_v1alpha1.Gateway
 	httproutes           map[types.NamespacedName]*gatewayapi_v1alpha1.HTTPRoute
 	tlsroutes            map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute
@@ -77,7 +77,7 @@ func (kc *KubernetesCache) init() {
 	kc.secrets = make(map[types.NamespacedName]*v1.Secret)
 	kc.httpproxydelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
 	kc.services = make(map[types.NamespacedName]*v1.Service)
-	kc.namespaces = make(map[types.NamespacedName]*v1.Namespace)
+	kc.namespaces = make(map[string]*v1.Namespace)
 	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.HTTPRoute)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute)
 	kc.backendpolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha1.BackendPolicy)
@@ -170,7 +170,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		kc.services[k8s.NamespacedNameOf(obj)] = obj
 		return kc.serviceTriggersRebuild(obj)
 	case *v1.Namespace:
-		kc.namespaces[k8s.NamespacedNameOf(obj)] = obj
+		kc.namespaces[obj.Name] = obj
 		return true
 	case *v1beta1.Ingress:
 		if kc.matchesIngressClass(obj) {
@@ -352,9 +352,8 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		delete(kc.services, m)
 		return ok
 	case *v1.Namespace:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.namespaces[m]
-		delete(kc.namespaces, m)
+		_, ok := kc.namespaces[obj.Name]
+		delete(kc.namespaces, obj.Name)
 		return ok
 	case *v1beta1.Ingress:
 		m := k8s.NamespacedNameOf(obj)


### PR DESCRIPTION
Namespaces don't have a "namespace", so keying off of them is incorrect, so this
changes the namespace key to be scoped to only the name.

Updates #3466

Signed-off-by: Steve Sloka <slokas@vmware.com>