### PR TITLE
Remove not supported TLS value in doc

### DIFF
--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -77,7 +77,7 @@ type ExtensionServiceSpec struct {
 	UpstreamValidation *contour_api_v1.UpstreamValidation `json:"validation,omitempty"`
 
 	// Protocol may be used to specify (or override) the protocol used to reach this Service.
-	// Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+	// Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=h2;h2c

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -61,7 +61,7 @@ spec:
                     type: string
                 type: object
               protocol:
-                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
                 enum:
                 - h2
                 - h2c

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -240,7 +240,7 @@ spec:
                     type: string
                 type: object
               protocol:
-                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.
+                description: Protocol may be used to specify (or override) the protocol used to reach this Service. Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
                 enum:
                 - h2
                 - h2c

--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -3173,7 +3173,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>
@@ -3318,7 +3318,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Protocol may be used to specify (or override) the protocol used to reach this Service.
-Values may be tls, h2, h2c. If omitted, protocol-selection falls back on Service annotations.</p>
+Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Only h2 or h2c options are supported.
Extension service will connect contour with other services that use gRPC
protocol. gRPC only works with HTTP/2. So TLS option is not relevant
here.

Fixes: https://github.com/projectcontour/contour/issues/3497