### PR TITLE
internal/dag: Fix processing of httproutes validation

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -117,7 +117,6 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			if selMatches && nsMatches {
 				// Empty Selector matches all routes.
 				matchingRoutes = append(matchingRoutes, route)
-				break
 			}
 		}
 


### PR DESCRIPTION
When processing through HTTPRoutes to validate if they match the configured Gateway,
any additional HTTPRoutes would not get processed after the first one. This was
due to an unneeded "break" in the code stopping execution for valid routes.

Fixes #3591

Signed-off-by: Steve Sloka <slokas@vmware.com>