### PR TITLE
Draft: A bit more ginkgo-ey style tests and helper wrappers

### DIFF
--- a/test/e2e/gateway/005_request_header_modifier_test.go
+++ b/test/e2e/gateway/005_request_header_modifier_test.go
@@ -18,6 +18,7 @@ package gateway
 import (
 	"net/http"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,234 +26,230 @@ import (
 	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
-func testRequestHeaderModifierForwardTo(fx *e2e.Framework) {
-	t := fx.T()
-	namespace := "gateway-005-request-header-modifier-forward-to"
+var _ = Describe("005-gateway-request-header-modifier", func() {
+	withHTTPGateway(func() {
+		Context("header modification on HTTPRoute rule ForwardTo", f.NamespacedTest(func(namespace string) {
+			It("works", func() {
+				f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
+				f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-	fx.CreateNamespace(namespace)
-	defer fx.DeleteNamespace(namespace)
-
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
-
-	route := &gatewayv1alpha1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "http-filter-1",
-			Labels:    map[string]string{"app": "filter"},
-		},
-		Spec: gatewayv1alpha1.HTTPRouteSpec{
-			Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
-			Gateways: &gatewayv1alpha1.RouteGateways{
-				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
-			},
-			Rules: []gatewayv1alpha1.HTTPRouteRule{
-				{
-					Matches: []gatewayv1alpha1.HTTPRouteMatch{
-						{
-							Path: &gatewayv1alpha1.HTTPPathMatch{
-								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-								Value: stringPtr("/filter"),
-							},
-						},
+				route := &gatewayv1alpha1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "http-filter-1",
+						Labels:    map[string]string{"app": "filter"},
 					},
-					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
-						{
-							ServiceName: stringPtr("echo-header-filter"),
-							Port:        portNumPtr(80),
-							Filters: []gatewayv1alpha1.HTTPRouteFilter{
-								{
-									Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
-										Add: map[string]string{
-											"My-Header": "Foo",
+					Spec: gatewayv1alpha1.HTTPRouteSpec{
+						Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
+						Gateways: &gatewayv1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+						},
+						Rules: []gatewayv1alpha1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1alpha1.HTTPRouteMatch{
+									{
+										Path: &gatewayv1alpha1.HTTPPathMatch{
+											Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+											Value: stringPtr("/filter"),
 										},
-										Set: map[string]string{
-											"Replace-Header": "Bar",
+									},
+								},
+								ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+									{
+										ServiceName: stringPtr("echo-header-filter"),
+										Port:        portNumPtr(80),
+										Filters: []gatewayv1alpha1.HTTPRouteFilter{
+											{
+												Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
+												RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
+													Add: map[string]string{
+														"My-Header": "Foo",
+													},
+													Set: map[string]string{
+														"Replace-Header": "Bar",
+													},
+													Remove: []string{"Other-Header"},
+												},
+											},
 										},
-										Remove: []string{"Other-Header"},
+									},
+								},
+							},
+							{
+								Matches: []gatewayv1alpha1.HTTPRouteMatch{
+									{
+										Path: &gatewayv1alpha1.HTTPPathMatch{
+											Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+											Value: stringPtr("/nofilter"),
+										},
+									},
+								},
+								ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+									{
+										ServiceName: stringPtr("echo-header-nofilter"),
+										Port:        portNumPtr(80),
 									},
 								},
 							},
 						},
 					},
-				},
-				{
-					Matches: []gatewayv1alpha1.HTTPRouteMatch{
-						{
-							Path: &gatewayv1alpha1.HTTPPathMatch{
-								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-								Value: stringPtr("/nofilter"),
-							},
-						},
+				}
+				f.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+
+				// Check the route with the RequestHeaderModifier filter.
+				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+					Host: string(route.Spec.Hostnames[0]),
+					Path: "/filter",
+					RequestOpts: []func(*http.Request){
+						e2e.OptSetHeaders(map[string]string{
+							"Other-Header":   "Remove",
+							"Replace-Header": "Tobe-Replaced",
+						}),
 					},
-					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
-						{
-							ServiceName: stringPtr("echo-header-nofilter"),
-							Port:        portNumPtr(80),
-						},
+					Condition: e2e.HasStatusCode(200),
+				})
+				require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
+				body := f.GetEchoResponseBody(res.Body)
+				assert.Equal(f.T(), "echo-header-filter", body.Service)
+
+				assert.Equal(f.T(), "Foo", body.RequestHeaders.Get("My-Header"))
+				assert.Equal(f.T(), "Bar", body.RequestHeaders.Get("Replace-Header"))
+
+				_, found := body.RequestHeaders["Other-Header"]
+				assert.False(f.T(), found, "Other-Header was found on the response")
+
+				// Check the route without any filters.
+				res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+					Host: string(route.Spec.Hostnames[0]),
+					Path: "/nofilter",
+					RequestOpts: []func(*http.Request){
+						e2e.OptSetHeaders(map[string]string{
+							"Other-Header": "Exist",
+						}),
 					},
-				},
-			},
-		},
-	}
-	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+					Condition: e2e.HasStatusCode(200),
+				})
+				require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
+				body = f.GetEchoResponseBody(res.Body)
+				assert.Equal(f.T(), "echo-header-nofilter", body.Service)
 
-	// Check the route with the RequestHeaderModifier filter.
-	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-		Host: string(route.Spec.Hostnames[0]),
-		Path: "/filter",
-		RequestOpts: []func(*http.Request){
-			e2e.OptSetHeaders(map[string]string{
-				"Other-Header":   "Remove",
-				"Replace-Header": "Tobe-Replaced",
-			}),
-		},
-		Condition: e2e.HasStatusCode(200),
-	})
-	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-	body := fx.GetEchoResponseBody(res.Body)
-	assert.Equal(t, "echo-header-filter", body.Service)
+				assert.Equal(f.T(), "Exist", body.RequestHeaders.Get("Other-Header"))
 
-	assert.Equal(t, "Foo", body.RequestHeaders.Get("My-Header"))
-	assert.Equal(t, "Bar", body.RequestHeaders.Get("Replace-Header"))
+				_, found = body.RequestHeaders["My-Header"]
+				assert.False(f.T(), found, "My-Header was found on the response")
+			})
+		}))
 
