### PR TITLE
internal/envoy/v3: Bootstrap clusters with IPs configured as STATIC

### DIFF
--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -163,7 +163,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 				Name:                 "contour",
 				AltStatName:          strings.Join([]string{c.Namespace, "contour", strconv.Itoa(c.GetXdsGRPCPort())}, "_"),
 				ConnectTimeout:       protobuf.Duration(5 * time.Second),
-				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
+				ClusterDiscoveryType: ClusterDiscoveryTypeForAddress(c.GetXdsAddress(), envoy_cluster_v3.Cluster_STRICT_DNS),
 				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
 				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
 					ClusterName: "contour",
@@ -198,7 +198,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 				Name:                 "service-stats",
 				AltStatName:          strings.Join([]string{c.Namespace, "service-stats", strconv.Itoa(c.GetAdminPort())}, "_"),
 				ConnectTimeout:       protobuf.Duration(250 * time.Millisecond),
-				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_LOGICAL_DNS),
+				ClusterDiscoveryType: ClusterDiscoveryTypeForAddress(c.GetAdminAddress(), envoy_cluster_v3.Cluster_LOGICAL_DNS),
 				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
 				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
 					ClusterName: "service-stats",

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -44,7 +44,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -101,7 +101,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -129,7 +129,7 @@ func TestBootstrap(t *testing.T) {
     "lds_config": {
       "api_config_source": {
         "api_type": "GRPC",
-		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -143,7 +143,7 @@ func TestBootstrap(t *testing.T) {
     "cds_config": {
       "api_config_source": {
         "api_type": "GRPC",
-	 	"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -179,7 +179,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -236,7 +236,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9200",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -248,6 +248,141 @@ func TestBootstrap(t *testing.T) {
                     "address": {
                       "socket_address": {
                         "address": "8.8.8.8",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+        "transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "8.8.8.8",
+        "port_value": 9200
+      }
+    }
+  }
+}`,
+		},
+		"--admin-address=someaddr --admin-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:         "envoy.json",
+				AdminAddress: "someaddr",
+				AdminPort:    9200,
+				Namespace:    "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STATIC",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9200",
+        "type": "LOGICAL_DNS",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "someaddr",
                         "port_value": 9200
                       }
                     }
@@ -294,7 +429,142 @@ func TestBootstrap(t *testing.T) {
     "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
-        "address": "8.8.8.8",
+        "address": "someaddr",
+        "port_value": 9200
+      }
+    }
+  }
+}`,
+		},
+		"--admin-address=::1 --admin-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:         "envoy.json",
+				AdminAddress: "::1",
+				AdminPort:    9200,
+				Namespace:    "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_8001",
+        "type": "STATIC",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 8001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9200",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "::1",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+		"transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+      "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "::1",
         "port_value": 9200
       }
     }
@@ -313,7 +583,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -370,7 +640,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -412,7 +682,7 @@ func TestBootstrap(t *testing.T) {
     "cds_config": {
       "api_config_source": {
         "api_type": "GRPC",
-		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -448,7 +718,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_9200",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -505,7 +775,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -570,6 +840,276 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
+		"--xds-address=contour --xds-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:        "envoy.json",
+				XDSAddress:  "contour",
+				XDSGRPCPort: 9200,
+				Namespace:   "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_9200",
+        "type": "STRICT_DNS",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "contour",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {	
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",	
+            "explicit_http_config": {	
+              "http2_protocol_options": {}	
+            }	
+          }	
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+        "transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+        "transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
+		"--xds-address=::1 --xds-port=9200": {
+			config: envoy.BootstrapConfig{
+				Path:        "envoy.json",
+				XDSAddress:  "::1",
+				XDSGRPCPort: 9200,
+				Namespace:   "testing-ns",
+			},
+			wantedBootstrapConfig: `{
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "contour",
+        "alt_stat_name": "testing-ns_contour_9200",
+        "type": "STATIC",
+        "connect_timeout": "5s",
+        "load_assignment": {
+          "cluster_name": "contour",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "::1",
+                        "port_value": 9200
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            },
+            {
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 60000000,
+              "max_retries": 50
+            }
+          ]
+        },
+        "typed_extension_protocol_options": {
+          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+            "explicit_http_config": {
+              "http2_protocol_options": {}
+            }
+          }
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_probes": 3,
+            "keepalive_time": 30,
+            "keepalive_interval": 5
+          }
+        }
+      },
+      {
+        "name": "service-stats",
+        "alt_stat_name": "testing-ns_service-stats_9001",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "load_assignment": {
+          "cluster_name": "service-stats",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "127.0.0.1",
+                        "port_value": 9001
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+        "transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    },
+    "cds_config": {
+      "api_config_source": {
+        "api_type": "GRPC",
+        "transport_api_version": "V3",
+        "grpc_services": [
+          {
+            "envoy_grpc": {
+              "cluster_name": "contour"
+            }
+          }
+        ]
+      },
+	  "resource_api_version": "V3"
+    }
+  },
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 9001
+      }
+    }
+  }
+}`,
+		},
 		"--xds-address=8.8.8.8 --xds-port=9200 --dns-lookup-family=v6": {
 			config: envoy.BootstrapConfig{
 				Path:            "envoy.json",
@@ -584,7 +1124,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_9200",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -642,7 +1182,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -670,7 +1210,7 @@ func TestBootstrap(t *testing.T) {
     "lds_config": {
       "api_config_source": {
         "api_type": "GRPC",
- 		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -684,140 +1224,7 @@ func TestBootstrap(t *testing.T) {
     "cds_config": {
       "api_config_source": {
         "api_type": "GRPC",
- 		"transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-	  "resource_api_version": "V3"
-    }
-  },
-  "admin": {
-    "access_log_path": "/dev/null",
-    "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
-      }
-    }
-  }
-}`,
-		},
-		"--stats-address=8.8.8.8 --stats-port=9200": {
-			config: envoy.BootstrapConfig{
-				Path:      "envoy.json",
-				Namespace: "testing-ns",
-			},
-			wantedBootstrapConfig: `{
-  "static_resources": {
-    "clusters": [
-      {
-        "name": "contour",
-        "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STRICT_DNS",
-        "connect_timeout": "5s",
-        "load_assignment": {
-          "cluster_name": "contour",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 8001
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "circuit_breakers": {
-          "thresholds": [
-            {
-              "priority": "HIGH",
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            },
-            {
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            }
-          ]
-        },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {	
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",	
-            "explicit_http_config": {	
-              "http2_protocol_options": {}	
-            }	
-          }	
-        },
-        "upstream_connection_options": {
-          "tcp_keepalive": {
-            "keepalive_probes": 3,
-            "keepalive_time": 30,
-            "keepalive_interval": 5
-          }
-        }
-      },
-      {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
-        "connect_timeout": "0.250s",
-        "load_assignment": {
-          "cluster_name": "service-stats",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  },
- "dynamic_resources": {
-    "lds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
- 		"transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-	  "resource_api_version": "V3"
-    },
-    "cds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
- 		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -855,7 +1262,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "contour",
         "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STRICT_DNS",
+        "type": "STATIC",
         "connect_timeout": "5s",
         "load_assignment": {
           "cluster_name": "contour",
@@ -940,7 +1347,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9001",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -968,7 +1375,7 @@ func TestBootstrap(t *testing.T) {
     "lds_config": {
       "api_config_source": {
         "api_type": "GRPC",
- 		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -982,7 +1389,7 @@ func TestBootstrap(t *testing.T) {
     "cds_config": {
       "api_config_source": {
         "api_type": "GRPC",
- 		"transport_api_version": "V3",
+        "transport_api_version": "V3",
         "grpc_services": [
           {
             "envoy_grpc": {
@@ -1021,7 +1428,7 @@ func TestBootstrap(t *testing.T) {
             {
               "name": "contour",
               "alt_stat_name": "testing-ns_contour_8001",
-              "type": "STRICT_DNS",
+              "type": "STATIC",
               "connect_timeout": "5s",
               "load_assignment": {
                 "cluster_name": "contour",
@@ -1102,7 +1509,7 @@ func TestBootstrap(t *testing.T) {
             {
               "name": "service-stats",
               "alt_stat_name": "testing-ns_service-stats_9001",
-              "type": "LOGICAL_DNS",
+              "type": "STATIC",
               "connect_timeout": "0.250s",
               "load_assignment": {
                 "cluster_name": "service-stats",

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -14,6 +14,7 @@
 package v3
 
 import (
+	"net"
 	"strings"
 	"time"
 
@@ -228,6 +229,17 @@ func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
 // ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
 func ClusterDiscoveryType(t envoy_cluster_v3.Cluster_DiscoveryType) *envoy_cluster_v3.Cluster_Type {
 	return &envoy_cluster_v3.Cluster_Type{Type: t}
+}
+
+// ClusterDiscoveryTypeForAddress returns the type of a ClusterDiscovery as a Cluster_type.
+// If the provided address is an IP, overrides the type to STATIC, otherwise uses the
+// passed in type.
+func ClusterDiscoveryTypeForAddress(address string, t envoy_cluster_v3.Cluster_DiscoveryType) *envoy_cluster_v3.Cluster_Type {
+	clusterType := t
+	if net.ParseIP(address) != nil {
+		clusterType = envoy_cluster_v3.Cluster_STATIC
+	}
+	return &envoy_cluster_v3.Cluster_Type{Type: clusterType}
 }
 
 // parseDNSLookupFamily parses the dnsLookupFamily string into a envoy_cluster_v3.Cluster_DnsLookupFamily


### PR DESCRIPTION
Strict/Logical DNS clusters fail to parse ipv6 IPs and according to the
Envoy documentation should not use an IP
See: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/service_discovery#arch-overview-service-discovery-types
See: https://github.com/envoyproxy/envoy/issues/10489

Limited to bootstrap clusters for now

Also cleans up whitespace in tests

Updates: #3564
Updates: #3284