### PR TITLE
.github/workflows: set stale PR close time to 30 days

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,8 +19,8 @@ jobs:
         stale-pr-message: >
           Marking this PR stale since there has been no activity for 14
           days. It will be closed if there is no activity for another
-          90 days.
+          30 days.
         stale-issue-label: 'lifecycle/stale'
         stale-pr-label: 'lifecycle/stale'
         days-before-stale: 14
-        days-before-close: 90
+        days-before-close: 30


### PR DESCRIPTION
The current settings are to mark PRs stale after 14 days
of no activity, and then to close after another 90 days
of no activity. This lowers the time to close after being
marked stale to 30 days, so stale PRs don't hang around
for so long.

Signed-off-by: Steve Kriss <krisss@vmware.com>