### PR TITLE
pkg/config: Make gatewayconfig optional

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -522,7 +522,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 
 			builder := Builder{
 				Source: KubernetesCache{
-					Gateway: types.NamespacedName{
+					ConfiguredGateway: types.NamespacedName{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -45,8 +45,8 @@ type KubernetesCache struct {
 	// If not set, defaults to DEFAULT_INGRESS_CLASS.
 	IngressClass string
 
-	// Gateway defines the current Gateway which Contour is configured to watch.
-	Gateway types.NamespacedName
+	// ConfiguredGateway defines the current Gateway which Contour is configured to watch.
+	ConfiguredGateway types.NamespacedName
 
 	// Secrets that are referred from the configuration file.
 	ConfiguredSecretRefs []*types.NamespacedName
@@ -108,14 +108,14 @@ func (kc *KubernetesCache) matchesIngressClass(obj metav1.Object) bool {
 // belongs to the Gateway that this cache is using.
 func (kc *KubernetesCache) matchesGateway(obj *gatewayapi_v1alpha1.Gateway) bool {
 
-	if k8s.NamespacedNameOf(obj) != kc.Gateway {
+	if k8s.NamespacedNameOf(obj) != kc.ConfiguredGateway {
 		kind := k8s.KindOf(obj)
 
 		kc.WithField("name", obj.GetName()).
 			WithField("namespace", obj.GetNamespace()).
 			WithField("kind", kind).
-			WithField("configured gateway name", kc.Gateway.Name).
-			WithField("configured gateway namespace", kc.Gateway.Namespace).
+			WithField("configured gateway name", kc.ConfiguredGateway.Name).
+			WithField("configured gateway namespace", kc.ConfiguredGateway.Namespace).
 			Debug("ignoring object with unmatched gateway")
 		return false
 	}

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -727,7 +727,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				ConfiguredSecretRefs: []*types.NamespacedName{
 					{Name: "secretReferredByConfigFile", Namespace: "default"}},
 				FieldLogger: fixture.NewTestLogger(t),
-				Gateway: types.NamespacedName{
+				ConfiguredGateway: types.NamespacedName{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
@@ -745,7 +745,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 	cache := func(objs ...interface{}) *KubernetesCache {
 		cache := KubernetesCache{
 			FieldLogger: fixture.NewTestLogger(t),
-			Gateway: types.NamespacedName{
+			ConfiguredGateway: types.NamespacedName{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
@@ -1351,7 +1351,7 @@ func TestSecretTriggersRebuild(t *testing.T) {
 	cache := func(objs ...interface{}) *KubernetesCache {
 		cache := KubernetesCache{
 			FieldLogger: fixture.NewTestLogger(t),
-			Gateway: types.NamespacedName{
+			ConfiguredGateway: types.NamespacedName{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -44,10 +44,17 @@ func (s ServerType) Validate() error {
 }
 
 // Validate the GatewayConfig.
-// Name & Namespace must be specified.
-func (g GatewayParameters) Validate() error {
+func (g *GatewayParameters) Validate() error {
 
 	var errorString string
+	if g == nil {
+		return nil
+	}
+
+	if len(g.Name) == 0 && len(g.Namespace) == 0 {
+		return nil
+	}
+
 	if len(g.Name) == 0 {
 		errorString = "name required"
 	}
@@ -486,7 +493,7 @@ type Parameters struct {
 
 	// GatewayConfig contains parameters for the gateway-api Gateway that Contour
 	// is configured to serve traffic.
-	GatewayConfig GatewayParameters `yaml:"gateway,omitempty"`
+	GatewayConfig *GatewayParameters `yaml:"gateway,omitempty"`
 
 	// Address to be placed in status.loadbalancer field of Ingress objects.
 	// May be either a literal IP address or a host name.
@@ -630,10 +637,6 @@ func Defaults() Parameters {
 		Kubeconfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		Server: ServerParameters{
 			XDSServerType: ContourServerType,
-		},
-		GatewayConfig: GatewayParameters{
-			Name:      "contour",
-			Namespace: contourNamespace,
 		},
 		IngressStatusAddress:      "",
 		AccessLogFormat:           DEFAULT_ACCESS_LOG_TYPE,

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -49,9 +49,6 @@ debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
   xds-server-type: contour
-gateway:
-  name: contour
-  namespace: projectcontour
 accesslog-format: envoy
 json-fields:
 - '@timestamp'
@@ -165,9 +162,17 @@ func TestValidateServerType(t *testing.T) {
 }
 
 func TestValidateGatewayParameters(t *testing.T) {
-	assert.EqualError(t, GatewayParameters{Name: "gwname", Namespace: ""}.Validate(), "invalid Gateway parameters specified: namespace required")
-	assert.EqualError(t, GatewayParameters{Name: "", Namespace: "ns"}.Validate(), "invalid Gateway parameters specified: name required")
-	assert.EqualError(t, GatewayParameters{Name: "", Namespace: ""}.Validate(), "invalid Gateway parameters specified: name required, namespace required")
+	// Namespace is required if name is passed.
+	gw := &GatewayParameters{Name: "gwname", Namespace: ""}
+	assert.EqualError(t, gw.Validate(), "invalid Gateway parameters specified: namespace required")
+
+	// Name is required if namespace if passed.
+	gw = &GatewayParameters{Name: "", Namespace: "ns"}
+	assert.EqualError(t, gw.Validate(), "invalid Gateway parameters specified: name required")
+
+	// Not required if both aren't passed.
+	gw = &GatewayParameters{Name: "", Namespace: ""}
+	assert.Equal(t, nil, gw.Validate())
 }
 
 func TestValidateAccessLogType(t *testing.T) {


### PR DESCRIPTION
Takes away the default gatewayapi gateway configuration and makes it optional. This helps determine
which listener configuration values should be used for Contour.

This does change behavior in the config file, however, it's against an alpha api without any usage so to me this is fine to change. 

Fixes #3479

Signed-off-by: Steve Sloka <slokas@vmware.com>