### PR TITLE
internal/dag: Add weight processing to HTTPRoute.ForwardTos

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -55,6 +55,36 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
+	kuardService2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard2",
+			Namespace: "projectcontour",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
+	kuardService3 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuard3",
+			Namespace: "projectcontour",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
 	kuardServiceCustomNs := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -267,16 +297,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				"test.projectcontour.io",
 			},
 			Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-				Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-					Path: gatewayapi_v1alpha1.HTTPPathMatch{
-						Type:  "Prefix",
-						Value: "/",
-					},
-				}},
-				ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-					ServiceName: pointer.StringPtr("kuard"),
-					Port:        gatewayPort(8080),
-				}},
+				Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+				ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 			}},
 		},
 	}
@@ -296,16 +318,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				"test.projectcontour.io",
 			},
 			Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-				Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-					Path: gatewayapi_v1alpha1.HTTPPathMatch{
-						Type:  "Prefix",
-						Value: "/",
-					},
-				}},
-				ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-					ServiceName: pointer.StringPtr("blogsvc"),
-					Port:        gatewayPort(80),
-				}},
+				Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+				ForwardTo: httpRouteForwardTo("blogsvc", 80, 1),
 			}},
 		},
 	}
@@ -447,7 +461,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -463,7 +477,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -484,7 +498,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -493,7 +507,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -513,7 +527,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -535,7 +549,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -544,7 +558,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardServiceCustomNs))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardServiceCustomNs))),
 					),
 				},
 			),
@@ -572,16 +586,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							"test.projectcontour.io",
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-								Path: gatewayapi_v1alpha1.HTTPPathMatch{
-									Type:  "Prefix",
-									Value: "/",
-								},
-							}},
-							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-								ServiceName: pointer.StringPtr("kuard"),
-								Port:        gatewayPort(8080),
-							}},
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -590,7 +596,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardServiceCustomNs))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardServiceCustomNs))),
 					),
 				},
 			),
@@ -619,22 +625,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							"test.projectcontour.io",
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-								Path: gatewayapi_v1alpha1.HTTPPathMatch{
-									Type:  "Prefix",
-									Value: "/",
-								},
-							}},
-							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-								ServiceName: pointer.StringPtr("kuard"),
-								Port:        gatewayPort(8080),
-							}},
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
 				&gatewayapi_v1alpha1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-twp",
+						Name:      "basic-two",
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
@@ -642,16 +640,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							"another.projectcontour.io",
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-								Path: gatewayapi_v1alpha1.HTTPPathMatch{
-									Type:  "Prefix",
-									Value: "/",
-								},
-							}},
-							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-								ServiceName: pointer.StringPtr("kuard"),
-								Port:        gatewayPort(8080),
-							}},
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -660,8 +650,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("another.projectcontour.io", prefixroute("/", service(kuardServiceCustomNs))),
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardServiceCustomNs))),
+						virtualhost("another.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardServiceCustomNs))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardServiceCustomNs))),
 					),
 				},
 			),
@@ -690,7 +680,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -717,7 +707,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -758,7 +748,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -800,7 +790,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -827,10 +817,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}, {
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/blog"),
-							ForwardTo: httpRouteForwardTo("blogsvc", 80),
+							ForwardTo: httpRouteForwardTo("blogsvc", 80, 1),
 						}},
 					},
 				},
@@ -840,7 +830,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
-							prefixroute("/", service(kuardService)), prefixroute("/blog", service(blogService))),
+							prefixrouteHTTPRoute("/", service(kuardService)), prefixrouteHTTPRoute("/blog", service(blogService))),
 					),
 				},
 			),
@@ -867,7 +857,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -876,10 +866,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardService))),
-						virtualhost("test2.projectcontour.io", prefixroute("/", service(kuardService))),
-						virtualhost("test3.projectcontour.io", prefixroute("/", service(kuardService))),
-						virtualhost("test4.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
+						virtualhost("test2.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
+						virtualhost("test3.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
+						virtualhost("test4.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -900,7 +890,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -909,7 +899,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*", prefixroute("/", service(kuardService))),
+						virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -933,7 +923,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -942,7 +932,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("*.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -966,7 +956,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -992,7 +982,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1018,7 +1008,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1042,7 +1032,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1075,6 +1065,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
 								ServiceName: pointer.StringPtr("kuard"),
 								Port:        nil,
+								Weight:      1,
 							}},
 						}},
 					},
