### PR TITLE
Use debug log level for the "handling v3 xDS resource request" log message

### DIFF
--- a/internal/xds/v3/callbacks.go
+++ b/internal/xds/v3/callbacks.go
@@ -54,7 +54,8 @@ func logDiscoveryRequestDetails(l logrus.FieldLogger, req *envoy_service_discove
 	}
 
 	log = log.WithField("resource_names", req.ResourceNames).WithField("type_url", req.GetTypeUrl())
-	log.Info("handling v3 xDS resource request")
+
+	log.Debug("handling v3 xDS resource request")
 
 	return log
 }

--- a/internal/xds/v3/callbacks_test.go
+++ b/internal/xds/v3/callbacks_test.go
@@ -29,6 +29,8 @@ import (
 
 func TestLogDiscoveryRequestDetails(t *testing.T) {
 	log, logHook := test.NewNullLogger()
+	log.SetLevel(logrus.DebugLevel)
+
 	tests := map[string]struct {
 		discoveryReq    *envoy_service_discovery_v3.DiscoveryRequest
 		expectedLogMsg  string
@@ -135,6 +137,8 @@ func TestLogDiscoveryRequestDetails(t *testing.T) {
 
 func TestOnStreamRequestCallbackLogs(t *testing.T) {
 	log, logHook := test.NewNullLogger()
+	log.SetLevel(logrus.DebugLevel)
+
 	callbacks := NewRequestLoggingCallbacks(log)
 	err := callbacks.OnStreamRequest(999, &envoy_service_discovery_v3.DiscoveryRequest{
 		VersionInfo:   "req-version",


### PR DESCRIPTION
The `handling v3 xDS resource request` info message is quite verbose on the Contour setup with many Envoys, so it makes sense to set the log level for the message to debug.

Fixes: https://github.com/projectcontour/contour/issues/3483