### PR TITLE
cmd/contour: Remove deprecated flag 'experimental-service-apis'

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -149,7 +149,6 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 
 	serve.Flag("debug", "Enable debug logging.").Short('d').BoolVar(&ctx.Config.Debug)
 	serve.Flag("kubernetes-debug", "Enable Kubernetes client debug logging with log level.").PlaceHolder("<log level>").UintVar(&ctx.KubernetesDebug)
-	serve.Flag("experimental-service-apis", "DEPRECATED: Please configure the gateway.name & gateway.namespace in the configuration file.").BoolVar(&ctx.UseExperimentalServiceAPITypes)
 	return serve, ctx
 }
 
@@ -406,11 +405,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		if err := informOnResource(clients, k8s.IngressV1Beta1Resource(), &dynamicHandler); err != nil {
 			log.WithError(err).WithField("resource", k8s.IngressV1Beta1Resource()).Fatal("failed to create informer")
 		}
-	}
-
-	// Inform on gateway-api types if they are present.
-	if ctx.UseExperimentalServiceAPITypes {
-		log.Warn("DEPRECATED: The flag '--experimental-service-apis' is deprecated and should not be used. Please configure the gateway.name & gateway.namespace in the configuration file to specify which Gateway Contour will be watching.")
 	}
 
 	// Only inform on GatewayAPI resources if Gateway API is found.

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -81,33 +81,29 @@ type serveContext struct {
 
 	// DisableLeaderElection can only be set by command line flag.
 	DisableLeaderElection bool
-
-	// DEPRECATED: Configure the Gateway.Name & Gateway.Namespace in the configuration file.
-	UseExperimentalServiceAPITypes bool `yaml:"-"`
 }
 
 // newServeContext returns a serveContext initialized to defaults.
 func newServeContext() *serveContext {
 	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
 	return &serveContext{
-		Config:                         config.Defaults(),
-		statsAddr:                      "0.0.0.0",
-		statsPort:                      8002,
-		debugAddr:                      "127.0.0.1",
-		debugPort:                      6060,
-		healthAddr:                     "0.0.0.0",
-		healthPort:                     8000,
-		metricsAddr:                    "0.0.0.0",
-		metricsPort:                    8000,
-		httpAccessLog:                  xdscache_v3.DEFAULT_HTTP_ACCESS_LOG,
-		httpsAccessLog:                 xdscache_v3.DEFAULT_HTTPS_ACCESS_LOG,
-		httpAddr:                       "0.0.0.0",
-		httpsAddr:                      "0.0.0.0",
-		httpPort:                       8080,
-		httpsPort:                      8443,
-		PermitInsecureGRPC:             false,
-		DisableLeaderElection:          false,
-		UseExperimentalServiceAPITypes: false,
+		Config:                config.Defaults(),
+		statsAddr:             "0.0.0.0",
+		statsPort:             8002,
+		debugAddr:             "127.0.0.1",
+		debugPort:             6060,
+		healthAddr:            "0.0.0.0",
+		healthPort:            8000,
+		metricsAddr:           "0.0.0.0",
+		metricsPort:           8000,
+		httpAccessLog:         xdscache_v3.DEFAULT_HTTP_ACCESS_LOG,
+		httpsAccessLog:        xdscache_v3.DEFAULT_HTTPS_ACCESS_LOG,
+		httpAddr:              "0.0.0.0",
+		httpsAddr:             "0.0.0.0",
+		httpPort:              8080,
+		httpsPort:             8443,
+		PermitInsecureGRPC:    false,
+		DisableLeaderElection: false,
 		ServerConfig: ServerConfig{
 			xdsAddr: "127.0.0.1",
 			xdsPort: 8001,

--- a/site/docs/main/configuration.md
+++ b/site/docs/main/configuration.md
@@ -51,7 +51,6 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | `--disable-leader-election` | Disable leader election mechanism |
 | `-d, --debug`   |                  Enable debug logging |
 | `--kubernetes-debug=<log level>`  | Enable Kubernetes client debug logging |
-| `--experimental-service-apis` | DEPRECATED: Please configure the gateway.name & gateway.namespace in the configuration file. | 
 {: class="table thead-dark table-bordered"}
 <br>
 


### PR DESCRIPTION
Signed-off-by: Steve Sloka <slokas@vmware.com>