-	_, found := body.RequestHeaders["Other-Header"]
-	assert.False(t, found, "Other-Header was found on the response")
+		Context("header modification on HTTPRoute rule Filter", f.NamespacedTest(func(namespace string) {
+			It("works", func() {
+				f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
+				f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-	// Check the route without any filters.
-	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-		Host: string(route.Spec.Hostnames[0]),
-		Path: "/nofilter",
-		RequestOpts: []func(*http.Request){
-			e2e.OptSetHeaders(map[string]string{
-				"Other-Header": "Exist",
-			}),
-		},
-		Condition: e2e.HasStatusCode(200),
-	})
-	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-	body = fx.GetEchoResponseBody(res.Body)
-	assert.Equal(t, "echo-header-nofilter", body.Service)
-
-	assert.Equal(t, "Exist", body.RequestHeaders.Get("Other-Header"))
-
-	_, found = body.RequestHeaders["My-Header"]
-	assert.False(t, found, "My-Header was found on the response")
-}
-
-func testRequestHeaderModifierRule(fx *e2e.Framework) {
-	t := fx.T()
-	namespace := "gateway-005-request-header-modifier-rule"
-
-	fx.CreateNamespace(namespace)
-	defer fx.DeleteNamespace(namespace)
-
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
-
-	route := &gatewayv1alpha1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "http-filter-1",
-			Labels:    map[string]string{"app": "filter"},
-		},
-		Spec: gatewayv1alpha1.HTTPRouteSpec{
-			Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
-			Gateways: &gatewayv1alpha1.RouteGateways{
-				Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
-			},
-			Rules: []gatewayv1alpha1.HTTPRouteRule{
-				{
-					Matches: []gatewayv1alpha1.HTTPRouteMatch{
-						{
-							Path: &gatewayv1alpha1.HTTPPathMatch{
-								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-								Value: stringPtr("/filter"),
-							},
-						},
+				route := &gatewayv1alpha1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "http-filter-1",
+						Labels:    map[string]string{"app": "filter"},
 					},
-					Filters: []gatewayv1alpha1.HTTPRouteFilter{
-						{
-							Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
-								Add: map[string]string{
-									"My-Header": "Foo",
+					Spec: gatewayv1alpha1.HTTPRouteSpec{
+						Hostnames: []gatewayv1alpha1.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
+						Gateways: &gatewayv1alpha1.RouteGateways{
+							Allow: gatewayAllowTypePtr(gatewayv1alpha1.GatewayAllowAll),
+						},
+						Rules: []gatewayv1alpha1.HTTPRouteRule{
+							{
+								Matches: []gatewayv1alpha1.HTTPRouteMatch{
+									{
+										Path: &gatewayv1alpha1.HTTPPathMatch{
+											Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+											Value: stringPtr("/filter"),
+										},
+									},
 								},
-								Set: map[string]string{
-									"Replace-Header": "Bar",
+								Filters: []gatewayv1alpha1.HTTPRouteFilter{
+									{
+										Type: gatewayv1alpha1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayv1alpha1.HTTPRequestHeaderFilter{
+											Add: map[string]string{
+												"My-Header": "Foo",
+											},
+											Set: map[string]string{
+												"Replace-Header": "Bar",
+											},
+											Remove: []string{"Other-Header"},
+										},
+									},
 								},
-								Remove: []string{"Other-Header"},
+								ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+									{
+										ServiceName: stringPtr("echo-header-filter"),
+										Port:        portNumPtr(80),
+									},
+								},
+							},
+							{
+								Matches: []gatewayv1alpha1.HTTPRouteMatch{
+									{
+										Path: &gatewayv1alpha1.HTTPPathMatch{
+											Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
+											Value: stringPtr("/nofilter"),
+										},
+									},
+								},
+								ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
+									{
+										ServiceName: stringPtr("echo-header-nofilter"),
+										Port:        portNumPtr(80),
+									},
+								},
 							},
 						},
 					},
-					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
-						{
-							ServiceName: stringPtr("echo-header-filter"),
-							Port:        portNumPtr(80),
-						},
-					},
-				},
-				{
-					Matches: []gatewayv1alpha1.HTTPRouteMatch{
-						{
-							Path: &gatewayv1alpha1.HTTPPathMatch{
-								Type:  pathMatchTypePtr(gatewayv1alpha1.PathMatchPrefix),
-								Value: stringPtr("/nofilter"),
-							},
-						},
-					},
-					ForwardTo: []gatewayv1alpha1.HTTPRouteForwardTo{
-						{
-							ServiceName: stringPtr("echo-header-nofilter"),
-							Port:        portNumPtr(80),
-						},
-					},
-				},
-			},
-		},
-	}
-	fx.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
+				}
+				f.CreateHTTPRouteAndWaitFor(route, httpRouteAdmitted)
 
-	// Check the route with the RequestHeaderModifier filter.
-	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-		Host: string(route.Spec.Hostnames[0]),
-		Path: "/filter",
-		RequestOpts: []func(*http.Request){
-			e2e.OptSetHeaders(map[string]string{
-				"Other-Header":   "Remove",
-				"Replace-Header": "Tobe-Replaced",
-			}),
-		},
-		Condition: e2e.HasStatusCode(200),
+				// Check the route with the RequestHeaderModifier filter.
+				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+					Host: string(route.Spec.Hostnames[0]),
+					Path: "/filter",
+					RequestOpts: []func(*http.Request){
+						e2e.OptSetHeaders(map[string]string{
+							"Other-Header":   "Remove",
+							"Replace-Header": "Tobe-Replaced",
+						}),
+					},
+					Condition: e2e.HasStatusCode(200),
+				})
+				require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
+				body := f.GetEchoResponseBody(res.Body)
+				assert.Equal(f.T(), "echo-header-filter", body.Service)
+
+				assert.Equal(f.T(), "Foo", body.RequestHeaders.Get("My-Header"))
+				assert.Equal(f.T(), "Bar", body.RequestHeaders.Get("Replace-Header"))
+
+				_, found := body.RequestHeaders["Other-Header"]
+				assert.False(f.T(), found, "Other-Header was found on the response")
+
+				// Check the route without any filters.
+				res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+					Host: string(route.Spec.Hostnames[0]),
+					Path: "/nofilter",
+					RequestOpts: []func(*http.Request){
+						e2e.OptSetHeaders(map[string]string{
+							"Other-Header": "Exist",
+						}),
+					},
+					Condition: e2e.HasStatusCode(200),
+				})
+				require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
+				body = f.GetEchoResponseBody(res.Body)
+				assert.Equal(f.T(), "echo-header-nofilter", body.Service)
+
+				assert.Equal(f.T(), "Exist", body.RequestHeaders.Get("Other-Header"))
+
+				_, found = body.RequestHeaders["My-Header"]
+				assert.False(f.T(), found, "My-Header was found on the response")
+			})
+		}))
 	})
