### PR TITLE
cmd/contour: properly configure request/response headers policy

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -287,19 +287,19 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		}
 	}
 	if ctx.Config.Policy.RequestHeadersPolicy.Remove != nil {
-		requestHeadersPolicy.Remove = make([]string, len(ctx.Config.Policy.RequestHeadersPolicy.Remove))
+		requestHeadersPolicy.Remove = make([]string, 0, len(ctx.Config.Policy.RequestHeadersPolicy.Remove))
 		requestHeadersPolicy.Remove = append(requestHeadersPolicy.Remove, ctx.Config.Policy.RequestHeadersPolicy.Remove...)
 	}
 
 	var responseHeadersPolicy dag.HeadersPolicy
 	if ctx.Config.Policy.ResponseHeadersPolicy.Set != nil {
 		responseHeadersPolicy.Set = make(map[string]string)
-		for k, v := range ctx.Config.Policy.RequestHeadersPolicy.Set {
+		for k, v := range ctx.Config.Policy.ResponseHeadersPolicy.Set {
 			responseHeadersPolicy.Set[k] = v
 		}
 	}
 	if ctx.Config.Policy.ResponseHeadersPolicy.Remove != nil {
-		responseHeadersPolicy.Remove = make([]string, len(ctx.Config.Policy.ResponseHeadersPolicy.Remove))
+		responseHeadersPolicy.Remove = make([]string, 0, len(ctx.Config.Policy.ResponseHeadersPolicy.Remove))
 		responseHeadersPolicy.Remove = append(responseHeadersPolicy.Remove, ctx.Config.Policy.ResponseHeadersPolicy.Remove...)
 	}
 


### PR DESCRIPTION
Fixes two issues with configuring request/response headers policy.
The first issue was that the user's configured request headers to
set were inadvertently also being used as the response headers to
set. The second issue was that some harmless empty strings were
being added to the lists of request/response headers to remove.

Signed-off-by: Steve Kriss <krisss@vmware.com>