### PR TITLE
Remove old versions from matrix and add main row

### DIFF
--- a/site/_resources/compatibility-matrix.md
+++ b/site/_resources/compatibility-matrix.md
@@ -11,30 +11,25 @@ Other combinations *may* work, but are not tested or supported.
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version |
 | --------------- | :------------------- | ------------------- | ---------------- |
-| 1.14.1          | [1.17.2][15]         | 1.20, 1.19, 1.18    | [1.14.1][55]     |
-| 1.14.0          | [1.17.1][14]         | 1.20, 1.19, 1.18    | [1.14.0][54]     |
-| 1.13.1          | [1.17.1][14]         | 1.20, 1.19, 1.18    | [1.13.1][53]     |
-| 1.13.0          | [1.17.0][13]         | 1.20, 1.19, 1.18    | [1.13.0][52]     |
-| 1.12.0          | [1.17.0][13]         | 1.19, 1.18, 1.17    | [1.12.0][51]     |
-| 1.11.0          | [1.16.2][12]         | 1.19, 1.18, 1.17    | [1.11.0][50]     |
-| 1.10.1          | [1.16.2][12]         | 1.19, 1.18, 1.17    | N/A              |
-| 1.10.0          | [1.16.0][11]         | 1.19, 1.18, 1.17    | N/A              |
-| 1.9.0           | [1.15.1][10]         | 1.18, 1.17, 1.16    | N/A              |
-| 1.8.2           | [1.15.1][10]         | 1.18, 1.17, 1.16    | N/A              |
-| 1.8.1           | [1.15.0][9]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.8.0           | [1.15.0][9]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.7.0           | [1.15.0][9]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.6.1           | [1.14.3][8]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.6.0           | [1.14.2][7]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.5.1           | [1.14.2][7]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.5.0           | [1.14.1][6]          | 1.18, 1.17, 1.16    | N/A              |
-| 1.4.0           | [1.14.1][6]          | 1.17, 1.16, 1.15    | N/A              |
-| 1.3.0           | [1.13.1][5]          | 1.17, 1.16, 1.15    | N/A              |
-| 1.2.1           | [1.13.1][5]          | 1.17, 1.16, 1.15    | N/A              |
-| 1.2.0           | [1.13.0][4]          | 1.17, 1.16, 1.15    | N/A              |
-| 1.1.0           | [1.12.2][3]          | 1.15, 1.14, 1.13    | N/A              |
-| 1.0.1           | [1.12.2][3]          | 1.15, 1.14, 1.13    | N/A              |
-| 1.0.0           | [1.11.2][2]          | 1.15, 1.14, 1.13    | N/A              |
+| main            | [1.18.2][12]         | 1.20, 1.19, 1.18    | [main][50]       |
+| 1.14.1          | [1.17.2][11]         | 1.20, 1.19, 1.18    | [1.14.1][56]     |
+| 1.14.0          | [1.17.1][10]         | 1.20, 1.19, 1.18    | [1.14.0][55]     |
+| 1.13.1          | [1.17.1][10]         | 1.20, 1.19, 1.18    | [1.13.1][54]     |
+| 1.13.0          | [1.17.0][9]          | 1.20, 1.19, 1.18    | [1.13.0][53]     |
+| 1.12.0          | [1.17.0][9]          | 1.19, 1.18, 1.17    | [1.12.0][52]     |
+| 1.11.0          | [1.16.2][8]          | 1.19, 1.18, 1.17    | [1.11.0][51]     |
+| 1.10.1          | [1.16.2][8]          | 1.19, 1.18, 1.17    | N/A              |
+| 1.10.0          | [1.16.0][7]          | 1.19, 1.18, 1.17    | N/A              |
+| 1.9.0           | [1.15.1][6]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.8.2           | [1.15.1][6]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.8.1           | [1.15.0][5]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.8.0           | [1.15.0][5]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.7.0           | [1.15.0][5]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.6.1           | [1.14.3][4]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.6.0           | [1.14.2][3]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.5.1           | [1.14.2][3]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.5.0           | [1.14.1][2]          | 1.18, 1.17, 1.16    | N/A              |
+| 1.4.0           | [1.14.1][2]          | 1.17, 1.16, 1.15    | N/A              |
 
 <br />
 
@@ -97,28 +92,26 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 
 [1]: {{site.github.repository_url}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
 
-[2]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.11.2
-[3]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.12.2
-[4]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.13.0
-[5]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.13.1
-[6]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.1
-[7]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.2
-[8]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.3
-[9]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.0
-[10]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.1
-[11]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.0
-[12]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.2
-[13]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.0
-[14]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.1
-[15]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.2
+[2]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.1
+[3]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.2
+[4]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.3
+[5]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.0
+[6]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.1
+[7]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.0
+[8]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.2
+[9]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.0
+[10]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.1
+[11]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.17.2
+[12]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.18.2
 
 
-[50]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0
-[51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.12.0
-[52]: https://github.com/projectcontour/contour-operator/releases/tag/v1.13.0
-[53]: https://github.com/projectcontour/contour-operator/releases/tag/v1.13.1
-[54]: https://github.com/projectcontour/contour-operator/releases/tag/v1.14.0
-[55]: https://github.com/projectcontour/contour-operator/releases/tag/v1.14.1
+[50]: https://github.com/projectcontour/contour-operator
+[51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0
+[52]: https://github.com/projectcontour/contour-operator/releases/tag/v1.12.0
+[53]: https://github.com/projectcontour/contour-operator/releases/tag/v1.13.0
+[54]: https://github.com/projectcontour/contour-operator/releases/tag/v1.13.1
+[55]: https://github.com/projectcontour/contour-operator/releases/tag/v1.14.0
+[56]: https://github.com/projectcontour/contour-operator/releases/tag/v1.14.1
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix


### PR DESCRIPTION
So we can track main, make adding a new release easier
- When we bump Envoy or k8s supported versions we can bump this

Chopped off table up to previous year, we can limit this more if we think we should