-	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-	body := fx.GetEchoResponseBody(res.Body)
-	assert.Equal(t, "echo-header-filter", body.Service)
-
-	assert.Equal(t, "Foo", body.RequestHeaders.Get("My-Header"))
-	assert.Equal(t, "Bar", body.RequestHeaders.Get("Replace-Header"))
-
-	_, found := body.RequestHeaders["Other-Header"]
-	assert.False(t, found, "Other-Header was found on the response")
-
-	// Check the route without any filters.
-	res, ok = fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-		Host: string(route.Spec.Hostnames[0]),
-		Path: "/nofilter",
-		RequestOpts: []func(*http.Request){
-			e2e.OptSetHeaders(map[string]string{
-				"Other-Header": "Exist",
-			}),
-		},
-		Condition: e2e.HasStatusCode(200),
-	})
-	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-	body = fx.GetEchoResponseBody(res.Body)
-	assert.Equal(t, "echo-header-nofilter", body.Service)
-
-	assert.Equal(t, "Exist", body.RequestHeaders.Get("Other-Header"))
-
-	_, found = body.RequestHeaders["My-Header"]
-	assert.False(t, found, "My-Header was found on the response")
-}
+})

--- a/test/e2e/httpproxy/002_header_condition_match_test.go
+++ b/test/e2e/httpproxy/002_header_condition_match_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 
+	. "github.com/onsi/ginkgo"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
@@ -28,32 +29,209 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func testHeaderConditionMatch(fx *e2e.Framework) {
-	t := fx.T()
-	namespace := "002-header-condition-match"
+var _ = Describe("002-header-condition-match", f.NamespacedTest(func(namespace string) {
+	It("header match conditions route requests to different backends", func() {
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-present")
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-notpresent")
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-contains")
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-notcontains")
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-exact")
+		f.Fixtures.Echo.Deploy(namespace, "echo-header-notexact")
 
-	fx.CreateNamespace(namespace)
-	defer fx.DeleteNamespace(namespace)
-
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-present")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-notpresent")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-contains")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-notcontains")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-exact")
-	fx.Fixtures.Echo.Deploy(namespace, "echo-header-notexact")
-
-	// This HTTPProxy tests everything except the "notpresent" match type,
-	// which is tested separately below.
-	p := &contourv1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "header-conditions",
-		},
-		Spec: contourv1.HTTPProxySpec{
-			VirtualHost: &contourv1.VirtualHost{
-				Fqdn: "headerconditions.projectcontour.io",
+		// This HTTPProxy tests everything except the "notpresent" match type,
+		// which is tested separately below.
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "header-conditions",
 			},
-			Routes: []contourv1.Route{
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "headerconditions.projectcontour.io",
+				},
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-header-present",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Header: &contourv1.HeaderMatchCondition{
+									Name:    "Target-Present",
+									Present: true,
+								},
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-header-contains",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Header: &contourv1.HeaderMatchCondition{
+									Name:     "Target-Contains",
+									Contains: "ContainsValue",
+								},
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-header-notcontains",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Header: &contourv1.HeaderMatchCondition{
+									Name:        "Target-NotContains",
+									NotContains: "ContainsValue",
+								},
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-header-exact",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Header: &contourv1.HeaderMatchCondition{
+									Name:  "Target-Exact",
+									Exact: "ExactValue",
+								},
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-header-notexact",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Header: &contourv1.HeaderMatchCondition{
+									Name:     "Target-NotExact",
+									NotExact: "ExactValue",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+
+		type scenario struct {
+			headers        map[string]string
+			expectResponse int
+			expectService  string
+		}
+
+		cases := []scenario{
+			{
+				headers:        map[string]string{"Target-Present": "random"},
+				expectResponse: 200,
+				expectService:  "echo-header-present",
+			},
+			{
+				headers:        map[string]string{"Target-Contains": "random"},
+				expectResponse: 404,
+			},
+			{
+				headers:        map[string]string{"Target-Contains": "ContainsValue"},
+				expectResponse: 200,
+				expectService:  "echo-header-contains",
+			},
+			{
+				headers:        map[string]string{"Target-Contains": "xxx ContainsValue xxx"},
+				expectResponse: 200,
+				expectService:  "echo-header-contains",
+			},
+			{
+				headers:        map[string]string{"Target-NotContains": "ContainsValue"},
+				expectResponse: 404,
+			},
+			{
+				headers:        map[string]string{"Target-NotContains": "xxx ContainsValue xxx"},
+				expectResponse: 404,
+			},
+			{
+				headers:        map[string]string{"Target-NotContains": "random"},
+				expectResponse: 200,
+				expectService:  "echo-header-notcontains",
+			},
+			{
+				headers:        map[string]string{"Target-Exact": "random"},
+				expectResponse: 404,
+			},
+			{
+				headers:        map[string]string{"Target-Exact": "NotExactValue"},
+				expectResponse: 404,
+			},
+			{
+				headers:        map[string]string{"Target-Exact": "ExactValue"},
+				expectResponse: 200,
+				expectService:  "echo-header-exact",
+			},
+			{
+				headers:        map[string]string{"Target-NotExact": "random"},
+				expectResponse: 200,
+				expectService:  "echo-header-notexact",
+			},
+			{
+				headers:        map[string]string{"Target-NotExact": "NotExactValue"},
+				expectResponse: 200,
+				expectService:  "echo-header-notexact",
+			},
+			{
+				headers:        map[string]string{"Target-NotExact": "ExactValue"},
+				expectResponse: 404,
+			},
+		}
+
+		for _, tc := range cases {
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host: p.Spec.VirtualHost.Fqdn,
+				RequestOpts: []func(*http.Request){
+					e2e.OptSetHeaders(tc.headers),
+				},
+				Condition: e2e.HasStatusCode(tc.expectResponse),
+			})
+			if !assert.Truef(f.T(), ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
+				continue
+			}
+			if res.StatusCode != 200 {
+				// If we expected something other than a 200,
+				// then we don't need to check the body.
+				continue
+			}
+
+			body := f.GetEchoResponseBody(res.Body)
+			assert.Equal(f.T(), namespace, body.Namespace)
+			assert.Equal(f.T(), tc.expectService, body.Service)
+		}
+
+		// Specifically test the "notpresent" match type in isolation.
+		require.NoError(f.T(), retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(p), p); err != nil {
+				return err
+			}
+
+			p.Spec.Routes = []contourv1.Route{
 				{
 					Services: []contourv1.Service{
 						{
@@ -73,237 +251,56 @@ func testHeaderConditionMatch(fx *e2e.Framework) {
 				{
 					Services: []contourv1.Service{
 						{
-							Name: "echo-header-contains",
+							Name: "echo-header-notpresent",
 							Port: 80,
 						},
 					},
 					Conditions: []contourv1.MatchCondition{
 						{
 							Header: &contourv1.HeaderMatchCondition{
-								Name:     "Target-Contains",
-								Contains: "ContainsValue",
+								Name:       "Target-Present",
+								NotPresent: true,
 							},
 						},
 					},
 				},
-				{
-					Services: []contourv1.Service{
-						{
-							Name: "echo-header-notcontains",
-							Port: 80,
-						},
-					},
-					Conditions: []contourv1.MatchCondition{
-						{
-							Header: &contourv1.HeaderMatchCondition{
-								Name:        "Target-NotContains",
-								NotContains: "ContainsValue",
-							},
-						},
-					},
-				},
-				{
-					Services: []contourv1.Service{
-						{
-							Name: "echo-header-exact",
-							Port: 80,
-						},
-					},
-					Conditions: []contourv1.MatchCondition{
-						{
-							Header: &contourv1.HeaderMatchCondition{
-								Name:  "Target-Exact",
-								Exact: "ExactValue",
-							},
-						},
-					},
-				},
-				{
-					Services: []contourv1.Service{
-						{
-							Name: "echo-header-notexact",
-							Port: 80,
-						},
-					},
-					Conditions: []contourv1.MatchCondition{
-						{
-							Header: &contourv1.HeaderMatchCondition{
-								Name:     "Target-NotExact",
-								NotExact: "ExactValue",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	fx.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+			}
 
-	type scenario struct {
-		headers        map[string]string
-		expectResponse int
-		expectService  string
-	}
+			return f.Client.Update(context.TODO(), p)
+		}))
 
-	cases := []scenario{
-		{
-			headers:        map[string]string{"Target-Present": "random"},
-			expectResponse: 200,
-			expectService:  "echo-header-present",
-		},
-		{
-			headers:        map[string]string{"Target-Contains": "random"},
-			expectResponse: 404,
-		},
-		{
-			headers:        map[string]string{"Target-Contains": "ContainsValue"},
-			expectResponse: 200,
-			expectService:  "echo-header-contains",
-		},
-		{
-			headers:        map[string]string{"Target-Contains": "xxx ContainsValue xxx"},
-			expectResponse: 200,
-			expectService:  "echo-header-contains",
-		},
-		{
-			headers:        map[string]string{"Target-NotContains": "ContainsValue"},
-			expectResponse: 404,
-		},
-		{
-			headers:        map[string]string{"Target-NotContains": "xxx ContainsValue xxx"},
-			expectResponse: 404,
-		},
-		{
-			headers:        map[string]string{"Target-NotContains": "random"},
-			expectResponse: 200,
-			expectService:  "echo-header-notcontains",
-		},
-		{
-			headers:        map[string]string{"Target-Exact": "random"},
-			expectResponse: 404,
-		},
-		{
-			headers:        map[string]string{"Target-Exact": "NotExactValue"},
-			expectResponse: 404,
-		},
-		{
-			headers:        map[string]string{"Target-Exact": "ExactValue"},
-			expectResponse: 200,
-			expectService:  "echo-header-exact",
-		},
-		{
-			headers:        map[string]string{"Target-NotExact": "random"},
-			expectResponse: 200,
-			expectService:  "echo-header-notexact",
-		},
-		{
-			headers:        map[string]string{"Target-NotExact": "NotExactValue"},
-			expectResponse: 200,
-			expectService:  "echo-header-notexact",
-		},
-		{
-			headers:        map[string]string{"Target-NotExact": "ExactValue"},
-			expectResponse: 404,
-		},
-	}
-
-	for _, tc := range cases {
-		res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-			Host: p.Spec.VirtualHost.Fqdn,
-			RequestOpts: []func(*http.Request){
-				e2e.OptSetHeaders(tc.headers),
-			},
-			Condition: e2e.HasStatusCode(tc.expectResponse),
-		})
-		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
-			continue
-		}
-		if res.StatusCode != 200 {
-			// If we expected something other than a 200,
-			// then we don't need to check the body.
-			continue
-		}
-
-		body := fx.GetEchoResponseBody(res.Body)
-		assert.Equal(t, namespace, body.Namespace)
-		assert.Equal(t, tc.expectService, body.Service)
-	}
-
-	// Specifically test the "notpresent" match type in isolation.
-	require.NoError(t, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := fx.Client.Get(context.TODO(), client.ObjectKeyFromObject(p), p); err != nil {
-			return err
-		}
-
-		p.Spec.Routes = []contourv1.Route{
+		cases = []scenario{
 			{
-				Services: []contourv1.Service{
-					{
-						Name: "echo-header-present",
-						Port: 80,
-					},
-				},
-				Conditions: []contourv1.MatchCondition{
-					{
-						Header: &contourv1.HeaderMatchCondition{
-							Name:    "Target-Present",
-							Present: true,
-						},
-					},
-				},
+				headers:        map[string]string{"Target-Present": "random"},
+				expectResponse: 200,
+				expectService:  "echo-header-present",
 			},
 			{
-				Services: []contourv1.Service{
-					{
-						Name: "echo-header-notpresent",
-						Port: 80,
-					},
-				},
-				Conditions: []contourv1.MatchCondition{
-					{
-						Header: &contourv1.HeaderMatchCondition{
-							Name:       "Target-Present",
-							NotPresent: true,
-						},
-					},
-				},
+				headers:        nil,
+				expectResponse: 200,
+				expectService:  "echo-header-notpresent",
 			},
 		}
+		for _, tc := range cases {
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host: p.Spec.VirtualHost.Fqdn,
+				RequestOpts: []func(*http.Request){
+					e2e.OptSetHeaders(tc.headers),
+				},
+				Condition: e2e.HasStatusCode(tc.expectResponse),
+			})
+			if !assert.Truef(f.T(), ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
+				continue
+			}
+			if res.StatusCode != 200 {
+				// If we expected something other than a 200,
+				// then we don't need to check the body.
+				continue
+			}
 
-		return fx.Client.Update(context.TODO(), p)
-	}))
-
-	cases = []scenario{
-		{
-			headers:        map[string]string{"Target-Present": "random"},
-			expectResponse: 200,
-			expectService:  "echo-header-present",
-		},
-		{
-			headers:        nil,
-			expectResponse: 200,
-			expectService:  "echo-header-notpresent",
-		},
-	}
-	for _, tc := range cases {
-		res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-			Host: p.Spec.VirtualHost.Fqdn,
-			RequestOpts: []func(*http.Request){
-				e2e.OptSetHeaders(tc.headers),
-			},
-			Condition: e2e.HasStatusCode(tc.expectResponse),
-		})
-		if !assert.Truef(t, ok, "expected %d response code, got %d", tc.expectResponse, res.StatusCode) {
-			continue
+			body := f.GetEchoResponseBody(res.Body)
+			assert.Equal(f.T(), namespace, body.Namespace)
+			assert.Equal(f.T(), tc.expectService, body.Service)
 		}
