### PR TITLE
internal/dag: Process HTTPRoute.Spec.Gateways

### DIFF
--- a/_integration/testsuite/gatewayapi/001-path-condition-match.yaml
+++ b/_integration/testsuite/gatewayapi/001-path-condition-match.yaml
@@ -128,6 +128,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - conditions.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/002-header-condition-match.yaml
+++ b/_integration/testsuite/gatewayapi/002-header-condition-match.yaml
@@ -59,6 +59,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - conditions.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
+++ b/_integration/testsuite/gatewayapi/003-invalid-forwardto.yaml
@@ -68,6 +68,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - forwardto.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/004-post-header-modifier.yaml
+++ b/_integration/testsuite/gatewayapi/004-post-header-modifier.yaml
@@ -79,6 +79,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - postfilter.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/004-tls-gateway.yaml
+++ b/_integration/testsuite/gatewayapi/004-tls-gateway.yaml
@@ -158,6 +158,8 @@ metadata:
   labels:
     type: insecure
 spec:
+  gateways:
+    allow: All
   hostnames:
     - secure.projectcontour.io
   rules:
@@ -178,6 +180,8 @@ metadata:
   labels:
     type: secure
 spec:
+  gateways:
+    allow: All
   hostnames:
     - secure.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/005-pre-header-modifier.yaml
+++ b/_integration/testsuite/gatewayapi/005-pre-header-modifier.yaml
@@ -59,6 +59,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - prefilter.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/006-rewritehost.yaml
+++ b/_integration/testsuite/gatewayapi/006-rewritehost.yaml
@@ -59,6 +59,8 @@ metadata:
   labels:
     app: filter
 spec:
+  gateways:
+    allow: All
   hostnames:
     - hostrewrite.projectcontour.io
   rules:

--- a/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
+++ b/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
@@ -176,7 +176,7 @@ check_for_status_code [msg] {
 }
 
 check_for_service_routing [msg] {
-  msg := expect.response_service_is(Response, "echo-slash-default")
+  msg := expect.response_service_is(Response, "echo-slash-blue")
 }
 
 ---

--- a/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
+++ b/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
@@ -161,7 +161,7 @@ import data.contour.http.client
 import data.contour.http.client.url
 import data.contour.http.expect
 
