### PR TITLE
Add default gatewayconfig

### DIFF
--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -672,6 +672,10 @@ func Defaults() Parameters {
 		Listener: ListenerParameters{
 			ConnectionBalancer: "",
 		},
+		GatewayConfig: &GatewayParameters{
+			Name:      "contour",
+			Namespace: "projectcontour",
+		},
 	}
 }
 

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -49,6 +49,9 @@ debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
   xds-server-type: contour
+gateway:
+  name: contour
+  namespace: projectcontour
 accesslog-format: envoy
 json-fields:
 - '@timestamp'


### PR DESCRIPTION
https://github.com/projectcontour/contour/pull/3481 makes gatewayconfig optional so users always need to configure gatewayconfig. 
And so Gateway APIs stops working out of the box.

So this patch adds the default gatewayconfig.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>