### PR TITLE
site: pin v1.15.1 links to v1.15.1 instead of latest

### DIFF
--- a/site/content/docs/v1.15.1/config/fundamentals.md
+++ b/site/content/docs/v1.15.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url>}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.15.1/config/tls-termination.md
+++ b/site/content/docs/v1.15.1/config/tls-termination.md
@@ -219,4 +219,4 @@ spec:
       weight: 20
 ```
 
-[1]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.15.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.15.1/config/virtual-hosts.md
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/root-rbac
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
 [2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.15.1/configuration.md
+++ b/site/content/docs/v1.15.1/configuration.md
@@ -409,13 +409,13 @@ connects to Contour:
 | <nobr>--dns-lookup-family</nobr> | auto | Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6 or auto.  |
 
 
-[1]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/contour
+[7]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.15.1/deploy-options.md
+++ b/site/content/docs/v1.15.1/deploy-options.md
@@ -209,11 +209,11 @@ $ kubectl delete ns contour-operator
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/contour
+[2]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour
 [3]: #host-networking
 [4]: /guides/proxy-proto.md
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{< param github_url>}}/tree/{{< param latest_release_tag_name >}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour/02-service-envoy.yaml
 [8]: /getting-started.md
 [9]: config/fundamentals.md
 [10]: /guides/deploy-aws-nlb.md

--- a/site/content/docs/v1.15.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.15.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour


### PR DESCRIPTION
Have v1.15.1 docs link to the v1.15.1 GitHub repo tag
instead of the latest tag, since as soon as we cut a
new release latest will change to v1.16.0.

Signed-off-by: Steve Kriss <krisss@vmware.com>