### PR TITLE
Implement HTTPRouteFilterRequestHeaderModifier for HTTPRouteFilter

### DIFF
--- a/_integration/testsuite/gatewayapi/004-post-header-modifier.yaml
+++ b/_integration/testsuite/gatewayapi/004-post-header-modifier.yaml
@@ -1,0 +1,180 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-nofilter
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-nofilter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    app: filter
+spec:
+  hostnames:
+    - postfilter.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /filter
+      forwardTo:
+      - serviceName: echo-header-filter
+        port: 80
+        filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            add:
+              My-Header: Foo
+            set:
+              Replace-Header: Bar
+            remove:
+              - Other-Header
+    - matches:
+      - path:
+          type: Prefix
+          value: /nofilter
+      forwardTo:
+      - serviceName: echo-header-nofilter
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+import data.contour.http.response
+import data.builtin.result
+
+Response := client.Get({
+  "method": "GET",
+  "url": url.http("/filter"),
+  "headers": {
+    "Host": "postfilter.projectcontour.io",
+    "Other-Header": "Remove",
+    "Replace-Header": "Tobe-Replaced",
+    "User-Agent": client.ua("request-header-filter"),
+  }
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-header-filter")
+}
+
+check_for_host_header_add [msg] {
+  msg := expect.response_header_is(Response, "My-Header", "Foo")
+}
+
+check_for_host_header_remove [msg] {
+  msg := expect.response_header_does_not_have(Response, "Other-Header")
+}
+
+check_for_host_header_set [msg] {
+  msg := expect.response_header_is(Response, "Replace-Header", "Bar")
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+import data.contour.http.response
+import data.builtin.result
+
+Response := client.Get({
+  "method": "GET",
+  "url": url.http("/nofilter"),
+  "headers": {
+    "Host": "postfilter.projectcontour.io",
+    "Other-Header": "Exist",
+    "User-Agent": client.ua("request-header-filter"),
+  }
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-header-nofilter")
+}
+
+check_for_host_header_add [msg] {
+  msg := expect.response_header_is(Response, "Other-Header", "Exist")
+}
+
+check_for_host_header_remove [msg] {
+  msg := expect.response_header_does_not_have(Response, "My-Header")
+}

--- a/_integration/testsuite/gatewayapi/005-pre-header-modifier.yaml
+++ b/_integration/testsuite/gatewayapi/005-pre-header-modifier.yaml
@@ -1,0 +1,115 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    app: filter
+spec:
+  hostnames:
+    - prefilter.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+            My-Header: Foo
+          set:
+            Replace-Header: Bar
+          remove:
+            - Other-Header
+      forwardTo:
+      - serviceName: echo-header-filter
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+import data.contour.http.response
+import data.builtin.result
+
+Response := client.Get({
+  "method": "GET",
+  "url": url.http("/"),
+  "headers": {
+    "Host": "prefilter.projectcontour.io",
+    "Other-Header": "Remove",
+    "Replace-Header": "Tobe-Replaced",
+    "User-Agent": client.ua("request-header-filter"),
+  }
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_host_header_add [msg] {
+  msg := expect.response_header_is(Response, "My-Header", "Foo")
+}
+
+check_for_host_header_remove [msg] {
+  msg := expect.response_header_does_not_have(Response, "Other-Header")
+}
+
+check_for_host_header_set [msg] {
+  msg := expect.response_header_is(Response, "Replace-Header", "Bar")
+}

--- a/_integration/testsuite/gatewayapi/006-rewritehost.yaml
+++ b/_integration/testsuite/gatewayapi/006-rewritehost.yaml
@@ -1,0 +1,102 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    app: filter
+spec:
+  hostnames:
+    - hostrewrite.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          add:
+            Host: rewritten.com
+      forwardTo:
+      - serviceName: echo-header-filter
+        port: 80
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+import data.contour.http.response
+import data.builtin.result
+
+Response := client.Get({
+  "url": url.http("/"),
+  "headers": {
+    "Host": "hostrewrite.projectcontour.io",
+    "User-Agent": client.ua("host-rewrite-test"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_host_header [msg] {
+  response_body := response.body(Response)
+  response_host := object.get(response_body, "host", "")
+  response_host != "rewritten.com"
+  msg := result.Errorf("expected response host %s to be rewritten to prerewritten.com", [response_host])
+}

--- a/_integration/testsuite/policies/contour-expect.rego
+++ b/_integration/testsuite/policies/contour-expect.rego
@@ -111,3 +111,20 @@ response_header_has_prefix(response_object, header_name, header_prefix) = r {
     header_name, yaml.marshal(object.get(response.body(response_object), "Headers", {}))
   ])
 }
+
+# response_header_does_not_have(response_object, header_name)
+#
+# Checks whether the response body does not contain the matching header.
+response_header_does_not_have(response_object, header_name) = r {
+  # Pass if the header is there and contains the wanted value.
+  response_body := response.body(response_object)
+  response_headers := object.get(response_body, "headers", {})
+  values := response_headers[header_name]
+  r := result.Passf("value of response header %q was not removed", [header_name])
+} else  = r {
+  # Error if the header is present.
+  response_body := response.body(response_object)
+  response_headers := object.get(response_body, "headers", {})
+  values := response_headers[header_name]
+  r := result.Errorf("value of response header %q is %q, wanted removed", [header_name, values])
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -299,6 +299,7 @@ type HeadersPolicy struct {
 	// HostRewrite defines if a host should be rewritten on upstream requests
 	HostRewrite string
 
+	Add    map[string]string
 	Set    map[string]string
 	Remove []string
 }

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -22,11 +22,13 @@ import (
 	"time"
 
 	networking_v1 "k8s.io/api/networking/v1"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -186,6 +188,75 @@ func headersPolicyRoute(policy *contour_api_v1.HeadersPolicy, allowHostRewrite b
 		HostRewrite: hostRewrite,
 		Remove:      rl,
 	}, nil
+}
+
+// headersPolicyGatewayAPI builds a *HeaderPolicy for the supplied HTTPRequestHeaderFilter.
+// TODO: Take care about the order of operators once https://github.com/kubernetes-sigs/gateway-api/issues/480 was solved.
+func headersPolicyGatewayAPI(hf *gatewayapi_v1alpha1.HTTPRequestHeaderFilter) (*HeadersPolicy, error) {
+	set, add := make(map[string]string, len(hf.Set)), make(map[string]string, len(hf.Add))
+	hostRewrite := ""
+	errlist := []error{}
+	for k, v := range hf.Set {
+		key := http.CanonicalHeaderKey(k)
+		if _, ok := set[key]; ok {
+			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
+			continue
+		}
+		if key == "Host" {
+			hostRewrite = v
+			continue
+		}
+		if msgs := validation.IsHTTPHeaderName(key); len(msgs) != 0 {
+			errlist = append(errlist, fmt.Errorf("invalid set header %q: %v", key, msgs))
+			continue
+		}
+		set[key] = escapeHeaderValue(v, nil)
+	}
+	for k, v := range hf.Add {
+		key := http.CanonicalHeaderKey(k)
+		if _, ok := add[key]; ok {
+			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
+			continue
+		}
+		if key == "Host" {
+			hostRewrite = v
+			continue
+		}
+		if msgs := validation.IsHTTPHeaderName(key); len(msgs) != 0 {
+			errlist = append(errlist, fmt.Errorf("invalid add header %q: %v", key, msgs))
+			continue
+		}
+		add[key] = escapeHeaderValue(v, nil)
+	}
+
+	remove := sets.NewString()
+	for _, k := range hf.Remove {
+		key := http.CanonicalHeaderKey(k)
+		if remove.Has(key) {
+			errlist = append(errlist, fmt.Errorf("duplicate header removal: %q", key))
+			continue
+		}
+		if msgs := validation.IsHTTPHeaderName(key); len(msgs) != 0 {
+			errlist = append(errlist, fmt.Errorf("invalid remove header %q: %v", key, msgs))
+			continue
+		}
+		remove.Insert(key)
+	}
+	rl := remove.List()
+
+	if len(set) == 0 {
+		set = nil
+	}
+	if len(rl) == 0 {
+		rl = nil
+	}
+
+	return &HeadersPolicy{
+		Add:         add,
+		Set:         set,
+		HostRewrite: hostRewrite,
+		Remove:      rl,
+	}, utilerrors.NewAggregate(errlist)
 }
 
 func escapeHeaderValue(value string, dynamicHeaders map[string]string) string {

--- a/internal/envoy/route.go
+++ b/internal/envoy/route.go
@@ -63,6 +63,7 @@ func SingleSimpleCluster(clusters []*dag.Cluster) bool {
 	if cluster.RequestHeadersPolicy == nil {
 		// no request headers policy
 	} else if len(cluster.RequestHeadersPolicy.Set) != 0 ||
+		len(cluster.RequestHeadersPolicy.Add) != 0 ||
 		len(cluster.RequestHeadersPolicy.Remove) != 0 {
 		return false
 	}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -269,7 +269,7 @@ func weightedClusters(clusters []*dag.Cluster) *envoy_route_v3.WeightedCluster {
 			Weight: protobuf.UInt32(cluster.Weight),
 		}
 		if cluster.RequestHeadersPolicy != nil {
-			c.RequestHeadersToAdd = HeaderValueList(cluster.RequestHeadersPolicy.Set, false)
+			c.RequestHeadersToAdd = append(HeaderValueList(cluster.RequestHeadersPolicy.Set, false), HeaderValueList(cluster.RequestHeadersPolicy.Add, true)...)
 			c.RequestHeadersToRemove = cluster.RequestHeadersPolicy.Remove
 		}
 		if cluster.ResponseHeadersPolicy != nil {

--- a/internal/status/httproutestatus.go
+++ b/internal/status/httproutestatus.go
@@ -31,6 +31,7 @@ type RouteReasonType string
 const ReasonNotImplemented RouteReasonType = "NotImplemented"
 const ReasonPathMatchType RouteReasonType = "PathMatchType"
 const ReasonHeaderMatchType RouteReasonType = "HeaderMatchType"
+const ReasonHTTPRouteFilterType RouteReasonType = "HTTPRouteFilterType"
 const ReasonDegraded RouteReasonType = "Degraded"
 const ReasonValid RouteReasonType = "Valid"
 const ReasonErrorsExist RouteReasonType = "ErrorsExist"

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -156,7 +156,7 @@ func (v *routeVisitor) onVirtualHost(vh *dag.VirtualHost) {
 			Action: envoy_v3.RouteRoute(route),
 		}
 		if route.RequestHeadersPolicy != nil {
-			rt.RequestHeadersToAdd = envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+			rt.RequestHeadersToAdd = append(envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false), envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Add, true)...)
 			rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
 		}
 		if route.ResponseHeadersPolicy != nil {
@@ -206,7 +206,7 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 		}
 
 		if route.RequestHeadersPolicy != nil {
-			rt.RequestHeadersToAdd = envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false)
+			rt.RequestHeadersToAdd = append(envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false), envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Add, true)...)
 			rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove
 		}
 		if route.ResponseHeadersPolicy != nil {


### PR DESCRIPTION
This patch implements HTTPRouteFilterRequestHeaderModifier for HTTPRouteFilter.

[HTTPRouteFilter](https://gateway-api.sigs.k8s.io/spec/#networking.x-k8s.io/v1alpha1.HTTPRouteFilter) is defined in `HTTPRouteForwardTo` and `HTTPRouteRule`. This patch
adds `HTTPRouteFilterRequestHeaderModifier` for both fields.

/cc @stevesloka @youngnick @sunjayBhatia

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>