### PR TITLE
internal/dag: Rebuild DAG if secret or service related to a Gatway or HTTPRoute changes

### DIFF
--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -467,10 +467,6 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 		}
 	}
 
-	// TODO: This checks for ANY httproute that matches
-	// a service, however, it's possible that the route
-	// doesn't match the selector/namespaces defined on
-	// the gateway and is a noop dag rebuild.
 	for _, route := range kc.httproutes {
 		if route.Namespace != service.Namespace {
 			continue
@@ -582,8 +578,7 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 			}
 
 			ref := listener.TLS.CertificateRef
-			if ref.Kind == "Secret" &&
-				(ref.Group == "core" || ref.Group == "v1") {
+			if ref.Kind == "Secret" && ref.Group == "core" {
 				if kc.gateway.Namespace == secret.Namespace && ref.Name == secret.Name {
 					return true
 				}

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
@@ -1075,6 +1076,506 @@ func TestLookupService(t *testing.T) {
 				assert.Equal(t, tc.wantSvc, gotSvc)
 				assert.Equal(t, tc.wantPort, gotPort)
 			}
+		})
+	}
+}
+
+func TestServiceTriggersRebuild(t *testing.T) {
+
+	cache := func(objs ...interface{}) *KubernetesCache {
+		cache := KubernetesCache{
+			FieldLogger: fixture.NewTestLogger(t),
+		}
+		for _, o := range objs {
+			cache.Insert(o)
+		}
+		return &cache
+	}
+
+	service := func(namespace, name string) *v1.Service {
+		return &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	ingressBackendService := func(namespace, name string) *networking_v1.Ingress {
+		return &networking_v1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: networking_v1.IngressSpec{
+				Rules: []networking_v1.IngressRule{{
+					Host: "test.projectcontour.io",
+					IngressRuleValue: networking_v1.IngressRuleValue{
+						HTTP: &networking_v1.HTTPIngressRuleValue{
+							Paths: []networking_v1.HTTPIngressPath{{
+								Backend: networking_v1.IngressBackend{
+									Service: &networking_v1.IngressServiceBackend{
+										Name: name,
+										Port: networking_v1.ServiceBackendPort{
+											Number: 80,
+										},
+									},
+								},
+							}},
+						},
+					},
+				}},
+			},
+		}
+	}
+
+	ingressDefaultBackend := func(namespace, name string) *networking_v1.Ingress {
+		return &networking_v1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: backendv1(name, intstr.FromInt(80)),
+				Rules: []networking_v1.IngressRule{{
+					Host: "test.projectcontour.io",
+				}},
+			},
+		}
+	}
+
+	httpProxy := func(namespace, name string) *contour_api_v1.HTTPProxy {
+		return &contour_api_v1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: contour_api_v1.HTTPProxySpec{
+				Routes: []contour_api_v1.Route{{
+					Services: []contour_api_v1.Service{{
+						Name: name,
+						Port: 80,
+					}},
+				}},
+				TCPProxy: nil,
+				Includes: nil,
+			},
+		}
+	}
+
+	tcpProxy := func(namespace, name string) *contour_api_v1.HTTPProxy {
+		return &contour_api_v1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: contour_api_v1.HTTPProxySpec{
+				TCPProxy: &contour_api_v1.TCPProxy{
+					Services: []contour_api_v1.Service{{
+						Name: name,
+						Port: 90,
+					}},
+				},
+				Includes: nil,
+			},
+		}
+	}
+
+	httpRoute := func(namespace, name string) *gatewayapi_v1alpha1.HTTPRoute {
+		return &gatewayapi_v1alpha1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+				Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+					ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+						ServiceName: pointer.StringPtr(name),
+					}},
+				}},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		cache *KubernetesCache
+		svc   *v1.Service
+		want  bool
+	}{
+		"empty cache does not trigger rebuild": {
+			cache: cache(),
+			svc:   service("default", "service-1"),
+			want:  false,
+		},
+		"ingress backend exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				ingressBackendService("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"ingress backend does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				ingressBackendService("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"ingress default backend exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				ingressDefaultBackend("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"ingress default backend does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				ingressDefaultBackend("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"httpproxy exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				httpProxy("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"httpproxy does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				httpProxy("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"tcproxy exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				tcpProxy("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"tcpproxy does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				tcpProxy("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"httproute exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				httpRoute("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"httproute does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				httpRoute("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cache.serviceTriggersRebuild(tc.svc))
+		})
+	}
+}
+
+func TestSecretTriggersRebuild(t *testing.T) {
+
+	secret := func(namespace, name string) *v1.Secret {
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: v1.SecretTypeTLS,
+			Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
+		}
+	}
+
+	caSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ca",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			CACertificateKey: []byte(fixture.CERTIFICATE),
+		},
+	}
+
+	tlsCertificateDelegation := func(namespace, name string, targetNamespaces ...string) *contour_api_v1.TLSCertificateDelegation {
+		return &contour_api_v1.TLSCertificateDelegation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: contour_api_v1.TLSCertificateDelegationSpec{
+				Delegations: []contour_api_v1.CertificateDelegation{{
+					SecretName:       name,
+					TargetNamespaces: targetNamespaces,
+				}},
+			},
+		}
+	}
+
+	ingress := func(namespace, name, secretName string) *networking_v1.Ingress {
+		return &networking_v1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: networking_v1.IngressSpec{
+				TLS: []networking_v1.IngressTLS{{
+					SecretName: secretName,
+				}},
+			},
+		}
+	}
+
+	cache := func(objs ...interface{}) *KubernetesCache {
+		cache := KubernetesCache{
+			FieldLogger: fixture.NewTestLogger(t),
+			Gateway: types.NamespacedName{
+				Name:      "contour",
+				Namespace: "projectcontour",
+			},
+		}
+		for _, o := range objs {
+			cache.Insert(o)
+		}
+		return &cache
+	}
+
+	httpProxy := func(namespace, name, secretName string) *contour_api_v1.HTTPProxy {
+		return &contour_api_v1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: contour_api_v1.HTTPProxySpec{
+				VirtualHost: &contour_api_v1.VirtualHost{
+					Fqdn: "",
+					TLS: &contour_api_v1.TLS{
+						SecretName: secretName,
+					},
+				},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		cache  *KubernetesCache
+		secret *v1.Secret
+		want   bool
+	}{
+		"empty cache does not trigger rebuild": {
+			cache:  cache(),
+			secret: secret("default", "secret"),
+			want:   false,
+		},
+		"CA secret triggers rebuild": {
+			cache:  cache(),
+			secret: caSecret,
+			want:   true,
+		},
+		"ingress secret triggers rebuild": {
+			cache: cache(
+				ingress("default", "secret", "secret"),
+			),
+			secret: secret("default", "secret"),
+			want:   true,
+		},
+		"ingress with delegated secret (specific namespace) triggers rebuild": {
+			cache: cache(
+				tlsCertificateDelegation("default", "tlscert", "user"),
+				ingress("user", "ingress", "default/tlscert"),
+			),
+			secret: secret("default", "tlscert"),
+			want:   true,
+		},
+		"ingress with delegated secret ('*' namespace) triggers rebuild": {
+			cache: cache(
+				tlsCertificateDelegation("default", "tlscert", "*"),
+				ingress("user", "ingress", "default/tlscert"),
+			),
+			secret: secret("default", "tlscert"),
+			want:   true,
+		},
+		"httpproxy empty vhost does not trigger rebuild": {
+			cache: cache(
+				&contour_api_v1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "proxy",
+						Namespace: "default",
+					},
+					Spec: contour_api_v1.HTTPProxySpec{},
+				},
+			),
+			secret: secret("default", "tlscert"),
+			want:   false,
+		},
+		"httpproxy empty TLS does not trigger rebuild": {
+			cache: cache(
+				&contour_api_v1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "proxy",
+						Namespace: "default",
+					},
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							Fqdn: "test.projectcontour.io",
+						},
+					},
+				},
+			),
+			secret: secret("default", "tlscert"),
+			want:   false,
+		},
+		"httpproxy secret triggers rebuild": {
+			cache: cache(
+				httpProxy("default", "proxy", "tlscert"),
+			),
+			secret: secret("default", "tlscert"),
+			want:   true,
+		},
+		"httpproxy with delegated secret (specific namespace) triggers rebuild": {
+			cache: cache(
+				tlsCertificateDelegation("default", "tlscert", "user"),
+				httpProxy("user", "ingress", "default/tlscert"),
+			),
+			secret: secret("default", "tlscert"),
+			want:   true,
+		},
+		"httpproxy with delegated secret ('*' namespace) triggers rebuild": {
+			cache: cache(
+				tlsCertificateDelegation("default", "tlscert", "*"),
+				httpProxy("user", "ingress", "default/tlscert"),
+			),
+			secret: secret("default", "tlscert"),
+			want:   true,
+		},
+		"configuration file secret triggers rebuild": {
+			cache: &KubernetesCache{
+				FieldLogger: fixture.NewTestLogger(t),
+				ConfiguredSecretRefs: []*types.NamespacedName{{
+					Namespace: "user",
+					Name:      "tlscert",
+				}},
+			},
+			secret: secret("user", "tlscert"),
+			want:   true,
+		},
+		"no defined gateway does not trigger rebuild": {
+			cache: &KubernetesCache{
+				FieldLogger: fixture.NewTestLogger(t),
+				gateway:     nil,
+			},
+			secret: secret("default", "tlscert"),
+			want:   false,
+		},
+		"gateway does not define TLS on listener, does not trigger rebuild": {
+			cache: cache(
+				&gatewayapi_v1alpha1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1alpha1.GatewaySpec{
+						Listeners: []gatewayapi_v1alpha1.Listener{{
+							TLS: nil,
+						}},
+					},
+				},
+			),
+			secret: secret("default", "tlscert"),
+			want:   false,
+		},
+		"gateway does not define TLS.CertificateRef on listener, does not trigger rebuild": {
+			cache: cache(
+				&gatewayapi_v1alpha1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1alpha1.GatewaySpec{
+						Listeners: []gatewayapi_v1alpha1.Listener{{
+							TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+								CertificateRef: nil,
+							},
+						}},
+					},
+				},
+			),
+			secret: secret("default", "tlscert"),
+			want:   false,
+		},
+		"gateway listener references secret, triggers rebuild (core Group)": {
+			cache: cache(
+				&gatewayapi_v1alpha1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1alpha1.GatewaySpec{
+						Listeners: []gatewayapi_v1alpha1.Listener{{
+							TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+								CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
+									Group: "core",
+									Kind:  "Secret",
+									Name:  "tlscert",
+								},
+							},
+						}},
+					},
+				},
+			),
+			secret: secret("projectcontour", "tlscert"),
+			want:   true,
+		},
+		"gateway listener references secret, triggers rebuild (v1 Group)": {
+			cache: cache(
+				&gatewayapi_v1alpha1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1alpha1.GatewaySpec{
+						Listeners: []gatewayapi_v1alpha1.Listener{{
+							TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+								CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
+									Group: "v1",
+									Kind:  "Secret",
+									Name:  "tlscert",
+								},
+							},
+						}},
+					},
+				},
+			),
+			secret: secret("projectcontour", "tlscert"),
+			want:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cache.secretTriggersRebuild(tc.secret))
 		})
 	}
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -1559,7 +1559,7 @@ func TestSecretTriggersRebuild(t *testing.T) {
 						Listeners: []gatewayapi_v1alpha1.Listener{{
 							TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
 								CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
-									Group: "v1",
+									Group: "core",
 									Kind:  "Secret",
 									Name:  "tlscert",
 								},


### PR DESCRIPTION
If a secret referenced by a Gateway or a service referenced by a HTTPRoute changes, the dag
should be rebuilt.

Also, adds missing tests for ingress, httpproxy, and secret delegation that were missing.

Closes #3476.

Signed-off-by: Steve Sloka <slokas@vmware.com>