### PR TITLE
internal/dag: Return an HTTP503 if the service on an invalid ForwardTo

### DIFF
--- a/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
+++ b/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
@@ -83,7 +83,7 @@ spec:
           type: Prefix
           value: /invalidport
       forwardTo:
-      - serviceName: invalid
+      - serviceName: echo-slash-default
     - matches:
         - path:
             type: Prefix

--- a/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
+++ b/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
@@ -1,0 +1,233 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-prefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-noprefix
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-exact
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-exact
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: All
+        selector:
+          matchLabels:
+            app: filter
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+  labels:
+    app: filter
+spec:
+  hostnames:
+    - forwardto.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /invalidref
+      forwardTo:
+      - serviceName: invalid
+        port: 80
+    - matches:
+      - path:
+          type: Prefix
+          value: /invalidport
+      forwardTo:
+      - serviceName: invalid
+    - matches:
+        - path:
+            type: Prefix
+            value: /invalidservicename
+      forwardTo:
+        - serviceName:
+          port: 80
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      forwardTo:
+      - serviceName: echo-slash-default
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.http("/"),
+  "headers": {
+    "Host": "forwardto.projectcontour.io",
+    "User-Agent": client.ua("invalid-forwardto"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.http("/invalidref"),
+  "headers": {
+    "Host": "forwardto.projectcontour.io",
+    "User-Agent": client.ua("invalid-forwardto"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 503)
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.http("/invalidport"),
+  "headers": {
+   "Host": "forwardto.projectcontour.io",
+   "User-Agent": client.ua("invalid-forwardto"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 503)
+}
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+Response := client.Get({
+  "url": url.http("/invalidservicename"),
+  "headers": {
+    "Host": "forwardto.projectcontour.io",
+    "User-Agent": client.ua("invalid-forwardto"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 503)
+}
+

--- a/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
+++ b/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
@@ -149,7 +149,7 @@ spec:
             type: Prefix
             value: /invalidservicename
       forwardTo:
-        - serviceName:
+        - serviceName: ""
           port: 80
     - matches:
       - path:

--- a/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
+++ b/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
@@ -18,46 +18,6 @@ metadata:
   name: ingress-conformance-echo
 $apply:
   fixture:
-    as: echo-slash-prefix
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
-    as: echo-slash-prefix
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
-    as: echo-slash-noprefix
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
-    as: echo-slash-noprefix
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
     as: echo-slash-default
 
 ---
@@ -69,26 +29,6 @@ metadata:
 $apply:
   fixture:
     as: echo-slash-default
-
----
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
-    as: echo-slash-exact
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: ingress-conformance-echo
-$apply:
-  fixture:
-    as: echo-slash-exact
 
 ---
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -983,7 +983,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 			},
-			want: listeners(),
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("*", directResponseRoute("/", 503)),
+					),
+				},
+			),
 		},
 		// If port is not defined the route will be marked as invalid (#3352).
 		"missing port": {
@@ -9821,6 +9828,13 @@ func routes(routes ...*Route) map[string]*Route {
 		m[conditionsToString(r)] = r
 	}
 	return m
+}
+
+func directResponseRoute(prefix string, statusCode uint32) *Route {
+	return &Route{
+		PathMatchCondition: prefixString(prefix),
+		DirectResponse:     &DirectResponse{StatusCode: statusCode},
+	}
 }
 
 func prefixroute(prefix string, first *Service, rest ...*Service) *Route {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -15,6 +15,7 @@ package dag
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -954,7 +955,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			want: listeners(),
 		},
 		// If the ServiceName referenced from an HTTPRoute is missing,
-		// the route should not be added.
+		// the route should return an HTTP503.
 		"missing service": {
 			gateway: gatewayWithSelector,
 			objs: []interface{}{
@@ -987,7 +988,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*", directResponseRoute("/", 503)),
+						virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
 					),
 				},
 			),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -182,6 +182,13 @@ func (hc *HeaderMatchCondition) String() string {
 	return "header: " + details
 }
 
