### PR TITLE
bump kubernetes version to use v1.21.0

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -19,11 +19,11 @@ jobs:
         # image to use) for each kubernetes_version value.
         include:
           - kubernetes_version: "kubernetes:latest"
-            node_image: "docker.io/kindest/node:v1.20.2"
+            node_image: "stevesloka/kind-node:v1.21.0"
           - kubernetes_version: "kubernetes:n-1"
-            node_image: "docker.io/kindest/node:v1.19.7"
+            node_image: "docker.io/kindest/node:v1.20.2"
           - kubernetes_version: "kubernetes:n-2"
-            node_image: "docker.io/kindest/node:v1.18.15"
+            node_image: "docker.io/kindest/node:v1.19.7"
     steps:
       - uses: actions/checkout@v2
       - name: add deps to path

--- a/_integration/testsuite/make-kind-cluster.sh
+++ b/_integration/testsuite/make-kind-cluster.sh
@@ -58,6 +58,9 @@ fi
 # Create a fresh kind cluster.
 if ! kind::cluster::exists "$CLUSTERNAME" ; then
   kind::cluster::create
+
+  # Print the k8s version for verification
+  ${KUBECTL} version
 fi
 
 # Push test images into the cluster.

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -39,11 +39,19 @@ case "$#" in
 esac
 
 
-download \
-    "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERS}/kind-${OS}-amd64" \
-    "${DESTDIR}/kind"
+# Install latest version of kind.
+go get sigs.k8s.io/kind@master
 
-chmod +x  "${DESTDIR}/kind"
+# Move the $GOPATH/bin/kind binary to local since Github actions
+# have their own version installed.
+mv /home/runner/go/bin/kind ${DESTDIR}/kind
+
+# Uncomment this once v0.11 of Kind is released.
+#download \
+#    "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERS}/kind-${OS}-amd64" \
+#    "${DESTDIR}/kind"
+#
+#chmod +x  "${DESTDIR}/kind"
 
 download \
     "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERS}/bin/${OS}/amd64/kubectl" \


### PR DESCRIPTION
Note the following changes will need to be reverted
once full upstream versions are available:

- Install latest version of Kind
- Use custom kind node image

Signed-off-by: Steve Sloka <slokas@vmware.com>