### PR TITLE
header match conditions: add support for notpresent

### DIFF
--- a/_integration/testsuite/httpproxy/002-header-condition-match.yaml
+++ b/_integration/testsuite/httpproxy/002-header-condition-match.yaml
@@ -38,6 +38,26 @@ metadata:
   name: ingress-conformance-echo
 $apply:
   fixture:
+    as: echo-header-notpresent
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-header-notpresent
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
     as: echo-header-contains
 
 ---
@@ -128,6 +148,13 @@ spec:
         name: Target-Present
         present: true
   - services:
+    - name: echo-header-notpresent
+      port: 80
+    conditions:
+    - header:
+        name: Target-Present
+        notpresent: true
+  - services:
     - name: echo-header-contains
       port: 80
     conditions:
@@ -200,6 +227,8 @@ random := sprintf("%d", [time.now_ns()])
 
 cases := {
   { "header": "Target-Present", "value": random, "status": 200, "service": "echo-header-present" },
+  
+  { "status": 200, "service": "echo-header-notpresent" },
 
   { "header": "Target-Contains", "value": random, "status": 404 },
   { "header": "Target-Contains", "value": "ContainsValue", "status": 200, "service": "echo-header-contains" },

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -81,6 +81,12 @@ type HeaderMatchCondition struct {
 	// +optional
 	Present bool `json:"present,omitempty"`
 
+	// NotPresent specifies that condition is true when the named header
+	// is not present. Note that setting NotPresent to false does not
+	// make the condition true if the named header is present.
+	// +optional
+	NotPresent bool `json:"notpresent,omitempty"`
+
 	// Contains specifies a substring that must be present in
 	// the header value.
 	// +optional

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -501,6 +501,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -588,6 +594,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -852,6 +864,15 @@ spec:
                                                       is true if the header has any
                                                       other value.
                                                     type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when
+                                                      the named header is not present.
+                                                      Note that setting NotPresent
+                                                      to false does not make the condition
+                                                      true if the named header is
+                                                      present.
+                                                    type: boolean
                                                   present:
                                                     description: Present specifies
                                                       that condition is true when
@@ -1697,6 +1718,14 @@ spec:
                                                     is true if the header has any
                                                     other value.
                                                   type: string
+                                                notpresent:
+                                                  description: NotPresent specifies
+                                                    that condition is true when the
+                                                    named header is not present. Note
+                                                    that setting NotPresent to false
+                                                    does not make the condition true
+                                                    if the named header is present.
+                                                  type: boolean
                                                 present:
                                                   description: Present specifies that
                                                     condition is true when the named

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -680,6 +680,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -767,6 +773,12 @@ spec:
                                   value must not be equal to. The condition is true
                                   if the header has any other value.
                                 type: string
+                              notpresent:
+                                description: NotPresent specifies that condition is
+                                  true when the named header is not present. Note
+                                  that setting NotPresent to false does not make the
+                                  condition true if the named header is present.
+                                type: boolean
                               present:
                                 description: Present specifies that condition is true
                                   when the named header is present, regardless of
@@ -1031,6 +1043,15 @@ spec:
                                                       is true if the header has any
                                                       other value.
                                                     type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when
+                                                      the named header is not present.
+                                                      Note that setting NotPresent
+                                                      to false does not make the condition
+                                                      true if the named header is
+                                                      present.
+                                                    type: boolean
                                                   present:
                                                     description: Present specifies
                                                       that condition is true when
@@ -1876,6 +1897,14 @@ spec:
                                                     is true if the header has any
                                                     other value.
                                                   type: string
+                                                notpresent:
+                                                  description: NotPresent specifies
+                                                    that condition is true when the
+                                                    named header is not present. Note
+                                                    that setting NotPresent to false
+                                                    does not make the condition true
+                                                    if the named header is present.
+                                                  type: boolean
                                                 present:
                                                   description: Present specifies that
                                                     condition is true when the named

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -125,6 +125,19 @@ func TestHeaderMatchConditions(t *testing.T) {
 				MatchType: "present",
 			}},
 		},
