### PR TITLE
test/e2e: add HTTPProxy tests 016,017,019,020

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -257,15 +256,11 @@ func (f *Framework) GetEchoResponseBody(body []byte) EchoResponseBody {
 }
 
 type EchoResponseBody struct {
-	Path      string      `json:"path"`
-	Host      string      `json:"host"`
-	Headers   http.Header `json:"headers"`
-	Namespace string      `json:"namespace"`
-	Ingress   string      `json:"ingress"`
-	Service   string      `json:"service"`
-	Pod       string      `json:"pod"`
-}
-
-func (erb *EchoResponseBody) GetHeader(name string) string {
-	return strings.Join(erb.Headers[name], ",")
+	Path           string      `json:"path"`
+	Host           string      `json:"host"`
+	RequestHeaders http.Header `json:"headers"`
+	Namespace      string      `json:"namespace"`
+	Ingress        string      `json:"ingress"`
+	Service        string      `json:"service"`
+	Pod            string      `json:"pod"`
 }

--- a/test/e2e/gateway/005_request_header_modifier_test.go
+++ b/test/e2e/gateway/005_request_header_modifier_test.go
@@ -114,10 +114,10 @@ func testRequestHeaderModifierForwardTo(fx *e2e.Framework) {
 	body := fx.GetEchoResponseBody(res.Body)
 	assert.Equal(t, "echo-header-filter", body.Service)
 
-	assert.Equal(t, "Foo", body.Headers.Get("My-Header"))
-	assert.Equal(t, "Bar", body.Headers.Get("Replace-Header"))
+	assert.Equal(t, "Foo", body.RequestHeaders.Get("My-Header"))
+	assert.Equal(t, "Bar", body.RequestHeaders.Get("Replace-Header"))
 
-	_, found := body.Headers["Other-Header"]
+	_, found := body.RequestHeaders["Other-Header"]
 	assert.False(t, found, "Other-Header was found on the response")
 
 	// Check the route without any filters.
@@ -135,9 +135,9 @@ func testRequestHeaderModifierForwardTo(fx *e2e.Framework) {
 	body = fx.GetEchoResponseBody(res.Body)
 	assert.Equal(t, "echo-header-nofilter", body.Service)
 
-	assert.Equal(t, "Exist", body.Headers.Get("Other-Header"))
+	assert.Equal(t, "Exist", body.RequestHeaders.Get("Other-Header"))
 
-	_, found = body.Headers["My-Header"]
+	_, found = body.RequestHeaders["My-Header"]
 	assert.False(t, found, "My-Header was found on the response")
 }
 
@@ -230,10 +230,10 @@ func testRequestHeaderModifierRule(fx *e2e.Framework) {
 	body := fx.GetEchoResponseBody(res.Body)
 	assert.Equal(t, "echo-header-filter", body.Service)
 
-	assert.Equal(t, "Foo", body.Headers.Get("My-Header"))
-	assert.Equal(t, "Bar", body.Headers.Get("Replace-Header"))
+	assert.Equal(t, "Foo", body.RequestHeaders.Get("My-Header"))
+	assert.Equal(t, "Bar", body.RequestHeaders.Get("Replace-Header"))
 
-	_, found := body.Headers["Other-Header"]
+	_, found := body.RequestHeaders["Other-Header"]
 	assert.False(t, found, "Other-Header was found on the response")
 
 	// Check the route without any filters.
@@ -251,8 +251,8 @@ func testRequestHeaderModifierRule(fx *e2e.Framework) {
 	body = fx.GetEchoResponseBody(res.Body)
 	assert.Equal(t, "echo-header-nofilter", body.Service)
 
-	assert.Equal(t, "Exist", body.Headers.Get("Other-Header"))
+	assert.Equal(t, "Exist", body.RequestHeaders.Get("Other-Header"))
 
-	_, found = body.Headers["My-Header"]
+	_, found = body.RequestHeaders["My-Header"]
 	assert.False(t, found, "My-Header was found on the response")
 }

--- a/test/e2e/httpproxy/016_dynamic_headers_test.go
+++ b/test/e2e/httpproxy/016_dynamic_headers_test.go
@@ -1,0 +1,188 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package httpproxy
+
+import (
+	"net/http"
+	"strings"
+
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testDynamicHeaders(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "016-dynamic-headers"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "dynamic-headers",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "dynamicheaders.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name:                  "ingress-conformance-echo",
+							Port:                  80,
+							RequestHeadersPolicy:  &contourv1.HeadersPolicy{},
+							ResponseHeadersPolicy: &contourv1.HeadersPolicy{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	requestHeaders := map[string]string{
+		"Request-Header":                  "foo",
+		"X-App-Weight":                    "100%",
+		"X-Envoy-Hostname":                "%HOSTNAME%",
+		"X-Envoy-Unknown":                 "%UNKNOWN%",
+		"X-Envoy-Upstream-Remote-Address": "%UPSTREAM_REMOTE_ADDRESS%",
+		"X-Request-Host":                  "%REQ(Host)%",
+		"X-Request-Missing-Header":        "%REQ(Missing-Header)%ook",
+		"X-Host-Protocol":                 "%REQ(Host)% - %PROTOCOL%",
+		"X-Dynamic-Header-1":              "%DOWNSTREAM_REMOTE_ADDRESS%",
+		"X-Dynamic-Header-2":              "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%",
+		"X-Dynamic-Header-3":              "%DOWNSTREAM_LOCAL_ADDRESS%",
+		"X-Dynamic-Header-4":              "%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%",
+		"X-Dynamic-Header-5":              "%DOWNSTREAM_LOCAL_PORT%",
+		"X-Dynamic-Header-6":              "%DOWNSTREAM_LOCAL_URI_SAN%",
+		"X-Dynamic-Header-7":              "%DOWNSTREAM_PEER_URI_SAN%",
+		"X-Dynamic-Header-8":              "%DOWNSTREAM_LOCAL_SUBJECT%",
+		"X-Dynamic-Header-9":              "%DOWNSTREAM_PEER_SUBJECT%",
+		"X-Dynamic-Header-10":             "%DOWNSTREAM_PEER_ISSUER%",
+		"X-Dynamic-Header-11":             "%DOWNSTREAM_TLS_SESSION_ID%",
+		"X-Dynamic-Header-12":             "%DOWNSTREAM_TLS_CIPHER%",
+		"X-Dynamic-Header-13":             "%DOWNSTREAM_TLS_VERSION%",
+		"X-Dynamic-Header-14":             "%DOWNSTREAM_PEER_FINGERPRINT_256%",
+		"X-Dynamic-Header-15":             "%DOWNSTREAM_PEER_FINGERPRINT_1%",
+		"X-Dynamic-Header-16":             "%DOWNSTREAM_PEER_SERIAL%",
+		"X-Dynamic-Header-17":             "%DOWNSTREAM_PEER_CERT%",
+		"X-Dynamic-Header-18":             "%DOWNSTREAM_PEER_CERT_V_START%",
+		"X-Dynamic-Header-19":             "%DOWNSTREAM_PEER_CERT_V_END%",
+		"X-Dynamic-Header-20":             "%HOSTNAME%",
+		"X-Dynamic-Header-21":             "%PROTOCOL%",
+		"X-Dynamic-Header-22":             "%UPSTREAM_REMOTE_ADDRESS%",
+		"X-Dynamic-Header-23":             "%RESPONSE_FLAGS%",
+		"X-Dynamic-Header-24":             "%RESPONSE_CODE_DETAILS%",
+		"X-Contour-Namespace":             "%CONTOUR_NAMESPACE%",
+		"X-Contour-Service":               "%CONTOUR_SERVICE_NAME%:%CONTOUR_SERVICE_PORT%",
+	}
+	for k, v := range requestHeaders {
+		hv := contourv1.HeaderValue{
+			Name:  k,
+			Value: v,
+		}
+		p.Spec.Routes[0].Services[0].RequestHeadersPolicy.Set = append(p.Spec.Routes[0].Services[0].RequestHeadersPolicy.Set, hv)
+	}
+
+	responseHeaders := map[string]string{
+		"Response-Header":                 "bar",
+		"X-App-Weight":                    "100%",
+		"X-Envoy-Hostname":                "%HOSTNAME%",
+		"X-Envoy-Unknown":                 "%UNKNOWN%",
+		"X-Envoy-Upstream-Remote-Address": "%UPSTREAM_REMOTE_ADDRESS%",
+		"X-Request-Host":                  "%REQ(Host)%",
+		"X-Request-Missing-Header":        "%REQ(Missing-Header)%ook",
+		"X-Host-Protocol":                 "%REQ(Host)% - %PROTOCOL%",
+		"X-Dynamic-Header-1":              "%DOWNSTREAM_REMOTE_ADDRESS%",
+		"X-Dynamic-Header-2":              "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%",
+		"X-Dynamic-Header-3":              "%DOWNSTREAM_LOCAL_ADDRESS%",
+		"X-Dynamic-Header-4":              "%DOWNSTREAM_LOCAL_ADDRESS_WITHOUT_PORT%",
+		"X-Dynamic-Header-5":              "%DOWNSTREAM_LOCAL_PORT%",
+		"X-Dynamic-Header-6":              "%DOWNSTREAM_LOCAL_URI_SAN%",
+		"X-Dynamic-Header-7":              "%DOWNSTREAM_PEER_URI_SAN%",
+		"X-Dynamic-Header-8":              "%DOWNSTREAM_LOCAL_SUBJECT%",
+		"X-Dynamic-Header-9":              "%DOWNSTREAM_PEER_SUBJECT%",
+		"X-Dynamic-Header-10":             "%DOWNSTREAM_PEER_ISSUER%",
+		"X-Dynamic-Header-11":             "%DOWNSTREAM_TLS_SESSION_ID%",
+		"X-Dynamic-Header-12":             "%DOWNSTREAM_TLS_CIPHER%",
+		"X-Dynamic-Header-13":             "%DOWNSTREAM_TLS_VERSION%",
+		"X-Dynamic-Header-14":             "%DOWNSTREAM_PEER_FINGERPRINT_256%",
+		"X-Dynamic-Header-15":             "%DOWNSTREAM_PEER_FINGERPRINT_1%",
+		"X-Dynamic-Header-16":             "%DOWNSTREAM_PEER_SERIAL%",
+		"X-Dynamic-Header-17":             "%DOWNSTREAM_PEER_CERT%",
+		"X-Dynamic-Header-18":             "%DOWNSTREAM_PEER_CERT_V_START%",
+		"X-Dynamic-Header-19":             "%DOWNSTREAM_PEER_CERT_V_END%",
+		"X-Dynamic-Header-20":             "%HOSTNAME%",
+		"X-Dynamic-Header-21":             "%PROTOCOL%",
+		"X-Dynamic-Header-22":             "%UPSTREAM_REMOTE_ADDRESS%",
+		"X-Dynamic-Header-23":             "%RESPONSE_FLAGS%",
+		"X-Dynamic-Header-24":             "%RESPONSE_CODE_DETAILS%",
+	}
+	for k, v := range responseHeaders {
+		hv := contourv1.HeaderValue{
+			Name:  k,
+			Value: v,
+		}
+		p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set = append(p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set, hv)
+	}
+
+	fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	body := fx.GetEchoResponseBody(res.Body)
+
+	// Both request and response headers should match
+	// all of these assertions.
+	headerSets := map[string]http.Header{
+		"request":  body.RequestHeaders,
+		"response": res.Headers,
+	}
+	for name, headers := range headerSets {
+		t.Logf("Checking %s headers", name)
+
+		// Check simple percentage escape
+		assert.Equal(t, "100%", headers.Get("X-App-Weight"))
+
+		// Check known good Envoy dynamic header value
+		assert.True(t, strings.HasPrefix(headers.Get("X-Envoy-Hostname"), "envoy-"), "X-Envoy-Hostname does not start with 'envoy-'")
+
+		// Check unknown Envoy dynamic header value
+		assert.Equal(t, "%UNKNOWN%", headers.Get("X-Envoy-Unknown"))
+
+		// Check valid Envoy REQ value for header that exists
+		assert.Equal(t, body.Host, headers.Get("X-Request-Host"))
+
+		// Check invalid Envoy REQ value for header that does not exist
+		assert.Equal(t, "ook", headers.Get("X-Request-Missing-Header"))
+
+		// Check header value with dynamic and non-dynamic content and multiple dynamic fields
+		assert.Equal(t, body.Host+" - HTTP/1.1", headers.Get("X-Host-Protocol"))
+	}
+
+	// Check dynamic service headers are populated as expected (only on request headers)
+	assert.Equal(t, "ingress-conformance-echo:80", body.RequestHeaders.Get("X-Contour-Service"))
+}

--- a/test/e2e/httpproxy/017_host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/017_host_header_rewrite_test.go
@@ -1,0 +1,73 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package httpproxy
+
+import (
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testHostHeaderRewrite(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "017-host-header-rewrite"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "host-header-rewrite",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "hostheaderrewrite.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "ingress-conformance-echo",
+							Port: 80,
+						},
+					},
+					RequestHeadersPolicy: &contourv1.HeadersPolicy{
+						Set: []contourv1.HeaderValue{
+							{
+								Name:  "Host",
+								Value: "rewritten.com",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	assert.Equal(t, "rewritten.com", fx.GetEchoResponseBody(res.Body).Host)
+}

--- a/test/e2e/httpproxy/019_local_rate_limiting_test.go
+++ b/test/e2e/httpproxy/019_local_rate_limiting_test.go
@@ -1,0 +1,179 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package httpproxy
+
+import (
+	"context"
+
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testLocalRateLimitingVirtualHost(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "019-local-rate-limiting-vhost"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "vhostlocalratelimit",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "vhostlocalratelimit.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a local rate limit policy on the virtual host.
+	p.Spec.VirtualHost.RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Local: &contourv1.LocalRateLimitPolicy{
+			Requests: 1,
+			Unit:     "hour",
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+}
+
+func testLocalRateLimitingRoute(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "019-local-rate-limiting-route"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "routelocalratelimit",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "routelocalratelimit.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+					Conditions: []contourv1.MatchCondition{
+						{
+							Prefix: "/unlimited",
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a local rate limit policy on the first route.
+	p.Spec.Routes[0].RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Local: &contourv1.LocalRateLimitPolicy{
+			Requests: 1,
+			Unit:     "hour",
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+
+	// Make a request against the route that doesn't have rate limiting
+	// to confirm we still get a 200 for that route.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Path:      "/unlimited",
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
+}

--- a/test/e2e/httpproxy/020_global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/020_global_rate_limiting_test.go
@@ -1,0 +1,378 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package httpproxy
+
+import (
+	"context"
+
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testGlobalRateLimitingVirtualHostNonTLS(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "020-global-rate-limiting-vhost-non-tls"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "globalratelimitvhostnontls",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "globalratelimitvhostnontls.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a global rate limit policy on the virtual host.
+	p.Spec.VirtualHost.RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Global: &contourv1.GlobalRateLimitPolicy{
+			Descriptors: []contourv1.RateLimitDescriptor{
+				{
+					Entries: []contourv1.RateLimitDescriptorEntry{
+						{
+							GenericKey: &contourv1.GenericKeyDescriptor{
+								Value: "vhostlimit",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+}
+
+func testGlobalRateLimitingRouteNonTLS(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "020-global-rate-limiting-route-non-tls"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "globalratelimitroutenontls",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "globalratelimitroutenontls.projectcontour.io",
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+					Conditions: []contourv1.MatchCondition{
+						{
+							Prefix: "/unlimited",
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a global rate limit policy on the first route.
+	p.Spec.Routes[0].RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Global: &contourv1.GlobalRateLimitPolicy{
+			Descriptors: []contourv1.RateLimitDescriptor{
+				{
+					Entries: []contourv1.RateLimitDescriptorEntry{
+						{
+							GenericKey: &contourv1.GenericKeyDescriptor{
+								Key:   "route_limit_key",
+								Value: "routelimit",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+
+	// Make a request against the route that doesn't have rate limiting
+	// to confirm we still get a 200 for that route.
+	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Path:      "/unlimited",
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
+}
+
+func testGlobalRateLimitingVirtualHostTLS(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "020-global-rate-limiting-vhost-tls"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+	fx.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitvhosttls.projectcontour.io")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "globalratelimitvhosttls",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "globalratelimitvhosttls.projectcontour.io",
+				TLS: &contourv1.TLS{
+					SecretName: "echo",
+				},
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a global rate limit policy on the virtual host.
+	p.Spec.VirtualHost.RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Global: &contourv1.GlobalRateLimitPolicy{
+			Descriptors: []contourv1.RateLimitDescriptor{
+				{
+					Entries: []contourv1.RateLimitDescriptorEntry{
+						{
+							GenericKey: &contourv1.GenericKeyDescriptor{
+								Value: "tlsvhostlimit",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+}
+
+func testGlobalRateLimitingRouteTLS(fx *e2e.Framework) {
+	t := fx.T()
+	namespace := "020-global-rate-limiting-route-tls"
+
+	fx.CreateNamespace(namespace)
+	defer fx.DeleteNamespace(namespace)
+
+	fx.Fixtures.Echo.Deploy(namespace, "echo")
+	fx.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitroutetls.projectcontour.io")
+
+	p := &contourv1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "globalratelimitroutetls",
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: &contourv1.VirtualHost{
+				Fqdn: "globalratelimitroutetls.projectcontour.io",
+				TLS: &contourv1.TLS{
+					SecretName: "echo",
+				},
+			},
+			Routes: []contourv1.Route{
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+				},
+				{
+					Services: []contourv1.Service{
+						{
+							Name: "echo",
+							Port: 80,
+						},
+					},
+					Conditions: []contourv1.MatchCondition{
+						{
+							Prefix: "/unlimited",
+						},
+					},
+				},
+			},
+		},
+	}
+	p, _ = fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+	// Wait until we get a 200 from the proxy confirming
+	// the pods are up and serving traffic.
+	res, ok := fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Add a global rate limit policy on the first route.
+	p.Spec.Routes[0].RateLimitPolicy = &contourv1.RateLimitPolicy{
+		Global: &contourv1.GlobalRateLimitPolicy{
+			Descriptors: []contourv1.RateLimitDescriptor{
+				{
+					Entries: []contourv1.RateLimitDescriptorEntry{
+						{
+							GenericKey: &contourv1.GenericKeyDescriptor{
+								Value: "tlsroutelimit",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, fx.Client.Update(context.TODO(), p))
+
+	// Make a request against the proxy, confirm a 200 response
+	// is returned since we're allowed one request per hour.
+	res, ok = fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+	// Make another request against the proxy, confirm a 429 response
+	// is now gotten since we've exceeded the rate limit.
+	res, ok = fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Condition: e2e.HasStatusCode(429),
+	})
+	require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
+
+	// Make a request against the route that doesn't have rate limiting
+	// to confirm we still get a 200 for that route.
+	res, ok = fx.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+		Host:      p.Spec.VirtualHost.Fqdn,
+		Path:      "/unlimited",
+		Condition: e2e.HasStatusCode(200),
+	})
+	require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
+}

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -61,6 +61,30 @@ var _ = Describe("HTTPProxy", func() {
 	It("012-https-fallback-certificate", func() {
 		testHTTPSFallbackCertificate(f)
 	})
+	It("016-dynamic-headers", func() {
+		testDynamicHeaders(f)
+	})
+	It("017-host-header-rewrite", func() {
+		testHostHeaderRewrite(f)
+	})
+	It("019-local-rate-limiting-vhost", func() {
+		testLocalRateLimitingVirtualHost(f)
+	})
+	It("019-local-rate-limiting-route", func() {
+		testLocalRateLimitingRoute(f)
+	})
+	It("020-global-rate-limiting-vhost-non-tls", func() {
+		testGlobalRateLimitingVirtualHostNonTLS(f)
+	})
+	It("020-global-rate-limiting-route-non-tls", func() {
+		testGlobalRateLimitingRouteNonTLS(f)
+	})
+	It("020-global-rate-limiting-vhost-tls", func() {
+		testGlobalRateLimitingVirtualHostTLS(f)
+	})
+	It("020-global-rate-limiting-route-tls", func() {
+		testGlobalRateLimitingRouteTLS(f)
+	})
 })
 
 // httpProxyValid returns true if the proxy has a .status.currentStatus


### PR DESCRIPTION
Updates #3621.

Signed-off-by: Steve Kriss <krisss@vmware.com>

(I omitted 018 from this because it requires backend TLS which I haven't implemented the framework code for yet; will do it along with the other backend TLS stuff shortly).