### PR TITLE
internal/dag: Implement Gateway.Listener.Hostname when processing HTTPRoutes

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -318,7 +318,10 @@ func (p *GatewayAPIProcessor) computeHosts(hostnames []gatewayapi_v1alpha1.Hostn
 }
 
 func removeFirstDNSLabel(input string) string {
-	return input[strings.IndexAny(input, ".")+1:]
+	if strings.Contains(input, ".") {
+		return input[strings.IndexAny(input, "."):]
+	}
+	return input
 }
 
 func validHostName(hostname string) error {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -276,12 +276,6 @@ func (p *GatewayAPIProcessor) computeHosts(hostnames []gatewayapi_v1alpha1.Hostn
 
 		hostname := string(host)
 
-		//// A "*" hostname matches anything.
-		//if hostname == "*" {
-		//	hosts[hostname] = struct{}{}
-		//	continue
-		//}
-
 		// Validate the hostname.
 		if err := validHostName(hostname); err != nil {
 			errors = append(errors, err)

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -276,11 +276,11 @@ func (p *GatewayAPIProcessor) computeHosts(hostnames []gatewayapi_v1alpha1.Hostn
 
 		hostname := string(host)
 
-		// A "*" hostname matches anything.
-		if hostname == "*" {
-			hosts[hostname] = struct{}{}
-			continue
-		}
+		//// A "*" hostname matches anything.
+		//if hostname == "*" {
+		//	hosts[hostname] = struct{}{}
+		//	continue
+		//}
 
 		// Validate the hostname.
 		if err := validHostName(hostname); err != nil {
@@ -306,17 +306,6 @@ func (p *GatewayAPIProcessor) computeHosts(hostnames []gatewayapi_v1alpha1.Hostn
 					errors = append(errors, fmt.Errorf("gateway hostname %q does not match route hostname %q", lhn, hostname))
 					continue
 				}
-				//} else if strings.Contains(hostname, "*") {
-
-				//if removeFirstDNSLabel(lhn) != removeFirstDNSLabel(hostname) {
-				//	errors = append(errors, fmt.Errorf("hostnames hostname %q does not match gateway hostname %q", hostname, lhn))
-				//	continue
-				//}
-
-				// The Listener hostname is not a wildcard, but the route is a wildcard.
-				// Since the gateway is more specific, use that to match the route against.
-				//hosts[lhn] = struct{}{}
-				//continue
 			} else {
 				// Validate the gateway listener hostname matches the hostnames hostname.
 				errors = append(errors, fmt.Errorf("gateway hostname %q does not match route hostname %q", lhn, hostname))

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -272,7 +272,7 @@ func TestComputeHosts(t *testing.T) {
 			want:      map[string]struct{}{},
 			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match route hostname \"too.many.labels.projectcontour.io\"")},
 		},
-		"listener wildcard host with wildcard hostnames": {
+		"listener wildcard host with wildcard hostname": {
 			listenerHost: listenerHostname("*"),
 			hostnames: []gatewayapi_v1alpha1.Hostname{
 				"*.projectcontour.io",
@@ -281,6 +281,14 @@ func TestComputeHosts(t *testing.T) {
 				"*.projectcontour.io": {},
 			},
 			wantError: nil,
+		},
+		"listener wildcard host with invalid wildcard hostname": {
+			listenerHost: listenerHostname("*"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("invalid hostname \"*\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]")},
 		},
 	}
 

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -27,166 +27,261 @@ import (
 
 func TestComputeHosts(t *testing.T) {
 	tests := map[string]struct {
-		route     *gatewayapi_v1alpha1.HTTPRoute
-		want      []string
-		wantError []error
+		listenerHost *gatewayapi_v1alpha1.Hostname
+		hostnames    []gatewayapi_v1alpha1.Hostname
+		want         map[string]struct{}
+		wantError    []error
 	}{
 		"single host": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"test.projectcontour.io",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"test.projectcontour.io",
 			},
-			want:      []string{"test.projectcontour.io"},
+			want: map[string]struct{}{
+				"test.projectcontour.io": {},
+			},
 			wantError: []error(nil),
 		},
 		"single DNS label hostname": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"projectcontour",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"projectcontour",
 			},
-			want:      []string{"projectcontour"},
+			want: map[string]struct{}{
+				"projectcontour": {},
+			},
 			wantError: []error(nil),
 		},
 		"multiple hosts": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"test.projectcontour.io",
-						"test1.projectcontour.io",
-						"test2.projectcontour.io",
-						"test3.projectcontour.io",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"test.projectcontour.io",
+				"test1.projectcontour.io",
+				"test2.projectcontour.io",
+				"test3.projectcontour.io",
 			},
-			want:      []string{"test.projectcontour.io", "test1.projectcontour.io", "test2.projectcontour.io", "test3.projectcontour.io"},
+			want: map[string]struct{}{
+				"test.projectcontour.io":  {},
+				"test1.projectcontour.io": {},
+				"test2.projectcontour.io": {},
+				"test3.projectcontour.io": {},
+			},
 			wantError: []error(nil),
 		},
 		"no host": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{},
+			listenerHost: nil,
+			hostnames:    []gatewayapi_v1alpha1.Hostname{},
+			want: map[string]struct{}{
+				"*": {},
 			},
-			want:      []string{"*"},
 			wantError: []error(nil),
 		},
 		"IP in host": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"1.2.3.4",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"1.2.3.4",
 			},
