### PR TITLE
Add k8s min version clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Its goal is to expand upon the functionality of the Ingress API to allow for a r
 
 ## Prerequisites
 
-Contour requires Kubernetes version 1.16 or later, for [v1 Custom Resource Definition support](https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/#custom-resources-reach-general-availability).
+Contour requires Kubernetes version 1.19 or later, for [stable Ingress v1 support](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
 RBAC must be enabled on your cluster.
 

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -45,7 +45,7 @@ However, combinations not listed are not tested or supported by the Contour main
 
 The `client-go` package includes a [compatibility matrix][99] as to what Kubernetes API versions are supported with the version of client-go.
 
-__Note:__ Since Contour now uses `apiextensions.k8s.io/v1` for Custom Resource Definitions (CRDs), the minimum compatible Kubernetes version is v1.16.
+__Note:__ As of version 1.16.0, since Contour only subscribes to Ingress v1 resources (and no longer falls back to Ingress v1beta1), the minimum compatible Kubernetes version is 1.19.
 
 ## Envoy Extensions
 Contour requires the following Envoy extensions.


### PR DESCRIPTION
- We dropped support for k8s 1.18
- Contour 1.16.0 stopped falling back to Ingress v1beta1 resources

Updates: #3749