### PR TITLE
internal/featuretests: Remove Ingress v1beta1

### DIFF
--- a/internal/featuretests/kubernetes.go
+++ b/internal/featuretests/kubernetes.go
@@ -18,13 +18,9 @@ package featuretests
 import (
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// TODO: Use only v1 Ingress only as v1beta1 will be removed in a
-// kubernetes version soon.
 func IngressBackend(svc *v1.Service) *networking_v1.IngressBackend {
 	return &networking_v1.IngressBackend{
 		Service: &networking_v1.IngressServiceBackend{
@@ -33,13 +29,6 @@ func IngressBackend(svc *v1.Service) *networking_v1.IngressBackend {
 				Number: svc.Spec.Ports[0].Port,
 			},
 		},
-	}
-}
-
-func IngressV1Beta1Backend(svc *v1.Service) *v1beta1.IngressBackend {
-	return &v1beta1.IngressBackend{
-		ServiceName: svc.Name,
-		ServicePort: intstr.FromInt(int(svc.Spec.Ports[0].Port)),
 	}
 }
 

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -27,10 +27,9 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
@@ -146,13 +145,10 @@ func TestBackendClientAuthenticationWithIngress(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 443})
 	rh.OnAdd(svc)
 
-	ingress := &v1beta1.Ingress{
+	ingress := &networking_v1.Ingress{
 		ObjectMeta: fixture.ObjectMeta("authenticated"),
-		Spec: v1beta1.IngressSpec{
-			Backend: &v1beta1.IngressBackend{
-				ServiceName: "backend",
-				ServicePort: intstr.FromInt(443),
-			},
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(svc),
 		},
 	}
 	rh.OnAdd(ingress)

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/protobuf"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -50,16 +50,13 @@ func TestExternalNameService(t *testing.T) {
 			Type:         v1.ServiceTypeExternalName,
 		})
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
 			Namespace: s1.Namespace,
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: &v1beta1.IngressBackend{
-				ServiceName: s1.Name,
-				ServicePort: intstr.FromInt(80),
-			},
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnAdd(s1)

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
@@ -50,7 +49,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 	// Ingress
 	{
 		// --- ingress class matches explicitly
-		ingressValid := &v1beta1.Ingress{
+		ingressValid := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
@@ -58,8 +57,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 					"kubernetes.io/ingress.class": "linkerd",
 				},
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 
@@ -80,7 +79,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		})
 
 		// --- wrong ingress class specified
-		ingressWrongClass := &v1beta1.Ingress{
+		ingressWrongClass := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
@@ -88,8 +87,8 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 					"kubernetes.io/ingress.class": "invalid",
 				},
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 
@@ -103,13 +102,13 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		})
 
 		// --- no ingress class specified
-		ingressNoClass := &v1beta1.Ingress{
+		ingressNoClass := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 		rh.OnUpdate(ingressWrongClass, ingressNoClass)
@@ -275,13 +274,13 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 	// Ingress
 	{
 		// --- no ingress class specified
-		ingressNoClass := &v1beta1.Ingress{
+		ingressNoClass := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 
@@ -302,7 +301,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		})
 
 		// --- matching ingress class specified
-		ingressMatchingClass := &v1beta1.Ingress{
+		ingressMatchingClass := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
@@ -310,8 +309,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 					"kubernetes.io/ingress.class": "contour",
 				},
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 
@@ -332,7 +331,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		})
 
 		// --- non-matching ingress class specified
-		ingressNonMatchingClass := &v1beta1.Ingress{
+		ingressNonMatchingClass := &networking_v1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      IngressName,
 				Namespace: Namespace,
@@ -340,8 +339,8 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 					"kubernetes.io/ingress.class": "invalid",
 				},
 			},
-			Spec: v1beta1.IngressSpec{
-				Backend: featuretests.IngressV1Beta1Backend(svc),
+			Spec: networking_v1.IngressSpec{
+				DefaultBackend: featuretests.IngressBackend(svc),
 			},
 		}
 		rh.OnUpdate(ingressMatchingClass, ingressNonMatchingClass)