+// DirectResponse allows for a specific HTTP status code
+// to be the response to a route request vs routing to
+// an envoy cluster.
+type DirectResponse struct {
+	StatusCode uint32
+}
+
 // Route defines the properties of a route to a Cluster.
 type Route struct {
 
@@ -235,6 +242,11 @@ type Route struct {
 	// RequestHashPolicies is a list of policies for configuring hashes on
 	// request attributes.
 	RequestHashPolicies []RequestHashPolicy
+
+	// DirectResponse allows for a specific HTTP status code
+	// to be the response to a route request vs routing to
+	// an envoy cluster.
+	DirectResponse *DirectResponse
 }
 
 // HasPathPrefix returns whether this route has a PrefixPathCondition.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -16,6 +16,7 @@ package dag
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"strings"
 
 	"github.com/projectcontour/contour/internal/status"
@@ -283,7 +284,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 					// route still matches the configured conditions since the
 					// service is missing or invalid.
 					route.DirectResponse = &DirectResponse{
-						StatusCode: 503,
+						StatusCode: http.StatusServiceUnavailable,
 					}
 				}
 				vhost.addRoute(route)

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -250,6 +250,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 
 		// Validate the ForwardTos.
 		for _, forward := range rule.ForwardTo {
+
 			// Verify the service is valid
 			if forward.ServiceName == nil {
 				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServiceName must be specified.")
@@ -273,15 +274,18 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRo
 			services = append(services, service)
 		}
 
-		if len(services) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "All Spec.Rules.ForwardTos are invalid.")
-			continue
-		}
-
 		routes := p.routes(matchconditions, services)
 		for _, vhost := range hosts {
 			vhost := p.dag.EnsureVirtualHost(ListenerName{Name: vhost, ListenerName: "ingress_http"})
 			for _, route := range routes {
+				if len(services) == 0 {
+					// Configure a direct response HTTP status code of 503 so the
+					// route still matches the configured conditions since the
+					// service is missing or invalid.
+					route.DirectResponse = &DirectResponse{
+						StatusCode: 503,
+					}
+				}
 				vhost.addRoute(route)
 			}
 		}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2811,11 +2811,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
 		}, {
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "All Spec.Rules.ForwardTos are invalid.",
-		}, {
 			Type:    "Admitted",
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  "ErrorsExist",
@@ -2858,11 +2853,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonDegraded),
 			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
-		}, {
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "All Spec.Rules.ForwardTos are invalid.",
 		}, {
 			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
 			Status:  contour_api_v1.ConditionFalse,

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -103,6 +103,17 @@ func RouteMatch(route *dag.Route) *envoy_route_v3.RouteMatch {
 	}
 }
 
+// Route_DirectResponse creates a *envoy_route_v3.Route_DirectResponse for the
+// http status code supplied. This allows a direct response to a route request
+// with an HTTP status code without needing to route to a specific cluster.
+func RouteDirectResponse(response *dag.DirectResponse) *envoy_route_v3.Route_DirectResponse {
+	return &envoy_route_v3.Route_DirectResponse{
+		DirectResponse: &envoy_route_v3.DirectResponseAction{
+			Status: response.StatusCode,
+		},
+	}
+}
+
 // RouteRoute creates a *envoy_route_v3.Route_Route for the services supplied.
 // If len(services) is greater than one, the route's action will be a
 // weighted cluster.

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -554,6 +554,37 @@ func TestRouteRoute(t *testing.T) {
 	}
 }
 
+func TestRouteDirectResponse(t *testing.T) {
+	tests := map[string]struct {
+		directResponse *dag.DirectResponse
+		want           *envoy_route_v3.Route_DirectResponse
+	}{
+		"503": {
+			directResponse: &dag.DirectResponse{StatusCode: 503},
+			want: &envoy_route_v3.Route_DirectResponse{
+				DirectResponse: &envoy_route_v3.DirectResponseAction{
+					Status: 503,
+				},
+			},
+		},
+		"402": {
+			directResponse: &dag.DirectResponse{StatusCode: 402},
+			want: &envoy_route_v3.Route_DirectResponse{
+				DirectResponse: &envoy_route_v3.DirectResponseAction{
+					Status: 402,
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := RouteDirectResponse(tc.directResponse)
+			protobuf.ExpectEqual(t, tc.want, got)
+		})
+	}
+}
+
 func TestWeightedClusters(t *testing.T) {
 	tests := map[string]struct {
 		clusters []*dag.Cluster

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -143,6 +143,14 @@ func (v *routeVisitor) onVirtualHost(vh *dag.VirtualHost) {
 				Action: envoy_v3.UpgradeHTTPS(),
 			}
 		}
+
+		if route.DirectResponse != nil {
+			return &envoy_route_v3.Route{
+				Match:  envoy_v3.RouteMatch(route),
+				Action: envoy_v3.RouteDirectResponse(route.DirectResponse),
+			}
+		}
+
 		rt := &envoy_route_v3.Route{
 			Match:  envoy_v3.RouteMatch(route),
 			Action: envoy_v3.RouteRoute(route),
@@ -185,10 +193,18 @@ func (v *routeVisitor) onSecureVirtualHost(svh *dag.SecureVirtualHost) {
 	}
 
 	toEnvoyRoute := func(route *dag.Route) *envoy_route_v3.Route {
+		if route.DirectResponse != nil {
+			return &envoy_route_v3.Route{
+				Match:  envoy_v3.RouteMatch(route),
+				Action: envoy_v3.RouteDirectResponse(route.DirectResponse),
+			}
+		}
+
 		rt := &envoy_route_v3.Route{
 			Match:  envoy_v3.RouteMatch(route),
 			Action: envoy_v3.RouteRoute(route),
 		}
+
 		if route.RequestHeadersPolicy != nil {
 			rt.RequestHeadersToAdd = envoy_v3.HeaderValueList(route.RequestHeadersPolicy.Set, false)
 			rt.RequestHeadersToRemove = route.RequestHeadersPolicy.Remove


### PR DESCRIPTION
If the service on an HTTPRoute.Spec.Rule.ForwardTo is invalid or missing, an HTTP503 should be returned.

Fixes #3553

Signed-off-by: Steve Sloka <slokas@vmware.com>