### PR TITLE
update RBAC permissions for gateway-api types to allow for Status to be updated

### DIFF
--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -91,6 +91,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies/status
+  - httproutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+- apiGroups:
   - projectcontour.io
   resources:
   - extensionservices

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1912,6 +1912,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - backendpolicies/status
+  - httproutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+- apiGroups:
   - projectcontour.io
   resources:
   - extensionservices

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -54,6 +54,7 @@ func IngressV1Resources() []schema.GroupVersionResource {
 }
 
 // +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gateways;httproutes;backendpolicies;tlsroutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=httproutes/status;backendpolicies/status;tlsroutes/status,verbs=update
 
 // GatewayAPIResources ...
 func GatewayAPIResources() []schema.GroupVersionResource {


### PR DESCRIPTION
The current RBAC permissions didn't allow for status to be updated from the Contour service account. This updates those so it can write status. 

Signed-off-by: Steve Sloka <slokas@vmware.com>