-			want: []string(nil),
+			want: map[string]struct{}{},
 			wantError: []error{
 				fmt.Errorf("hostname \"1.2.3.4\" must be a DNS name, not an IP address"),
 			},
 		},
 		"valid wildcard hostname": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"*.projectcontour.io",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
 			},
-			want:      []string{"*.projectcontour.io"},
+			want: map[string]struct{}{
+				"*.projectcontour.io": {},
+			},
 			wantError: []error(nil),
 		},
 		"invalid wildcard hostname": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"*.*.projectcontour.io",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.*.projectcontour.io",
 			},
-			want: []string(nil),
+			want: map[string]struct{}{},
 			wantError: []error{
 				fmt.Errorf("invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
 			},
 		},
 		"invalid hostname": {
-			route: &gatewayapi_v1alpha1.HTTPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "basic",
-					Namespace: "projectcontour",
-					Labels: map[string]string{
-						"app":  "contour",
-						"type": "controller",
-					},
-				},
-				Spec: gatewayapi_v1alpha1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha1.Hostname{
-						"#projectcontour.io",
-					},
-				},
+			listenerHost: nil,
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"#projectcontour.io",
 			},
-			want: []string(nil),
+			want: map[string]struct{}{},
 			wantError: []error{
-				fmt.Errorf("invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
+				fmt.Errorf("invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
 			},
+		},
+		"invalid listener hostname": {
+			listenerHost: listenerHostname("#projectcontour.io"),
+			hostnames:    []gatewayapi_v1alpha1.Hostname{},
+			want:         map[string]struct{}{},
+			wantError: []error{
+				fmt.Errorf("invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
+			},
+		},
+		"invalid listener wildcard hostname": {
+			listenerHost: listenerHostname("*.*.projectcontour.io"),
+			hostnames:    []gatewayapi_v1alpha1.Hostname{},
+			want:         map[string]struct{}{},
+			wantError: []error{
+				fmt.Errorf("invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"),
+			},
+		},
+		"listener host & hostnames host do not exactly match": {
+			listenerHost: listenerHostname("listener.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("gateway hostname \"listener.projectcontour.io\" does not match hostnames hostname \"http.projectcontour.io\"")},
+		},
+		"listener host & hostnames host exactly match": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host & multi hostnames host exactly match one host": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+				"http2.projectcontour.io",
+				"http3.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: []error{
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"http2.projectcontour.io\""),
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"http3.projectcontour.io\""),
+			},
+		},
+		"listener host & hostnames host match wildcard host": {
+			listenerHost: listenerHostname("*.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host & hostnames host do not match wildcard host": {
+			listenerHost: listenerHostname("*.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.example.com",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match hostnames hostname \"http.example.com\"")},
+		},
+		"listener host & wildcard hostnames host match": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host & wildcard hostname and matching hostname match": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+				"http.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host & wildcard hostname and non-matching hostname don't match": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+				"not.matching.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: []error{fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"not.matching.io\"")},
+		},
+		"listener host wildcard & wildcard hostnames host match": {
+			listenerHost: listenerHostname("*.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"*.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener wildcard matchall host & host match": {
+			listenerHost: listenerHostname("*"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener wildcard matchall host & multiple host match": {
+			listenerHost: listenerHostname("*"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"http.projectcontour.io",
+				"http2.projectcontour.io",
+				"http3.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"http.projectcontour.io":  {},
+				"http2.projectcontour.io": {},
+				"http3.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host & hostname not defined match": {
+			listenerHost: listenerHostname("http.projectcontour.io"),
+			hostnames:    []gatewayapi_v1alpha1.Hostname{},
+			want: map[string]struct{}{
+				"http.projectcontour.io": {},
+			},
+			wantError: nil,
+		},
+		"listener host with many labels doesn't match hostnames wildcard host": {
+			listenerHost: listenerHostname("too.many.labels.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("hostnames hostname \"*.projectcontour.io\" does not match gateway hostname \"too.many.labels.projectcontour.io\"")},
+		},
+		"listener wildcard host doesn't match hostnames with many labels host": {
+			listenerHost: listenerHostname("*.projectcontour.io"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"too.many.labels.projectcontour.io",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match hostnames hostname \"too.many.labels.projectcontour.io\"")},
+		},
+		"listener wildcard host with wildcard hostnames": {
+			listenerHost: listenerHostname("*"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"*.projectcontour.io",
+			},
+			want: map[string]struct{}{
+				"*.projectcontour.io": {},
+			},
+			wantError: nil,
 		},
 	}
 
@@ -197,11 +292,16 @@ func TestComputeHosts(t *testing.T) {
 				FieldLogger: fixture.NewTestLogger(t),
 			}
 
-			got, gotError := processor.computeHosts(tc.route.Spec.Hostnames)
+			got, gotError := processor.computeHosts(tc.hostnames, tc.listenerHost)
 			assert.Equal(t, tc.want, got)
 			assert.Equal(t, tc.wantError, gotError)
 		})
 	}
