### PR TITLE
GOPROXY can be overridden in container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG BUILD_BASE_IMAGE
 FROM --platform=$BUILDPLATFORM $BUILD_BASE_IMAGE AS build
 WORKDIR /contour
 
-ENV GOPROXY=https://proxy.golang.org
+ARG BUILD_GOPROXY
+ENV GOPROXY=${BUILD_GOPROXY}
 COPY go.mod go.sum /contour/
 RUN go mod download
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ BUILD_BASE_IMAGE ?= golang:1.16.4
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0
 
+# Go module mirror to use.
+BUILD_GOPROXY ?= https://proxy.golang.org
+
 # Used to supply a local Envoy docker container an IP to connect to that is running
 # 'contour serve'. On MacOS this will work, but may not on other OSes. Defining
 # LOCALIP as an env var before running 'make local' will solve that.
@@ -109,6 +112,7 @@ multiarch-build: ## Build and optionally push a multi-arch Contour container ima
 	@mkdir -p $(shell pwd)/image
 	docker buildx build $(IMAGE_RESULT_FLAG) \
 		--platform $(IMAGE_PLATFORMS) \
+		--build-arg "BUILD_GOPROXY=$(BUILD_GOPROXY)" \
 		--build-arg "BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE)" \
 		--build-arg "BUILD_VERSION=$(BUILD_VERSION)" \
 		--build-arg "BUILD_BRANCH=$(BUILD_BRANCH)" \
@@ -121,6 +125,7 @@ multiarch-build: ## Build and optionally push a multi-arch Contour container ima
 
 container: ## Build the Contour container image
 	docker build \
+		--build-arg "BUILD_GOPROXY=$(BUILD_GOPROXY)" \
 		--build-arg "BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE)" \
 		--build-arg "BUILD_VERSION=$(BUILD_VERSION)" \
 		--build-arg "BUILD_BRANCH=$(BUILD_BRANCH)" \


### PR DESCRIPTION
So that Makefile docker build commands etc. do not need modification if
the variable needs to be changed.