### PR TITLE
site: Fix virtual hosts page with bad links

### DIFF
--- a/site/content/docs/main/config/virtual-hosts.md
+++ b/site/content/docs/main/config/virtual-hosts.md
@@ -123,7 +123,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.

--- a/site/content/docs/v1.10.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.10.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.10.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.10.1/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.11.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.11.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.12.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.12.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.13.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.13.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.13.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.13.1/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.14.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.14.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.14.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.14.1/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.15.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.15.0/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.
@@ -128,5 +128,5 @@ An example of this is included in the [examples directory][1] and shows how you 
 _**Note:** The restricted root namespace feature is only supported for HTTPProxy CRDs.
 `--root-namespaces` does not affect the operation of Ingress objects._
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.VirtualHost
+[1]: {{< param github_url>}}/tree/{{< param version >}}/examples/root-rbac
+[2]: api/#projectcontour.io/v1.VirtualHost

--- a/site/content/docs/v1.15.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.15.1/config/virtual-hosts.md
@@ -119,7 +119,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.

--- a/site/content/docs/v1.16.0/config/virtual-hosts.md
+++ b/site/content/docs/v1.16.0/config/virtual-hosts.md
@@ -123,7 +123,7 @@ Only users permitted to operate in those namespaces can therefore create HTTPPro
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--root-namespaces`, which will restrict Contour to only searching the defined namespaces for root HTTPProxy. This CLI flag accepts a comma separated list of namespaces where HTTPProxy are valid (e.g. `--root-namespaces=default,kube-system,my-admin-namespace`).
 
-HTTPProxy with a defined [`virtualhost`][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
+HTTPProxy with a defined [virtualhost][2] field that are not in one of the allowed root namespaces will be flagged as `invalid` and will be ignored by Contour.
 
 Additionally, when defined, Contour will only watch for Kubernetes secrets in these namespaces ignoring changes in all other namespaces.
 Proper RBAC rules should also be created to restrict what namespaces Contour has access matching the namespaces passed to the command line flag.


### PR DESCRIPTION
Updates #3712

**Note! Needs #3757 to make the reference back to the API Page virtual hosts to work properly.** 

Signed-off-by: Steve Sloka <slokas@vmware.com>