### PR TITLE
test/e2e: add Gateway API tests 001..005

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,3 +59,6 @@ issues:
   - linters:
     - golint
     text: "don't use ALL_CAPS in Go names; use CamelCase"
+  - path: test/e2e
+    linters:
+      - bodyclose

--- a/test/e2e/gateway/001_path_condition_match_test.go
+++ b/test/e2e/gateway/001_path_condition_match_test.go
@@ -1,0 +1,151 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testGatewayPathConditionMatch(t *testing.T, fx *e2e.Framework) {
+	namespace := "gateway-001-path-condition-match"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-slash-prefix")
+	fx.Fixtures.Echo.Deploy(namespace, "echo-slash-noprefix")
+	fx.Fixtures.Echo.Deploy(namespace, "echo-slash-default")
+	fx.Fixtures.Echo.Deploy(namespace, "echo-slash-exact")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "http-filter-1",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewaypathconditions.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/path/prefix/"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-prefix"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/path/prefix"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-noprefix"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchExact),
+								Value: stringPtr("/path/exact"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-exact"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-default"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+	cases := map[string]string{
+		"/":                "echo-slash-default",
+		"/foo":             "echo-slash-default",
+		"/path/prefix":     "echo-slash-noprefix",
+		"/path/prefixfoo":  "echo-slash-noprefix",
+		"/path/prefix/":    "echo-slash-prefix",
+		"/path/prefix/foo": "echo-slash-prefix",
+		"/path/exact":      "echo-slash-exact",
+		"/path/exactfoo":   "echo-slash-default",
+		"/path/exact/":     "echo-slash-default",
+		"/path/exact/foo":  "echo-slash-default",
+	}
+
+	for path, expectedService := range cases {
+		t.Logf("Querying %q, expecting service %q", path, expectedService)
+
+		res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      string(route.Spec.Hostnames[0]),
+			Path:      path,
+			Condition: e2e.HasStatusCode(200),
+		})
+		if !assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode) {
+			continue
+		}
+
+		body := fx.GetEchoResponseBody(res.Body)
+		assert.Equal(t, namespace, body.Namespace)
+		assert.Equal(t, expectedService, body.Service)
+	}
+}

--- a/test/e2e/gateway/002_header_condition_match_test.go
+++ b/test/e2e/gateway/002_header_condition_match_test.go
@@ -1,0 +1,118 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testGatewayHeaderConditionMatch(t *testing.T, fx *e2e.Framework) {
+	namespace := "gateway-002-header-condition-match"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-header-exact")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "http-filter-1",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewayheaderconditions.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/"),
+							},
+							Headers: &gatewayv1alpha1.HTTPHeaderMatch{
+								Type: headerMatchTypePtr(gatewayv1alpha1.HeaderMatchExact),
+								Values: map[string]string{
+									"My-Header": "Foo",
+								},
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-header-exact"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+	type scenario struct {
+		headers        map[string]string
+		expectResponse int
+		expectService  string
+	}
+
+	cases := []scenario{
+		{
+			headers:        map[string]string{"My-Header": "Foo"},
+			expectResponse: 200,
+			expectService:  "echo-header-exact",
+		},
+		{
+			headers:        map[string]string{"My-Header": "NotFoo"},
+			expectResponse: 404,
+		},
+		{
+			headers:        map[string]string{"Other-Header": "Foo"},
+			expectResponse: 404,
+		},
+	}
+
+	for _, tc := range cases {
+		res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host: string(route.Spec.Hostnames[0]),
+			RequestOpts: []func(*http.Request){
+				e2e.OptSetHeaders(tc.headers),
+			},
+			Condition: e2e.HasStatusCode(tc.expectResponse),
+		})
+		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
+			continue
+		}
+		if res.StatusCode != 200 {
+			// If we expected something other than a 200,
+			// then we don't need to check the body.
+			continue
+		}
+
+		body := fx.GetEchoResponseBody(res.Body)
+		assert.Equal(t, namespace, body.Namespace)
+		assert.Equal(t, tc.expectService, body.Service)
+	}
+}

