### PR TITLE
test/e2e: add Gateway tests 006, 007

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ integration: check-integration
 e2e:
 	./_integration/testsuite/make-kind-cluster.sh
 	./_integration/testsuite/install-contour-working.sh
-	go test -v -tags e2e -p 1 ./test/e2e/...
+	go test -v -tags e2e -p 1 -timeout 20m ./test/e2e/...
 	./_integration/testsuite/cleanup.sh
 
 check-ingress-conformance: ## Run Ingress controller conformance

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -43,8 +43,9 @@ type Echo struct {
 // Deploy creates the ingress-conformance-echo fixture, specifically
 // the deployment and service, in the given namespace and with the given name, or
 // fails the test if it encounters an error. Namespace is defaulted to "default"
-// and name is defaulted to "ingress-conformance-echo" if not provided.
-func (e *Echo) Deploy(ns, name string) {
+// and name is defaulted to "ingress-conformance-echo" if not provided. Returns
+// a cleanup function.
+func (e *Echo) Deploy(ns, name string) func() {
 	valOrDefault := func(val, defaultVal string) string {
 		if val != "" {
 			return val
@@ -138,4 +139,9 @@ func (e *Echo) Deploy(ns, name string) {
 		},
 	}
 	require.NoError(e.t, e.client.Create(context.TODO(), service))
+
+	return func() {
+		require.NoError(e.t, e.client.Delete(context.TODO(), service))
+		require.NoError(e.t, e.client.Delete(context.TODO(), deployment))
+	}
 }

--- a/test/e2e/gateway/006_host_rewrite_test.go
+++ b/test/e2e/gateway/006_host_rewrite_test.go
@@ -1,0 +1,86 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testHostRewrite(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "gateway-006-host-rewrite"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+
+	route := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "host-rewrite",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"hostrewrite.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+								Value: stringPtr("/"),
+							},
+						},
+					},
+					Filters: []gatewayv1alpha1.HTTPRouteFilter{
+						{
+							Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
+								Add: map[string]string{
+									"Host": "rewritten.com",
+								},
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      string(route.Spec.Hostnames[0]),
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body := fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo", body.Service)
+	assert.Equal(t, "rewritten.com", body.Host)
+}

--- a/test/e2e/gateway/007_gateway_allow_type_test.go
+++ b/test/e2e/gateway/007_gateway_allow_type_test.go
@@ -1,0 +1,226 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package gateway
+
+import (
+	"context"
+
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
+)
+
+func testGatewayAllowType(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "gateway-007-gateway-allow-type"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo-blue")
+
+	cleanup := fx.Fixtures.Echo.Deploy("projectcontour", "echo")
+	defer cleanup()
+
+	// This route allows gateways from a list, and the actual gateway
+	// is included in the list.
+	gatewayInAllowedListRoute := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "gateway-in-allowed-list",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewayallowtype.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
+				GatewayRefs: []gatewayv1alpha1.GatewayReference{
+					{
+						Name:      "contour",
+						Namespace: "projectcontour",
+					},
+				},
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchExact),
+								Value: stringPtr("/gateway-in-allowed-list"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-blue"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(gatewayInAllowedListRoute, httpRouteAdmitted)
+
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      string(gatewayInAllowedListRoute.Spec.Hostnames[0]),
+		Path:      "/gateway-in-allowed-list",
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	body := fx.GetEchoResponseBody(res.Body)
+	assert.Equal(t, "echo-blue", body.Service)
+
+	// This route allows gateways from a list, and the actual gateway
+	// is *NOT* included in the list.
+	gatewayNotInAllowedListRoute := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "gateway-not-in-allowed-list",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewayallowtype.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowFromList),
+				GatewayRefs: []gatewayv1alpha1.GatewayReference{
+					{
+						Name:      "invalid-name",
+						Namespace: "invalid-ns",
+					},
+				},
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchExact),
+								Value: stringPtr("/gateway-not-in-allowed-list"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-blue"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	// can't wait for admitted because it'll be invalid
+	require.NoError(t, fx.Client.Create(context.TODO(), gatewayNotInAllowedListRoute))
+
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      string(gatewayNotInAllowedListRoute.Spec.Hostnames[0]),
+		Path:      "/gateway-not-in-allowed-list",
+		Condition: e2e.HasStatusCode(404),
+	})
+	require.Truef(t, ok, "expected 404 response code, got %d", res.StatusCode)
+
+	// This route allows gateways in the same namespace, and the actual
+	// gateway is in the same namespace.
+	gatewayInSameNamespaceRoute := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "projectcontour",
+			Name:      "gateway-in-same-namespace",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewayallowtype.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowSameNamespace),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchExact),
+								Value: stringPtr("/gateway-in-same-namespace"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPRouteAndWaitFor(gatewayInSameNamespaceRoute, httpRouteAdmitted)
+	defer func() {
+		require.NoError(t, fx.Client.Delete(context.TODO(), gatewayInSameNamespaceRoute))
+	}()
+
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      string(gatewayInSameNamespaceRoute.Spec.Hostnames[0]),
+		Path:      "/gateway-in-same-namespace",
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// This route allows gateways in the same namespace, and the actual
+	// gateway is *NOT* in the same namespace.
+	gatewayNotInSameNamespaceRoute := &gatewayv1alpha1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "gateway-not-in-same-namespace",
+			Labels:    map[string]string{"app": "filter"},
+		},
+		Spec: gatewayv1alpha1.HTTPRouteSpec{
+			Hostnames: []gatewayv1alpha1.Hostname{"gatewayallowtype.gateway.projectcontour.io"},
+			Gateways: &gatewayv1alpha1.RouteGateways{
+				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowSameNamespace),
+			},
+			Rules: []gatewayv1alpha1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1alpha1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1alpha1.HTTPPathMatch{
+								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchExact),
+								Value: stringPtr("/gateway-not-in-same-namespace"),
+							},
+						},
+					},
+					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+						{
+							ServiceName: stringPtr("echo-blue"),
+							Port:        portNumPtr(80),
+						},
+					},
+				},
+			},
+		},
+	}
+	// can't wait for admitted because it'll be invalid
+	require.NoError(t, fx.Client.Create(context.TODO(), gatewayNotInSameNamespaceRoute))
+
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      string(gatewayNotInSameNamespaceRoute.Spec.Hostnames[0]),
+		Path:      "/gateway-not-in-same-namespace",
+		Condition: e2e.HasStatusCode(404),
+	})
+	require.Truef(t, ok, "expected 404 response code, got %d", res.StatusCode)
+}

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -100,6 +100,14 @@ var _ = Describe("Gateway API", func() {
 		It("005-request-header-modifier-rule", func() {
 			testRequestHeaderModifierRule(f)
 		})
+
+		It("006-host-rewrite", func() {
+			testHostRewrite(f)
+		})
+
+		It("007-gateway-allow-type", func() {
+			testGatewayAllowType(f)
+		})
 	})
 
 	Describe("TLS Gateway", func() {


### PR DESCRIPTION
Also bumps the test timeout from 10m (default) to 20m.

Updates #3621.

Signed-off-by: Steve Kriss <krisss@vmware.com>