@@ -1101,7 +1092,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchExact, "/blog"),
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1111,7 +1102,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
-							exactroute("/blog", service(kuardService))),
+							exactrouteHTTPRoute("/blog", service(kuardService))),
 					),
 				},
 			),
@@ -1151,7 +1142,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									Value: "/tech",
 								},
 							}},
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1161,9 +1152,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
-							prefixroute("/", service(kuardService)),
-							prefixroute("/blog", service(kuardService)),
-							prefixroute("/tech", service(kuardService))),
+							prefixrouteHTTPRoute("/", service(kuardService)),
+							prefixrouteHTTPRoute("/blog", service(kuardService)),
+							prefixrouteHTTPRoute("/tech", service(kuardService))),
 					),
 				},
 			),
@@ -1183,7 +1174,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name:         "test.projectcontour.io",
 								ListenerName: "ingress_https",
-								routes:       routes(prefixroute("/", service(kuardService))),
+								routes:       routes(prefixrouteHTTPRoute("/", service(kuardService))),
 							},
 							Secret: secret(sec1),
 						},
@@ -1230,7 +1221,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name:         "test.projectcontour.io",
 								ListenerName: "ingress_https",
-								routes:       routes(prefixroute("/", service(blogService))),
+								routes:       routes(prefixrouteHTTPRoute("/", service(blogService))),
 							},
 							Secret: secret(sec1),
 						},
@@ -1239,7 +1230,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(blogService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(blogService))),
 					),
 				},
 			),
@@ -1355,16 +1346,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							"*.*.projectcontour.io",
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{{
-								Path: gatewayapi_v1alpha1.HTTPPathMatch{
-									Type:  "Prefix",
-									Value: "/",
-								},
-							}},
-							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-								ServiceName: pointer.StringPtr("blogsvc"),
-								Port:        gatewayPort(80),
-							}},
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("blogsvc", 80, 1),
 						}},
 					},
 				},
@@ -1388,7 +1371,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							VirtualHost: VirtualHost{
 								Name:         "test.projectcontour.io",
 								ListenerName: "ingress_https",
-								routes:       routes(prefixroute("/", service(blogService))),
+								routes:       routes(prefixrouteHTTPRoute("/", service(blogService))),
 							},
 							Secret: secret(sec1),
 						},
@@ -1397,7 +1380,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("test.projectcontour.io", prefixroute("/", service(kuardService))),
+						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
 					),
 				},
 			),
@@ -1430,7 +1413,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									Values: map[string]string{"foo": "bar"},
 								},
 							}},
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1444,7 +1427,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							HeaderMatchConditions: []HeaderMatchCondition{
 								{Name: "foo", Value: "bar", MatchType: "exact", Invert: false},
 							},
-							Clusters: clusters(service(kuardService)),
+							Clusters: clustersWeight(service(kuardService)),
 						}),
 					),
 				},
@@ -1486,7 +1469,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										},
 									},
 								},
-								ForwardTo: httpRouteForwardTo("kuard", 8080),
+								ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 							}},
 					},
 				},
@@ -1497,14 +1480,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/blog"),
-							Clusters:           clusters(service(kuardService)),
+							Clusters:           clustersWeight(service(kuardService)),
 						},
 						&Route{
 							PathMatchCondition: prefixString("/tech"),
 							HeaderMatchConditions: []HeaderMatchCondition{
 								{Name: "foo", Value: "bar", MatchType: "exact", Invert: false},
 							},
-							Clusters: clusters(service(kuardService)),
+							Clusters: clustersWeight(service(kuardService)),
 						},
 					)),
 				},
