### PR TITLE
internal: Adds support for TLSRoute

### DIFF
--- a/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
+++ b/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
@@ -95,6 +95,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: INGRESS_NAME
+          value: *name
+        - name: SERVICE_NAME
+          value: *name
         - name: TLS_SERVER_CERT
           value: /run/secrets/certs/tls.crt
         - name: TLS_SERVER_PRIVKEY

--- a/_integration/testsuite/gatewayapi/008-tlsroute.yaml
+++ b/_integration/testsuite/gatewayapi/008-tlsroute.yaml
@@ -1,0 +1,187 @@
+# Copyright Project Contour Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+  import data.contour.resources
+
+  # Ensure that cert-manager is installed.
+  # Version check the certificates resource.
+
+  Group := "cert-manager.io"
+  Version := "v1"
+
+  have_certmanager_version {
+  v := resources.versions["certificates"]
+  v[_].Group == Group
+  v[_].Version == Version
+}
+
+  skip[msg] {
+  not resources.is_supported("certificates")
+  msg := "cert-manager is not installed"
+}
+
+  skip[msg] {
+  not have_certmanager_version
+
+  avail := resources.versions["certificates"]
+
+  msg := concat("\n", [
+  sprintf("cert-manager version %s/%s is not installed", [Group, Version]),
+  "available versions:",
+  yaml.marshal(avail)
+  ])
+}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: backend-server-cert
+spec:
+  dnsNames:
+    - tcp.projectcontour.io
+  secretName: backend-server-cert
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-conformance-echo-tls
+$apply:
+  fixture:
+    as: echo-slash-blue
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-conformance-echo-tls
+$apply:
+  fixture:
+    as: echo-slash-blue
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: contour-class
+spec:
+  controller: projectcontour.io/ingress-controller
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: contour
+  namespace: projectcontour
+spec:
+  gatewayClassName: contour-class
+  listeners:
+    - protocol: TLS
+      port: 443
+      routes:
+        kind: TLSRoute
+        namespaces:
+          from: "All"
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: TLSRoute
+metadata:
+  name: tlsroute1
+spec:
+  rules:
+  - matches:
+    - snis:
+      - tcp.projectcontour.io
+    forwardTo:
+    - serviceName: echo-slash-blue
+      port: 443
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+# Ensure / request returns 200 status code.
+Response := client.Get({
+  "url": url.https("/"),
+    "headers": {
+      "Host": "tcp.projectcontour.io",
+      "User-Agent": client.ua("tlsroute"),
+  },
+  "tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-slash-blue")
+}
+
+---
+
+apiVersion: networking.x-k8s.io/v1alpha1
+kind: TLSRoute
+metadata:
+  name: tlsroute1
+spec:
+  rules:
+    - forwardTo:
+        - serviceName: echo-slash-blue
+          port: 443
+
+---
+
+import data.contour.http.client
+import data.contour.http.client.url
+import data.contour.http.expect
+
+  # Ensure / request returns 200 status code.
+Response := client.Get({
+"url": url.https("/"),
+  "headers": {
+    "Host": "anything.should.work.now",
+    "User-Agent": client.ua("tlsroute"),
+  },
+"tls_insecure_skip_verify": true,
+})
+
+check_for_status_code [msg] {
+  msg := expect.response_status_is(Response, 200)
+}
+
+check_for_service_routing [msg] {
+  msg := expect.response_service_is(Response, "echo-slash-blue")
+}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -239,10 +239,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		kc.udproutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
 	case *gatewayapi_v1alpha1.TLSRoute:
-		m := k8s.NamespacedNameOf(obj)
-		// TODO(youngnick): Remove this once gateway-api actually have behavior
-		// other than being added to the cache.
-		kc.WithField("experimental", "gateway-api").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding TLSRoute")
 		kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
 	case *gatewayapi_v1alpha1.BackendPolicy:
@@ -339,9 +335,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 	case *gatewayapi_v1alpha1.TLSRoute:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.tlsroutes[m]
-		// TODO(youngnick): Remove this once gateway-api actually have behavior
-		// other than being removed from the cache.
-		kc.WithField("experimental", "gateway-api").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing TLSRoute")
 		delete(kc.tlsroutes, m)
 		return ok
 	case *gatewayapi_v1alpha1.BackendPolicy:

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -80,7 +80,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		// Validate the Kind on the selector is a supported type.
 		switch listener.Protocol {
 		case gatewayapi_v1alpha1.HTTPSProtocolType:
-			// Validate that if protocol is type HTTPS or TLS that TLS is defined.
+			// Validate that if protocol is type HTTPS, that TLS is defined.
 			if listener.TLS == nil {
 				p.Errorf("Listener.TLS is required when protocol is %q.", listener.Protocol)
 				continue

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	KindHTTPRoute = "HTTPRoute"
+	KindTLSRoute  = "TLSRoute"
 )
 
 // GatewayAPIProcessor translates Gateway API types into DAG
@@ -72,12 +73,13 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 
 	for _, listener := range p.source.gateway.Spec.Listeners {
 
-		var matchingRoutes []*gatewayapi_v1alpha1.HTTPRoute
+		var matchingHTTPRoutes []*gatewayapi_v1alpha1.HTTPRoute
+		var matchingTLSRoutes []*gatewayapi_v1alpha1.TLSRoute
 		var listenerSecret *Secret
 
 		// Validate the Kind on the selector is a supported type.
 		switch listener.Protocol {
-		case gatewayapi_v1alpha1.HTTPSProtocolType, gatewayapi_v1alpha1.TLSProtocolType:
+		case gatewayapi_v1alpha1.HTTPSProtocolType:
 			// Validate that if protocol is type HTTPS or TLS that TLS is defined.
 			if listener.TLS == nil {
 				p.Errorf("Listener.TLS is required when protocol is %q.", listener.Protocol)
@@ -90,7 +92,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 				// routes to be bound to this listener since it can't serve TLS traffic.
 				continue
 			}
-		case gatewayapi_v1alpha1.HTTPProtocolType:
+		case gatewayapi_v1alpha1.HTTPProtocolType, gatewayapi_v1alpha1.TLSProtocolType:
 			break
 		default:
 			p.Errorf("Listener.Protocol %q is not supported.", listener.Protocol)
@@ -106,7 +108,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		}
 
 		// Validate the Kind on the selector is a supported type.
-		if listener.Routes.Kind != KindHTTPRoute {
+		if listener.Routes.Kind != KindHTTPRoute && listener.Routes.Kind != KindTLSRoute {
 			p.Errorf("Listener.Routes.Kind %q is not supported.", listener.Routes.Kind)
 			continue
 		}
@@ -150,14 +152,46 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 
 				if gatewayAllowMatches {
 					// Empty Selector matches all routes.
-					matchingRoutes = append(matchingRoutes, route)
+					matchingHTTPRoutes = append(matchingHTTPRoutes, route)
 				}
 			}
 		}
 
-		// Process all the routes that match this Gateway.
-		for _, matchingRoute := range matchingRoutes {
+		for _, route := range p.source.tlsroutes {
+			// Filter the TLSRoutes that match the gateway which Contour is configured to watch.
+			// RouteBindingSelector defines a schema for associating routes with the Gateway.
+			// If Namespaces and Selector are defined, only routes matching both selectors are associated with the Gateway.
+
+			// ## RouteBindingSelector ##
+			//
+			// Selector specifies a set of route labels used for selecting routes to associate
+			// with the Gateway. If this Selector is defined, only routes matching the Selector
+			// are associated with the Gateway. An empty Selector matches all routes.
+
+			nsMatches, err := p.namespaceMatches(listener.Routes.Namespaces, route.Namespace)
+			if err != nil {
+				p.Errorf("error validating namespaces against Listener.Routes.Namespaces: %s", err)
+			}
+
+			selMatches, err := selectorMatches(listener.Routes.Selector, route.Labels)
+			if err != nil {
+				p.Errorf("error validating routes against Listener.Routes.Selector: %s", err)
+			}
+
+			if selMatches && nsMatches {
+				// Empty Selector matches all routes.
+				matchingTLSRoutes = append(matchingTLSRoutes, route)
+			}
+		}
+
+		// Process all the HTTPRoutes that match this Gateway.
+		for _, matchingRoute := range matchingHTTPRoutes {
 			p.computeHTTPRoute(matchingRoute, listenerSecret)
+		}
+
+		// Process all the routes that match this Gateway.
+		for _, matchingRoute := range matchingTLSRoutes {
+			p.computeTLSRoute(matchingRoute)
 		}
 	}
 }
