### PR TITLE
internal/k8s: Bump log test klog flush wait time

### DIFF
--- a/internal/k8s/log_test.go
+++ b/internal/k8s/log_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	// klog automatic flush interval is 5s but we can wait for less time to pass
 	// since we proactively call klog.Flush().
-	klogFlushWaitTime     = time.Millisecond * 20
+	klogFlushWaitTime     = time.Millisecond * 30
 	klogFlushWaitInterval = time.Millisecond * 1
 )
 


### PR DESCRIPTION
Flakes occurring on osx in CI so bump timeout