@@ -1534,7 +1517,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									Values: map[string]string{"foo": "bar"},
 								},
 							}},
-							ForwardTo: httpRouteForwardTo("kuard", 8080),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 						}},
 					},
 				},
@@ -1548,7 +1531,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							HeaderMatchConditions: []HeaderMatchCondition{
 								{Name: "foo", Value: "bar", MatchType: "exact", Invert: false},
 							},
-							Clusters: clusters(service(kuardService)),
+							Clusters: clustersWeight(service(kuardService)),
 						},
 					)),
 				},
@@ -1571,28 +1554,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{
-							{
-								Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{
-									{
-										Path: gatewayapi_v1alpha1.HTTPPathMatch{
-											Type:  "Prefix",
-											Value: "/",
-										},
-									},
+						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
+							Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
+								Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
+									Set: map[string]string{"custom-header-set": "foo-bar", "Host": "bar.com"},
+									Add: map[string]string{"custom-header-add": "foo-bar"},
 								},
-								ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-									ServiceName: pointer.StringPtr("kuard"),
-									Port:        gatewayPort(8080),
-								}},
-								Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
-									Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
-										Set: map[string]string{"custom-header-set": "foo-bar", "Host": "bar.com"},
-										Add: map[string]string{"custom-header-add": "foo-bar"},
-									},
-								}},
 							}},
+						}},
 					},
 				},
 			},
@@ -1602,7 +1574,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clusters(service(kuardService)),
+							Clusters:           clustersWeight(service(kuardService)),
 							RequestHeadersPolicy: &HeadersPolicy{
 								Set: map[string]string{
 									"Custom-Header-Set": "foo-bar", // Verify the header key is canonicalized.
@@ -1634,28 +1606,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{
-							{
-								Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{
-									{
-										Path: gatewayapi_v1alpha1.HTTPPathMatch{
-											Type:  "Prefix",
-											Value: "/",
-										},
+						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+							Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
+								ServiceName: pointer.StringPtr("kuard"),
+								Port:        gatewayPort(8080),
+								Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
+									Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
+										Set: map[string]string{"custom-header-set": "foo-bar", "Host": "bar.com"},
+										Add: map[string]string{"custom-header-add": "foo-bar"},
 									},
-								},
-								ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-									ServiceName: pointer.StringPtr("kuard"),
-									Port:        gatewayPort(8080),
-									Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
-										Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
-											Set: map[string]string{"custom-header-set": "foo-bar", "Host": "bar.com"},
-											Add: map[string]string{"custom-header-add": "foo-bar"},
-										},
-									}},
 								}},
+								Weight: 1,
 							}},
+						}},
 					},
 				},
 			},
@@ -1690,18 +1655,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{
 							{
-								Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{
-									{
-										Path: gatewayapi_v1alpha1.HTTPPathMatch{
-											Type:  "Prefix",
-											Value: "/",
-										},
-									},
-								},
-								ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
-									ServiceName: pointer.StringPtr("kuard"),
-									Port:        gatewayPort(8080),
-								}},
+								Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+								ForwardTo: httpRouteForwardTo("kuard", 8080, 1),
 								Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
 									Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
 									RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