+		"header not present": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: &contour_api_v1.HeaderMatchCondition{
+					Name:       "x-request-id",
+					NotPresent: true,
+				},
+			}},
+			want: []HeaderMatchCondition{{
+				Name:      "x-request-id",
+				MatchType: "present",
+				Invert:    true,
+			}},
+		},
 		"header name but missing condition": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Header: &contour_api_v1.HeaderMatchCondition{
@@ -483,6 +496,38 @@ func TestValidateHeaderMatchConditions(t *testing.T) {
 					Header: &contour_api_v1.HeaderMatchCondition{
 						Name:        "x-another-header",
 						NotContains: "abc",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		"'present' and 'notpresent' matchconditions for the same header are invalid": {
+			matchconditions: []contour_api_v1.MatchCondition{
+				{
+					Header: &contour_api_v1.HeaderMatchCondition{
+						Name:    "x-header",
+						Present: true,
+					},
+				}, {
+					Header: &contour_api_v1.HeaderMatchCondition{
+						Name:       "x-header",
+						NotPresent: true,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"'present' and 'notpresent' matchconditions for different headers are valid": {
+			matchconditions: []contour_api_v1.MatchCondition{
+				{
+					Header: &contour_api_v1.HeaderMatchCondition{
+						Name:    "x-header",
+						Present: true,
+					},
+				}, {
+					Header: &contour_api_v1.HeaderMatchCondition{
+						Name:       "x-different-header",
+						NotPresent: true,
 					},
 				},
 			},

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -761,12 +761,12 @@ func TestRateLimitPolicy(t *testing.T) {
 									RequestHeaderValueMatch: &contour_api_v1.RequestHeaderValueMatchDescriptor{
 										Headers: []contour_api_v1.HeaderMatchCondition{
 											{
-												Name:    "X-Header",
-												Present: true,
+												Name:       "X-Header",
+												NotPresent: true,
 											},
 										},
 										ExpectMatch: true,
-										Value:       "header-is-present",
+										Value:       "header-is-not-present",
 									},
 								},
 							},
@@ -785,10 +785,11 @@ func TestRateLimitPolicy(t *testing.T) {
 											{
 												Name:      "X-Header",
 												MatchType: "present",
+												Invert:    true,
 											},
 										},
 										ExpectMatch: true,
-										Value:       "header-is-present",
+										Value:       "header-is-not-present",
 									},
 								},
 							},

--- a/site/docs/main/config/api-reference.html
+++ b/site/docs/main/config/api-reference.html
@@ -1167,6 +1167,21 @@ is absent.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
+<code>notpresent</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NotPresent specifies that condition is true when the named header
+is not present. Note that setting NotPresent to false does not
+make the condition true if the named header is present.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>contains</code>
 <br>
 <em>

--- a/site/docs/main/config/request-routing.md
+++ b/site/docs/main/config/request-routing.md
@@ -74,9 +74,9 @@ Prefix conditions **must** start with a `/` if they are present.
 
 #### Header conditions
 
-For `header` conditions there is one required field, `name`, and five operator fields: `present`, `contains`, `notcontains`, `exact`, and `notexact`.
+For `header` conditions there is one required field, `name`, and six operator fields: `present`, `notpresent`, `contains`, `notcontains`, `exact`, and `notexact`.
 
-- `present` is a boolean and checks that the header is present. The value will not be checked.
+- `present` is a boolean and checks that the header is present. The value will not be checked. `notpresent` similarly checks that the header is *not* present.
 
 - `contains` is a string, and checks that the header contains the string. `notcontains` similarly checks that the header does *not* contain the string.
 


### PR DESCRIPTION
Adds support for the notpresent header match type.

Signed-off-by: Steve Kriss <krisss@vmware.com>