### PR TITLE
test/e2e: migrate to Ginkgo for running e2e's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jetstack/cert-manager v1.3.0
+	github.com/onsi/ginkgo v1.16.1
+	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jetstack/cert-manager v1.3.0
 	github.com/onsi/ginkgo v1.16.1
-	github.com/onsi/gomega v1.10.2
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobuffalo/flect v0.2.2 h1:PAVD7sp0KOdfswjAw9BpLCU9hXo7wFSzgpQ+zNeks/A=
@@ -506,8 +507,9 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -519,8 +521,9 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
+github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -858,6 +861,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 h1:8qxJSnu+7dRq6upnbntrmriWByIakBuct5OM/MdQC1M=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -931,6 +935,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -17,8 +17,8 @@ package e2e
 
 import (
 	"context"
-	"testing"
 
+	"github.com/onsi/ginkgo"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +37,7 @@ type Fixtures struct {
 // Echo manages the ingress-conformance-echo fixture.
 type Echo struct {
 	client client.Client
-	t      *testing.T
+	t      ginkgo.GinkgoTInterface
 }
 
 // Deploy creates the ingress-conformance-echo fixture, specifically

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -21,11 +21,11 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"testing"
 	"time"
 
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/onsi/ginkgo"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -62,10 +62,10 @@ type Framework struct {
 	// HTTP provides helpers for making HTTP/HTTPS requests.
 	HTTP *HTTP
 
-	t *testing.T
+	t ginkgo.GinkgoTInterface
 }
 
-func NewFramework(t *testing.T) *Framework {
+func NewFramework(t ginkgo.GinkgoTInterface) *Framework {
 	scheme := runtime.NewScheme()
 	require.NoError(t, kubescheme.AddToScheme(scheme))
 	require.NoError(t, contourv1.AddToScheme(scheme))
@@ -106,18 +106,10 @@ func NewFramework(t *testing.T) *Framework {
 	}
 }
 
-// RunParallel runs the provided set of subtests in parallel and blocks
-// until they're all done running.
-func (f *Framework) RunParallel(name string, subtests map[string]func(t *testing.T, f *Framework)) {
-	f.t.Run(name, func(t *testing.T) {
-		for name, tc := range subtests {
-			tc := tc
-			t.Run(name, func(t *testing.T) {
-				t.Parallel()
-				tc(t, f)
-			})
-		}
-	})
+// T exposes a GinkgoTInterface which exposes many of the same methods
+// as a *testing.T, for use in tests that previously required a *testing.T.
+func (f *Framework) T() ginkgo.GinkgoTInterface {
+	return f.t
 }
 
 // CreateHTTPProxyAndWaitFor creates the provided HTTPProxy in the Kubernetes API

--- a/test/e2e/gateway/001_path_condition_match_test.go
+++ b/test/e2e/gateway/001_path_condition_match_test.go
@@ -16,15 +16,14 @@
 package gateway
 
 import (
-	"testing"
-
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testGatewayPathConditionMatch(t *testing.T, fx *e2e.Framework) {
+func testGatewayPathConditionMatch(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-001-path-condition-match"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/gateway/002_header_condition_match_test.go
+++ b/test/e2e/gateway/002_header_condition_match_test.go
@@ -17,7 +17,6 @@ package gateway
 
 import (
 	"net/http"
-	"testing"
 
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,8 @@ import (
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testGatewayHeaderConditionMatch(t *testing.T, fx *e2e.Framework) {
+func testGatewayHeaderConditionMatch(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-002-header-condition-match"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/gateway/003_invalid_forward_to_test.go
+++ b/test/e2e/gateway/003_invalid_forward_to_test.go
@@ -16,8 +16,6 @@
 package gateway
 
 import (
-	"testing"
-
 	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +23,8 @@ import (
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testInvalidForwardTo(t *testing.T, fx *e2e.Framework) {
+func testInvalidForwardTo(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-003-invalid-forward-to"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/gateway/004_tls_gateway_test.go
+++ b/test/e2e/gateway/004_tls_gateway_test.go
@@ -16,15 +16,14 @@
 package gateway
 
 import (
-	"testing"
-
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testTLSGateway(t *testing.T, fx *e2e.Framework) {
+func testTLSGateway(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-004-tls-gateway"
 
 	fx.CreateNamespace(namespace)
@@ -32,9 +31,6 @@ func testTLSGateway(t *testing.T, fx *e2e.Framework) {
 
 	fx.Fixtures.Echo.Deploy(namespace, "echo-insecure")
 	fx.Fixtures.Echo.Deploy(namespace, "echo-secure")
-
-	cleanup := fx.CreateSelfSignedCert("projectcontour", "tlscert", "tlscert", "tls-gateway.projectcontour.io")
-	defer cleanup()
 
 	route := &gatewayv1alpha1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/gateway/005_request_header_modifier_test.go
+++ b/test/e2e/gateway/005_request_header_modifier_test.go
@@ -17,7 +17,6 @@ package gateway
 
 import (
 	"net/http"
-	"testing"
 
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +25,8 @@ import (
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testRequestHeaderModifierForwardTo(t *testing.T, fx *e2e.Framework) {
+func testRequestHeaderModifierForwardTo(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-005-request-header-modifier-forward-to"
 
 	fx.CreateNamespace(namespace)
@@ -141,7 +141,8 @@ func testRequestHeaderModifierForwardTo(t *testing.T, fx *e2e.Framework) {
 	assert.False(t, found, "My-Header was found on the response")
 }
 
-func testRequestHeaderModifierRule(t *testing.T, fx *e2e.Framework) {
+func testRequestHeaderModifierRule(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "gateway-005-request-header-modifier-rule"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -19,134 +19,150 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/projectcontour/contour/test/e2e"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-type testGroup struct {
-	name    string
-	gateway *gatewayv1alpha1.Gateway
-	tests   map[string]func(t *testing.T, f *e2e.Framework)
-}
-
-// getTests defines the test groups that make up the Gateway test suite.
-// Each group shares a single Gateway definition.
-func getTests() []*testGroup {
-	var testGroups []*testGroup
-
-	testGroups = append(testGroups, &testGroup{
-		name: "default gateway",
-		tests: map[string]func(t *testing.T, f *e2e.Framework){
-			"001-path-condition-match":               testGatewayPathConditionMatch,
-			"002-header-condition-match":             testGatewayHeaderConditionMatch,
-			"003-invalid-forward-to":                 testInvalidForwardTo,
-			"005-request-header-modifier-forward-to": testRequestHeaderModifierForwardTo,
-			"005-request-header-modifier-rule":       testRequestHeaderModifierRule,
-		},
-		gateway: &gatewayv1alpha1.Gateway{
-			// Namespace and name need to match what's
-			// configured in the Contour config file.
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "projectcontour",
-				Name:      "contour",
-			},
-			Spec: gatewayv1alpha1.GatewaySpec{
-				GatewayClassName: "contour-class",
-				Listeners: []gatewayv1alpha1.Listener{
-					{
-						Protocol: gatewayv1alpha1.HTTPProtocolType,
-						Port:     gatewayv1alpha1.PortNumber(80),
-						Routes: gatewayv1alpha1.RouteBindingSelector{
-							Kind: "HTTPRoute",
-							Namespaces: &gatewayv1alpha1.RouteNamespaces{
-								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
-							},
-							Selector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"app": "filter"},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
-	testGroups = append(testGroups, &testGroup{
-		name: "TLS gateway",
-		tests: map[string]func(t *testing.T, f *e2e.Framework){
-			"004-tls-gateway": testTLSGateway,
-		},
-		gateway: &gatewayv1alpha1.Gateway{
-			// Namespace and name need to match what's
-			// configured in the Contour config file.
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "projectcontour",
-				Name:      "contour",
-			},
-			Spec: gatewayv1alpha1.GatewaySpec{
-				GatewayClassName: "contour-class",
-				Listeners: []gatewayv1alpha1.Listener{
-					{
-						Protocol: gatewayv1alpha1.HTTPProtocolType,
-						Port:     gatewayv1alpha1.PortNumber(80),
-						Routes: gatewayv1alpha1.RouteBindingSelector{
-							Kind: "HTTPRoute",
-							Namespaces: &gatewayv1alpha1.RouteNamespaces{
-								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
-							},
-							Selector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"type": "insecure"},
-							},
-						},
-					},
-					{
-						Protocol: gatewayv1alpha1.HTTPSProtocolType,
-						Port:     gatewayv1alpha1.PortNumber(443),
-						TLS: &gatewayv1alpha1.GatewayTLSConfig{
-							CertificateRef: &gatewayv1alpha1.LocalObjectReference{
-								Group: "core",
-								Kind:  "Secret",
-								Name:  "tlscert",
-							},
-						},
-						Routes: gatewayv1alpha1.RouteBindingSelector{
-							Kind: "HTTPRoute",
-							Namespaces: &gatewayv1alpha1.RouteNamespaces{
-								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
-							},
-							Selector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"type": "secure"},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-
-	return testGroups
-}
-
 func TestGatewayAPI(t *testing.T) {
-	f := e2e.NewFramework(t)
-
-	for _, group := range getTests() {
-		func() {
-			require.NoError(t, f.Client.Create(context.TODO(), group.gateway))
-			defer func() {
-				// has to be wrapped in a defer func() {...} with no arguments because
-				// otherwise the arguments to require.NoError(...) are evaluated right away,
-				// i.e. the Delete(..) is called right away, not as part of the defer.
-				require.NoError(t, f.Client.Delete(context.TODO(), group.gateway))
-			}()
-
-			f.RunParallel(group.name, group.tests)
-		}()
-
-	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway API tests")
 }
+
+var _ = Describe("Gateway API", func() {
+	var f *e2e.Framework
+
+	BeforeEach(func() {
+		f = e2e.NewFramework(GinkgoT())
+	})
+
+	Describe("Insecure (Non-TLS) Gateway", func() {
+		var gateway *gatewayv1alpha1.Gateway
+
+		BeforeEach(func() {
+			gateway = &gatewayv1alpha1.Gateway{
+				// Namespace and name need to match what's
+				// configured in the Contour config file.
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "contour",
+				},
+				Spec: gatewayv1alpha1.GatewaySpec{
+					GatewayClassName: "contour-class",
+					Listeners: []gatewayv1alpha1.Listener{
+						{
+							Protocol: gatewayv1alpha1.HTTPProtocolType,
+							Port:     gatewayv1alpha1.PortNumber(80),
+							Routes: gatewayv1alpha1.RouteBindingSelector{
+								Kind: "HTTPRoute",
+								Namespaces: &gatewayv1alpha1.RouteNamespaces{
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+								},
+								Selector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "filter"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(f.Client.Create(context.TODO(), gateway)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(f.Client.Delete(context.TODO(), gateway)).To(Succeed())
+		})
+
+		It("001-path-condition-match", func() {
+			testGatewayPathConditionMatch(f)
+		})
+
+		It("002-header-condition-match", func() {
+			testGatewayHeaderConditionMatch(f)
+		})
+
+		It("003-invalid-forward-to", func() {
+			testInvalidForwardTo(f)
+		})
+
+		It("005-request-header-modifier-forward-to", func() {
+			testRequestHeaderModifierForwardTo(f)
+		})
+
+		It("005-request-header-modifier-rule", func() {
+			testRequestHeaderModifierRule(f)
+		})
+	})
+
+	Describe("TLS Gateway", func() {
+		var gateway *gatewayv1alpha1.Gateway
+		var cleanupCert func()
+
+		BeforeEach(func() {
+			gateway = &gatewayv1alpha1.Gateway{
+				// Namespace and name need to match what's
+				// configured in the Contour config file.
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "contour",
+				},
+				Spec: gatewayv1alpha1.GatewaySpec{
+					GatewayClassName: "contour-class",
+					Listeners: []gatewayv1alpha1.Listener{
+						{
+							Protocol: gatewayv1alpha1.HTTPProtocolType,
+							Port:     gatewayv1alpha1.PortNumber(80),
+							Routes: gatewayv1alpha1.RouteBindingSelector{
+								Kind: "HTTPRoute",
+								Namespaces: &gatewayv1alpha1.RouteNamespaces{
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+								},
+								Selector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"type": "insecure"},
+								},
+							},
+						},
+						{
+							Protocol: gatewayv1alpha1.HTTPSProtocolType,
+							Port:     gatewayv1alpha1.PortNumber(443),
+							TLS: &gatewayv1alpha1.GatewayTLSConfig{
+								CertificateRef: &gatewayv1alpha1.LocalObjectReference{
+									Group: "core",
+									Kind:  "Secret",
+									Name:  "tlscert",
+								},
+							},
+							Routes: gatewayv1alpha1.RouteBindingSelector{
+								Kind: "HTTPRoute",
+								Namespaces: &gatewayv1alpha1.RouteNamespaces{
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+								},
+								Selector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"type": "secure"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(f.Client.Create(context.TODO(), gateway)).To(Succeed())
+			cleanupCert = f.CreateSelfSignedCert("projectcontour", "tlscert", "tlscert", "tls-gateway.projectcontour.io")
+		})
+
+		AfterEach(func() {
+			Expect(f.Client.Delete(context.TODO(), gateway)).To(Succeed())
+			cleanupCert()
+		})
+
+		It("004-tls-gateway", func() {
+			testTLSGateway(f)
+		})
+	})
+})
 
 func stringPtr(s string) *string {
 	return &s

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 func TestGatewayAPI(t *testing.T) {
-	RegisterFailHandler(Fail)
 	RunSpecs(t, "Gateway API tests")
 }
 
@@ -41,6 +40,12 @@ var _ = Describe("Gateway API", func() {
 	Describe("Insecure (Non-TLS) Gateway", func() {
 		var gateway *gatewayv1alpha1.Gateway
 
+		// Note, this ends up creating the Gateway before each spec
+		// case (and deleting it after) which is not really necessary
+		// since all of these specs use the same Gateway. Consider
+		// moving each unique Gateway into its own test suite and using
+		// BeforeSuite/AfterSuit to create/delete the Gateway once, or
+		// some other similar structure.
 		BeforeEach(func() {
 			gateway = &gatewayv1alpha1.Gateway{
 				// Namespace and name need to match what's
@@ -69,11 +74,11 @@ var _ = Describe("Gateway API", func() {
 				},
 			}
 
-			Expect(f.Client.Create(context.TODO(), gateway)).To(Succeed())
+			require.NoError(f.T(), f.Client.Create(context.TODO(), gateway))
 		})
 
 		AfterEach(func() {
-			Expect(f.Client.Delete(context.TODO(), gateway)).To(Succeed())
+			require.NoError(f.T(), f.Client.Delete(context.TODO(), gateway))
 		})
 
 		It("001-path-condition-match", func() {
@@ -149,12 +154,12 @@ var _ = Describe("Gateway API", func() {
 				},
 			}
 
-			Expect(f.Client.Create(context.TODO(), gateway)).To(Succeed())
+			require.NoError(f.T(), f.Client.Create(context.TODO(), gateway))
 			cleanupCert = f.CreateSelfSignedCert("projectcontour", "tlscert", "tlscert", "tls-gateway.projectcontour.io")
 		})
 
 		AfterEach(func() {
-			Expect(f.Client.Delete(context.TODO(), gateway)).To(Succeed())
+			require.NoError(f.T(), f.Client.Delete(context.TODO(), gateway))
 			cleanupCert()
 		})
 

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -19,9 +19,9 @@ import (
 	"crypto/tls"
 	"io/ioutil"
 	"net/http"
-	"testing"
 	"time"
 
+	"github.com/onsi/ginkgo"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -43,7 +43,7 @@ type HTTP struct {
 	// operations before giving up.
 	RetryTimeout time.Duration
 
-	t *testing.T
+	t ginkgo.GinkgoTInterface
 }
 
 type HTTPRequestOpts struct {

--- a/test/e2e/httpproxy/002_header_condition_match_test.go
+++ b/test/e2e/httpproxy/002_header_condition_match_test.go
@@ -18,7 +18,6 @@ package httpproxy
 import (
 	"context"
 	"net/http"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -28,7 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testHeaderConditionMatch(t *testing.T, fx *e2e.Framework) {
+func testHeaderConditionMatch(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "002-header-condition-match"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/003_path_condition_match_test.go
+++ b/test/e2e/httpproxy/003_path_condition_match_test.go
@@ -16,15 +16,14 @@
 package httpproxy
 
 import (
-	"testing"
-
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testPathConditionMatch(t *testing.T, fx *e2e.Framework) {
+func testPathConditionMatch(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "003-path-condition-match"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/004_https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/004_https_sni_enforcement_test.go
@@ -17,7 +17,6 @@ package httpproxy
 
 import (
 	"crypto/tls"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -26,7 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testHTTPSSNIEnforcement(t *testing.T, fx *e2e.Framework) {
+func testHTTPSSNIEnforcement(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "004-https-sni-enforcement"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/005_pod_restart_test.go
+++ b/test/e2e/httpproxy/005_pod_restart_test.go
@@ -17,7 +17,6 @@ package httpproxy
 
 import (
 	"context"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -29,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testPodRestart(t *testing.T, fx *e2e.Framework) {
+func testPodRestart(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "005-pod-restart"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/006_merge_slash_test.go
+++ b/test/e2e/httpproxy/006_merge_slash_test.go
@@ -16,8 +16,6 @@
 package httpproxy
 
 import (
-	"testing"
-
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testMergeSlash(t *testing.T, fx *e2e.Framework) {
+func testMergeSlash(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "006-merge-slash"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/008_tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/008_tcproute_https_termination_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -29,7 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testTCPRouteHTTPSTermination(t *testing.T, fx *e2e.Framework) {
+func testTCPRouteHTTPSTermination(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "008-tcp-route-https-termination"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/009_https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/009_https_misdirected_request_test.go
@@ -17,7 +17,6 @@ package httpproxy
 
 import (
 	"crypto/tls"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -26,7 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testHTTPSMisdirectedRequest(t *testing.T, fx *e2e.Framework) {
+func testHTTPSMisdirectedRequest(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "009-https-misdirected-request"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/010_include_prefix_condition_test.go
+++ b/test/e2e/httpproxy/010_include_prefix_condition_test.go
@@ -17,7 +17,6 @@ package httpproxy
 
 import (
 	"context"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -26,8 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testIncludePrefixCondition(t *testing.T, fx *e2e.Framework) {
+func testIncludePrefixCondition(fx *e2e.Framework) {
 	var (
+		t              = fx.T()
 		baseNamespace  = "010-include-prefix-condition"
 		appNamespace   = "010-include-prefix-condition-app"
 		adminNamespace = "010-include-prefix-condition-admin"

--- a/test/e2e/httpproxy/012_https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/012_https_fallback_certificate_test.go
@@ -17,7 +17,6 @@ package httpproxy
 
 import (
 	"crypto/tls"
-	"testing"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -26,7 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testHTTPSFallbackCertificate(t *testing.T, fx *e2e.Framework) {
+func testHTTPSFallbackCertificate(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "012-https-fallback-certificate"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -18,27 +18,52 @@ package httpproxy
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-// subtests defines the tests to run as part of the HTTPProxy
-// suite.
-var subtests = map[string]func(t *testing.T, f *e2e.Framework){
-	"002-header-condition-match":     testHeaderConditionMatch,
-	"003-path-condition-match":       testPathConditionMatch,
-	"004-https-sni-enforcement":      testHTTPSSNIEnforcement,
-	"005-pod-restart":                testPodRestart,
-	"006-merge-slash":                testMergeSlash,
-	"008-tcproute-https-termination": testTCPRouteHTTPSTermination,
-	"009-https-misdirected-request":  testHTTPSMisdirectedRequest,
-	"010-include-prefix-condition":   testIncludePrefixCondition,
-	"012-https-fallback-certificate": testHTTPSFallbackCertificate,
+func TestHTTPProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTPProxy tests")
 }
 
-func TestHTTPProxy(t *testing.T) {
-	e2e.NewFramework(t).RunParallel("group", subtests)
-}
+var _ = Describe("HTTPProxy", func() {
+	var f *e2e.Framework
+
+	BeforeEach(func() {
+		f = e2e.NewFramework(GinkgoT())
+	})
+
+	It("002-header-condition-match", func() {
+		testHeaderConditionMatch(f)
+	})
+	It("003-path-condition-match", func() {
+		testPathConditionMatch(f)
+	})
+	It("004-https-sni-enforcement", func() {
+		testHTTPSSNIEnforcement(f)
+	})
+	It("005-pod-restart", func() {
+		testPodRestart(f)
+	})
+	It("006-merge-slash", func() {
+		testMergeSlash(f)
+	})
+	It("008-tcproute-https-termination", func() {
+		testTCPRouteHTTPSTermination(f)
+	})
+	It("009-https-misdirected-request", func() {
+		testHTTPSMisdirectedRequest(f)
+	})
+	It("010-include-prefix-condition", func() {
+		testIncludePrefixCondition(f)
+	})
+	It("012-https-fallback-certificate", func() {
+		testHTTPSFallbackCertificate(f)
+	})
+})
 
 // httpProxyValid returns true if the proxy has a .status.currentStatus
 // of "valid".

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -19,13 +19,11 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 )
 
 func TestHTTPProxy(t *testing.T) {
-	RegisterFailHandler(Fail)
 	RunSpecs(t, "HTTPProxy tests")
 }
 

--- a/test/e2e/ingress/002_ensure_v1beta1_test.go
+++ b/test/e2e/ingress/002_ensure_v1beta1_test.go
@@ -17,7 +17,6 @@ package ingress
 
 import (
 	"context"
-	"testing"
 
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,8 @@ import (
 )
 
 // Explicitly ensure v1beta1 resources continue to work.
-func testEnsureV1Beta1(t *testing.T, fx *e2e.Framework) {
+func testEnsureV1Beta1(fx *e2e.Framework) {
+	t := fx.T()
 	namespace := "002-ingress-ensure-v1beta1"
 
 	fx.CreateNamespace(namespace)

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-func TestHTTPProxy(t *testing.T) {
+func TestIngress(t *testing.T) {
 	RunSpecs(t, "Ingress tests")
 }
 
-var _ = Describe("HTTPProxy", func() {
+var _ = Describe("Ingress", func() {
 	var f *e2e.Framework
 
 	BeforeEach(func() {

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -18,15 +18,22 @@ package ingress
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-// subtests defines the tests to run as part of the Ingress
-// suite.
-var subtests = map[string]func(t *testing.T, f *e2e.Framework){
-	"002-ingress-ensure-v1beta1": testEnsureV1Beta1,
+func TestHTTPProxy(t *testing.T) {
+	RunSpecs(t, "Ingress tests")
 }
 
-func TestIngress(t *testing.T) {
-	e2e.NewFramework(t).RunParallel("group", subtests)
-}
+var _ = Describe("HTTPProxy", func() {
+	var f *e2e.Framework
+
+	BeforeEach(func() {
+		f = e2e.NewFramework(GinkgoT())
+	})
+
+	It("002-ingress-ensure-v1beta1", func() {
+		testEnsureV1Beta1(f)
+	})
+})


### PR DESCRIPTION
Introduces Ginkgo for running the E2E tests. Currently runs
subtests sequentially; parallelism to be re-introduced in
a subsequent PR.

Updates #3621.

Signed-off-by: Steve Kriss <krisss@vmware.com>