@@ -195,37 +229,42 @@ func isSecretRef(certificateRef *gatewayapi_v1alpha1.LocalObjectReference) bool 
 	return strings.ToLower(certificateRef.Kind) == "secret" && strings.ToLower(certificateRef.Group) == "core"
 }
 
-func (p *GatewayAPIProcessor) computeHosts(route *gatewayapi_v1alpha1.HTTPRoute) ([]string, []error) {
+func (p *GatewayAPIProcessor) computeHosts(hostnames []gatewayapi_v1alpha1.Hostname) ([]string, []error) {
 	// Determine the hosts on the route, if no hosts
 	// are defined, then set to "*".
 	var hosts []string
 	var errors []error
-	if len(route.Spec.Hostnames) == 0 {
+	if len(hostnames) == 0 {
 		hosts = append(hosts, "*")
 		return hosts, nil
 	}
 
-	for _, host := range route.Spec.Hostnames {
+	for _, host := range hostnames {
 
 		hostname := string(host)
-		if isIP := net.ParseIP(hostname) != nil; isIP {
-			errors = append(errors, fmt.Errorf("hostname %q must be a DNS name, not an IP address", hostname))
+		if err := validHostName(hostname); err != nil {
+			errors = append(errors, err)
 			continue
-		}
-		if strings.Contains(hostname, "*") {
-			if errs := validation.IsWildcardDNS1123Subdomain(hostname); errs != nil {
-				errors = append(errors, fmt.Errorf("invalid hostname %q: %v", hostname, errs))
-				continue
-			}
-		} else {
-			if errs := validation.IsDNS1123Subdomain(hostname); errs != nil {
-				errors = append(errors, fmt.Errorf("invalid listener hostname %q: %v", hostname, errs))
-				continue
-			}
 		}
 		hosts = append(hosts, string(host))
 	}
 	return hosts, errors
+}
+
+func validHostName(hostname string) error {
+	if isIP := net.ParseIP(hostname) != nil; isIP {
+		return fmt.Errorf("hostname %q must be a DNS name, not an IP address", hostname)
+	}
+	if strings.Contains(hostname, "*") {
+		if errs := validation.IsWildcardDNS1123Subdomain(hostname); errs != nil {
+			return fmt.Errorf("invalid hostname %q: %v", hostname, errs)
+		}
+	} else {
+		if errs := validation.IsDNS1123Subdomain(hostname); errs != nil {
+			return fmt.Errorf("invalid listener hostname %q: %v", hostname, errs)
+		}
+	}
+	return nil
 }
 
 // namespaceMatches returns true if the namespaces selector matches
@@ -315,11 +354,106 @@ func selectorMatches(selector *metav1.LabelSelector, objLabels map[string]string
 	return true, nil
 }
 
+func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha1.TLSRoute) {
+
+	routeAccessor, commit := p.dag.StatusCache.ConditionsAccessor(k8s.NamespacedNameOf(route), route.Generation, status.ResourceTLSRoute, route.Status.Gateways)
+	defer commit()
+
+	for _, rule := range route.Spec.Rules {
+		var hosts []string
+		var matchErrors []error
+		totalSnis := 0
+
+		// Build the set of SNIs that are applied to this TLSRoute.
+		for _, match := range rule.Matches {
+			for _, snis := range match.SNIs {
+				totalSnis++
+				if err := validHostName(string(snis)); err != nil {
+					matchErrors = append(matchErrors, err)
+					continue
+				}
+				hosts = append(hosts, string(snis))
+			}
+		}
+
+		// If there are any errors with the supplied hostnames, then
+		// add a condition to the route.
+		for _, err := range matchErrors {
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
+		}
+
+		// If all the supplied SNIs are invalid, then this route is invalid
+		// and should be dropped.
+		if len(matchErrors) != 0 && len(matchErrors) == totalSnis {
+			continue
+		}
+
+		// If SNIs is unspecified, then all
+		// requests associated with the gateway TLS listener will match.
+		// This can be used to define a default backend for a TLS listener.
+		if len(hosts) == 0 {
+			hosts = []string{"*"}
+		}
+
+		if len(rule.ForwardTo) == 0 {
+			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.ForwardTo must be specified.")
+			continue
+		}
+
+		var proxy TCPProxy
+		for _, forward := range rule.ForwardTo {
+			// Verify the service is valid
+			if forward.ServiceName == nil {
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServiceName must be specified.")
+				continue
+			}
+
+			// TODO: Do not require port to be present (#3352).
+			if forward.Port == nil {
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "Spec.Rules.ForwardTo.ServicePort must be specified.")
+				continue
+			}
+
+			meta := types.NamespacedName{Name: *forward.ServiceName, Namespace: route.Namespace}
+
+			// TODO: Refactor EnsureService to take an int32 so conversion to intstr is not needed.
+			service, err := p.dag.EnsureService(meta, intstr.FromInt(int(*forward.Port)), p.source)
+			if err != nil {
+				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("Service %q does not exist", meta.Name))
+				continue
+			}
+			proxy.Clusters = append(proxy.Clusters, &Cluster{
+				Upstream: service,
+				SNI:      service.ExternalName,
+			})
+		}
+
+		if len(proxy.Clusters) == 0 {
+			// No valid clusters so the route should get rejected.
+			continue
+		}
+
+		for _, host := range hosts {
+			secure := p.dag.EnsureSecureVirtualHost(ListenerName{Name: host, ListenerName: "ingress_https"})
+			secure.TCPProxy = &proxy
+		}
+	}
+
+	// Determine if any errors exist in conditions and set the "Admitted"
+	// condition accordingly.
+	switch len(routeAccessor.Conditions) {
+	case 0:
+		routeAccessor.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionTrue, status.ReasonValid, "Valid TLSRoute")
+	default:
+		routeAccessor.AddCondition(gatewayapi_v1alpha1.ConditionRouteAdmitted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
+	}
+}
+
 func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha1.HTTPRoute, listenerSecret *Secret) {
 	routeAccessor, commit := p.dag.StatusCache.ConditionsAccessor(k8s.NamespacedNameOf(route), route.Generation, status.ResourceHTTPRoute, route.Status.Gateways)
 	defer commit()
 
-	hosts, errs := p.computeHosts(route)
+	hosts, errs := p.computeHosts(route.Spec.Hostnames)
 	for _, err := range errs {
 		routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
 	}

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -197,7 +197,7 @@ func TestComputeHosts(t *testing.T) {
 				FieldLogger: fixture.NewTestLogger(t),
 			}
 
-			got, gotError := processor.computeHosts(tc.route)
+			got, gotError := processor.computeHosts(tc.route.Spec.Hostnames)
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, tc.wantError, gotError)
 		})

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2853,7 +2853,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
+					Message: "Spec.Rules.ForwardTo.ServiceName must be specified",
 				},
 				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
 					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -2914,7 +2914,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "Service \"invalid-one\" does not exist, Service \"invalid-two\" does not exist",