--- a/test/e2e/gateway/003_invalid_forward_to_test.go
+++ b/test/e2e/gateway/003_invalid_forward_to_test.go
@@ -1,0 +1,167 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testInvalidForwardTo(t *testing.T, fx *e2e.Framework) {
+	namespace := "gateway-003-invalid-forward-to"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-slash-default")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "http-filter-1",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"invalidforwardto.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/invalidref"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("invalid"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/invalidport"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-default"),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/invalidservicename"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr(""),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-slash-default"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	// The HTTPRoute won't be fully valid, so just wait for it to have any Gateway
+	// status.
+	fx.CreateHTTPRouteAndWaitFor(route, func(route *gatewayv1alpha1.HTTPRoute) bool {
+		return len(route.Status.Gateways) > 0
+	})
+
+	type scenario struct {
+		path           string
+		expectResponse int
+		expectService  string
+	}
+
+	cases := []scenario{
+		{
+			path:           "/",
+			expectResponse: 200,
+			expectService:  "echo-slash-default",
+		},
+		{
+			path:           "/invalidref",
+			expectResponse: 503,
+		},
+		{
+			path:           "/invalidport",
+			expectResponse: 503,
+		},
+		{
+			path:           "/invalidservicename",
+			expectResponse: 503,
+		},
+	}
+
+	for _, tc := range cases {
+		res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      string(route.Spec.Hostnames[0]),
+			Path:      tc.path,
+			Condition: e2e.HasStatusCode(tc.expectResponse),
+		})
+		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
+			continue
+		}
+		if res.StatusCode != 200 {
+			// If we expected something other than a 200,
+			// then we don't need to check the body.
+			continue
+		}
+
+		body := fx.GetEchoResponseBody(res.Body)
+		assert.Equal(t, namespace, body.Namespace)
+		assert.Equal(t, tc.expectService, body.Service)
+	}
+}

