### PR TITLE
internal/dag: Filter on Gateway.Listener.Protocol for supported types

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1276,39 +1276,6 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		//"Only the Spec.Listener.Protocol: HTTPS should be valid for a TLS Listener Gateway": {
-		//	gateway: &gatewayapi_v1alpha1.Gateway{
-		//		ObjectMeta: metav1.ObjectMeta{
-		//			Name:      "contour",
-		//			Namespace: "projectcontour",
-		//		},
-		//		Spec: gatewayapi_v1alpha1.GatewaySpec{
-		//			Listeners: []gatewayapi_v1alpha1.Listener{{
-		//				Port:     443,
-		//				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
-		//				TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
-		//					CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
-		//						Group: "core",
-		//						Kind:  "Secret",
-		//						Name:  sec1.Name,
-		//					},
-		//				},
-		//				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
-		//					Kind: KindHTTPRoute,
-		//					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
-		//						From: gatewayapi_v1alpha1.RouteSelectAll,
-		//					},
-		//				},
-		//			}},
-		//		},
-		//	},
-		//	objs: []interface{}{
-		//		sec1,
-		//		blogService,
-		//		httpRouteProtocolHTTPS,
-		//	},
-		//	want: listeners(),
-		//},
 		"TLS Listener Gateway CertificateRef must be type core.Secret": {
 			gateway: &gatewayapi_v1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1159,7 +1159,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"insert basic single route, single hostname, gateway with TLS": {
+		"insert basic single route, single hostname, gateway with TLS, HTTP protocol is ignored": {
 			gateway: &gatewayapi_v1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "contour",
@@ -1168,7 +1168,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Spec: gatewayapi_v1alpha1.GatewaySpec{
 					Listeners: []gatewayapi_v1alpha1.Listener{{
 						Port:     443,
-						Protocol: gatewayapi_v1alpha1.HTTPSProtocolType,
+						Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
 						TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
 							CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
 								Group: "core",
@@ -1190,9 +1190,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				genericHTTPRoute,
 			},
-			want: listeners(),
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(
+						virtualhost("test.projectcontour.io",
+							prefixrouteHTTPRoute("/", service(kuardService)),
+						)),
+				},
+			),
 		},
-		"insert basic single route, single hostname, gateway with TLS, invalid listener protocol": {
+		"insert basic single route, single hostname, gateway with TLS": {
 			gateway: gatewayWithOnlyTLS,
 			objs: []interface{}{
 				sec1,
@@ -1268,39 +1276,39 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"Only the Spec.Listener.Protocol: HTTPS should be valid for a TLS Listener Gateway": {
-			gateway: &gatewayapi_v1alpha1.Gateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "contour",
-					Namespace: "projectcontour",
-				},
-				Spec: gatewayapi_v1alpha1.GatewaySpec{
-					Listeners: []gatewayapi_v1alpha1.Listener{{
-						Port:     443,
-						Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
-						TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
-							CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
-								Group: "core",
-								Kind:  "Secret",
-								Name:  sec1.Name,
-							},
-						},
-						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
-							Kind: KindHTTPRoute,
-							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
-								From: gatewayapi_v1alpha1.RouteSelectAll,
-							},
-						},
-					}},
-				},
-			},
-			objs: []interface{}{
-				sec1,
-				blogService,
-				httpRouteProtocolHTTPS,
-			},
-			want: listeners(),
-		},
+		//"Only the Spec.Listener.Protocol: HTTPS should be valid for a TLS Listener Gateway": {
+		//	gateway: &gatewayapi_v1alpha1.Gateway{
+		//		ObjectMeta: metav1.ObjectMeta{
+		//			Name:      "contour",
+		//			Namespace: "projectcontour",
+		//		},
+		//		Spec: gatewayapi_v1alpha1.GatewaySpec{
+		//			Listeners: []gatewayapi_v1alpha1.Listener{{
+		//				Port:     443,
+		//				Protocol: gatewayapi_v1alpha1.HTTPProtocolType,
+		//				TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+		//					CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
+		//						Group: "core",
+		//						Kind:  "Secret",
+		//						Name:  sec1.Name,
+		//					},
+		//				},
+		//				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+		//					Kind: KindHTTPRoute,
+		//					Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+		//						From: gatewayapi_v1alpha1.RouteSelectAll,
+		//					},
+		//				},
+		//			}},
+		//		},
+		//	},
+		//	objs: []interface{}{
+		//		sec1,
+		//		blogService,
+		//		httpRouteProtocolHTTPS,
+		//	},
+		//	want: listeners(),
+		//},
 		"TLS Listener Gateway CertificateRef must be type core.Secret": {
 			gateway: &gatewayapi_v1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1160,6 +1160,39 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			),
 		},
 		"insert basic single route, single hostname, gateway with TLS": {
+			gateway: &gatewayapi_v1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
+				Spec: gatewayapi_v1alpha1.GatewaySpec{
+					Listeners: []gatewayapi_v1alpha1.Listener{{
+						Port:     443,
+						Protocol: gatewayapi_v1alpha1.HTTPProtocolType, // <--- invalid protocol, must be "HTTPS"
+						TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
+							CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
+								Group: "core",
+								Kind:  "Secret",
+								Name:  sec1.Name,
+							},
+						},
+						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+							Kind: KindHTTPRoute,
+							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+								From: gatewayapi_v1alpha1.RouteSelectAll,
+							},
+						},
+					}},
+				},
+			},
+			objs: []interface{}{
+				sec1,
+				kuardService,
+				genericHTTPRoute,
+			},
+			want: listeners(),
+		},
+		"insert basic single route, single hostname, gateway with TLS, invalid listener protocol": {
 			gateway: gatewayWithOnlyTLS,
 			objs: []interface{}{
 				sec1,
@@ -1352,6 +1385,50 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 			},
+			want: listeners(),
+		},
+		"Invalid listener protocol type (TCP)": {
+			gateway: &gatewayapi_v1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
+				Spec: gatewayapi_v1alpha1.GatewaySpec{
+					Listeners: []gatewayapi_v1alpha1.Listener{{
+						Port:     80,
+						Protocol: gatewayapi_v1alpha1.TCPProtocolType,
+						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+							Kind: KindHTTPRoute,
+							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+								From: gatewayapi_v1alpha1.RouteSelectAll,
+							},
+						},
+					}},
+				},
+			},
+			objs: []interface{}{genericHTTPRoute},
+			want: listeners(),
+		},
+		"Invalid listener protocol type (UDP)": {
+			gateway: &gatewayapi_v1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
+				Spec: gatewayapi_v1alpha1.GatewaySpec{
+					Listeners: []gatewayapi_v1alpha1.Listener{{
+						Port:     80,
+						Protocol: gatewayapi_v1alpha1.UDPProtocolType,
+						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+							Kind: KindHTTPRoute,
+							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+								From: gatewayapi_v1alpha1.RouteSelectAll,
+							},
+						},
+					}},
+				},
+			},
+			objs: []interface{}{genericHTTPRoute},
 			want: listeners(),
 		},
 		"insert basic single route, single hostname, gateway with TLS & Insecure Listeners, different selectors": {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1200,6 +1200,32 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
+		"insert basic single route, single hostname, gateway with TLS, HTTPS protocol missing certificateRef": {
+			gateway: &gatewayapi_v1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
+				Spec: gatewayapi_v1alpha1.GatewaySpec{
+					Listeners: []gatewayapi_v1alpha1.Listener{{
+						Port:     443,
+						Protocol: gatewayapi_v1alpha1.HTTPSProtocolType,
+						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+							Kind: KindHTTPRoute,
+							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+								From: gatewayapi_v1alpha1.RouteSelectAll,
+							},
+						},
+					}},
+				},
+			},
+			objs: []interface{}{
+				sec1,
+				kuardService,
+				genericHTTPRoute,
+			},
+			want: listeners(),
+		},
 		"insert basic single route, single hostname, gateway with TLS": {
 			gateway: gatewayWithOnlyTLS,
 			objs: []interface{}{

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1168,7 +1168,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Spec: gatewayapi_v1alpha1.GatewaySpec{
 					Listeners: []gatewayapi_v1alpha1.Listener{{
 						Port:     443,
-						Protocol: gatewayapi_v1alpha1.HTTPProtocolType, // <--- invalid protocol, must be "HTTPS"
+						Protocol: gatewayapi_v1alpha1.HTTPSProtocolType,
 						TLS: &gatewayapi_v1alpha1.GatewayTLSConfig{
 							CertificateRef: &gatewayapi_v1alpha1.LocalObjectReference{
 								Group: "core",

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1406,6 +1406,28 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []interface{}{genericHTTPRoute},
 			want: listeners(),
 		},
+		"Invalid listener protocol type (custom)": {
+			gateway: &gatewayapi_v1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "contour",
+					Namespace: "projectcontour",
+				},
+				Spec: gatewayapi_v1alpha1.GatewaySpec{
+					Listeners: []gatewayapi_v1alpha1.Listener{{
+						Port:     80,
+						Protocol: "projectcontour.io/HTTPUDP",
+						Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+							Kind: KindHTTPRoute,
+							Namespaces: gatewayapi_v1alpha1.RouteNamespaces{
+								From: gatewayapi_v1alpha1.RouteSelectAll,
+							},
+						},
+					}},
+				},
+			},
+			objs: []interface{}{genericHTTPRoute},
+			want: listeners(),
+		},
 		"insert basic single route, single hostname, gateway with TLS & Insecure Listeners, different selectors": {
 			gateway: gatewaywithtlsDifferentselectors,
 			objs: []interface{}{

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -81,13 +81,6 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 
 		// Check for TLS on the Gateway.
 		if listener.TLS != nil {
-			if listener.Protocol != gatewayapi_v1alpha1.HTTPSProtocolType &&
-				listener.Protocol != gatewayapi_v1alpha1.TLSProtocolType {
-				p.Errorf("Listener.Protocol type must be %q or %q if specifying \"tls\" on a Gateway.",
-					gatewayapi_v1alpha1.HTTPSProtocolType, gatewayapi_v1alpha1.TLSProtocolType)
-				continue
-			}
-
 			if listenerSecret = p.validGatewayTLS(listener); listenerSecret == nil {
 				// If TLS was configured on the Listener, but it's invalid, don't allow any
 				// routes to be bound to this listener since it can't serve TLS traffic.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -77,6 +77,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			// Validate that if protocol is type HTTPS or TLS that TLS is defined.
 			if listener.TLS == nil {
 				p.Errorf("Listener.TLS is required when protocol is %q.", listener.Protocol)
+				continue
 			}
 
 			// Check for TLS on the Gateway.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -72,20 +72,24 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		var listenerSecret *Secret
 
 		// Validate the Kind on the selector is a supported type.
-		if listener.Protocol != gatewayapi_v1alpha1.HTTPProtocolType &&
-			listener.Protocol != gatewayapi_v1alpha1.HTTPSProtocolType &&
-			listener.Protocol != gatewayapi_v1alpha1.TLSProtocolType {
-			p.Errorf("Listener.Protocol %q is not supported.", listener.Protocol)
-			continue
-		}
+		switch listener.Protocol {
+		case gatewayapi_v1alpha1.HTTPSProtocolType, gatewayapi_v1alpha1.TLSProtocolType:
+			// Validate that if protocol is type HTTPS or TLS that TLS is defined.
+			if listener.TLS == nil {
+				p.Errorf("Listener.TLS is required when protocol is %q.", listener.Protocol)
+			}
 
-		// Check for TLS on the Gateway.
-		if listener.TLS != nil {
+			// Check for TLS on the Gateway.
 			if listenerSecret = p.validGatewayTLS(listener); listenerSecret == nil {
 				// If TLS was configured on the Listener, but it's invalid, don't allow any
 				// routes to be bound to this listener since it can't serve TLS traffic.
 				continue
 			}
+		case gatewayapi_v1alpha1.HTTPProtocolType:
+			break
+		default:
+			p.Errorf("Listener.Protocol %q is not supported.", listener.Protocol)
+			continue
 		}
 
 		// Validate the Group on the selector is a supported type.


### PR DESCRIPTION
Filters the Protocol on gateway listeners for only valid types (e.g. HTTP, HTTPS, TLS).

Fixes #3540

Signed-off-by: Steve Sloka <slokas@vmware.com>