### PR TITLE
apis/projectcontour: add omitempty JSON tag to caSecret

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -793,7 +793,7 @@ type DownstreamValidation struct {
 	// The client certificate must validate against the certificates in the bundle.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
-	CACertificate string `json:"caSecret"`
+	CACertificate string `json:"caSecret,omitempty"`
 
 	// SkipClientCertValidation disables downstream client certificate
 	// validation. Defaults to false. This field is intended to be used in


### PR DESCRIPTION
caSecret is now optional in downstream validation since
skipClientCertValidation can be true. Adds an omitempty
JSON tag to omit the field when serializing to JSON and
it hasn't been specified.

Signed-off-by: Steve Kriss <krisss@vmware.com>