@@ -1719,7 +1674,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clusters(service(kuardService)),
+							Clusters:           clustersWeight(service(kuardService)),
 							RequestHeadersPolicy: &HeadersPolicy{
 								Set:         map[string]string{"Custom-Header-Set": "foo-bar"},
 								Add:         map[string]string{}, // Invalid header should not be set.
@@ -1749,17 +1704,11 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{
 							{
-								Matches: []gatewayapi_v1alpha1.HTTPRouteMatch{
-									{
-										Path: gatewayapi_v1alpha1.HTTPPathMatch{
-											Type:  "Prefix",
-											Value: "/",
-										},
-									},
-								},
+								Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
 								ForwardTo: []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
 									ServiceName: pointer.StringPtr("kuard"),
 									Port:        gatewayPort(8080),
+									Weight:      1,
 									Filters: []gatewayapi_v1alpha1.HTTPRouteFilter{{
 										Type: gatewayapi_v1alpha1.HTTPRouteFilterRequestHeaderModifier,
 										RequestHeaderModifier: &gatewayapi_v1alpha1.HTTPRequestHeaderFilter{
@@ -1781,6 +1730,167 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Clusters:           clusterHeaders(map[string]string{"Custom-Header-Set": "foo-bar"}, map[string]string{}, nil, "bar.com", service(kuardService)),
 						},
 					)),
+				},
+			),
+		},
+		"different weights for multiple forwardTos": {
+			gateway: gatewayWithSelector,
+			objs: []interface{}{
+				kuardService,
+				kuardService2,
+				kuardService3,
+				&gatewayapi_v1alpha1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+						Labels: map[string]string{
+							"app":  "contour",
+							"type": "controller",
+						},
+					},
+					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+							Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwards(
+								httpRouteForwardTo("kuard", 8080, 5),
+								httpRouteForwardTo("kuard2", 8080, 10),
+								httpRouteForwardTo("kuard3", 8080, 15),
+							),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("*", prefixrouteHTTPRoute("/",
+							&Service{
+								Weighted: WeightedService{
+									Weight:           5,
+									ServiceName:      kuardService.Name,
+									ServiceNamespace: kuardService.Namespace,
+									ServicePort:      kuardService.Spec.Ports[0],
+								},
+							},
+							&Service{
+								Weighted: WeightedService{
+									Weight:           10,
+									ServiceName:      kuardService2.Name,
+									ServiceNamespace: kuardService2.Namespace,
+									ServicePort:      kuardService2.Spec.Ports[0],
+								},
+							},
+							&Service{
+								Weighted: WeightedService{
+									Weight:           15,
+									ServiceName:      kuardService3.Name,
+									ServiceNamespace: kuardService3.Namespace,
+									ServicePort:      kuardService3.Spec.Ports[0],
+								},
+							},
+						)),
+					),
+				},
+			),
+		},
+		"one service weight zero w/weights for other forwardTos": {
+			gateway: gatewayWithSelector,
+			objs: []interface{}{
+				kuardService,
+				kuardService2,
+				kuardService3,
+				&gatewayapi_v1alpha1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+						Labels: map[string]string{
+							"app":  "contour",
+							"type": "controller",
+						},
+					},
+					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+							Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwards(
+								httpRouteForwardTo("kuard", 8080, 5),
+								httpRouteForwardTo("kuard2", 8080, 0),
+								httpRouteForwardTo("kuard3", 8080, 15),
+							),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("*", prefixrouteHTTPRoute("/",
+							&Service{
+								Weighted: WeightedService{
+									Weight:           5,
+									ServiceName:      kuardService.Name,
+									ServiceNamespace: kuardService.Namespace,
+									ServicePort:      kuardService.Spec.Ports[0],
+								},
+							},
+							&Service{
+								Weighted: WeightedService{
+									Weight:           0,
+									ServiceName:      kuardService2.Name,
+									ServiceNamespace: kuardService2.Namespace,
+									ServicePort:      kuardService2.Spec.Ports[0],
+								},
+							},
+							&Service{
+								Weighted: WeightedService{
+									Weight:           15,
+									ServiceName:      kuardService3.Name,
+									ServiceNamespace: kuardService3.Namespace,
+									ServicePort:      kuardService3.Spec.Ports[0],
+								},
+							},
+						)),
+					),
+				},
+			),
+		},
+		"weight of zero for a single forwardTo results in 503": {
+			gateway: gatewayWithSelector,
+			objs: []interface{}{
+				kuardService,
+				kuardService2,
+				kuardService3,
+				&gatewayapi_v1alpha1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+						Labels: map[string]string{
+							"app":  "contour",
+							"type": "controller",
+						},
+					},
+					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+							ForwardTo: httpRouteForwardTo("kuard", 8080, 0),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("*", directResponseRouteService("/", http.StatusServiceUnavailable, &Service{
+							Weighted: WeightedService{
+								Weight:           0,
+								ServiceName:      kuardService.Name,
+								ServiceNamespace: kuardService.Namespace,
+								ServicePort:      kuardService.Spec.Ports[0],
+							},
+						})),
+					),
 				},
 			),
 		},
