### PR TITLE
_integration, test/e2e: update ingress conformance echo image

### DIFF
--- a/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
+++ b/_integration/testsuite/fixtures/ingress-conformance-echo.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: conformance-echo
-        image: k8s.gcr.io/ingressconformance/echoserver:v0.0.1
+        image: k8s.gcr.io/ingressconformance/echoserver@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
         env:
         - name: INGRESS_NAME
           value: *name
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
       - name: conformance-echo
-        image: tsaarni/echoserver:latest
+        image: k8s.gcr.io/ingressconformance/echoserver@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
         env:
         - name: POD_NAME
           valueFrom:

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -81,7 +81,7 @@ func (e *Echo) Deploy(ns, name string) func() {
 					Containers: []corev1.Container{
 						{
 							Name:  "conformance-echo",
-							Image: "k8s.gcr.io/ingressconformance/echoserver:v0.0.1",
+							Image: "k8s.gcr.io/ingressconformance/echoserver@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52",
 							Env: []corev1.EnvVar{
 								{
 									Name:  "INGRESS_NAME",
@@ -193,7 +193,7 @@ func (e *EchoSecure) Deploy(ns, name string) func() {
 					Containers: []corev1.Container{
 						{
 							Name:  "conformance-echo",
-							Image: "tsaarni/echoserver:latest",
+							Image: "k8s.gcr.io/ingressconformance/echoserver@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52",
 							Env: []corev1.EnvVar{
 								{
 									Name:  "INGRESS_NAME",


### PR DESCRIPTION
Updates the ingress-conformance-echo Docker image used in
_integration and test/e2e to be the latest version in the
official location. Removes the custom build of it for TLS
support.

Updates #3584.

Signed-off-by: Steve Kriss <krisss@vmware.com>