### PR TITLE
internal: Allow listeners to be created dynamically if provided otherwise defaulted

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -304,12 +304,22 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	}
 
 	listenerConfig := xdscache_v3.ListenerConfig{
-		UseProxyProto:                 ctx.useProxyProto,
-		HTTPAddress:                   ctx.httpAddr,
-		HTTPPort:                      ctx.httpPort,
+		UseProxyProto: ctx.useProxyProto,
+		HTTPListeners: map[string]xdscache_v3.Listener{
+			"ingress_http": {
+				Name:    "ingress_http",
+				Address: ctx.httpAddr,
+				Port:    ctx.httpPort,
+			},
+		},
+		HTTPSListeners: map[string]xdscache_v3.Listener{
+			"ingress_https": {
+				Name:    "ingress_https",
+				Address: ctx.httpsAddr,
+				Port:    ctx.httpsPort,
+			},
+		},
 		HTTPAccessLog:                 ctx.httpAccessLog,
-		HTTPSAddress:                  ctx.httpsAddr,
-		HTTPSPort:                     ctx.httpsPort,
 		HTTPSAccessLog:                ctx.httpsAccessLog,
 		AccessLogType:                 ctx.Config.AccessLogFormat,
 		AccessLogFields:               ctx.Config.AccessLogFields,

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -92,7 +92,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
@@ -121,7 +121,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
@@ -140,7 +140,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
@@ -159,7 +159,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
@@ -188,7 +188,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
@@ -217,7 +217,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Kind: KindHTTPRoute,
 				},