@@ -10337,6 +10447,15 @@ func directResponseRoute(prefix string, statusCode uint32) *Route {
 	}
 }
 
+func directResponseRouteService(prefix string, statusCode uint32, first *Service, rest ...*Service) *Route {
+	services := append([]*Service{first}, rest...)
+	return &Route{
+		PathMatchCondition: prefixString(prefix),
+		DirectResponse:     &DirectResponse{StatusCode: statusCode},
+		Clusters:           clustersWeight(services...),
+	}
+}
+
 func httpRouteMatch(pathType gatewayapi_v1alpha1.PathMatchType, value string) []gatewayapi_v1alpha1.HTTPRouteMatch {
 	return []gatewayapi_v1alpha1.HTTPRouteMatch{{
 		Path: gatewayapi_v1alpha1.HTTPPathMatch{
@@ -10346,10 +10465,20 @@ func httpRouteMatch(pathType gatewayapi_v1alpha1.PathMatchType, value string) []
 	}}
 }
 
-func httpRouteForwardTo(serviceName string, port int) []gatewayapi_v1alpha1.HTTPRouteForwardTo {
+func httpRouteForwards(forwards ...[]gatewayapi_v1alpha1.HTTPRouteForwardTo) []gatewayapi_v1alpha1.HTTPRouteForwardTo {
+	var fwds []gatewayapi_v1alpha1.HTTPRouteForwardTo
+
+	for _, f := range forwards {
+		fwds = append(fwds, f...)
+	}
+	return fwds
+}
+
+func httpRouteForwardTo(serviceName string, port int, weight int32) []gatewayapi_v1alpha1.HTTPRouteForwardTo {
 	return []gatewayapi_v1alpha1.HTTPRouteForwardTo{{
 		ServiceName: pointer.StringPtr(serviceName),
 		Port:        gatewayPort(port),
+		Weight:      weight,
 	}}
 }
 
@@ -10361,11 +10490,19 @@ func prefixroute(prefix string, first *Service, rest ...*Service) *Route {
 	}
 }
 
-func exactroute(path string, first *Service, rest ...*Service) *Route {
+func prefixrouteHTTPRoute(prefix string, first *Service, rest ...*Service) *Route {
+	services := append([]*Service{first}, rest...)
+	return &Route{
+		PathMatchCondition: prefixString(prefix),
+		Clusters:           clustersWeight(services...),
+	}
+}
+
+func exactrouteHTTPRoute(path string, first *Service, rest ...*Service) *Route {
 	services := append([]*Service{first}, rest...)
 	return &Route{
 		PathMatchCondition: &ExactMatchCondition{Path: path},
-		Clusters:           clusters(services...),
+		Clusters:           clustersWeight(services...),
 	}
 }
 
@@ -10425,6 +10562,7 @@ func clusterHeaders(requestSet map[string]string, requestAdd map[string]string, 
 				Remove:      requestRemove,
 				HostRewrite: hostRewrite,
 			},
+			Weight: s.Weighted.Weight,
 		})
 	}
 	return c
@@ -10435,6 +10573,17 @@ func clusters(services ...*Service) (c []*Cluster) {
 		c = append(c, &Cluster{
 			Upstream: s,
 			Protocol: s.Protocol,
+		})
+	}
+	return c
+}
+
+func clustersWeight(services ...*Service) (c []*Cluster) {
+	for _, s := range services {
+		c = append(c, &Cluster{
+			Upstream: s,
+			Protocol: s.Protocol,
+			Weight:   s.Weighted.Weight,
 		})
 	}
 	return c


### PR DESCRIPTION
Adds weight processing to the HTTPRoute.ForwardTos. If not specified,
defaults to the API default of "1". If set to zero, and all other services
are also set to zero or are invalid, an HTTP 503 response is returned.

Fixes #3560

Signed-off-by: Steve Sloka <slokas@vmware.com>