+}
+
+func listenerHostname(host string) *gatewayapi_v1alpha1.Hostname {
+	h := gatewayapi_v1alpha1.Hostname(host)
+	return &h
 }
 
 func TestNamespaceMatches(t *testing.T) {

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -290,6 +290,24 @@ func TestComputeHosts(t *testing.T) {
 			want:      map[string]struct{}{},
 			wantError: []error{fmt.Errorf("invalid hostname \"*\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]")},
 		},
+		"listener wildcard host with bare hostname": {
+			listenerHost: listenerHostname("*"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"foo",
+			},
+			want: map[string]struct{}{
+				"foo": {},
+			},
+			wantError: nil,
+		},
+		"listener wildcard host with bare hostname is invalid": {
+			listenerHost: listenerHostname("*.foo"),
+			hostnames: []gatewayapi_v1alpha1.Hostname{
+				"foo",
+			},
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("gateway hostname \"*.foo\" does not match route hostname \"foo\"")},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -138,7 +138,7 @@ func TestComputeHosts(t *testing.T) {
 				"http.projectcontour.io",
 			},
 			want:      map[string]struct{}{},
-			wantError: []error{fmt.Errorf("gateway hostname \"listener.projectcontour.io\" does not match hostnames hostname \"http.projectcontour.io\"")},
+			wantError: []error{fmt.Errorf("gateway hostname \"listener.projectcontour.io\" does not match route hostname \"http.projectcontour.io\"")},
 		},
 		"listener host & hostnames host exactly match": {
 			listenerHost: listenerHostname("http.projectcontour.io"),
@@ -161,8 +161,8 @@ func TestComputeHosts(t *testing.T) {
 				"http.projectcontour.io": {},
 			},
 			wantError: []error{
-				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"http2.projectcontour.io\""),
-				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"http3.projectcontour.io\""),
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"http2.projectcontour.io\""),
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"http3.projectcontour.io\""),
 			},
 		},
 		"listener host & hostnames host match wildcard host": {
@@ -181,17 +181,15 @@ func TestComputeHosts(t *testing.T) {
 				"http.example.com",
 			},
 			want:      map[string]struct{}{},
-			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match hostnames hostname \"http.example.com\"")},
+			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match route hostname \"http.example.com\"")},
 		},
