### PR TITLE
internal/xdscache/v3: Sort dag Routes before converting to Envoy Routes

### DIFF
--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -78,32 +78,32 @@ func mergeHeaderMatchConditions(conds []contour_api_v1.MatchCondition) []HeaderM
 		case cond.Header.Present:
 			hc = append(hc, HeaderMatchCondition{
 				Name:      cond.Header.Name,
-				MatchType: "present",
+				MatchType: HeaderMatchTypePresent,
 			})
 		case cond.Header.Contains != "":
 			hc = append(hc, HeaderMatchCondition{
 				Name:      cond.Header.Name,
 				Value:     cond.Header.Contains,
-				MatchType: "contains",
+				MatchType: HeaderMatchTypeContains,
 			})
 		case cond.Header.NotContains != "":
 			hc = append(hc, HeaderMatchCondition{
 				Name:      cond.Header.Name,
 				Value:     cond.Header.NotContains,
-				MatchType: "contains",
+				MatchType: HeaderMatchTypeContains,
 				Invert:    true,
 			})
 		case cond.Header.Exact != "":
 			hc = append(hc, HeaderMatchCondition{
 				Name:      cond.Header.Name,
 				Value:     cond.Header.Exact,
-				MatchType: "exact",
+				MatchType: HeaderMatchTypeExact,
 			})
 		case cond.Header.NotExact != "":
 			hc = append(hc, HeaderMatchCondition{
 				Name:      cond.Header.Name,
 				Value:     cond.Header.NotExact,
-				MatchType: "exact",
+				MatchType: HeaderMatchTypeExact,
 				Invert:    true,
 			})
 		}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -129,6 +129,18 @@ func (rc *RegexMatchCondition) String() string {
 	return "regex: " + rc.Regex
 }
 