--- a/internal/featuretests/v3/retrypolicy_test.go
+++ b/internal/featuretests/v3/retrypolicy_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -37,7 +37,7 @@ func TestRetryPolicy(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hello",
 			Namespace: s1.Namespace,
@@ -47,8 +47,8 @@ func TestRetryPolicy(t *testing.T) {
 				"projectcontour.io/per-try-timeout": "120ms",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: featuretests.IngressV1Beta1Backend(s1),
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnAdd(i1)
@@ -67,7 +67,7 @@ func TestRetryPolicy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	i2 := &v1beta1.Ingress{
+	i2 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hello", Namespace: "default",
 			Annotations: map[string]string{
@@ -76,8 +76,8 @@ func TestRetryPolicy(t *testing.T) {
 				"projectcontour.io/per-try-timeout": "120ms",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: featuretests.IngressV1Beta1Backend(s1),
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnUpdate(i1, i2)
@@ -96,7 +96,7 @@ func TestRetryPolicy(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	i3 := &v1beta1.Ingress{
+	i3 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hello", Namespace: "default",
 			Annotations: map[string]string{
@@ -105,8 +105,8 @@ func TestRetryPolicy(t *testing.T) {
 				"projectcontour.io/per-try-timeout": "120ms",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: featuretests.IngressV1Beta1Backend(s1),
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnUpdate(i2, i3)

--- a/internal/featuretests/v3/timeoutpolicy_test.go
+++ b/internal/featuretests/v3/timeoutpolicy_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -38,7 +38,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-ing",
 			Namespace: svc.Namespace,
@@ -46,8 +46,8 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 				"projectcontour.io/response-timeout": "1m20s",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: featuretests.IngressV1Beta1Backend(svc),
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(svc),
 		},
 	}
 	rh.OnAdd(i1)
@@ -67,7 +67,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	i2 := &v1beta1.Ingress{
+	i2 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-ing",
 			Namespace: svc.Namespace,
@@ -94,7 +94,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	i3 := &v1beta1.Ingress{
+	i3 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-ing",
 			Namespace: svc.Namespace,
@@ -121,7 +121,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	i4 := &v1beta1.Ingress{
+	i4 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard-ing",
 			Namespace: svc.Namespace,

--- a/internal/featuretests/v3/tlsprotocolversion_test.go
+++ b/internal/featuretests/v3/tlsprotocolversion_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,22 +47,22 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "http", Port: 80})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: s1.Namespace,
 		},
-		Spec: v1beta1.IngressSpec{
-			TLS: []v1beta1.IngressTLS{{
+		Spec: networking_v1.IngressSpec{
+			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: sec1.Name,
 			}},
-			Rules: []v1beta1.IngressRule{{
+			Rules: []networking_v1.IngressRule{{
 				Host: "kuard.example.com",
-				IngressRuleValue: v1beta1.IngressRuleValue{
-					HTTP: &v1beta1.HTTPIngressRuleValue{
-						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *featuretests.IngressV1Beta1Backend(s1),
+				IngressRuleValue: networking_v1.IngressRuleValue{
+					HTTP: &networking_v1.HTTPIngressRuleValue{
+						Paths: []networking_v1.HTTPIngressPath{{
+							Backend: *featuretests.IngressBackend(s1),
 						}},
 					},
 				},
@@ -90,7 +90,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	i2 := &v1beta1.Ingress{
+	i2 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
 			Namespace: sec1.Namespace,
@@ -98,17 +98,17 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 				"projectcontour.io/tls-minimum-protocol-version": "1.3",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			TLS: []v1beta1.IngressTLS{{
+		Spec: networking_v1.IngressSpec{
+			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
 				SecretName: sec1.Name,
 			}},
-			Rules: []v1beta1.IngressRule{{
+			Rules: []networking_v1.IngressRule{{
 				Host: "kuard.example.com",
-				IngressRuleValue: v1beta1.IngressRuleValue{
-					HTTP: &v1beta1.HTTPIngressRuleValue{
-						Paths: []v1beta1.HTTPIngressPath{{
-							Backend: *featuretests.IngressV1Beta1Backend(s1),
+				IngressRuleValue: networking_v1.IngressRuleValue{
+					HTTP: &networking_v1.HTTPIngressRuleValue{
+						Paths: []networking_v1.HTTPIngressPath{{
+							Backend: *featuretests.IngressBackend(s1),
 						}},
 					},
 				},

--- a/internal/featuretests/v3/upstreamprotocol_test.go
+++ b/internal/featuretests/v3/upstreamprotocol_test.go
@@ -17,9 +17,10 @@ import (
 	"testing"
 
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -35,16 +36,13 @@ func TestUpstreamProtocolTLS(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
 			Namespace: "default",
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: &v1beta1.IngressBackend{
-				ServiceName: "kuard",
-				ServicePort: intstr.FromInt(443),
-			},
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnAdd(i1)
@@ -80,16 +78,13 @@ func TestUpstreamProtocolH2C(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
 			Namespace: "default",
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: &v1beta1.IngressBackend{
-				ServiceName: "kuard",
-				ServicePort: intstr.FromInt(443),
-			},
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnAdd(i1)
@@ -125,16 +120,13 @@ func TestUpstreamProtocolH2(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8888)})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
 			Namespace: "default",
 		},
-		Spec: v1beta1.IngressSpec{
-			Backend: &v1beta1.IngressBackend{
-				ServiceName: "kuard",
-				ServicePort: intstr.FromInt(443),
-			},
+		Spec: networking_v1.IngressSpec{
+			DefaultBackend: featuretests.IngressBackend(s1),
 		},
 	}
 	rh.OnAdd(i1)

--- a/internal/featuretests/v3/websockets_test.go
+++ b/internal/featuretests/v3/websockets_test.go
@@ -20,9 +20,10 @@ import (
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
+	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -35,7 +36,7 @@ func TestWebsocketsIngress(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(s1)
 
-	i1 := &v1beta1.Ingress{
+	i1 := &networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ws",
 			Namespace: s1.Namespace,
@@ -43,17 +44,14 @@ func TestWebsocketsIngress(t *testing.T) {
 				"projectcontour.io/websocket-routes": "/ws2",
 			},
 		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{{
+		Spec: networking_v1.IngressSpec{
+			Rules: []networking_v1.IngressRule{{
 				Host: "websocket.hello.world",
-				IngressRuleValue: v1beta1.IngressRuleValue{
-					HTTP: &v1beta1.HTTPIngressRuleValue{
-						Paths: []v1beta1.HTTPIngressPath{{
-							Path: "/ws2",
-							Backend: v1beta1.IngressBackend{
-								ServiceName: s1.Name,
-								ServicePort: intstr.FromInt(80),
-							},
+				IngressRuleValue: networking_v1.IngressRuleValue{
+					HTTP: &networking_v1.HTTPIngressRuleValue{
+						Paths: []networking_v1.HTTPIngressPath{{
+							Path:    "/ws2",
+							Backend: *featuretests.IngressBackend(s1),
 						}},
 					},
 				},


### PR DESCRIPTION
Removes Ingress v1beta1 from tests as v1 is present in
all supported k8s versions and v1beta1 resources are
subscribed to with v1 informers.

Updates: #3628