@@ -233,7 +233,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Spec: gatewayapi_v1alpha1.GatewaySpec{
 			Listeners: []gatewayapi_v1alpha1.Listener{{
 				Port:     80,
-				Protocol: "HTTP",
+				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -569,7 +569,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Spec: gatewayapi_v1alpha1.GatewaySpec{
 					Listeners: []gatewayapi_v1alpha1.Listener{{
 						Port:     80,
-						Protocol: "HTTP",
+						Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 							Kind: "INVALID",
 						},
@@ -618,7 +618,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Spec: gatewayapi_v1alpha1.GatewaySpec{
 					Listeners: []gatewayapi_v1alpha1.Listener{{
 						Port:     80,
-						Protocol: "HTTP",
+						Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
 							Kind:  "HTTPRoute",
 							Group: "INVALID",
@@ -5903,7 +5903,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "foo.com",
+								Name:         "foo.com",
+								ListenerName: "ingress_https",
 								routes: routes(
 									routeUpgrade("/", service(s1)),
 								),
@@ -5930,7 +5931,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "foo.com",
+								Name:         "foo.com",
+								ListenerName: "ingress_https",
 								routes: routes(
 									routeUpgrade("/", service(s1)),
 								),
@@ -5996,7 +5998,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "b.example.com",
+								Name:         "b.example.com",
+								ListenerName: "ingress_https",
 								routes: routes(
 									prefixroute("/", service(s1)),
 								),
@@ -6076,7 +6079,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "b.example.com",
+								Name:         "b.example.com",
+								ListenerName: "ingress_https",
 								routes: routes(
 									prefixroute("/", service(s1)),
 								),
@@ -7317,7 +7321,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 								routes: routes(
 									routeUpgrade("/", service(s1))),
 							},
@@ -7341,7 +7346,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7384,7 +7390,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "www.example.com", // this is proxy39, not proxy38
+								Name:         "www.example.com", // this is proxy39, not proxy38
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7404,7 +7411,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "www.example.com",
+								Name:         "www.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7425,7 +7433,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "www.example.com",
+								Name:         "www.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7445,7 +7454,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "passthrough.example.com",
+								Name:         "passthrough.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7821,7 +7831,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
+								Name:         "kuard.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7852,7 +7863,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
+								Name:         "kuard.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7893,7 +7905,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "kuard.example.com",
+								Name:         "kuard.example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -7980,7 +7993,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 							},
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
@@ -8038,7 +8052,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 							},
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
@@ -8095,7 +8110,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 							},
 							MinTLSVersion: "",
 							TCPProxy: &TCPProxy{
@@ -8178,7 +8194,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name: "example.com",
+								Name:         "example.com",
+								ListenerName: "ingress_https",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: []*Cluster{{
@@ -8475,8 +8492,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8570,8 +8588,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8634,8 +8653,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8771,8 +8791,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8780,8 +8801,9 @@ func TestDAGInsert(t *testing.T) {
 						},
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "projectcontour.io",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "projectcontour.io",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8831,8 +8853,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -8883,8 +8906,9 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:   "example.com",
-								routes: routes(routeUpgrade("/", service(s9))),
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+								routes:       routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -9682,16 +9706,18 @@ func virtualhosts(vx ...Vertex) []Vertex {
 
 func virtualhost(name string, first *Route, rest ...*Route) *VirtualHost {
 	return &VirtualHost{
-		Name:   name,
-		routes: routes(append([]*Route{first}, rest...)...),
+		Name:         name,
+		ListenerName: "ingress_http",
+		routes:       routes(append([]*Route{first}, rest...)...),
 	}
 }
 
 func securevirtualhost(name string, sec *v1.Secret, first *Route, rest ...*Route) *SecureVirtualHost {
 	return &SecureVirtualHost{
 		VirtualHost: VirtualHost{
-			Name:   name,
-			routes: routes(append([]*Route{first}, rest...)...),
+			Name:         name,
+			ListenerName: "ingress_https",
+			routes:       routes(append([]*Route{first}, rest...)...),
 		},
 		MinTLSVersion: "1.2",
 		Secret:        secret(sec),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -425,6 +425,8 @@ type VirtualHost struct {
 	// as defined by RFC 3986.
 	Name string
 
+	ListenerName string
+
 	// CORSPolicy is the cross-origin policy to apply to the VirtualHost.
 	CORSPolicy *CORSPolicy
 
@@ -511,6 +513,11 @@ func (s *SecureVirtualHost) Valid() bool {
 	// 1. it has a secret and at least one route.
 	// 2. it has a tcpproxy, because the tcpproxy backend may negotiate TLS itself.
 	return (s.Secret != nil && len(s.routes) > 0) || s.TCPProxy != nil
+}
+
+type ListenerName struct {
+	Name         string
+	ListenerName string
 }
 
 // A Listener represents a TCP socket that accepts

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -255,7 +255,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 
 		routes := p.routes(pathPrefixes, services)
 		for _, vhost := range hosts {
-			vhost := p.dag.EnsureVirtualHost(vhost)
+			vhost := p.dag.EnsureVirtualHost(ListenerName{Name: vhost, ListenerName: "ingress_http"})
 			for _, route := range routes {
 				vhost.addRoute(route)
 			}

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -190,7 +190,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				return
 			}
 
-			svhost := p.dag.EnsureSecureVirtualHost(host)
+			svhost := p.dag.EnsureSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"})
 			svhost.Secret = sec
 			// default to a minimum TLS version of 1.2 if it's not specified
 			svhost.MinTLSVersion = annotation.MinTLSVersion(tls.MinimumProtocolVersion, "1.2")
@@ -302,7 +302,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 	}
 
 	routes := p.computeRoutes(validCond, proxy, proxy, nil, nil, tlsEnabled)
-	insecure := p.dag.EnsureVirtualHost(host)
+	insecure := p.dag.EnsureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_http"})
 	cp, err := toCORSPolicy(proxy.Spec.VirtualHost.CORSPolicy)
 	if err != nil {
 		validCond.AddErrorf(contour_api_v1.ConditionTypeCORSError, "PolicyDidNotParse",
@@ -324,7 +324,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 	// if TLS is enabled for this virtual host and there is no tcp proxy defined,
 	// then add routes to the secure virtualhost definition.
 	if tlsEnabled && proxy.Spec.TCPProxy == nil {
-		secure := p.dag.EnsureSecureVirtualHost(host)
+		secure := p.dag.EnsureSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"})
 		secure.CORSPolicy = cp
 
 		rlp, err := rateLimitPolicy(proxy.Spec.VirtualHost.RateLimitPolicy)
@@ -699,7 +699,7 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(validCond *contour_api_v1.
 				SNI:                  s.ExternalName,
 			})
 		}
-		secure := p.dag.EnsureSecureVirtualHost(host)
+		secure := p.dag.EnsureSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"})
 		secure.TCPProxy = &proxy
 
 		return true

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -86,7 +86,7 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 			// ahead and create the SecureVirtualHost for this
 			// Ingress.
 			for _, host := range tls.Hosts {
-				svhost := p.dag.EnsureSecureVirtualHost(host)
+				svhost := p.dag.EnsureSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"})
 				svhost.Secret = sec
 				// default to a minimum TLS version of 1.2 if it's not specified
 				svhost.MinTLSVersion = annotation.MinTLSVersion(annotation.ContourAnnotation(ing, "tls-minimum-protocol-version"), "1.2")
@@ -168,14 +168,14 @@ func (p *IngressProcessor) computeIngressRule(ing *networking_v1.Ingress, rule n
 
 		// should we create port 80 routes for this ingress
 		if annotation.TLSRequired(ing) || annotation.HTTPAllowed(ing) {
-			vhost := p.dag.EnsureVirtualHost(host)
+			vhost := p.dag.EnsureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_http"})
 			vhost.addRoute(r)
 		}
 
 		// computeSecureVirtualhosts will have populated b.securevirtualhosts
 		// with the names of tls enabled ingress objects. If host exists then
 		// it is correctly configured for TLS.
-		if svh := p.dag.GetSecureVirtualHost(host); svh != nil && host != "*" {
+		if svh := p.dag.GetSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"}); svh != nil && host != "*" {
 			svh.addRoute(r)
 		}
 	}

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -594,7 +594,7 @@ func TestLDSStreamEmpty(t *testing.T) {
 	defer done()
 
 	// assert that streaming LDS with no ingresses does not stall.
-	c.Request(listenerType, "HTTP").Equals(&envoy_discovery_v3.DiscoveryResponse{
+	c.Request(listenerType, "ingress_http").Equals(&envoy_discovery_v3.DiscoveryResponse{
 		VersionInfo: "0",
 		TypeUrl:     listenerType,
 		Nonce:       "0",
@@ -743,10 +743,20 @@ func TestLDSIngressHTTPSUseProxyProtocol(t *testing.T) {
 
 func TestLDSCustomAddressAndPort(t *testing.T) {
 	rh, c, done := setup(t, func(conf *xdscache_v3.ListenerConfig) {
-		conf.HTTPAddress = "127.0.0.100"
-		conf.HTTPPort = 9100
-		conf.HTTPSAddress = "127.0.0.200"
-		conf.HTTPSPort = 9200
+		conf.HTTPListeners = map[string]xdscache_v3.Listener{
+			"ingress_http": {
+				Name:    "ingress_http",
+				Address: "127.0.0.100",
+				Port:    9100,
+			},
+		}
+		conf.HTTPSListeners = map[string]xdscache_v3.Listener{
+			"ingress_https": {
+				Name:    "ingress_https",
+				Address: "127.0.0.200",
+				Port:    9200,
+			},
+		}
 	})
 	defer done()
 

--- a/internal/xdscache/v3/listener_test.go
+++ b/internal/xdscache/v3/listener_test.go
@@ -604,10 +604,20 @@ func TestListenerVisit(t *testing.T) {
 		},
 		"http listener on non default port": { // issue 72
 			ListenerConfig: ListenerConfig{
-				HTTPAddress:  "127.0.0.100",
-				HTTPPort:     9100,
-				HTTPSAddress: "127.0.0.200",
-				HTTPSPort:    9200,
+				HTTPListeners: map[string]Listener{
+					ENVOY_HTTP_LISTENER: {
+						Name:    ENVOY_HTTP_LISTENER,
+						Address: "127.0.0.100",
+						Port:    9100,
+					},
+				},
+				HTTPSListeners: map[string]Listener{
+					ENVOY_HTTPS_LISTENER: {
+						Name:    ENVOY_HTTPS_LISTENER,
+						Address: "127.0.0.200",
+						Port:    9200,
+					},
+				},
 			},
 			objs: []interface{}{
 				&v1beta1.Ingress{

--- a/internal/xdscache/v3/visitor_test.go
+++ b/internal/xdscache/v3/visitor_test.go
@@ -111,7 +111,8 @@ func TestVisitListeners(t *testing.T) {
 				VirtualHosts: virtualhosts(
 					&dag.SecureVirtualHost{
 						VirtualHost: dag.VirtualHost{
-							Name: "tcpproxy.example.com",
+							Name:         "tcpproxy.example.com",
+							ListenerName: "ingress_https",
 						},
 						TCPProxy: p1,
 						Secret: &dag.Secret{


### PR DESCRIPTION
Since the GatewayAPI Gateway needs to be the driver of the ports/addresses that get exposed, we need a way to push that through to Envoy. At the same time, if there are multiple listeners, need a way to provision that to Envoy. 

This sets up the DAG to accept multiple listeners vs the current static `insecure` & `secure`.

Updates #2287

Signed-off-by: Steve Sloka <slokas@vmware.com>