+const (
+	// HeaderMatchTypeExact matches a header value exactly.
+	HeaderMatchTypeExact = "exact"
+
+	// HeaderMatchTypeContains matches a header value if it contains the
+	// provided value.
+	HeaderMatchTypeContains = "contains"
+
+	// HeaderMatchTypePresent matches a header if it is present in a request.
+	HeaderMatchTypePresent = "present"
+)
+
 // HeaderMatchCondition matches request headers by MatchType
 type HeaderMatchCondition struct {
 	Name      string

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -347,11 +347,11 @@ func headerMatcher(headers []dag.HeaderMatchCondition) []*envoy_route_v3.HeaderM
 		}
 
 		switch h.MatchType {
-		case "exact":
+		case dag.HeaderMatchTypeExact:
 			header.HeaderMatchSpecifier = &envoy_route_v3.HeaderMatcher_ExactMatch{ExactMatch: h.Value}
-		case "contains":
+		case dag.HeaderMatchTypeContains:
 			header.HeaderMatchSpecifier = containsMatch(h.Value)
-		case "present":
+		case dag.HeaderMatchTypePresent:
 			header.HeaderMatchSpecifier = &envoy_route_v3.HeaderMatcher_PresentMatch{PresentMatch: true}
 		}
 		envoyHeaders = append(envoyHeaders, header)

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -47,7 +47,7 @@ type headerMatchConditionSorter []dag.HeaderMatchCondition
 func (s headerMatchConditionSorter) Len() int      { return len(s) }
 func (s headerMatchConditionSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s headerMatchConditionSorter) Less(i, j int) bool {
-	sortValue := func(a dag.HeaderMatchCondition, b dag.HeaderMatchCondition) bool {
+	compareValue := func(a dag.HeaderMatchCondition, b dag.HeaderMatchCondition) bool {
 		switch strings.Compare(a.Value, b.Value) {
 		case -1:
 			return true
@@ -71,7 +71,7 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 			// Exact matches are most specific so they sort first.
 			switch s[j].MatchType {
 			case dag.HeaderMatchTypeExact:
-				return sortValue(s[i], s[j])
+				return compareValue(s[i], s[j])
 			case dag.HeaderMatchTypeContains:
 				return true
 			case dag.HeaderMatchTypePresent:
@@ -81,7 +81,7 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 			// Contains matches sort ahead of Present matches.
 			switch s[j].MatchType {
 			case dag.HeaderMatchTypeContains:
-				return sortValue(s[i], s[j])
+				return compareValue(s[i], s[j])
 			case dag.HeaderMatchTypePresent:
 				return true
 			}

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -23,7 +23,7 @@ import (
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/dag"
 )
 
 // Sorts the given route configuration values by name.
@@ -40,13 +40,13 @@ func (s virtualHostSorter) Len() int           { return len(s) }
 func (s virtualHostSorter) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s virtualHostSorter) Less(i, j int) bool { return s[i].Name < s[j].Name }
 
-// Sorts HeaderMatcher objects, first by the header name,
-// then by their matcher conditions (textually).
-type headerMatcherSorter []*envoy_route_v3.HeaderMatcher
+// Sorts HeaderMatchCondition objects, first by the header name,
+// then by their matcher conditions type.
+type headerMatchConditionSorter []dag.HeaderMatchCondition
 
-func (s headerMatcherSorter) Len() int      { return len(s) }
-func (s headerMatcherSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s headerMatcherSorter) Less(i, j int) bool {
+func (s headerMatchConditionSorter) Len() int      { return len(s) }
+func (s headerMatchConditionSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s headerMatchConditionSorter) Less(i, j int) bool {
 	val := strings.Compare(s[i].Name, s[j].Name)
 	switch val {
 	case -1:
@@ -54,44 +54,63 @@ func (s headerMatcherSorter) Less(i, j int) bool {
 	case 1:
 		return false
 	case 0:
-		return proto.CompactTextString(s[i]) < proto.CompactTextString(s[j])
+		switch s[i].MatchType {
+		case dag.HeaderMatchTypeExact:
+			// Exact matches are most specific so they sort first.
+			switch s[j].MatchType {
+			case dag.HeaderMatchTypeContains:
+				return true
+			case dag.HeaderMatchTypePresent:
+				return true
+			}
+		case dag.HeaderMatchTypeContains:
+			// Contains matches sort ahead of Present matches.
+			switch s[j].MatchType {
+			case dag.HeaderMatchTypePresent:
+				return true
+			}
+		case dag.HeaderMatchTypePresent:
+			// These sort last.
+			return false
+		}
 	}
 
-	panic("bad comparison")
+	return false
 }
 
-// longestRouteByHeaders compares the HeaderMatcher slices for lhs and rhs and
-// returns true if lhs is longer.
-func longestRouteByHeaders(lhs, rhs *envoy_route_v3.Route) bool {
-	if len(lhs.Match.Headers) == len(rhs.Match.Headers) {
-		pair := make([]*envoy_route_v3.HeaderMatcher, 2)
+// longestRouteByHeaderConditions compares the HeaderMatchCondition slices for
+// lhs and rhs and returns true if lhs is longer.
+func longestRouteByHeaderConditions(lhs, rhs *dag.Route) bool {
+	if len(lhs.HeaderMatchConditions) == len(rhs.HeaderMatchConditions) {
+		pair := make([]dag.HeaderMatchCondition, 2)
 
-		for i := 0; i < len(lhs.Match.Headers); i++ {
-			pair[0] = lhs.Match.Headers[i]
-			pair[1] = rhs.Match.Headers[i]
+		for i := 0; i < len(lhs.HeaderMatchConditions); i++ {
+			pair[0] = lhs.HeaderMatchConditions[i]
+			pair[1] = rhs.HeaderMatchConditions[i]
 
-			if headerMatcherSorter(pair).Less(0, 1) {
+			if headerMatchConditionSorter(pair).Less(0, 1) {
 				return true
 			}
 		}
 	}
 
-	return len(lhs.Match.Headers) > len(rhs.Match.Headers)
+	return len(lhs.HeaderMatchConditions) > len(rhs.HeaderMatchConditions)
 }
 
 // Sorts the given Route slice in place. Routes are ordered first by
-// longest prefix (or regex), then by the length of the HeaderMatch
+// type (exact sorts before regex, sorts before prefix) and then
+// longest path match value, then by the length of the HeaderMatch
 // slice (if any). The HeaderMatch slice is also ordered by the matching
 // header name.
-type routeSorter []*envoy_route_v3.Route
+type routeSorter []*dag.Route
 
 func (s routeSorter) Len() int      { return len(s) }
 func (s routeSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s routeSorter) Less(i, j int) bool {
-	switch a := s[i].Match.PathSpecifier.(type) {
-	case *envoy_route_v3.RouteMatch_Prefix:
-		switch b := s[j].Match.PathSpecifier.(type) {
-		case *envoy_route_v3.RouteMatch_Prefix:
+	switch a := s[i].PathMatchCondition.(type) {
+	case *dag.PrefixMatchCondition:
+		switch b := s[j].PathMatchCondition.(type) {
+		case *dag.PrefixMatchCondition:
 			cmp := strings.Compare(a.Prefix, b.Prefix)
 			switch cmp {
 			case 1:
@@ -100,13 +119,13 @@ func (s routeSorter) Less(i, j int) bool {
 			case -1:
 				return false
 			default:
-				return longestRouteByHeaders(s[i], s[j])
+				return longestRouteByHeaderConditions(s[i], s[j])
 			}
 		}
-	case *envoy_route_v3.RouteMatch_SafeRegex:
-		switch b := s[j].Match.PathSpecifier.(type) {
-		case *envoy_route_v3.RouteMatch_SafeRegex:
-			cmp := strings.Compare(a.SafeRegex.Regex, b.SafeRegex.Regex)
+	case *dag.RegexMatchCondition:
+		switch b := s[j].PathMatchCondition.(type) {
+		case *dag.RegexMatchCondition:
+			cmp := strings.Compare(a.Regex, b.Regex)
 			switch cmp {
 			case 1:
 				// Sort longest regex first.
@@ -114,9 +133,27 @@ func (s routeSorter) Less(i, j int) bool {
 			case -1:
 				return false
 			default:
-				return longestRouteByHeaders(s[i], s[j])
+				return longestRouteByHeaderConditions(s[i], s[j])
 			}
-		case *envoy_route_v3.RouteMatch_Prefix:
+		case *dag.PrefixMatchCondition:
+			return true
+		}
+	case *dag.ExactMatchCondition:
+		switch b := s[j].PathMatchCondition.(type) {
+		case *dag.ExactMatchCondition:
+			cmp := strings.Compare(a.Path, b.Path)
+			switch cmp {
+			case 1:
+				// Sort longest path first.
+				return true
+			case -1:
+				return false
+			default:
+				return longestRouteByHeaderConditions(s[i], s[j])
+			}
+		case *dag.PrefixMatchCondition:
+			return true
+		case *dag.RegexMatchCondition:
 			return true
 		}
 	}
@@ -212,10 +249,10 @@ func For(v interface{}) sort.Interface {
 		return routeConfigurationSorter(v)
 	case []*envoy_route_v3.VirtualHost:
 		return virtualHostSorter(v)
-	case []*envoy_route_v3.Route:
+	case []*dag.Route:
 		return routeSorter(v)
-	case []*envoy_route_v3.HeaderMatcher:
-		return headerMatcherSorter(v)
+	case []dag.HeaderMatchCondition:
+		return headerMatchConditionSorter(v)
 	case []*envoy_cluster_v3.Cluster:
 		return clusterSorter(v)
 	case []*envoy_endpoint_v3.ClusterLoadAssignment:

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -53,7 +53,7 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 		return true
 	case 1:
 		return false
-	case 0:
+	default:
 		switch s[i].MatchType {
 		case dag.HeaderMatchTypeExact:
 			// Exact matches are most specific so they sort first.
@@ -69,13 +69,9 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 			case dag.HeaderMatchTypePresent:
 				return true
 			}
-		case dag.HeaderMatchTypePresent:
-			// These sort last.
-			return false
 		}
+		return false
 	}
-
-	return false
 }
 
 // longestRouteByHeaderConditions compares the HeaderMatchCondition slices for

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -148,6 +148,9 @@ func TestSortRoutesPathMatch(t *testing.T) {
 			PathMatchCondition: matchRegex(`/foo((\/).*)*`),
 		},
 		{
+			PathMatchCondition: matchRegex("/"),
+		},
+		{
 			PathMatchCondition: matchRegex("."),
 		},
 		{
@@ -173,6 +176,48 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 			// Although the header names are the same, this value
 			// should sort before the next one because it is
 			// textually longer.
+			PathMatchCondition: matchExact("/pathexact"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("header-name", "header-value"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/pathexact"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				presentHeader("header-name"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/pathexact"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("long-header-name", "long-header-value"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/pathexact"),
+		},
+		{
+			PathMatchCondition: matchRegex("/pathregex"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("header-name", "header-value"),
+			},
+		},
+		{
+			PathMatchCondition: matchRegex("/pathregex"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				presentHeader("header-name"),
+			},
+		},
+		{
+			PathMatchCondition: matchRegex("/pathregex"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("long-header-name", "long-header-value"),
+			},
+		},
+		{
+			PathMatchCondition: matchRegex("/pathregex"),
+		},
+		{
 			PathMatchCondition: matchPrefix("/path"),
 			HeaderMatchConditions: []dag.HeaderMatchCondition{
 				exactHeader("header-name", "header-value"),
@@ -221,6 +266,7 @@ func TestSortHeaderMatchConditions(t *testing.T) {
 		// Note that if the header names are the same, we
 		// order by the type, "exact" sorts before "contains"
 		// which sorts before "present" in terms of specificity.
+		presentHeader("ashort"),
 		exactHeader("header-name", "anything"),
 		containsHeader("header-name", "something"),
 		presentHeader("header-name"),
@@ -228,10 +274,11 @@ func TestSortHeaderMatchConditions(t *testing.T) {
 	}
 
 	have := []dag.HeaderMatchCondition{
+		want[4],
 		want[3],
+		want[0],
 		want[2],
 		want[1],
-		want[0],
 	}
 
 	sort.Stable(For(have))

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -63,7 +63,7 @@ func TestSortRouteConfiguration(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortVirtualHosts(t *testing.T) {
@@ -84,7 +84,7 @@ func TestSortVirtualHosts(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func matchPrefix(str string) *dag.PrefixMatchCondition {
@@ -103,6 +103,11 @@ func matchExact(str string) *dag.ExactMatchCondition {
 	return &dag.ExactMatchCondition{
 		Path: str,
 	}
+}
+
+func invertHeaderMatch(h dag.HeaderMatchCondition) dag.HeaderMatchCondition {
+	h.Invert = true
+	return h
 }
 
 func exactHeader(name string, value string) dag.HeaderMatchCondition {
@@ -167,7 +172,7 @@ func TestSortRoutesPathMatch(t *testing.T) {
 	have := shuffleRoutes(want)
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortRoutesLongestHeaders(t *testing.T) {
@@ -258,7 +263,7 @@ func TestSortSecrets(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortHeaderMatchConditions(t *testing.T) {
@@ -282,7 +287,59 @@ func TestSortHeaderMatchConditions(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
+}
+
+func TestSortHeaderMatchConditionsInverted(t *testing.T) {
+	// Inverted matches sort after standard matches.
+	want := []dag.HeaderMatchCondition{
+		exactHeader("header-name", "anything"),
+		invertHeaderMatch(exactHeader("header-name", "anything")),
+		containsHeader("header-name", "something"),
+		invertHeaderMatch(containsHeader("header-name", "something")),
+		presentHeader("header-name"),
+		invertHeaderMatch(presentHeader("header-name")),
+	}
+
+	have := []dag.HeaderMatchCondition{
+		want[5],
+		want[4],
+		want[3],
+		want[2],
+		want[1],
+		want[0],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, want, have)
+}
+
+func TestSortHeaderMatchConditionsValue(t *testing.T) {
+	// Use string comparison to sort values.
+	want := []dag.HeaderMatchCondition{
+		exactHeader("header-name", "a"),
+		invertHeaderMatch(exactHeader("header-name", "a")),
+		exactHeader("header-name", "b"),
+		exactHeader("header-name", "c"),
+		containsHeader("header-name", "a"),
+		invertHeaderMatch(containsHeader("header-name", "a")),
+		containsHeader("header-name", "b"),
+		containsHeader("header-name", "c"),
+	}
+
+	have := []dag.HeaderMatchCondition{
+		want[6],
+		want[5],
+		want[4],
+		want[7],
+		want[2],
+		want[1],
+		want[0],
+		want[3],
+	}
+
+	sort.Stable(For(have))
+	assert.Equal(t, want, have)
 }
 
 func TestSortClusters(t *testing.T) {
@@ -297,7 +354,7 @@ func TestSortClusters(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortClusterLoadAssignments(t *testing.T) {
@@ -312,7 +369,7 @@ func TestSortClusterLoadAssignments(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortHTTPWeightedClusters(t *testing.T) {
@@ -338,7 +395,7 @@ func TestSortHTTPWeightedClusters(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortTCPWeightedClusters(t *testing.T) {
@@ -364,7 +421,7 @@ func TestSortTCPWeightedClusters(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortListeners(t *testing.T) {
@@ -379,7 +436,7 @@ func TestSortListeners(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }
 
 func TestSortFilterChains(t *testing.T) {
@@ -417,5 +474,5 @@ func TestSortFilterChains(t *testing.T) {
 	}
 
 	sort.Stable(For(have))
-	assert.Equal(t, have, want)
+	assert.Equal(t, want, have)
 }

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -138,27 +138,27 @@ func (v *routeVisitor) onVirtualHost(vh *dag.VirtualHost) {
 				Match:  envoy_v3.RouteMatch(route),
 				Action: envoy_v3.UpgradeHTTPS(),
 			}
-		} else {
-			rt := &envoy_route_v3.Route{
-				Match:  envoy_v3.RouteMatch(route),
-				Action: envoy_v3.RouteRoute(route),
-			}
-			if route.RequestHeadersPolicy != nil {
-				rt.RequestHeadersToAdd = envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false)
-				rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
-			}
-			if route.ResponseHeadersPolicy != nil {
-				rt.ResponseHeadersToAdd = envoy_v3.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
-				rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
-			}
-			if route.RateLimitPolicy != nil && route.RateLimitPolicy.Local != nil {
-				if rt.TypedPerFilterConfig == nil {
-					rt.TypedPerFilterConfig = map[string]*any.Any{}
-				}
-				rt.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"] = envoy_v3.LocalRateLimitConfig(route.RateLimitPolicy.Local, "vhost."+vh.Name)
-			}
-			return rt
 		}
+		rt := &envoy_route_v3.Route{
+			Match:  envoy_v3.RouteMatch(route),
+			Action: envoy_v3.RouteRoute(route),
+		}
+		if route.RequestHeadersPolicy != nil {
+			rt.RequestHeadersToAdd = envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+			rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
+		}
+		if route.ResponseHeadersPolicy != nil {
+			rt.ResponseHeadersToAdd = envoy_v3.HeaderValueList(route.ResponseHeadersPolicy.Set, false)
+			rt.ResponseHeadersToRemove = route.ResponseHeadersPolicy.Remove
+		}
+		if route.RateLimitPolicy != nil && route.RateLimitPolicy.Local != nil {
+			if rt.TypedPerFilterConfig == nil {
+				rt.TypedPerFilterConfig = map[string]*any.Any{}
+			}
+			rt.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"] = envoy_v3.LocalRateLimitConfig(route.RateLimitPolicy.Local, "vhost."+vh.Name)
+		}
+		return rt
+
 	}
 
 	if len(routes) > 0 {

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -321,6 +321,14 @@ func (v *routeVisitor) visit(vertex dag.Vertex) {
 // first by path match type, path match value via string comparison and
 // then by the length of the HeaderMatch slice (if any). The HeaderMatch
 // slice is also ordered by the matching header name.
+// We sort dag.Route objects before converting to Envoy types to ensure
+// more accurate ordering of route matches. Contour route match types may
+// be implemented by Envoy route match types that change over time, or by
+// types that do not exactly match to the type in Contour (e.g. using a
+// regex matcher to implement a different type of match). Sorting based on
+// Contour types instead ensures we can sort from most to least specific
+// route match regardless of the underlying Envoy type that is used to
+// implement the match.
 func sortRoutes(routes []*dag.Route) {
 	for _, r := range routes {
 		sort.Stable(sorter.For(r.HeaderMatchConditions))

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcontour/contour/internal/dag"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2832,65 +2833,81 @@ func TestRouteVisit(t *testing.T) {
 
 func TestSortLongestRouteFirst(t *testing.T) {
 	tests := map[string]struct {
-		routes []*envoy_route_v3.Route
-		want   []*envoy_route_v3.Route
+		routes []*dag.Route
+		want   []*dag.Route
 	}{
 		"two prefixes": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/"),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}, {
-				Match: routePrefix("/longer"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/longer"},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/longer"),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/longer"},
 			}, {
-				Match: routePrefix("/"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}},
 		},
 		"two regexes": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routeRegex("/v2"),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/v2"},
 			}, {
-				Match: routeRegex("/v1/.+"),
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/v1/.+"},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routeRegex("/v2"),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/v2"},
 			}, {
-				Match: routeRegex("/v1/.+"),
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/v1/.+"},
 			}},
 		},
-		"regex sorts before prefix": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routeRegex("/api/v?"),
+		"two exact matches": {
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/foo"},
 			}, {
-				Match: routePrefix("/"),
-			}, {
-				Match: routeRegex(".*"),
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/foo/"},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routeRegex("/api/v?"),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/foo/"},
 			}, {
-				Match: routeRegex(".*"),
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/foo"},
+			}},
+		},
+		"exact sorts before regex sorts before prefix": {
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/api/v?"},
 			}, {
-				Match: routePrefix("/"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+			}, {
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: ".*"},
+			}, {
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/api/"},
+			}},
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.ExactMatchCondition{Path: "/api/"},
+			}, {
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: "/api/v?"},
+			}, {
+				PathMatchCondition: &dag.RegexMatchCondition{Regex: ".*"},
+			}, {
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}},
 		},
 		"more headers sort before less": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/"),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}, {
-				Match: routePrefix("/", dag.HeaderMatchCondition{
-					Name:      "x-request-id",
-					MatchType: "present",
-				}),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-id", MatchType: "present"},
+				},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/", dag.HeaderMatchCondition{
-					Name:      "x-request-id",
-					MatchType: "present",
-				}),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-id", MatchType: "present"},
+				},
 			}, {
-				Match: routePrefix("/"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}},
 		},
 
@@ -2902,71 +2919,77 @@ func TestSortLongestRouteFirst(t *testing.T) {
 		// allows us to avoid comparing the header matches
 		// unless necessary.
 		"longest path before longest headers": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/", dag.HeaderMatchCondition{
-					Name:      "x-request-id",
-					MatchType: "present",
-				}),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-id", MatchType: "present"},
+				},
 			}, {
-				Match: routePrefix("/longest/path/match"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/longest/path/match"},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/longest/path/match"),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/longest/path/match"},
 			}, {
-				Match: routePrefix("/", dag.HeaderMatchCondition{
-					Name:      "x-request-id",
-					MatchType: "present",
-				}),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-id", MatchType: "present"},
+				},
 			}},
 		},
 
 		// The path and the length of header condition list are equal,
 		// so we should order lexicographically by header name.
 		"headers sort stably by name": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "zzz-2", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "zzz-1", MatchType: "present"},
-				),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "zzz-2", MatchType: "present"},
+					{Name: "zzz-1", MatchType: "present"},
+				},
 			}, {
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "aaa-2", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "aaa-1", MatchType: "present"},
-				),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "aaa-2", MatchType: "present"},
+					{Name: "aaa-1", MatchType: "present"},
+				},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "aaa-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "aaa-2", MatchType: "present"},
-				),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "aaa-1", MatchType: "present"},
+					{Name: "aaa-2", MatchType: "present"},
+				},
 			}, {
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "zzz-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "zzz-2", MatchType: "present"},
-				),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "zzz-1", MatchType: "present"},
+					{Name: "zzz-2", MatchType: "present"},
+				},
 			}},
 		},
 
 		// If we have multiple conditions on the same header, ensure
 		// that we order on the match type too.
 		"headers order by match type": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/"),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}, {
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "x-request-2", MatchType: "present", Invert: true},
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "exact", Value: "foo"},
-				),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-1", MatchType: "present"},
+					{Name: "x-request-2", MatchType: "present", Invert: true},
+					{Name: "x-request-1", MatchType: "exact", Value: "foo"},
+				},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "exact", Value: "foo"},
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "x-request-2", MatchType: "present", Invert: true},
-				),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-1", MatchType: "exact", Value: "foo"},
+					{Name: "x-request-1", MatchType: "present"},
+					{Name: "x-request-2", MatchType: "present", Invert: true},
+				},
 			}, {
-				Match: routePrefix("/"),
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
 			}},
 		},
 
