### PR TITLE
interna/k8s: Remove v1beta1 usage

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -394,17 +394,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		inf.AddEventHandler(&dynamicHandler)
 	}
 
-	// If Ingress v1 resource exist, then add informers to watch, otherwise
-	// add Ingress v1beta1 informers.
-	if clients.ResourcesExist(k8s.IngressV1Resources()...) {
-		for _, r := range k8s.IngressV1Resources() {
-			if err := informOnResource(clients, r, &dynamicHandler); err != nil {
-				log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
-			}
-		}
-	} else {
-		if err := informOnResource(clients, k8s.IngressV1Beta1Resource(), &dynamicHandler); err != nil {
-			log.WithError(err).WithField("resource", k8s.IngressV1Beta1Resource()).Fatal("failed to create informer")
+	for _, r := range k8s.IngressV1Resources() {
+		if err := informOnResource(clients, r, &dynamicHandler); err != nil {
+			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
 

--- a/internal/k8s/clients_test.go
+++ b/internal/k8s/clients_test.go
@@ -31,17 +31,13 @@ func TestResourceKindExists(t *testing.T) {
 			Name: "networking.k8s.io",
 			Versions: []metav1.GroupVersionForDiscovery{
 				{
-					GroupVersion: "networking.k8s.io/v1beta1",
-					Version:      "v1beta1",
+					GroupVersion: "networking.k8s.io/v1",
+					Version:      "v1",
 				},
-			},
-			PreferredVersion: metav1.GroupVersionForDiscovery{
-				GroupVersion: "networking.k8s.io/v1",
-				Version:      "v1",
 			},
 		},
 		VersionedResources: map[string][]metav1.APIResource{
-			"v1beta1": {
+			"v1": {
 				{
 					Name:               "ingressclasses",
 					Namespaced:         false,
@@ -53,7 +49,7 @@ func TestResourceKindExists(t *testing.T) {
 					Name:               "ingresses",
 					Namespaced:         true,
 					Kind:               "Ingress",
-					Verbs:              metav1.Verbs{"create", "delete", "deletecolrection", "get", "list", "patch", "update", "watch"},
+					Verbs:              metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 					ShortNames:         []string{"ing"},
 					StorageVersionHash: "ZOAfGflaKd0=",
 				},
@@ -75,17 +71,17 @@ func TestResourceKindExists(t *testing.T) {
 
 	valid := schema.GroupVersionResource{
 		Group:    "networking.k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "ingress",
 	}
 
 	invalid := schema.GroupVersionResource{
 		Group:    "networking.k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "phony",
 	}
 
-	assert.True(t, clients.ResourcesExist(valid), "v1beta1 ingress exists")
-	assert.False(t, clients.ResourcesExist(invalid), "v1beta1 phony exists")
-	assert.False(t, clients.ResourcesExist(valid, valid, invalid), "v1beta1 phony exists")
+	assert.True(t, clients.ResourcesExist(valid), "v1 ingress exists")
+	assert.False(t, clients.ResourcesExist(invalid), "v1 phony exists")
+	assert.False(t, clients.ResourcesExist(valid, valid, invalid), "v1 phony exists")
 }

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 )
 
 // isStatusEqual checks that two objects of supported Kubernetes types
@@ -26,7 +25,6 @@ import (
 //
 // Currently supports:
 // networking.k8s.io/ingress/v1
-// networking.k8s.io/ingress/v1beta1
 // projectcontour.io/v1
 func isStatusEqual(objA, objB interface{}) bool {
 
@@ -34,13 +32,6 @@ func isStatusEqual(objA, objB interface{}) bool {
 	case *networking_v1.Ingress:
 		switch b := objB.(type) {
 		case *networking_v1.Ingress:
-			if cmp.Equal(a.Status, b.Status) {
-				return true
-			}
-		}
-	case *v1beta1.Ingress:
-		switch b := objB.(type) {
-		case *v1beta1.Ingress:
 			if cmp.Equal(a.Status, b.Status) {
 				return true
 			}

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -18,7 +18,6 @@ import (
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	networking_v1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
@@ -40,10 +39,6 @@ func DefaultResources() []schema.GroupVersionResource {
 		contour_api_v1alpha1.ExtensionServiceGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 	}
-}
-
-func IngressV1Beta1Resource() schema.GroupVersionResource {
-	return networking_v1beta1.SchemeGroupVersion.WithResource("ingresses")
 }
 
 func IngressV1Resources() []schema.GroupVersionResource {

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -70,6 +70,8 @@ func VersionOf(obj interface{}) string {
 		switch obj := obj.(type) {
 		case *v1.Secret, *v1.Service, *v1.Endpoints:
 			return v1.SchemeGroupVersion.String()
+		case *networking_v1.Ingress:
+			return networking_v1.SchemeGroupVersion.String()
 		case *contour_api_v1.HTTPProxy, *contour_api_v1.TLSCertificateDelegation:
 			return contour_api_v1.GroupVersion.String()
 		case *v1alpha1.ExtensionService:

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -18,7 +18,6 @@ import (
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -40,8 +39,6 @@ func KindOf(obj interface{}) string {
 			return "Service"
 		case *v1.Endpoints:
 			return "Endpoints"
-		case *v1beta1.Ingress:
-			return "Ingress"
 		case *networking_v1.Ingress:
 			return "Ingress"
 		case *contour_api_v1.HTTPProxy:
@@ -73,8 +70,6 @@ func VersionOf(obj interface{}) string {
 		switch obj := obj.(type) {
 		case *v1.Secret, *v1.Service, *v1.Endpoints:
 			return v1.SchemeGroupVersion.String()
-		case *v1beta1.Ingress:
-			return v1beta1.SchemeGroupVersion.String()
 		case *contour_api_v1.HTTPProxy, *contour_api_v1.TLSCertificateDelegation:
 			return contour_api_v1.GroupVersion.String()
 		case *v1alpha1.ExtensionService:

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -34,7 +33,6 @@ func TestKindOf(t *testing.T) {
 		{"Service", &v1.Service{}},
 		{"Endpoints", &v1.Endpoints{}},
 		{"Pod", &v1.Pod{}},
-		{"Ingress", &v1beta1.Ingress{}},
 		{"Ingress", &networking_v1.Ingress{}},
 		{"HTTPProxy", &contour_api_v1.HTTPProxy{}},
 		{"TLSCertificateDelegation", &contour_api_v1.TLSCertificateDelegation{}},
@@ -60,7 +58,6 @@ func TestVersionOf(t *testing.T) {
 		{"v1", &v1.Secret{}},
 		{"v1", &v1.Service{}},
 		{"v1", &v1.Endpoints{}},
-		{"networking.k8s.io/v1beta1", &v1beta1.Ingress{}},
 		{"projectcontour.io/v1", &contour_api_v1.HTTPProxy{}},
 		{"projectcontour.io/v1", &contour_api_v1.TLSCertificateDelegation{}},
 		{"projectcontour.io/v1alpha1", &v1alpha1.ExtensionService{}},

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -58,6 +58,7 @@ func TestVersionOf(t *testing.T) {
 		{"v1", &v1.Secret{}},
 		{"v1", &v1.Service{}},
 		{"v1", &v1.Endpoints{}},
+		{"networking.k8s.io/v1", &networking_v1.Ingress{}},
 		{"projectcontour.io/v1", &contour_api_v1.HTTPProxy{}},
 		{"projectcontour.io/v1", &contour_api_v1.TLSCertificateDelegation{}},
 		{"projectcontour.io/v1alpha1", &v1alpha1.ExtensionService{}},

--- a/internal/k8s/scheme.go
+++ b/internal/k8s/scheme.go
@@ -16,7 +16,6 @@ package k8s
 import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
@@ -32,7 +31,6 @@ func NewContourScheme() (*runtime.Scheme, error) {
 		contour_api_v1alpha1.AddToScheme,
 		scheme.AddToScheme,
 		gatewayapi_v1alpha1.AddToScheme,
-		v1beta1.AddToScheme,
 	}
 
 	if err := b.AddToScheme(s); err != nil {

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
@@ -95,14 +94,6 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		o.GetObjectKind().SetGroupVersionKind(networking_v1.SchemeGroupVersion.WithKind("ingress"))
 		typed = o.DeepCopy()
 		gvr = networking_v1.SchemeGroupVersion.WithResource("ingresses")
-	case *v1beta1.Ingress:
-		if !ingress_validation.MatchesIngressClassName(o, s.IngressClassName) {
-			logNoMatch(s.Logger.WithField("ingress-class-name", pointer.StringPtrDerefOr(o.Spec.IngressClassName, "")), o)
-			return
-		}
-		o.GetObjectKind().SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("ingress"))
-		typed = o.DeepCopy()
-		gvr = v1beta1.SchemeGroupVersion.WithResource("ingresses")
 	case *contour_api_v1.HTTPProxy:
 		if !annotation.MatchesIngressClass(o, s.IngressClassName) {
 			logNoMatch(s.Logger, o)
@@ -131,10 +122,6 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 		StatusMutatorFunc(func(obj interface{}) interface{} {
 			switch o := obj.(type) {
 			case *networking_v1.Ingress:
-				dco := o.DeepCopy()
-				dco.Status.LoadBalancer = loadBalancerStatus
-				return dco
-			case *v1beta1.Ingress:
 				dco := o.DeepCopy()
 				dco.Status.LoadBalancer = loadBalancerStatus
 				return dco

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
@@ -328,97 +327,6 @@ func TestStatusAddressUpdater(t *testing.T) {
 			preop:            simpleIngressGenerator(objName, "phony", "notcorrect", emptyLBStatus),
 			postop:           simpleIngressGenerator(objName, "phony", "notcorrect", ipLBStatus),
 		},
-		"ingress v1beta1: no-op update": {
-			status:           emptyLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "", emptyLBStatus),
-		},
-		"ingress v1beta1: add an IP should update": {
-			status:           ipLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "", ipLBStatus),
-		},
-		"ingress v1beta1: unset ingressclass should not update": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "", emptyLBStatus),
-		},
-		"ingress v1beta1: not-configured ingressclass, annotation set to default, should update": {
-			status:           ipLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, annotation.DEFAULT_INGRESS_CLASS_NAME, "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, annotation.DEFAULT_INGRESS_CLASS_NAME, "", ipLBStatus),
-		},
-		"ingress v1beta1: not-configured ingressclass, spec field set to default, should update": {
-			status:           ipLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "contour", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "contour", ipLBStatus),
-		},
-		"ingress v1beta1: not-configured ingressclass, annotation set, should not update": {
-			status:           ipLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "something", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "something", "", emptyLBStatus),
-		},
-		"ingress v1beta1: not-configured ingressclass, spec field set, should not update": {
-			status:           ipLBStatus,
-			ingressClassName: "",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "something", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "something", emptyLBStatus),
-		},
-		"ingress v1beta1: non-matching ingressclass annotation should not update": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "other", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "other", "", emptyLBStatus),
-		},
-		"ingress v1beta1: non-matching ingressclass spec field should not update": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "other", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "other", emptyLBStatus),
-		},
-		"ingress v1beta1: matching ingressclass annotation should update": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "phony", "", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "phony", "", ipLBStatus),
-		},
-		"ingress v1beta1: matching ingressclass spec field should update": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "", "phony", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "", "phony", ipLBStatus),
-		},
-		"ingress v1beta1: non-matching ingressclass annotation should not update, overrides spec field": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "other", "phony", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "other", "phony", emptyLBStatus),
-		},
-		"ingress v1beta1: matching ingressclass spec field should update, overrides spec field": {
-			status:           ipLBStatus,
-			ingressClassName: "phony",
-			gvr:              ingressGVR,
-			preop:            simpleIngressV1Beta1Generator(objName, "phony", "notcorrect", emptyLBStatus),
-			postop:           simpleIngressV1Beta1Generator(objName, "phony", "notcorrect", ipLBStatus),
-		},
 	}
 
 	for name, tc := range testCases {
@@ -483,34 +391,6 @@ func simpleIngressGenerator(name, ingressClassAnnotation, ingressClassSpec strin
 			IngressClassName: ingressClassName,
 		},
 		Status: networking_v1.IngressStatus{
-			LoadBalancer: lbstatus,
-		},
-	}
-}
-
-func simpleIngressV1Beta1Generator(name, ingressClassAnnotation, ingressClassSpec string, lbstatus v1.LoadBalancerStatus) *v1beta1.Ingress {
-	annotations := make(map[string]string)
-	if ingressClassAnnotation != "" {
-		annotations["kubernetes.io/ingress.class"] = ingressClassAnnotation
-	}
-	var ingressClassName *string
-	if ingressClassSpec != "" {
-		ingressClassName = pointer.StringPtr(ingressClassSpec)
-	}
-	return &v1beta1.Ingress{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ingress",
-			APIVersion: "networking.k8s.io/v1beta1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   name,
-			Annotations: annotations,
-		},
-		Spec: v1beta1.IngressSpec{
-			IngressClassName: ingressClassName,
-		},
-		Status: v1beta1.IngressStatus{
 			LoadBalancer: lbstatus,
 		},
 	}


### PR DESCRIPTION
- Removes informer for v1beta1
- Removes status updater/informer for v1beta1
- Ensures k8s versions older than 1.19 are incompatible
  as we are relying on Ingress v1 existing

Updates: #3628