### PR TITLE
site: Fix links to api reference

### DIFF
--- a/site/content/docs/v1.1.0/api.md
+++ b/site/content/docs/v1.1.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.10.0/config/api.md
+++ b/site/content/docs/v1.10.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.10.1/config/api.md
+++ b/site/content/docs/v1.10.1/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.11.0/config/api.md
+++ b/site/content/docs/v1.11.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.12.0/config/api.md
+++ b/site/content/docs/v1.12.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.13.0/config/api.md
+++ b/site/content/docs/v1.13.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.13.1/config/api.md
+++ b/site/content/docs/v1.13.1/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.14.0/config/api.md
+++ b/site/content/docs/v1.14.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.14.1/config/api.md
+++ b/site/content/docs/v1.14.1/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.15.0/config/api.md
+++ b/site/content/docs/v1.15.0/config/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.2.0/api.md
+++ b/site/content/docs/v1.2.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.2.1/api.md
+++ b/site/content/docs/v1.2.1/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.3.0/api.md
+++ b/site/content/docs/v1.3.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.4.0/api.md
+++ b/site/content/docs/v1.4.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.5.0/api.md
+++ b/site/content/docs/v1.5.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.5.1/api.md
+++ b/site/content/docs/v1.5.1/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.6.0/api.md
+++ b/site/content/docs/v1.6.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.6.1/api.md
+++ b/site/content/docs/v1.6.1/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.7.0/api.md
+++ b/site/content/docs/v1.7.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.8.0/api.md
+++ b/site/content/docs/v1.8.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.8.1/api.md
+++ b/site/content/docs/v1.8.1/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.8.2/api.md
+++ b/site/content/docs/v1.8.2/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 

--- a/site/content/docs/v1.9.0/api.md
+++ b/site/content/docs/v1.9.0/api.md
@@ -1,4 +1,4 @@
 # Contour API Reference
 
-{% include_relative api-reference.html %}
+{{% include-html api-reference.html %}}
 


### PR DESCRIPTION
Some links to the api reference are broken, this fixes the include for the new
Hugo site.

Updates #3712

Signed-off-by: Steve Sloka <slokas@vmware.com>