+					Message: "service \"invalid-one\" does not exist, service \"invalid-two\" does not exist",
 				},
 				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
 					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -2960,7 +2960,7 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
+					Message: "Spec.Rules.ForwardTo.ServicePort must be specified",
 				},
 				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
 					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -3405,16 +3405,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "Spec.Rules.ForwardTo.ServiceName must be specified",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3451,16 +3457,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "Service \"invalid-one\" does not exist, Service \"invalid-two\" does not exist",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "service \"invalid-one\" does not exist, service \"invalid-two\" does not exist",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3490,16 +3502,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
-		}, {
-			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "Spec.Rules.ForwardTo.ServicePort must be specified",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3525,16 +3543,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "At least one Spec.Rules.ForwardTo must be specified.",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "At least one Spec.Rules.ForwardTo must be specified.",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3564,16 +3588,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3603,16 +3633,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 
@@ -3642,16 +3678,22 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 					}},
 				},
 			}},
-		want: []metav1.Condition{{
-			Type:    string(status.ConditionResolvedRefs),
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  string(status.ReasonDegraded),
-			Message: "hostname \"1.2.3.4\" must be a DNS name, not an IP address",
-		}, {
-			Type:    "Admitted",
-			Status:  contour_api_v1.ConditionFalse,
-			Reason:  "ErrorsExist",
-			Message: "Errors found, check other Conditions for details.",
+		want: []*status.ConditionsUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			Conditions: map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition{
+				status.ConditionResolvedRefs: {
+					Type:    string(status.ConditionResolvedRefs),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  string(status.ReasonDegraded),
+					Message: "hostname \"1.2.3.4\" must be a DNS name, not an IP address",
+				},
+				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
+					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+					Status:  contour_api_v1.ConditionFalse,
+					Reason:  "ErrorsExist",
+					Message: "Errors found, check other Conditions for details.",
+				},
+			},
 		}},
 	})
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3378,4 +3378,280 @@ func TestGatewayAPIDAGStatus(t *testing.T) {
 			},
 		}},
 	})