-		"listener host & wildcard hostnames host match": {
+		"listener host & wildcard hostnames host do not match": {
 			listenerHost: listenerHostname("http.projectcontour.io"),
 			hostnames: []gatewayapi_v1alpha1.Hostname{
 				"*.projectcontour.io",
 			},
-			want: map[string]struct{}{
-				"http.projectcontour.io": {},
-			},
-			wantError: nil,
+			want:      map[string]struct{}{},
+			wantError: []error{fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"*.projectcontour.io\"")},
 		},
 		"listener host & wildcard hostname and matching hostname match": {
 			listenerHost: listenerHostname("http.projectcontour.io"),
@@ -202,7 +200,7 @@ func TestComputeHosts(t *testing.T) {
 			want: map[string]struct{}{
 				"http.projectcontour.io": {},
 			},
-			wantError: nil,
+			wantError: []error{fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"*.projectcontour.io\"")},
 		},
 		"listener host & wildcard hostname and non-matching hostname don't match": {
 			listenerHost: listenerHostname("http.projectcontour.io"),
@@ -210,10 +208,11 @@ func TestComputeHosts(t *testing.T) {
 				"*.projectcontour.io",
 				"not.matching.io",
 			},
-			want: map[string]struct{}{
-				"http.projectcontour.io": {},
+			want: map[string]struct{}{},
+			wantError: []error{
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"*.projectcontour.io\""),
+				fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match route hostname \"not.matching.io\""),
 			},
-			wantError: []error{fmt.Errorf("gateway hostname \"http.projectcontour.io\" does not match hostnames hostname \"not.matching.io\"")},
 		},
 		"listener host wildcard & wildcard hostnames host match": {
 			listenerHost: listenerHostname("*.projectcontour.io"),
@@ -263,7 +262,7 @@ func TestComputeHosts(t *testing.T) {
 				"*.projectcontour.io",
 			},
 			want:      map[string]struct{}{},
-			wantError: []error{fmt.Errorf("hostnames hostname \"*.projectcontour.io\" does not match gateway hostname \"too.many.labels.projectcontour.io\"")},
+			wantError: []error{fmt.Errorf("gateway hostname \"too.many.labels.projectcontour.io\" does not match route hostname \"*.projectcontour.io\"")},
 		},
 		"listener wildcard host doesn't match hostnames with many labels host": {
 			listenerHost: listenerHostname("*.projectcontour.io"),
@@ -271,7 +270,7 @@ func TestComputeHosts(t *testing.T) {
 				"too.many.labels.projectcontour.io",
 			},
 			want:      map[string]struct{}{},
-			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match hostnames hostname \"too.many.labels.projectcontour.io\"")},
+			wantError: []error{fmt.Errorf("gateway hostname \"*.projectcontour.io\" does not match route hostname \"too.many.labels.projectcontour.io\"")},
 		},
 		"listener wildcard host with wildcard hostnames": {
 			listenerHost: listenerHostname("*"),

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3086,7 +3086,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+					Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 				},
 				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
 					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),
@@ -3732,7 +3732,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "invalid listener hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
+					Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 				},
 				gatewayapi_v1alpha1.ConditionRouteAdmitted: {
 					Type:    string(gatewayapi_v1alpha1.ConditionRouteAdmitted),


### PR DESCRIPTION
Take into account gateway.listeners.hostname into account when processing HTTPRoutes
which applies to all HTTPRoutes selected for that listener.

Fixes #3561

Signed-off-by: Steve Sloka <slokas@vmware.com>