### PR TITLE
Fixes Site Bugs for v1.16.0 Release

### DIFF
--- a/site/content/examples/kuard.yaml
+++ b/site/content/examples/kuard.yaml
@@ -41,7 +41,7 @@ metadata:
   labels:
     app: kuard
 spec:
-  backend:
+  defaultBackend:
     service:
       name: kuard
       port:

--- a/site/content/resources/release-process.md
+++ b/site/content/resources/release-process.md
@@ -48,8 +48,8 @@ export CONTOUR_OPERATOR_UPSTREAM_REMOTE_NAME=upstream
 go run ./hack/release/prepare-release.go $CONTOUR_RELEASE_VERSION
 ```
 
-1. Add the new release to the compatibility matrix (`/site/_resources/compatibility-matrix.md`).
-1. Document upgrade instructions for the new release (`/site/_resources/upgrading.md`).
+1. Add the new release to the compatibility matrix (`site/content/resources/compatibility-matrix.md`).
+1. Document upgrade instructions for the new release (`site/content/resources/upgrading.md`).
 1. Commit all changes, push the branch, and PR it into `main`.
 
 _Note: the PR will probably fail the siteproof check due to [#2032](https://github.com/projectcontour/contour/issues/2032). It's a good idea to scan the CI log for any true issues._


### PR DESCRIPTION
- Updates references to compatibility matrix and upgrade docs based on new site layout.
- Updates the Ingress resource to comply with the latest spec as the existing `backend` field has been removed:
```
$ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
deployment.apps/kuard created
service/kuard created
error: error validating "https://projectcontour.io/examples/kuard.yaml": error validating data: ValidationError(Ingress.spec): unknown field "backend" in io.k8s.api.networking.v1.IngressSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

Signed-off-by: Daneyon Hansen <daneyonhansen@gmail.com>