-		if res.StatusCode != 200 {
-			// If we expected something other than a 200,
-			// then we don't need to check the body.
-			continue
-		}
-
-		body := fx.GetEchoResponseBody(res.Body)
-		assert.Equal(t, namespace, body.Namespace)
-		assert.Equal(t, tc.expectService, body.Service)
-	}
-}
+	})
+}))

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -23,75 +23,71 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
+var f = e2e.NewFramework()
+
 func TestHTTPProxy(t *testing.T) {
 	RunSpecs(t, "HTTPProxy tests")
 }
 
-var _ = Describe("HTTPProxy", func() {
-	var f *e2e.Framework
-
-	BeforeEach(func() {
-		f = e2e.NewFramework(GinkgoT())
-	})
-
-	It("002-header-condition-match", func() {
-		testHeaderConditionMatch(f)
-	})
-	It("003-path-condition-match", func() {
-		testPathConditionMatch(f)
-	})
-	It("004-https-sni-enforcement", func() {
-		testHTTPSSNIEnforcement(f)
-	})
-	It("005-pod-restart", func() {
-		testPodRestart(f)
-	})
-	It("006-merge-slash", func() {
-		testMergeSlash(f)
-	})
-	It("008-tcproute-https-termination", func() {
-		testTCPRouteHTTPSTermination(f)
-	})
-	It("009-https-misdirected-request", func() {
-		testHTTPSMisdirectedRequest(f)
-	})
-	It("010-include-prefix-condition", func() {
-		testIncludePrefixCondition(f)
-	})
-	It("012-https-fallback-certificate", func() {
-		testHTTPSFallbackCertificate(f)
-	})
-	It("014-external-auth", func() {
-		testExternalAuth(f)
-	})
-	It("015-http-health-checks", func() {
-		testHTTPHealthChecks(f)
-	})
-	It("016-dynamic-headers", func() {
-		testDynamicHeaders(f)
-	})
-	It("017-host-header-rewrite", func() {
-		testHostHeaderRewrite(f)
-	})
-	It("019-local-rate-limiting-vhost", func() {
-		testLocalRateLimitingVirtualHost(f)
-	})
-	It("019-local-rate-limiting-route", func() {
-		testLocalRateLimitingRoute(f)
-	})
-	It("020-global-rate-limiting-vhost-non-tls", func() {
-		testGlobalRateLimitingVirtualHostNonTLS(f)
-	})
-	It("020-global-rate-limiting-route-non-tls", func() {
-		testGlobalRateLimitingRouteNonTLS(f)
-	})
-	It("020-global-rate-limiting-vhost-tls", func() {
-		testGlobalRateLimitingVirtualHostTLS(f)
-	})
-	It("020-global-rate-limiting-route-tls", func() {
-		testGlobalRateLimitingRouteTLS(f)
-	})
-})
+// var _ = Describe("HTTPProxy", func() {
+// 	It("002-header-condition-match", func() {
+// 		testHeaderConditionMatch(f)
+// 	})
+// 	It("003-path-condition-match", func() {
+// 		testPathConditionMatch(f)
+// 	})
+// 	It("004-https-sni-enforcement", func() {
+// 		testHTTPSSNIEnforcement(f)
+// 	})
+// 	It("005-pod-restart", func() {
+// 		testPodRestart(f)
+// 	})
+// 	It("006-merge-slash", func() {
+// 		testMergeSlash(f)
+// 	})
+// 	It("008-tcproute-https-termination", func() {
+// 		testTCPRouteHTTPSTermination(f)
+// 	})
+// 	It("009-https-misdirected-request", func() {
+// 		testHTTPSMisdirectedRequest(f)
+// 	})
+// 	It("010-include-prefix-condition", func() {
+// 		testIncludePrefixCondition(f)
+// 	})
+// 	It("012-https-fallback-certificate", func() {
+// 		testHTTPSFallbackCertificate(f)
+// 	})
+// 	It("014-external-auth", func() {
+// 		testExternalAuth(f)
+// 	})
+// 	It("015-http-health-checks", func() {
+// 		testHTTPHealthChecks(f)
+// 	})
+// 	It("016-dynamic-headers", func() {
+// 		testDynamicHeaders(f)
+// 	})
+// 	It("017-host-header-rewrite", func() {
+// 		testHostHeaderRewrite(f)
+// 	})
+// 	It("019-local-rate-limiting-vhost", func() {
+// 		testLocalRateLimitingVirtualHost(f)
+// 	})
+// 	It("019-local-rate-limiting-route", func() {
+// 		testLocalRateLimitingRoute(f)
+// 	})
+// 	It("020-global-rate-limiting-vhost-non-tls", func() {
+// 		testGlobalRateLimitingVirtualHostNonTLS(f)
+// 	})
+// 	It("020-global-rate-limiting-route-non-tls", func() {
+// 		testGlobalRateLimitingRouteNonTLS(f)
+// 	})
+// 	It("020-global-rate-limiting-vhost-tls", func() {
+// 		testGlobalRateLimitingVirtualHostTLS(f)
+// 	})
+// 	It("020-global-rate-limiting-route-tls", func() {
+// 		testGlobalRateLimitingRouteTLS(f)
+// 	})
+// })
 
 // httpProxyValid returns true if the proxy has a .status.currentStatus
 // of "valid".