-# Ensure / request returns 200 status code since
+# Ensure /blue request returns 200 status code since
 # it matches the gatewayRef.
 Response := client.Get({
   "url": url.http("/blue"),
@@ -208,7 +208,7 @@ import data.contour.http.client
 import data.contour.http.client.url
 import data.contour.http.expect
 
-# Ensure / request returns 404 status code since
+# Ensure /green request returns 404 status code since
 # the HTTPRoute does not match the gatewayRef.
 Response := client.Get({
   "url": url.http("/green"),

--- a/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
+++ b/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
@@ -1,0 +1,247 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-default
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+  namespace: projectcontour
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-conformance-echo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-conformance-echo
+    spec:
+      containers:
+        - name: conformance-echo
+          image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
+          env:
+            - name: INGRESS_NAME
+              value: ingress-conformance-echo
+            - name: SERVICE_NAME
+              value: ingress-conformance-echo
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http-api
+              containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+  namespace: projectcontour
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-api
+  selector:
+    app.kubernetes.io/name: ingress-conformance-echo
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: HTTP
+      port: 80
+      routes:
+        kind: HTTPRoute
+        namespaces:
+          from: "All"
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+spec:
+  gateways:
+    allow: FromList
+    gatewayRefs:
+      - name: contour
+        namespace: projectcontour
+  hostnames:
+    - http.projectcontour.io
+  rules:
+    - matches:
+      - path:
+          type: Prefix
+          value: /
+      forwardTo:
+      - serviceName: echo-slash-default
+        port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure / request returns 200 status code since
+# it matches the gatewayRef.
+Response := client.Get({
+  "url": url.http("/"),
+    "headers": {
+      "Host": "http.projectcontour.io",
+      "User-Agent": client.ua("insecure"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-slash-default")
+}
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-1
+spec:
+  gateways:
+    allow: FromList
+    gatewayRefs:
+      - name: wrong
+        namespace: reference
+  hostnames:
+    - http.projectcontour.io
+  rules:
+    - matches:
+        - path:
+            type: Prefix
+            value: /
+      forwardTo:
+        - serviceName: echo-slash-default
+          port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure / request returns 404 status code since
+# the HTTPRoute does not match the gatewayRef.
+Response := client.Get({
+  "url": url.http("/"),
+  "headers": {
+    "Host": "http.projectcontour.io",
+    "User-Agent": client.ua("insecure"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 404)
+}
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: HTTPRoute
+metadata:
+  name: http-filter-2
+  namespace: projectcontour
+spec:
+  gateways:
+    allow: SameNamespace
+  hostnames:
+    - http.projectcontour.io
+  rules:
+    - matches:
+        - path:
+            type: Prefix
+            value: /same
+      forwardTo:
+        - serviceName: ingress-conformance-echo
+          port: 80
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure /same request returns 200 status code since
+# it matches the SameNamespace.
+Response := client.Get({
+"url": url.http("/same"),
+  "headers": {
+    "Host": "http.projectcontour.io",
+    "User-Agent": client.ua("insecure"),
+  },
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "ingress-conformance-echo")
+}

--- a/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
+++ b/_integration/testsuite/gatewayapi/007-httproute-gatewayallowtype.yaml
@@ -18,7 +18,7 @@ metadata:
   name: ingress-conformance-echo
 $apply:
   fixture:
-    as: echo-slash-default
+    as: echo-slash-blue
 
 ---
 
@@ -28,7 +28,28 @@ metadata:
   name: ingress-conformance-echo
 $apply:
   fixture:
-    as: echo-slash-default
+    as: echo-slash-blue
+
+---
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-green
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo
+$apply:
+  fixture:
+    as: echo-slash-green
 
 ---
 
@@ -129,9 +150,9 @@ spec:
     - matches:
       - path:
           type: Prefix
-          value: /
+          value: /blue
       forwardTo:
-      - serviceName: echo-slash-default
+      - serviceName: echo-slash-blue
         port: 80
 
 ---
@@ -143,7 +164,7 @@ import data.contour.http.expect
 # Ensure / request returns 200 status code since
 # it matches the gatewayRef.
 Response := client.Get({
-  "url": url.http("/"),
+  "url": url.http("/blue"),
     "headers": {
       "Host": "http.projectcontour.io",
       "User-Agent": client.ua("insecure"),
@@ -176,9 +197,9 @@ spec:
     - matches:
         - path:
             type: Prefix
-            value: /
+            value: /green
       forwardTo:
-        - serviceName: echo-slash-default
+        - serviceName: echo-slash-green
           port: 80
 
 ---
@@ -190,7 +211,7 @@ import data.contour.http.expect
 # Ensure / request returns 404 status code since
 # the HTTPRoute does not match the gatewayRef.
 Response := client.Get({
-  "url": url.http("/"),
+  "url": url.http("/green"),
   "headers": {
     "Host": "http.projectcontour.io",
     "User-Agent": client.ua("insecure"),

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -293,8 +293,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-			Gateways: gatewayapi_v1alpha1.RouteGateways{
-				Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+			Gateways: &gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
@@ -317,8 +317,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-			Gateways: gatewayapi_v1alpha1.RouteGateways{
-				Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+			Gateways: &gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
@@ -499,8 +499,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "projectcontour",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -553,8 +553,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -594,8 +594,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -637,8 +637,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -680,8 +680,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -707,8 +707,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "projectcontour",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -750,8 +750,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowFromList,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowFromList),
 							GatewayRefs: []gatewayapi_v1alpha1.GatewayReference{{
 								Name:      "contour",
 								Namespace: "projectcontour",
@@ -797,8 +797,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowFromList,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowFromList),
 							GatewayRefs: []gatewayapi_v1alpha1.GatewayReference{{
 								Name:      "wrong",
 								Namespace: "reference",
@@ -836,8 +836,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -854,8 +854,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Namespace: "custom",
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"another.projectcontour.io",
@@ -1033,8 +1033,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1073,8 +1073,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1115,8 +1115,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
@@ -1148,8 +1148,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"*.projectcontour.io",
@@ -1263,8 +1263,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
@@ -1322,8 +1322,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1360,8 +1360,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1617,6 +1617,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
+						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"*.*.projectcontour.io",
 						},
@@ -1740,8 +1743,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1791,8 +1794,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1854,8 +1857,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1901,8 +1904,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -1956,8 +1959,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -2005,8 +2008,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -2057,8 +2060,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Hostnames: []gatewayapi_v1alpha1.Hostname{
 							"test.projectcontour.io",
@@ -2109,8 +2112,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
@@ -2173,8 +2176,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
@@ -2237,8 +2240,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 					},
 					Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-						Gateways: gatewayapi_v1alpha1.RouteGateways{
-							Allow: gatewayapi_v1alpha1.GatewayAllowSameNamespace,
+						Gateways: &gatewayapi_v1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
 						},
 						Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
 							Matches:   httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -133,9 +133,12 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 
 			// If all the match criteria for this HTTPRoute match the Gateway, then add
 			// the route to the set of matchingRoutes.
-			if selMatches && nsMatches && p.gatewayMatches(route) {
-				// Empty Selector matches all routes.
-				matchingRoutes = append(matchingRoutes, route)
+			if selMatches && nsMatches {
+
+				if p.gatewayMatches(route) {
+					// Empty Selector matches all routes.
+					matchingRoutes = append(matchingRoutes, route)
+				}
 			}
 		}
 
@@ -262,7 +265,7 @@ func (p *GatewayAPIProcessor) namespaceMatches(namespaces *gatewayapi_v1alpha1.R
 // matches one from the list.
 func (p *GatewayAPIProcessor) gatewayMatches(route *gatewayapi_v1alpha1.HTTPRoute) bool {
 
-	switch route.Spec.Gateways.Allow {
+	switch *route.Spec.Gateways.Allow {
 	case gatewayapi_v1alpha1.GatewayAllowAll:
 		return true
 	case gatewayapi_v1alpha1.GatewayAllowFromList:
@@ -529,4 +532,8 @@ func pathMatchTypePtr(pmt gatewayapi_v1alpha1.PathMatchType) *gatewayapi_v1alpha
 
 func headerMatchTypePtr(hmt gatewayapi_v1alpha1.HeaderMatchType) *gatewayapi_v1alpha1.HeaderMatchType {
 	return &hmt
+}
+
+func gatewayAllowTypePtr(gwType gatewayapi_v1alpha1.GatewayAllowType) *gatewayapi_v1alpha1.GatewayAllowType {
+	return &gwType
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2570,8 +2570,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2606,8 +2606,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2652,8 +2652,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2693,8 +2693,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2743,8 +2743,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2791,8 +2791,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2831,8 +2831,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2888,8 +2888,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2929,8 +2929,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -2966,8 +2966,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"*.*.projectcontour.io",
@@ -3003,8 +3003,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"#projectcontour.io",
@@ -3040,8 +3040,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"1.2.3.4",
@@ -3077,8 +3077,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -3121,8 +3121,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -3165,8 +3165,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
@@ -3212,8 +3212,8 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Gateways: gatewayapi_v1alpha1.RouteGateways{
-						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2570,6 +2570,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2603,6 +2606,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2646,6 +2652,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2684,6 +2693,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2731,6 +2743,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2776,6 +2791,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2813,6 +2831,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2867,6 +2888,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2905,6 +2929,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -2939,6 +2966,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"*.*.projectcontour.io",
 					},
@@ -2973,6 +3003,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"#projectcontour.io",
 					},
@@ -3007,6 +3040,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"1.2.3.4",
 					},
@@ -3041,6 +3077,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -3082,6 +3121,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -3123,6 +3165,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},
@@ -3167,6 +3212,9 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					},
 				},
 				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+					},
 					Hostnames: []gatewayapi_v1alpha1.Hostname{
 						"test.projectcontour.io",
 					},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2478,6 +2478,11 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 								Port:     80,
 								Protocol: "HTTP",
 								Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "contour",
+										},
+									},
 									Kind: KindHTTPRoute,
 								},
 							}},
@@ -2522,26 +2527,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 		})
 	}
 
-	gateway := &gatewayapi_v1alpha1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "contour",
-			Namespace: "projectcontour",
-		},
-		Spec: gatewayapi_v1alpha1.GatewaySpec{
-			Listeners: []gatewayapi_v1alpha1.Listener{{
-				Port:     80,
-				Protocol: "HTTP",
-				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app": "contour",
-						},
-					},
-				},
-			}},
-		},
-	}
-
 	kuardService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -2559,7 +2544,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "simple httproute", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2595,7 +2579,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "invalid prefix match for httproute", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2641,7 +2624,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "regular expression match not yet supported for httproute", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2682,7 +2664,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "RegularExpression header match not yet supported for httproute", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2732,7 +2713,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.tls not yet supported for httproute", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2780,7 +2760,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.forwardTo.serviceName not specified", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2821,7 +2800,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.forwardTo.serviceName invalid on two matches", testcase{
 		objs: []interface{}{
-			gateway,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
@@ -2877,7 +2855,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.forwardTo.servicePort not specified", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2918,7 +2895,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.forwardTo not specified", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2955,7 +2931,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.hostname: invalid wildcard", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2992,7 +2967,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.hostname: invalid hostname", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3029,7 +3003,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.hostname: invalid hostname, ip address", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3066,7 +3039,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "HTTPRouteFilterRequestMirror not yet supported for httproute rule", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3110,7 +3082,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "HTTPRouteFilterRequestMirror not yet supported for httproute forwardto", testcase{
 		objs: []interface{}{
-			gateway,
+
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3154,7 +3126,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "Invalid RequestHeaderModifier due to duplicated headers", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3201,7 +3172,6 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 
 	run(t, "Invalid RequestHeaderModifier after forward due to invalid headers", testcase{
 		objs: []interface{}{
-			gateway,
 			kuardService,
 			&gatewayapi_v1alpha1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3243,6 +3213,37 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			Status:  contour_api_v1.ConditionFalse,
 			Reason:  string(status.ReasonErrorsExist),
 			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "gateway selectors match but spec.gateways.allowtype doesn't", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowSameNamespace),
+					},
+					Hostnames: []gatewayapi_v1alpha1.Hostname{
+						"projectcontour.io",
+					},
+					Rules: []gatewayapi_v1alpha1.HTTPRouteRule{{
+						Matches: httpRouteMatch(gatewayapi_v1alpha1.PathMatchPrefix, "/"),
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "GatewayAllowMismatch",
+			Message: "Gateway RouteSelector matches, but GatewayAllow has mismatch.",
 		}},
 	})
 }

--- a/internal/featuretests/v3/gatewayapi_test.go
+++ b/internal/featuretests/v3/gatewayapi_test.go
@@ -100,8 +100,8 @@ func TestGateway_TLS(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-			Gateways: gatewayapi_v1alpha1.RouteGateways{
-				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			Gateways: &gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
@@ -193,4 +193,8 @@ func pathMatchTypePtr(pmt gatewayapi_v1alpha1.PathMatchType) *gatewayapi_v1alpha
 
 func routeSelectTypePtr(rst gatewayapi_v1alpha1.RouteSelectType) *gatewayapi_v1alpha1.RouteSelectType {
 	return &rst
+}
+
+func gatewayAllowTypePtr(gwType gatewayapi_v1alpha1.GatewayAllowType) *gatewayapi_v1alpha1.GatewayAllowType {
+	return &gwType
 }

--- a/internal/featuretests/v3/gatewayapi_test.go
+++ b/internal/featuretests/v3/gatewayapi_test.go
@@ -100,6 +100,9 @@ func TestGateway_TLS(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+			Gateways: gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
 			},

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -145,8 +145,8 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-			Gateways: gatewayapi_v1alpha1.RouteGateways{
-				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			Gateways: &gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
@@ -189,8 +189,8 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-			Gateways: gatewayapi_v1alpha1.RouteGateways{
-				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			Gateways: &gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
 			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -145,6 +145,9 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+			Gateways: gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
 			},
@@ -186,6 +189,9 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 			},
 		},
 		Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
+			Gateways: gatewayapi_v1alpha1.RouteGateways{
+				Allow: gatewayapi_v1alpha1.GatewayAllowAll,
+			},
 			Hostnames: []gatewayapi_v1alpha1.Hostname{
 				"test.projectcontour.io",
 			},

--- a/internal/status/httproutestatus.go
+++ b/internal/status/httproutestatus.go
@@ -35,6 +35,7 @@ const ReasonHTTPRouteFilterType RouteReasonType = "HTTPRouteFilterType"
 const ReasonDegraded RouteReasonType = "Degraded"
 const ReasonValid RouteReasonType = "Valid"
 const ReasonErrorsExist RouteReasonType = "ErrorsExist"
+const ReasonGatewayAllowMismatch RouteReasonType = "GatewayAllowMismatch"
 
 type HTTPRouteUpdate struct {
 	FullName           types.NamespacedName


### PR DESCRIPTION
Implement support for HTTPRoutes.Spec.Gateways to allow an HTTPRoute to define how it
binds to a Gateway via "All", "SameNamespace", or "FromList".

Fixes #3615

Signed-off-by: Steve Sloka <steve@stevesloka.com>