+
+	run(t, "TLSRoute: spec.rules.forwardTo.serviceName not specified", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"test.projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: nil,
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "Spec.Rules.ForwardTo.ServiceName must be specified.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.forwardTo.serviceName invalid on two matches", testcase{
+		objs: []interface{}{
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"test.projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("invalid-one"),
+							Port:        gatewayPort(8080),
+						}},
+					}, {
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"another.projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("invalid-two"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "Service \"invalid-one\" does not exist, Service \"invalid-two\" does not exist",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.forwardTo.servicePort not specified", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"test.projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        nil,
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "Spec.Rules.ForwardTo.ServicePort must be specified.",
+		}, {
+			Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.forwardTo not specified", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"test.projectcontour.io"},
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "At least one Spec.Rules.ForwardTo must be specified.",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.hostname: invalid wildcard", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"*.*.projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.hostname: invalid hostname", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"#projectcontour.io"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
+
+	run(t, "TLSRoute: spec.rules.hostname: invalid hostname, ip address", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1alpha1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+					Gateways: &gatewayapi_v1alpha1.RouteGateways{
+						Allow: gatewayAllowTypePtr(gatewayapi_v1alpha1.GatewayAllowAll),
+					},
+					Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+						Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+							SNIs: []gatewayapi_v1alpha1.Hostname{"1.2.3.4"},
+						}},
+						ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+							ServiceName: pointer.StringPtr("kuard"),
+							Port:        gatewayPort(8080),
+						}},
+					}},
+				},
+			}},
+		want: []metav1.Condition{{
+			Type:    string(status.ConditionResolvedRefs),
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  string(status.ReasonDegraded),
+			Message: "hostname \"1.2.3.4\" must be a DNS name, not an IP address",
+		}, {
+			Type:    "Admitted",
+			Status:  contour_api_v1.ConditionFalse,
+			Reason:  "ErrorsExist",
+			Message: "Errors found, check other Conditions for details.",
+		}},
+	})
 }

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -1,0 +1,170 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/projectcontour/contour/internal/dag"
+	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
+	"github.com/projectcontour/contour/internal/fixture"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func TestTLSRoute(t *testing.T) {
+	rh, c, done := setup(t)
+	defer done()
+
+	//s1 := &v1.Secret{
+	//	ObjectMeta: metav1.ObjectMeta{
+	//		Name:      "secret",
+	//		Namespace: "default",
+	//	},
+	//	Type: "kubernetes.io/tls",
+	//	Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+	//}
+
+	svc := fixture.NewService("correct-backend").
+		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
+
+	//rh.OnAdd(s1)
+	rh.OnAdd(svc)
+
+	rh.OnAdd(&gatewayapi_v1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "contour",
+			Namespace: "projectcontour",
+		},
+		Spec: gatewayapi_v1alpha1.GatewaySpec{
+			Listeners: []gatewayapi_v1alpha1.Listener{{
+				Port:     443,
+				Protocol: "TLS",
+				Routes: gatewayapi_v1alpha1.RouteBindingSelector{
+					Namespaces: &gatewayapi_v1alpha1.RouteNamespaces{
+						From: routeSelectTypePtr(gatewayapi_v1alpha1.RouteSelectAll),
+					},
+					Kind: dag.KindTLSRoute,
+				},
+			}},
+		},
+	})
+
+	route1 := &gatewayapi_v1alpha1.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+			Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+				Matches: []gatewayapi_v1alpha1.TLSRouteMatch{{
+					SNIs: []gatewayapi_v1alpha1.Hostname{
+						"tcp.projectcontour.io",
+					},
+				}},
+				ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+					ServiceName: pointer.StringPtr("correct-backend"),
+					Port:        gatewayPort(80),
+				}},
+			}},
+		},
+	}
+
+	rh.OnAdd(route1)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []*envoy_listener_v3.FilterChain{{
+					Filters: envoy_v3.Filters(
+						tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"),
+					),
+					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+						ServerNames: []string{"tcp.projectcontour.io"},
+					},
+				}},
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+			staticListener(),
+		),
+		TypeUrl: listenerType,
+	})
+
+	// check that ingress_http is empty
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration("ingress_http"),
+		),
+		TypeUrl: routeType,
+	})
+
+	// Route2 doesn't define any SNIs, so this should become the default backend.
+	route2 := &gatewayapi_v1alpha1.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "basic",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1alpha1.TLSRouteSpec{
+			Rules: []gatewayapi_v1alpha1.TLSRouteRule{{
+				ForwardTo: []gatewayapi_v1alpha1.RouteForwardTo{{
+					ServiceName: pointer.StringPtr("correct-backend"),
+					Port:        gatewayPort(80),
+				}},
+			}},
+		},
+	}
+
+	rh.OnUpdate(route1, route2)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				FilterChains: []*envoy_listener_v3.FilterChain{{
+					Filters: envoy_v3.Filters(
+						tcpproxy("ingress_https", "default/correct-backend/80/da39a3ee5e"),
+					),
+					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+						TransportProtocol: "tls",
+					},
+				}},
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+			staticListener(),
+		),
+		TypeUrl: listenerType,
+	})
+
+	// check that ingress_http is empty
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration("ingress_http"),
+		),
+		TypeUrl: routeType,
+	})
+}


### PR DESCRIPTION
Add support for TLSRoute to enable Passthrough TCP Proxying to pods via SNI.

Note: This is currently rebased from https://github.com/projectcontour/contour/pull/3620 which makes the Status bits more generic. Merging that first will make this PR smaller. 

Updates #3440

Signed-off-by: Steve Sloka <slokas@vmware.com>