### PR TITLE
test/e2e: wait for client certs to be ready

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -136,8 +136,10 @@ func NewFramework(t ginkgo.GinkgoTInterface) *Framework {
 			t:             t,
 		},
 		Certs: &Certs{
-			client: crClient,
-			t:      t,
+			client:        crClient,
+			retryInterval: time.Second,
+			retryTimeout:  60 * time.Second,
+			t:             t,
 		},
 		t: t,
 	}


### PR DESCRIPTION
Fixes a flake where the secrets are not available by
the time the test tries to download their contents.

Updates #3621.

Signed-off-by: Steve Kriss <krisss@vmware.com>