### PR TITLE
internal/dag: Add informers for TCPRoutes & UDPRoutes

### DIFF
--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -85,7 +85,9 @@ rules:
   - backendpolicies
   - gateways
   - httproutes
+  - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -95,7 +97,9 @@ rules:
   resources:
   - backendpolicies/status
   - httproutes/status
+  - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1906,7 +1906,9 @@ rules:
   - backendpolicies
   - gateways
   - httproutes
+  - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list
@@ -1916,7 +1918,9 @@ rules:
   resources:
   - backendpolicies/status
   - httproutes/status
+  - tcproutes/status
   - tlsroutes/status
+  - udproutes/status
   verbs:
   - update
 - apiGroups:

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -917,6 +917,24 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert gateway-api TCPRoute": {
+			obj: &gatewayapi_v1alpha1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcproute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"insert gateway-api UDPRoute": {
+			obj: &gatewayapi_v1alpha1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udproute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
 		"insert gateway-api TLSRoute": {
 			obj: &gatewayapi_v1alpha1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1183,6 +1201,36 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove gateway-api TCPRoute": {
+			cache: cache(&gatewayapi_v1alpha1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcproute",
+					Namespace: "default",
+				},
+			}),
+			obj: &gatewayapi_v1alpha1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcproute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove gateway-api UDPRoute": {
+			cache: cache(&gatewayapi_v1alpha1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udproute",
+					Namespace: "default",
+				},
+			}),
+			obj: &gatewayapi_v1alpha1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udproute",
 					Namespace: "default",
 				},
 			},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -53,8 +53,8 @@ func IngressV1Resources() []schema.GroupVersionResource {
 	}
 }
 
-// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gateways;httproutes;backendpolicies;tlsroutes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=httproutes/status;backendpolicies/status;tlsroutes/status,verbs=update
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gateways;httproutes;backendpolicies;tlsroutes;tcproutes;udproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=httproutes/status;backendpolicies/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
 
 // GatewayAPIResources ...
 func GatewayAPIResources() []schema.GroupVersionResource {
@@ -74,8 +74,15 @@ func GatewayAPIResources() []schema.GroupVersionResource {
 		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
 		Version:  gatewayapi_v1alpha1.GroupVersion.Version,
 		Resource: "tlsroutes",
-	},
-	}
+	}, {
+		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
+		Version:  gatewayapi_v1alpha1.GroupVersion.Version,
+		Resource: "tcproutes",
+	}, {
+		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
+		Version:  gatewayapi_v1alpha1.GroupVersion.Version,
+		Resource: "udproutes",
+	}}
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch


### PR DESCRIPTION
Adds informers to add TCP/UDP Routes to the k8s cache to allow setting status
on them in a future PR.

Updates #3441 #3442

Signed-off-by: Steve Sloka <slokas@vmware.com>