--- a/test/e2e/gateway/005_request_header_modifier_test.go
+++ b/test/e2e/gateway/005_request_header_modifier_test.go
@@ -1,0 +1,257 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testRequestHeaderModifierForwardTo(t *testing.T, fx *e2e.Framework) {
+	namespace := "gateway-005-request-header-modifier-forward-to"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
+	fx.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "http-filter-1",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/filter"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-header-filter"),
+							Port:        portNumPtr(80),
+							Filters: []gatewayv1alpha1.HTTPRouteFilter{
+								{
+									Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
+										Add: map[string]string{
+											"My-Header": "Foo",
+										},
+										Set: map[string]string{
+											"Replace-Header": "Bar",
+										},
+										Remove: []string{"Other-Header"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/nofilter"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-header-nofilter"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+	// Check the route with the RequestHeaderModifier filter.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host: string(route.Spec.Hostnames[0]),
+		Path: "/filter",
+		RequestOpts: []func(*http.Request){
+			e2e.OptSetHeaders(map[string]string{
+				"Other-Header":   "Remove",
+				"Replace-Header": "Tobe-Replaced",
+			}),
+		},
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body := fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo-header-filter", body.Service)
+
+	assert.Equal(t, "Foo", body.Headers.Get("My-Header"))
+	assert.Equal(t, "Bar", body.Headers.Get("Replace-Header"))
+
+	_, found := body.Headers["Other-Header"]
+	assert.False(t, found, "Other-Header was found on the response")
+
+	// Check the route without any filters.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host: string(route.Spec.Hostnames[0]),
+		Path: "/nofilter",
+		RequestOpts: []func(*http.Request){
+			e2e.OptSetHeaders(map[string]string{
+				"Other-Header": "Exist",
+			}),
+		},
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body = fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo-header-nofilter", body.Service)
+
+	assert.Equal(t, "Exist", body.Headers.Get("Other-Header"))
+
+	_, found = body.Headers["My-Header"]
+	assert.False(t, found, "My-Header was found on the response")
+}
+
+func testRequestHeaderModifierRule(t *testing.T, fx *e2e.Framework) {
+	namespace := "gateway-005-request-header-modifier-rule"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
+	fx.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "http-filter-1",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/filter"),
+							},
+						},
+					},
+					Filters: []gatewayv1alpha1.HTTPRouteFilter{
+						{
+							Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
+								Add: map[string]string{
+									"My-Header": "Foo",
+								},
+								Set: map[string]string{
+									"Replace-Header": "Bar",
+								},
+								Remove: []string{"Other-Header"},
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-header-filter"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/nofilter"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-header-nofilter"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+	// Check the route with the RequestHeaderModifier filter.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host: string(route.Spec.Hostnames[0]),
+		Path: "/filter",
+		RequestOpts: []func(*http.Request){
+			e2e.OptSetHeaders(map[string]string{
+				"Other-Header":   "Remove",
+				"Replace-Header": "Tobe-Replaced",
+			}),
+		},
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body := fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo-header-filter", body.Service)
+
+	assert.Equal(t, "Foo", body.Headers.Get("My-Header"))
+	assert.Equal(t, "Bar", body.Headers.Get("Replace-Header"))
+
+	_, found := body.Headers["Other-Header"]
+	assert.False(t, found, "Other-Header was found on the response")
+
+	// Check the route without any filters.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host: string(route.Spec.Hostnames[0]),
+		Path: "/nofilter",
+		RequestOpts: []func(*http.Request){
+			e2e.OptSetHeaders(map[string]string{
+				"Other-Header": "Exist",
+			}),
+		},
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body = fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo-header-nofilter", body.Service)
+
+	assert.Equal(t, "Exist", body.Headers.Get("Other-Header"))
+
+	_, found = body.Headers["My-Header"]
+	assert.False(t, found, "My-Header was found on the response")
+}

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -1,0 +1,192 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+type testGroup struct {
+	name    string
+	gateway *gatewayv1alpha1.Gateway
+	tests   map[string]func(t *testing.T, f *e2e.Framework)
+}
+
+// getTests defines the test groups that make up the Gateway test suite.
+// Each group shares a single Gateway definition.
+func getTests() []*testGroup {
+	var testGroups []*testGroup
+
+	testGroups = append(testGroups, &testGroup{
+		name: "default gateway",
+		tests: map[string]func(t *testing.T, f *e2e.Framework){
+			"001-path-condition-match":               testGatewayPathConditionMatch,
+			"002-header-condition-match":             testGatewayHeaderConditionMatch,
+			"003-invalid-forward-to":                 testInvalidForwardTo,
+			"005-request-header-modifier-forward-to": testRequestHeaderModifierForwardTo,
+			"005-request-header-modifier-rule":       testRequestHeaderModifierRule,
+		},
+		gateway: &gatewayv1alpha1.Gateway{
+			// Namespace and name need to match what's
+			// configured in the Contour config file.
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "projectcontour",
+				Name:      "contour",
+			},
+			Spec: gatewayv1alpha1.GatewaySpec{
+				GatewayClassName: "contour-class",
+				Listeners: []gatewayv1alpha1.Listener{
+					{
+						Protocol: gatewayv1alpha1.HTTPProtocolType,
+						Port:     gatewayv1alpha1.PortNumber(80),
+						Routes: gatewayv1alpha1.RouteBindingSelector{
+							Kind: "HTTPRoute",
+							Namespaces: &gatewayv1alpha1.RouteNamespaces{
+								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+							},
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "filter"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	testGroups = append(testGroups, &testGroup{
+		name: "TLS gateway",
+		tests: map[string]func(t *testing.T, f *e2e.Framework){
+			"004-tls-gateway": testTLSGateway,
+		},
+		gateway: &gatewayv1alpha1.Gateway{
+			// Namespace and name need to match what's
+			// configured in the Contour config file.
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "projectcontour",
+				Name:      "contour",
+			},
+			Spec: gatewayv1alpha1.GatewaySpec{
+				GatewayClassName: "contour-class",
+				Listeners: []gatewayv1alpha1.Listener{
+					{
+						Protocol: gatewayv1alpha1.HTTPProtocolType,
+						Port:     gatewayv1alpha1.PortNumber(80),
+						Routes: gatewayv1alpha1.RouteBindingSelector{
+							Kind: "HTTPRoute",
+							Namespaces: &gatewayv1alpha1.RouteNamespaces{
+								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+							},
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"type": "insecure"},
+							},
+						},
+					},
+					{
+						Protocol: gatewayv1alpha1.HTTPSProtocolType,
+						Port:     gatewayv1alpha1.PortNumber(443),
+						TLS: &gatewayv1alpha1.GatewayTLSConfig{
+							CertificateRef: &gatewayv1alpha1.LocalObjectReference{
+								Group: "core",
+								Kind:  "Secret",
+								Name:  "tlscert",
+							},
+						},
+						Routes: gatewayv1alpha1.RouteBindingSelector{
+							Kind: "HTTPRoute",
+							Namespaces: &gatewayv1alpha1.RouteNamespaces{
+								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+							},
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"type": "secure"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	return testGroups
+}
+
+func TestGatewayAPI(t *testing.T) {
+	f := e2e.NewFramework(t)
+
+	for _, group := range getTests() {
+		func() {
+			require.NoError(t, f.Client.Create(context.TODO(), group.gateway))
+			defer func() {
+				// has to be wrapped in a defer func() {...} with no arguments because
+				// otherwise the arguments to require.NoError(...) are evaluated right away,
+				// i.e. the Delete(..) is called right away, not as part of the defer.
+				require.NoError(t, f.Client.Delete(context.TODO(), group.gateway))
+			}()
+
+			f.RunParallel(group.name, group.tests)
+		}()
+
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func portNumPtr(port int) *gatewayv1alpha1.PortNumber {
+	pn := gatewayv1alpha1.PortNumber(port)
+	return &pn
+}
+
+func routeSelectTypePtr(val gatewayv1alpha1.RouteSelectType) *gatewayv1alpha1.RouteSelectType {
+	return &val
+}
+
+func pathMatchTypePtr(val gatewayv1alpha1.PathMatchType) *gatewayv1alpha1.PathMatchType {
+	return &val
+}
+
+func headerMatchTypePtr(val gatewayv1alpha1.HeaderMatchType) *gatewayv1alpha1.HeaderMatchType {
+	return &val
+}
+
+func gatewayAllowTypePtr(val gatewayv1alpha1.GatewayAllowType) *gatewayv1alpha1.GatewayAllowType {
+	return &val
+}
+
+// httpRouteAdmitted returns true if the route has a .status.conditions
+// entry of "Admitted: true".
+func httpRouteAdmitted(route *gatewayv1alpha1.HTTPRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Gateways {
+		for _, cond := range gw.Conditions {
+			if cond.Type == string(gatewayv1alpha1.ConditionRouteAdmitted) && cond.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/test/e2e/httpproxy/002_header_condition_match_test.go
+++ b/test/e2e/httpproxy/002_header_condition_match_test.go
@@ -212,7 +212,7 @@ func testHeaderConditionMatch(t *testing.T, fx *e2e.Framework) {
 			RequestOpts: []func(*http.Request){
 				e2e.OptSetHeaders(tc.headers),
 			},
-			Condition: e2e.HasStatusCode(tc.expectResponse), // nolint:bodyclose
+			Condition: e2e.HasStatusCode(tc.expectResponse),
 		})
 		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
 			continue
@@ -284,7 +284,7 @@ func testHeaderConditionMatch(t *testing.T, fx *e2e.Framework) {
 			RequestOpts: []func(*http.Request){
 				e2e.OptSetHeaders(tc.headers),
 			},
-			Condition: e2e.HasStatusCode(tc.expectResponse), // nolint:bodyclose
+			Condition: e2e.HasStatusCode(tc.expectResponse),
 		})
 		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
 			continue


### PR DESCRIPTION
Re-implements Gateway API tests 001..005 from
_integration/testsuite/gatewayapi as Go tests.

Updates #3621.

Signed-off-by: Steve Kriss <krisss@vmware.com>
