### PR TITLE
Bump go to 1.16.4

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.2'
+          go-version: '1.16.4'
       - name: test
         run: |
           make install
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.2'
+          go-version: '1.16.4'
       - name: test
         run: |
           make install
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16.2'
+          go-version: '1.16.4'
       - name: generate
         run: |
           make generate lint-yamllint lint-flags

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.16.2
+BUILD_BASE_IMAGE ?= golang:1.16.4
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0


### PR DESCRIPTION
See release notes:
https://golang.org/doc/devel/release.html#go1.16.minor