--- a/test/e2e/ingress/002_ensure_v1beta1_test.go
+++ b/test/e2e/ingress/002_ensure_v1beta1_test.go
@@ -18,6 +18,7 @@ package ingress
 import (
 	"context"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/extensions/v1beta1"
@@ -25,33 +26,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// Explicitly ensure v1beta1 resources continue to work.
-func testEnsureV1Beta1(fx *e2e.Framework) {
-	t := fx.T()
-	namespace := "002-ingress-ensure-v1beta1"
+var _ = Describe("002-ingress-ensure-v1beta1", f.NamespacedTest(func(namespace string) {
+	It("ensures Ingress v1beta1 resources work as expected", func() {
+		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
 
-	fx.CreateNamespace(namespace)
-	defer fx.DeleteNamespace(namespace)
-
-	fx.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
-
-	ingressHost := "v1beta1.projectcontour.io"
-	i := &v1beta1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "echo",
-		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
-				{
-					Host: ingressHost,
-					IngressRuleValue: v1beta1.IngressRuleValue{
-						HTTP: &v1beta1.HTTPIngressRuleValue{
-							Paths: []v1beta1.HTTPIngressPath{
-								{
-									Backend: v1beta1.IngressBackend{
-										ServiceName: "ingress-conformance-echo",
-										ServicePort: intstr.FromInt(80),
+		ingressHost := "v1beta1.projectcontour.io"
+		i := &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo",
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: ingressHost,
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Backend: v1beta1.IngressBackend{
+											ServiceName: "ingress-conformance-echo",
+											ServicePort: intstr.FromInt(80),
+										},
 									},
 								},
 							},
@@ -59,14 +55,14 @@ func testEnsureV1Beta1(fx *e2e.Framework) {
 					},
 				},
 			},
-		},
-	}
-	require.NoError(t, fx.Client.Create(context.TODO(), i))
+		}
+		require.NoError(f.T(), f.Client.Create(context.TODO(), i))
 
-	res, ok := fx.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-		Host:      ingressHost,
-		Path:      "/echo",
-		Condition: e2e.HasStatusCode(200),
+		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      ingressHost,
+			Path:      "/echo",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
 	})
-	require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-}
+}))

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -22,18 +22,8 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
+var f = e2e.NewFramework()
+
 func TestIngress(t *testing.T) {
 	RunSpecs(t, "Ingress tests")
 }
-
-var _ = Describe("Ingress", func() {
-	var f *e2e.Framework
-
-	BeforeEach(func() {
-		f = e2e.NewFramework(GinkgoT())
-	})
-
-	It("002-ingress-ensure-v1beta1", func() {
-		testEnsureV1Beta1(f)
-	})
-})


### PR DESCRIPTION
While messing around with the e2e test suite I started gravitating to doing thinks in a bit more ginkgo-ey style

Summary/some highlights:
- each file can have a top level `Describe` to register the tests in that file which is a bit more idiomatic ginkgo IMO
- added a framework wrapper for running a test in a unique namespace
- added a gateway package helper for running a block of tests with a HTTP Gateway
- framework can be a global test package variable to share across the package
- converted a few tests over so we can see if we like the patterns