@@ -2974,28 +2997,30 @@ func TestSortLongestRouteFirst(t *testing.T) {
 		// we don't need to compare the header conditions to
 		// order multiple routes with the same prefix.
 		"headers order in single route": {
-			routes: []*envoy_route_v3.Route{{
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "x-request-2", MatchType: "present", Invert: true},
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "exact", Value: "foo"},
-				),
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-1", MatchType: "present"},
+					{Name: "x-request-2", MatchType: "present", Invert: true},
+					{Name: "x-request-1", MatchType: "exact", Value: "foo"},
+				},
 			}},
-			want: []*envoy_route_v3.Route{{
-				Match: routePrefix("/",
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "exact", Value: "foo"},
-					dag.HeaderMatchCondition{Name: "x-request-1", MatchType: "present"},
-					dag.HeaderMatchCondition{Name: "x-request-2", MatchType: "present", Invert: true},
-				),
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "x-request-1", MatchType: "exact", Value: "foo"},
+					{Name: "x-request-1", MatchType: "present"},
+					{Name: "x-request-2", MatchType: "present", Invert: true},
+				},
 			}},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := append([]*envoy_route_v3.Route{}, tc.routes...) // shallow copy
+			got := append([]*dag.Route{}, tc.routes...) // shallow copy
 			sortRoutes(got)
-			protobuf.ExpectEqual(t, tc.want, got)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }


### PR DESCRIPTION
- This change is currently a no-op but in the future when we add more
path match types it will become important
- Extracted as its own change since it is relatively large and will
complicate reviewing other PRs
- When we add path segment prefix matching (in addition to the string
prefix matching we do today) for Ingress v1 this will become important
  - This new type of Prefix matching has to be implemented as a regex
  but should still sort after user requested regex matches
- Also adds sorting of Exact path matches which should come before all
other path match types
- Adds constants for the various header match types allowed
- Some cons: this change means we end up iterating the routes on a vhost twice each