### PR TITLE
internal/dag: Only process Gateway.Listener.Selector.Kind of HTTPRoute

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -74,9 +74,9 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		for _, listener := range p.source.gateway.Spec.Listeners {
 
 			// Validate the Group on the selector is a supported type.
-			if listener.Routes.Group != "" && listener.Routes.Group != "networking.x-k8s.io" {
+			if listener.Routes.Group != "" && listener.Routes.Group != gatewayapi_v1alpha1.GroupName {
 				// TODO: Set the “ResolvedRefs” condition to false for this listener with the “InvalidRoutesRef” reason.
-				p.Errorf("Listener.Routes.Group %q is not supported.", listener.Routes.Kind)
+				p.Errorf("Listener.Routes.Group %q is not supported.", listener.Routes.Group)
 				continue
 			}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -27,6 +27,10 @@ import (
 	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
+const (
+	KindHTTPRoute = "HTTPRoute"
+)
+
 // GatewayAPIProcessor translates Gateway API types into DAG
 // objects and adds them to the DAG.
 type GatewayAPIProcessor struct {
@@ -69,20 +73,27 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		// are associated with the Gateway. An empty Selector matches all routes.
 		for _, listener := range p.source.gateway.Spec.Listeners {
 
-			nsMatches, err := p.namespaceMatches(listener.Routes.Namespaces, route)
-			if err != nil {
-				p.Errorf("error validating namespaces against Listener.Routes.Namespaces: %s", err)
-			}
+			// Validate the Kind on the selector is a supported type.
+			switch listener.Routes.Kind {
+			case KindHTTPRoute:
+				nsMatches, err := p.namespaceMatches(listener.Routes.Namespaces, route)
+				if err != nil {
+					p.Errorf("error validating namespaces against Listener.Routes.Namespaces: %s", err)
+				}
 
-			selMatches, err := selectorMatches(listener.Routes.Selector, route.Labels)
-			if err != nil {
-				p.Errorf("error validating routes against Listener.Routes.Selector: %s", err)
-			}
+				selMatches, err := selectorMatches(listener.Routes.Selector, route.Labels)
+				if err != nil {
+					p.Errorf("error validating routes against Listener.Routes.Selector: %s", err)
+				}
 
-			if selMatches && nsMatches {
-				// Empty Selector matches all routes.
-				matchingRoutes = append(matchingRoutes, route)
-				break
+				if selMatches && nsMatches {
+					// Empty Selector matches all routes.
+					matchingRoutes = append(matchingRoutes, route)
+					break
+				}
+			default:
+				// TODO: Set the “ResolvedRefs” condition to false for this listener with the “InvalidRoutesRef” reason.
+				p.Errorf("Listener.Routes.Kind %q is not supported.", listener.Routes.Kind)
 			}
 		}
 	}


### PR DESCRIPTION
Only process currently supported types of HTTPRoute on the Gateway.Listener.Selector.Kind field.

Updates #3401

Signed-off-by: Steve Sloka <slokas@vmware.com>