### PR TITLE
site: bulk replacement of Jekyll templates

### DIFF
--- a/site/content/docs/main/config/ingress.md
+++ b/site/content/docs/main/config/ingress.md
@@ -77,4 +77,4 @@ If not provided, Contour will use the address of the Envoy service using the pas
 [5]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
 [6]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 [7]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-[8]: /docs/{{page.version}}/config/tls-delegation/
+[8]: /docs/{{< param version >}}/config/tls-delegation/

--- a/site/content/docs/main/config/tls-delegation.md
+++ b/site/content/docs/main/config/tls-delegation.md
@@ -45,4 +45,4 @@ In this example, the permission for Contour to reference the Secret `example-com
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
 [0]: https://github.com/projectcontour/contour/issues/3544
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/main/start-contributing.md
+++ b/site/content/docs/main/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/main/start-contributing.md
+++ b/site/content/docs/main/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.0.0/configuration.md
+++ b/site/content/docs/v1.0.0/configuration.md
@@ -30,4 +30,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.0.0/deploy-options.md
+++ b/site/content/docs/v1.0.0/deploy-options.md
@@ -219,12 +219,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: {% link docs/v1.0.0/ingressroute.md %}
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: {% link docs/v1.0.0/httpproxy.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.0.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.0.0/grpc-tls-howto.md
@@ -109,7 +109,7 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.0.0/httpproxy.md
+++ b/site/content/docs/v1.0.0/httpproxy.md
@@ -1104,7 +1104,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.0.0/ingressroute.md
+++ b/site/content/docs/v1.0.0/ingressroute.md
@@ -1005,7 +1005,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.0.0/start-contributing.md
+++ b/site/content/docs/v1.0.0/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.0.1/configuration.md
+++ b/site/content/docs/v1.0.1/configuration.md
@@ -30,4 +30,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.0.1/deploy-options.md
+++ b/site/content/docs/v1.0.1/deploy-options.md
@@ -219,12 +219,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: {% link docs/v1.0.1/ingressroute.md %}
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: {% link docs/v1.0.0/httpproxy.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.0.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.0.1/grpc-tls-howto.md
@@ -109,7 +109,7 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.0.1/httpproxy.md
+++ b/site/content/docs/v1.0.1/httpproxy.md
@@ -1104,7 +1104,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.0.1/ingressroute.md
+++ b/site/content/docs/v1.0.1/ingressroute.md
@@ -1005,7 +1005,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.0.1/start-contributing.md
+++ b/site/content/docs/v1.0.1/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.1.0/configuration.md
+++ b/site/content/docs/v1.1.0/configuration.md
@@ -32,4 +32,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.1.0/deploy-options.md
+++ b/site/content/docs/v1.1.0/deploy-options.md
@@ -224,12 +224,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.1.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.1.0/grpc-tls-howto.md
@@ -109,7 +109,7 @@ Note that we don't put the CA **key** into the cluster, there's no reason for th
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.1.0/httpproxy.md
+++ b/site/content/docs/v1.1.0/httpproxy.md
@@ -1264,7 +1264,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.1.0/ingressroute.md
+++ b/site/content/docs/v1.1.0/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.1.0/start-contributing.md
+++ b/site/content/docs/v1.1.0/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.10.0/README.md
+++ b/site/content/docs/v1.10.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.10.0/config/annotations.md
+++ b/site/content/docs/v1.10.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.10.0/config/client-authorization.md
+++ b/site/content/docs/v1.10.0/config/client-authorization.md
@@ -115,9 +115,9 @@ A route can overwrite the value for a context key by setting it in the
 context field of authorization policy for the route.
 
 [1]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
+[2]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
 [3]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto
-[4]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
-[5]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationServer
-[6]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationPolicy
+[4]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[5]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.AuthorizationServer
+[6]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.AuthorizationPolicy
 [7]: {% link _guides/external-authorization.md %}

--- a/site/content/docs/v1.10.0/config/fundamentals.md
+++ b/site/content/docs/v1.10.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.10.0/config/fundamentals.md
+++ b/site/content/docs/v1.10.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.10.0/config/tls-delegation.md
+++ b/site/content/docs/v1.10.0/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.10.0/configuration.md
+++ b/site/content/docs/v1.10.0/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.10.0/configuration.md
+++ b/site/content/docs/v1.10.0/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.10.0/deploy-options.md
+++ b/site/content/docs/v1.10.0/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.10.0/deploy-options.md
+++ b/site/content/docs/v1.10.0/deploy-options.md
@@ -196,12 +196,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
-[9]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[9]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}
 [11]: redeploy-envoy.md

--- a/site/content/docs/v1.10.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.10.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.10.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.10.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.10.0/start-contributing.md
+++ b/site/content/docs/v1.10.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.10.0/start-contributing.md
+++ b/site/content/docs/v1.10.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.10.1/README.md
+++ b/site/content/docs/v1.10.1/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.10.1/config/annotations.md
+++ b/site/content/docs/v1.10.1/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.10.1/config/client-authorization.md
+++ b/site/content/docs/v1.10.1/config/client-authorization.md
@@ -115,9 +115,9 @@ A route can overwrite the value for a context key by setting it in the
 context field of authorization policy for the route.
 
 [1]: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter
-[2]: /docs/{{page.version}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
+[2]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
 [3]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto
-[4]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
-[5]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationServer
-[6]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.AuthorizationPolicy
+[4]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[5]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.AuthorizationServer
+[6]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.AuthorizationPolicy
 [7]: {% link _guides/external-authorization.md %}

--- a/site/content/docs/v1.10.1/config/fundamentals.md
+++ b/site/content/docs/v1.10.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.10.1/config/fundamentals.md
+++ b/site/content/docs/v1.10.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.10.1/config/tls-delegation.md
+++ b/site/content/docs/v1.10.1/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.10.1/configuration.md
+++ b/site/content/docs/v1.10.1/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.10.1/configuration.md
+++ b/site/content/docs/v1.10.1/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.10.1/deploy-options.md
+++ b/site/content/docs/v1.10.1/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: {% link docs/{{page.version}}/config/fundamentals.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.10.1/deploy-options.md
+++ b/site/content/docs/v1.10.1/deploy-options.md
@@ -196,12 +196,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
-[9]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[9]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [10]: {% link _guides/deploy-aws-nlb.md %}
 [11]: redeploy-envoy.md

--- a/site/content/docs/v1.10.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.10.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.10.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.10.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.10.1/start-contributing.md
+++ b/site/content/docs/v1.10.1/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.10.1/start-contributing.md
+++ b/site/content/docs/v1.10.1/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.11.0/README.md
+++ b/site/content/docs/v1.11.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.11.0/config/annotations.md
+++ b/site/content/docs/v1.11.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.11.0/config/fundamentals.md
+++ b/site/content/docs/v1.11.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.11.0/config/fundamentals.md
+++ b/site/content/docs/v1.11.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.11.0/config/tls-delegation.md
+++ b/site/content/docs/v1.11.0/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.11.0/configuration.md
+++ b/site/content/docs/v1.11.0/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.11.0/configuration.md
+++ b/site/content/docs/v1.11.0/configuration.md
@@ -206,13 +206,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.11.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.11.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.11.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.11.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.11.0/start-contributing.md
+++ b/site/content/docs/v1.11.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.11.0/start-contributing.md
+++ b/site/content/docs/v1.11.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.12.0/README.md
+++ b/site/content/docs/v1.12.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.12.0/config/annotations.md
+++ b/site/content/docs/v1.12.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.12.0/config/fundamentals.md
+++ b/site/content/docs/v1.12.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.12.0/config/fundamentals.md
+++ b/site/content/docs/v1.12.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.12.0/config/tls-delegation.md
+++ b/site/content/docs/v1.12.0/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.12.0/configuration.md
+++ b/site/content/docs/v1.12.0/configuration.md
@@ -207,13 +207,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.12.0/configuration.md
+++ b/site/content/docs/v1.12.0/configuration.md
@@ -207,13 +207,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.12.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.12.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.12.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.12.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.12.0/start-contributing.md
+++ b/site/content/docs/v1.12.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.12.0/start-contributing.md
+++ b/site/content/docs/v1.12.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.13.0/README.md
+++ b/site/content/docs/v1.13.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.13.0/config/annotations.md
+++ b/site/content/docs/v1.13.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.13.0/config/fundamentals.md
+++ b/site/content/docs/v1.13.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.13.0/config/fundamentals.md
+++ b/site/content/docs/v1.13.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.13.0/config/tls-delegation.md
+++ b/site/content/docs/v1.13.0/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.13.0/configuration.md
+++ b/site/content/docs/v1.13.0/configuration.md
@@ -364,13 +364,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.13.0/configuration.md
+++ b/site/content/docs/v1.13.0/configuration.md
@@ -364,13 +364,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.13.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.13.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.13.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.13.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.13.0/start-contributing.md
+++ b/site/content/docs/v1.13.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.13.0/start-contributing.md
+++ b/site/content/docs/v1.13.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.13.1/README.md
+++ b/site/content/docs/v1.13.1/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.13.1/config/annotations.md
+++ b/site/content/docs/v1.13.1/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.13.1/config/fundamentals.md
+++ b/site/content/docs/v1.13.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.13.1/config/fundamentals.md
+++ b/site/content/docs/v1.13.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.13.1/config/tls-delegation.md
+++ b/site/content/docs/v1.13.1/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.13.1/configuration.md
+++ b/site/content/docs/v1.13.1/configuration.md
@@ -364,13 +364,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.13.1/configuration.md
+++ b/site/content/docs/v1.13.1/configuration.md
@@ -364,13 +364,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.13.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.13.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.13.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.13.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.13.1/start-contributing.md
+++ b/site/content/docs/v1.13.1/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.13.1/start-contributing.md
+++ b/site/content/docs/v1.13.1/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.14.0/README.md
+++ b/site/content/docs/v1.14.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.14.0/config/annotations.md
+++ b/site/content/docs/v1.14.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.14.0/config/fundamentals.md
+++ b/site/content/docs/v1.14.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.14.0/config/fundamentals.md
+++ b/site/content/docs/v1.14.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.14.0/config/tls-delegation.md
+++ b/site/content/docs/v1.14.0/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.14.0/configuration.md
+++ b/site/content/docs/v1.14.0/configuration.md
@@ -423,13 +423,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.14.0/configuration.md
+++ b/site/content/docs/v1.14.0/configuration.md
@@ -423,13 +423,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.14.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.14.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.14.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.14.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.14.0/start-contributing.md
+++ b/site/content/docs/v1.14.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.14.0/start-contributing.md
+++ b/site/content/docs/v1.14.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.14.1/README.md
+++ b/site/content/docs/v1.14.1/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.14.1/config/annotations.md
+++ b/site/content/docs/v1.14.1/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.14.1/config/fundamentals.md
+++ b/site/content/docs/v1.14.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.14.1/config/fundamentals.md
+++ b/site/content/docs/v1.14.1/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.14.1/config/tls-delegation.md
+++ b/site/content/docs/v1.14.1/config/tls-delegation.md
@@ -42,4 +42,4 @@ spec:
 In this example, the permission for Contour to reference the Secret `example-com-wildcard` in the `admin` namespace has been delegated to HTTPProxy objects in the `example-com` namespace.
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.14.1/configuration.md
+++ b/site/content/docs/v1.14.1/configuration.md
@@ -422,7 +422,7 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration

--- a/site/content/docs/v1.14.1/configuration.md
+++ b/site/content/docs/v1.14.1/configuration.md
@@ -422,7 +422,7 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration

--- a/site/content/docs/v1.14.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.14.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.14.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.14.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.14.1/start-contributing.md
+++ b/site/content/docs/v1.14.1/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.14.1/start-contributing.md
+++ b/site/content/docs/v1.14.1/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.15.0/README.md
+++ b/site/content/docs/v1.15.0/README.md
@@ -15,6 +15,6 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 [1]: https://www.envoyproxy.io/
-[2]: {% link docs/{{page.version}}/config/fundamentals.md %}
+[2]: {% link docs/{{< param version >}}/config/fundamentals.md %}
 [3]: {% link getting-started.md %}
 [4]: {% link _resources/compatibility-matrix.md %}

--- a/site/content/docs/v1.15.0/config/annotations.md
+++ b/site/content/docs/v1.15.0/config/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/circuit_breaker.proto#envoy-v3-api-field-config-cluster-v3-circuitbreakers-thresholds-max-retries
 [15]: fundamentals.md
 [16]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-require-tls
-[17]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.15.0/config/fundamentals.md
+++ b/site/content/docs/v1.15.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.15.0/config/fundamentals.md
+++ b/site/content/docs/v1.15.0/config/fundamentals.md
@@ -156,5 +156,5 @@ There are a number of working examples of HTTPProxy objects in the [`examples/ex
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: api.md

--- a/site/content/docs/v1.15.0/config/ingress.md
+++ b/site/content/docs/v1.15.0/config/ingress.md
@@ -78,4 +78,4 @@ If not provided, Contour will use the address of the Envoy service using the pas
 [5]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
 [6]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 [7]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-[8]: /docs/{{page.version}}/config/tls-delegation/
+[8]: /docs/{{< param version >}}/config/tls-delegation/

--- a/site/content/docs/v1.15.0/config/tls-delegation.md
+++ b/site/content/docs/v1.15.0/config/tls-delegation.md
@@ -45,4 +45,4 @@ In this example, the permission for Contour to reference the Secret `example-com
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
 [0]: https://github.com/projectcontour/contour/issues/3544
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.15.0/configuration.md
+++ b/site/content/docs/v1.15.0/configuration.md
@@ -423,13 +423,13 @@ connects to Contour:
 
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.15.0/configuration.md
+++ b/site/content/docs/v1.15.0/configuration.md
@@ -423,13 +423,13 @@ connects to Contour:
 
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.15.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.15.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.15.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.15.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.15.0/start-contributing.md
+++ b/site/content/docs/v1.15.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.15.0/start-contributing.md
+++ b/site/content/docs/v1.15.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.15.1/config/ingress.md
+++ b/site/content/docs/v1.15.1/config/ingress.md
@@ -78,4 +78,4 @@ If not provided, Contour will use the address of the Envoy service using the pas
 [5]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
 [6]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 [7]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-[8]: /docs/{{page.version}}/config/tls-delegation/
+[8]: /docs/{{< param version >}}/config/tls-delegation/

--- a/site/content/docs/v1.15.1/config/tls-delegation.md
+++ b/site/content/docs/v1.15.1/config/tls-delegation.md
@@ -45,4 +45,4 @@ In this example, the permission for Contour to reference the Secret `example-com
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
 [0]: https://github.com/projectcontour/contour/issues/3544
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.15.1/start-contributing.md
+++ b/site/content/docs/v1.15.1/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.15.1/start-contributing.md
+++ b/site/content/docs/v1.15.1/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.16.0/config/ingress.md
+++ b/site/content/docs/v1.16.0/config/ingress.md
@@ -77,4 +77,4 @@ If not provided, Contour will use the address of the Envoy service using the pas
 [5]: https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards
 [6]: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
 [7]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-[8]: /docs/{{page.version}}/config/tls-delegation/
+[8]: /docs/{{< param version >}}/config/tls-delegation/

--- a/site/content/docs/v1.16.0/config/tls-delegation.md
+++ b/site/content/docs/v1.16.0/config/tls-delegation.md
@@ -45,4 +45,4 @@ In this example, the permission for Contour to reference the Secret `example-com
 Also, the permission for Contour to reference the Secret `another-com-wildcard` from all namespaces has been delegated to all HTTPProxy objects in the cluster.
 
 [0]: https://github.com/projectcontour/contour/issues/3544
-[1]: /docs/{{page.version}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation
+[1]: /docs/{{< param version >}}/config/api/#projectcontour.io/v1.TLSCertificateDelegation

--- a/site/content/docs/v1.16.0/start-contributing.md
+++ b/site/content/docs/v1.16.0/start-contributing.md
@@ -12,9 +12,9 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.16.0/start-contributing.md
+++ b/site/content/docs/v1.16.0/start-contributing.md
@@ -15,6 +15,6 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}
 [5]: https://github.com/projectcontour/contour-operator/blob/main/docs/CONTRIBUTING.md
 [6]: https://github.com/projectcontour/contour-operator/issues

--- a/site/content/docs/v1.2.0/configuration.md
+++ b/site/content/docs/v1.2.0/configuration.md
@@ -32,4 +32,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.2.0/deploy-options.md
+++ b/site/content/docs/v1.2.0/deploy-options.md
@@ -231,12 +231,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.2.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.2.0/grpc-tls-howto.md
@@ -131,7 +131,7 @@ If using the built-in Contour certificate generation the following steps can be 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.2.0/httpproxy.md
+++ b/site/content/docs/v1.2.0/httpproxy.md
@@ -1302,7 +1302,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.2.0/ingressroute.md
+++ b/site/content/docs/v1.2.0/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.2.0/start-contributing.md
+++ b/site/content/docs/v1.2.0/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.2.1/configuration.md
+++ b/site/content/docs/v1.2.1/configuration.md
@@ -32,4 +32,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.2.1/deploy-options.md
+++ b/site/content/docs/v1.2.1/deploy-options.md
@@ -231,12 +231,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.2.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.2.1/grpc-tls-howto.md
@@ -131,7 +131,7 @@ If using the built-in Contour certificate generation the following steps can be 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.2.1/httpproxy.md
+++ b/site/content/docs/v1.2.1/httpproxy.md
@@ -1302,7 +1302,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.2.1/ingressroute.md
+++ b/site/content/docs/v1.2.1/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.2.1/start-contributing.md
+++ b/site/content/docs/v1.2.1/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.3.0/configuration.md
+++ b/site/content/docs/v1.3.0/configuration.md
@@ -32,4 +32,4 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml

--- a/site/content/docs/v1.3.0/deploy-options.md
+++ b/site/content/docs/v1.3.0/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.3.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.3.0/grpc-tls-howto.md
@@ -131,7 +131,7 @@ If using the built-in Contour certificate generation the following steps can be 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.3.0/httpproxy.md
+++ b/site/content/docs/v1.3.0/httpproxy.md
@@ -1302,7 +1302,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.3.0/ingressroute.md
+++ b/site/content/docs/v1.3.0/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.3.0/start-contributing.md
+++ b/site/content/docs/v1.3.0/start-contributing.md
@@ -10,6 +10,6 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues

--- a/site/content/docs/v1.4.0/configuration.md
+++ b/site/content/docs/v1.4.0/configuration.md
@@ -81,7 +81,7 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration

--- a/site/content/docs/v1.4.0/deploy-options.md
+++ b/site/content/docs/v1.4.0/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.4.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.4.0/grpc-tls-howto.md
@@ -131,7 +131,7 @@ If using the built-in Contour certificate generation the following steps can be 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][4].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.4.0/httpproxy.md
+++ b/site/content/docs/v1.4.0/httpproxy.md
@@ -1333,7 +1333,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.4.0/ingressroute.md
+++ b/site/content/docs/v1.4.0/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.4.0/start-contributing.md
+++ b/site/content/docs/v1.4.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.4.0/start-contributing.md
+++ b/site/content/docs/v1.4.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.5.0/configuration.md
+++ b/site/content/docs/v1.5.0/configuration.md
@@ -93,7 +93,7 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration

--- a/site/content/docs/v1.5.0/deploy-options.md
+++ b/site/content/docs/v1.5.0/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.5.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.5.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.5.0/httpproxy.md
+++ b/site/content/docs/v1.5.0/httpproxy.md
@@ -1408,7 +1408,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.5.0/ingressroute.md
+++ b/site/content/docs/v1.5.0/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.5.0/start-contributing.md
+++ b/site/content/docs/v1.5.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.5.0/start-contributing.md
+++ b/site/content/docs/v1.5.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.5.1/configuration.md
+++ b/site/content/docs/v1.5.1/configuration.md
@@ -93,7 +93,7 @@ data:
 
 _Note:_ The default example `contour` includes this [file][1] for easy deployment of Contour.
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration

--- a/site/content/docs/v1.5.1/deploy-options.md
+++ b/site/content/docs/v1.5.1/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.5.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.5.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.5.1/httpproxy.md
+++ b/site/content/docs/v1.5.1/httpproxy.md
@@ -1408,7 +1408,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.5.1/ingressroute.md
+++ b/site/content/docs/v1.5.1/ingressroute.md
@@ -1009,7 +1009,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
 [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
 [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/ingressroute
+[3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/ingressroute
 [4]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-routeaction-timeout
 [5]: https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/upstream/load_balancing/overview
-[6]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+[6]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.5.1/start-contributing.md
+++ b/site/content/docs/v1.5.1/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.5.1/start-contributing.md
+++ b/site/content/docs/v1.5.1/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.6.0/configuration.md
+++ b/site/content/docs/v1.6.0/configuration.md
@@ -116,10 +116,10 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.6.0/deploy-options.md
+++ b/site/content/docs/v1.6.0/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.6.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.6.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.6.0/httpproxy.md
+++ b/site/content/docs/v1.6.0/httpproxy.md
@@ -1407,7 +1407,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.6.0/start-contributing.md
+++ b/site/content/docs/v1.6.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.6.0/start-contributing.md
+++ b/site/content/docs/v1.6.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.6.1/configuration.md
+++ b/site/content/docs/v1.6.1/configuration.md
@@ -116,10 +116,10 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.6.1/deploy-options.md
+++ b/site/content/docs/v1.6.1/deploy-options.md
@@ -232,12 +232,12 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
 [6]: /docs/{{page.version}}/ingressroute
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.6.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.6.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.6.1/httpproxy.md
+++ b/site/content/docs/v1.6.1/httpproxy.md
@@ -1407,7 +1407,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout

--- a/site/content/docs/v1.6.1/start-contributing.md
+++ b/site/content/docs/v1.6.1/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.6.1/start-contributing.md
+++ b/site/content/docs/v1.6.1/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.7.0/configuration.md
+++ b/site/content/docs/v1.7.0/configuration.md
@@ -139,13 +139,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.7.0/deploy-options.md
+++ b/site/content/docs/v1.7.0/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.7.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.7.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.7.0/httpproxy.md
+++ b/site/content/docs/v1.7.0/httpproxy.md
@@ -1407,7 +1407,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
@@ -1416,5 +1416,5 @@ Some examples of invalid configurations that Contour provides statuses for:
  [9]: {% link docs/{{page.version}}/annotations.md %}
  [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/content/docs/v1.7.0/start-contributing.md
+++ b/site/content/docs/v1.7.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.7.0/start-contributing.md
+++ b/site/content/docs/v1.7.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.8.0/configuration.md
+++ b/site/content/docs/v1.8.0/configuration.md
@@ -138,13 +138,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.8.0/deploy-options.md
+++ b/site/content/docs/v1.8.0/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.8.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.8.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.8.0/httpproxy.md
+++ b/site/content/docs/v1.8.0/httpproxy.md
@@ -1407,7 +1407,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
@@ -1416,5 +1416,5 @@ Some examples of invalid configurations that Contour provides statuses for:
  [9]: {% link docs/{{page.version}}/annotations.md %}
  [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/content/docs/v1.8.0/start-contributing.md
+++ b/site/content/docs/v1.8.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.8.0/start-contributing.md
+++ b/site/content/docs/v1.8.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.8.1/configuration.md
+++ b/site/content/docs/v1.8.1/configuration.md
@@ -138,13 +138,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.8.1/deploy-options.md
+++ b/site/content/docs/v1.8.1/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.8.1/grpc-tls-howto.md
+++ b/site/content/docs/v1.8.1/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.8.1/httpproxy.md
+++ b/site/content/docs/v1.8.1/httpproxy.md
@@ -1407,7 +1407,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
@@ -1416,5 +1416,5 @@ Some examples of invalid configurations that Contour provides statuses for:
  [9]: {% link docs/{{page.version}}/annotations.md %}
  [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac
 

--- a/site/content/docs/v1.8.1/start-contributing.md
+++ b/site/content/docs/v1.8.1/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.8.1/start-contributing.md
+++ b/site/content/docs/v1.8.1/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.8.2/configuration.md
+++ b/site/content/docs/v1.8.2/configuration.md
@@ -179,13 +179,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.8.2/deploy-options.md
+++ b/site/content/docs/v1.8.2/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.8.2/grpc-tls-howto.md
+++ b/site/content/docs/v1.8.2/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.8.2/httpproxy.md
+++ b/site/content/docs/v1.8.2/httpproxy.md
@@ -1413,7 +1413,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
@@ -1422,4 +1422,4 @@ Some examples of invalid configurations that Contour provides statuses for:
  [9]: {% link docs/{{page.version}}/annotations.md %}
  [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.8.2/start-contributing.md
+++ b/site/content/docs/v1.8.2/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.8.2/start-contributing.md
+++ b/site/content/docs/v1.8.2/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/docs/v1.9.0/annotations.md
+++ b/site/content/docs/v1.9.0/annotations.md
@@ -86,4 +86,4 @@ A [Kubernetes Service][9] maps to an [Envoy Cluster][10]. Envoy clusters have ma
 [14]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/cluster/circuit_breaker.proto#envoy-api-field-cluster-circuitbreakers-thresholds-max-retries
 [15]: httpproxy.md
 [16]: https://www.envoyproxy.io/docs/envoy/v1.11.2/api-v2/api/v2/route/route.proto.html#envoy-api-field-route-virtualhost-require-tls
-[17]: /docs/{{page.version}}/api/#projectcontour.io/v1.UpstreamValidation
+[17]: /docs/{{< param version >}}/api/#projectcontour.io/v1.UpstreamValidation

--- a/site/content/docs/v1.9.0/configuration.md
+++ b/site/content/docs/v1.9.0/configuration.md
@@ -179,13 +179,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.9.0/configuration.md
+++ b/site/content/docs/v1.9.0/configuration.md
@@ -179,13 +179,13 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/01-contour-config.yaml
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml
 [2]: /guides/structured-logs
 [3]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [4]: https://golang.org/pkg/time/#ParseDuration
 [5]: https://godoc.org/github.com/projectcontour/contour/internal/envoy#DefaultFields
 [6]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour
 [8]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-idle-timeout
 [9]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#envoy-api-field-config-filter-network-http-connection-manager-v2-httpconnectionmanager-stream-idle-timeout
 [10]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/protocol.proto#envoy-api-field-core-httpprotocoloptions-max-connection-duration

--- a/site/content/docs/v1.9.0/deploy-options.md
+++ b/site/content/docs/v1.9.0/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.9.0/deploy-options.md
+++ b/site/content/docs/v1.9.0/deploy-options.md
@@ -196,11 +196,11 @@ $ kubectl delete ns projectcontour
 ```
 
 [1]: #running-without-a-kubernetes-loadbalancer
-[2]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/README.md
+[2]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/README.md
 [3]: #host-networking
 [4]: {% link _guides/proxy-proto.md %}
 [5]: https://github.com/kubernetes-up-and-running/kuard
-[7]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-service-envoy.yaml
+[7]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-service-envoy.yaml
 [8]: {% link getting-started.md %}
 [9]: httpproxy.md
 [10]: {% link _guides/deploy-aws-nlb.md %}

--- a/site/content/docs/v1.9.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.9.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{site.github.repository_url}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{site.github.repository_url}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour

--- a/site/content/docs/v1.9.0/grpc-tls-howto.md
+++ b/site/content/docs/v1.9.0/grpc-tls-howto.md
@@ -161,8 +161,8 @@ When using the built-in Contour certificate generation, the following steps can 
 Once this process is done, the certificates will be present as Secrets in the `projectcontour` namespace, as required by
 [examples/contour][5].
 
-[1]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/02-job-certgen.yaml
-[2]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-contour.ext
-[3]: {{< param github_url >}}/tree/{{page.version}}/_integration/cert-envoy.ext
-[4]: {{< param github_url >}}/tree/{{page.version}}/examples/contour/03-envoy.yaml
-[5]: {{< param github_url >}}/tree/{{page.version}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/02-job-certgen.yaml
+[2]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-contour.ext
+[3]: {{< param github_url >}}/tree/{{< param version >}}/_integration/cert-envoy.ext
+[4]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour/03-envoy.yaml
+[5]: {{< param github_url >}}/tree/{{< param version >}}/examples/contour

--- a/site/content/docs/v1.9.0/httpproxy.md
+++ b/site/content/docs/v1.9.0/httpproxy.md
@@ -1481,13 +1481,13 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{< param version >}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
  [7]: https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/arch_overview/upstream/load_balancing/overview
  [8]: #conditions
- [9]: {% link docs/{{page.version}}/annotations.md %}
- [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
+ [9]: {% link docs/{{< param version >}}/annotations.md %}
+ [10]: /docs/{{< param version >}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{< param version >}}/examples/root-rbac

--- a/site/content/docs/v1.9.0/httpproxy.md
+++ b/site/content/docs/v1.9.0/httpproxy.md
@@ -1481,7 +1481,7 @@ Some examples of invalid configurations that Contour provides statuses for:
 
  [1]: https://kubernetes.io/docs/concepts/services-networking/ingress/
  [2]: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
- [3]: {{site.github.repository_url}}/tree/{{page.version}}/examples/example-workload/httpproxy
+ [3]: {{< param github_url >}}/tree/{{page.version}}/examples/example-workload/httpproxy
  [4]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-timeout
  [5]: https://godoc.org/time#ParseDuration
  [6]: https://www.envoyproxy.io/docs/envoy/v1.14.2/api-v2/api/v2/route/route_components.proto#envoy-api-field-route-routeaction-idle-timeout
@@ -1490,4 +1490,4 @@ Some examples of invalid configurations that Contour provides statuses for:
  [9]: {% link docs/{{page.version}}/annotations.md %}
  [10]: /docs/{{page.version}}/api/#projectcontour.io/v1.Service
  [11]: configuration.md#fallback-certificate
- [12]: {{site.github.repository_url}}/tree/{{page.version}}/examples/root-rbac
+ [12]: {{< param github_url >}}/tree/{{page.version}}/examples/root-rbac

--- a/site/content/docs/v1.9.0/start-contributing.md
+++ b/site/content/docs/v1.9.0/start-contributing.md
@@ -10,7 +10,7 @@ Thanks for taking the time to join our community and start contributing!
   - Meeting notes can be found [here](https://hackmd.io/84Xbl4WBTpm7OBhaOAsSiw).
   - Meetings are recorded and can be found [here](https://www.youtube.com/playlist?list=PL7bmigfV0EqTBsPrnCkzhu0R4SAWnBjLj).
 
-[1]: {{site.github.repository_url}}/blob/main/CODE_OF_CONDUCT.md
-[2]: {{site.github.repository_url}}/blob/main/CONTRIBUTING.md
-[3]: {{site.github.repository_url}}/issues
+[1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
+[2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
+[3]: {{< param github_url >}}/issues
 [4]: {{site.footer_social_links.Slack.url}}

--- a/site/content/docs/v1.9.0/start-contributing.md
+++ b/site/content/docs/v1.9.0/start-contributing.md
@@ -13,4 +13,4 @@ Thanks for taking the time to join our community and start contributing!
 [1]: {{< param github_url >}}/blob/main/CODE_OF_CONDUCT.md
 [2]: {{< param github_url >}}/blob/main/CONTRIBUTING.md
 [3]: {{< param github_url >}}/issues
-[4]: {{site.footer_social_links.Slack.url}}
+[4]: {{< param slack_url >}}

--- a/site/content/guides/proxy-proto.md
+++ b/site/content/guides/proxy-proto.md
@@ -44,7 +44,7 @@ spec:
 ...
 spec:
   containers:
-  - image: docker.io/projectcontour/contour:{{ site.github.latest_release.tag_name }}
+  - image: docker.io/projectcontour/contour:{{< param latest_release_tag_name >}}
     imagePullPolicy: Always
     name: contour
     command: ["contour"]

--- a/site/content/posts/2019-04-22-Routing-Traffic-to-Applications-in-Kubernetes-with-Contour.md
+++ b/site/content/posts/2019-04-22-Routing-Traffic-to-Applications-in-Kubernetes-with-Contour.md
@@ -52,5 +52,5 @@ _Previously posted on <https://blogs.vmware.com/cloudnative/2019/03/08/routing-t
 
 [1]: https://en.wikipedia.org/wiki/OSI_model#Layer_7:_Application_Layer
 [2]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[3]: {{site.github.repository_url}}/blob/v0.10.0/design/tls-certificate-delegation.md
-[4]: {{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+
+[3]: {{< param github_url >}}/blob/v0.10.0/design/tls-certificate-delegation.md
+[4]: {{< param github_url >}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+

--- a/site/content/posts/2019-07-23-contour-v014.md
+++ b/site/content/posts/2019-07-23-contour-v014.md
@@ -60,8 +60,8 @@ We’re immensely grateful for all the community contributions that help make Co
 
 [1]: {% link img/posts/post-contour-split-deployment.png %}
 [2]: {% link docs/v1.0.0/grpc-tls-howto.md %}
-[3]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour
-[4]: {{site.github.repository_url}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/02-job-certgen.yaml
+[3]: {{< param github_url >}}/blob/{{site.github.latest_release.tag_name}}/examples/contour
+[4]: {{< param github_url >}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/02-job-certgen.yaml
 [5]: https://github.com/kubernetes-sigs/kind
 [6]: {% post_url 2019-07-11-kindly-running-contour %}
-[7]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+[7]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22

--- a/site/content/posts/2019-07-23-contour-v014.md
+++ b/site/content/posts/2019-07-23-contour-v014.md
@@ -60,8 +60,8 @@ We’re immensely grateful for all the community contributions that help make Co
 
 [1]: {% link img/posts/post-contour-split-deployment.png %}
 [2]: {% link docs/v1.0.0/grpc-tls-howto.md %}
-[3]: {{< param github_url >}}/blob/{{site.github.latest_release.tag_name}}/examples/contour
-[4]: {{< param github_url >}}/blob/{{site.github.latest_release.tag_name}}/examples/contour/02-job-certgen.yaml
+[3]: {{< param github_url >}}/blob/{{< param latest_release_tag_name >}}/examples/contour
+[4]: {{< param github_url >}}/blob/{{< param latest_release_tag_name >}}/examples/contour/02-job-certgen.yaml
 [5]: https://github.com/kubernetes-sigs/kind
 [6]: {% post_url 2019-07-11-kindly-running-contour %}
 [7]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22

--- a/site/content/posts/2019-09-27-from-ingressroute-to-httpproxy.md
+++ b/site/content/posts/2019-09-27-from-ingressroute-to-httpproxy.md
@@ -57,9 +57,9 @@ The final question that should be answered is, with the focus on layer 7 HTTP pr
 The short answer is Contour's layer 3/4 TCP proxying feature is not going away.
 Despite the cognitive dissonance, we're committed to supporting and enhancing Contour's TCP proxying abilities via the HTTPProxy CRD for the long term.
 
-[1]: {{site.github.repository_url}}/releases/tag/v1.0.0-beta.1
-[2]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/ingressroute.md
-[3]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md
-[4]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md#httpproxy-inclusion
-[5]: {{site.github.repository_url}}/blob/v1.0.0-beta.1/docs/httpproxy.md#conditions
+[1]: {{< param github_url >}}/releases/tag/v1.0.0-beta.1
+[2]: {{< param github_url >}}/blob/v1.0.0-beta.1/docs/ingressroute.md
+[3]: {{< param github_url >}}/blob/v1.0.0-beta.1/docs/httpproxy.md
+[4]: {{< param github_url >}}/blob/v1.0.0-beta.1/docs/httpproxy.md#httpproxy-inclusion
+[5]: {{< param github_url >}}/blob/v1.0.0-beta.1/docs/httpproxy.md#conditions
 [6]: {% link _guides/ingressroute-to-httpproxy.md %}

--- a/site/content/posts/2019-09-5-contour-v015.md
+++ b/site/content/posts/2019-09-5-contour-v015.md
@@ -89,11 +89,11 @@ We’re immensely grateful for all the community contributions that help make Co
 - [@so0k][8]
 - [@mattalberts][9]
 
-[1]: {{site.github.repository_url}}/releases/tag/v0.15.0
-[2]: {{site.github.repository_url}}/blob/v0.15.0/docs/upgrading.md
-[3]: {{site.github.repository_url}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+[1]: {{< param github_url >}}/releases/tag/v0.15.0
+[2]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md
+[3]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
 [4]: {% link img/posts/leader-election.png %}
-[5]: {{site.github.repository_url}}/blob/v0.15.0/docs/upgrading.md#enabling-leader-election
+[5]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md#enabling-leader-election
 [7]: https://github.com/DylanGraham
 [8]: https://github.com/so0k
 [9]: https://github.com/mattalberts

--- a/site/content/posts/2019-10-25-contour-v100rc2.md
+++ b/site/content/posts/2019-10-25-contour-v100rc2.md
@@ -57,7 +57,7 @@ This changes reduces the likelihood that Envoy can connect to a Contour instance
 
 Please consult the [Upgrading][7] document for information on upgrading from Contour 1.0.0-rc.1 to Contour 1.0.0-rc.2.
 
-[1]: {{site.github.repository_url}}/releases/tag/v1.0.0-rc.2
+[1]: {{< param github_url >}}/releases/tag/v1.0.0-rc.2
 [2]: /getting-started
 [3]: /guides
 [4]: /docs

--- a/site/content/posts/2019-11-01-announcing-contour-1.0.md
+++ b/site/content/posts/2019-11-01-announcing-contour-1.0.md
@@ -142,5 +142,5 @@ The sign of a strong community is how users communicate through Slack and GitHub
 
 _**Note**: Stats above were taken on  Oct. 31, 2019._
 
-[1]: {{site.github.repository_url}}/commit/788feabc67c4da76cd1ae3c9ac1998b43cb0e2f3
+[1]: {{< param github_url >}}/commit/788feabc67c4da76cd1ae3c9ac1998b43cb0e2f3
 [2]: {% link img/contour-1.0/contour-1.0-stats.png %}

--- a/site/content/posts/2020-04-27-client-cert-auth-ingress-improvements.md
+++ b/site/content/posts/2020-04-27-client-cert-auth-ingress-improvements.md
@@ -93,7 +93,7 @@ The Contour project is very community-driven and the team would love to hear you
 - We’ve heard that a number of teams have forked Contour and we would love to hear about what changes you needed, and to see if we can help to bring them upstream.
 Please consider coming to our community meeting, or contact us: either via an issue, or hit me up on Twitter [@youngnick](https://twitter.com/youngnick).
 
-If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted]({{site.github.repository_url}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+) and work with the team on how to resolve them. 
+If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted]({{< param github_url >}}/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22+) and work with the team on how to resolve them. 
 
 ## Are you a Contour user? We would love to know!
 If you're using Contour and want to add your organization to our adopters list, please visit this [page](https://github.com/projectcontour/contour/blob/main/ADOPTERS.md).

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -93,7 +93,7 @@ If you are providing your own Envoy it must be compiled with the following exten
 __Note:__ This list of extensions was last verified to be complete with Envoy v1.16.1.
 
 
-[1]: {{< param github_url >}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour
 
 [2]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.1
 [3]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.2

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -93,7 +93,7 @@ If you are providing your own Envoy it must be compiled with the following exten
 __Note:__ This list of extensions was last verified to be complete with Envoy v1.16.1.
 
 
-[1]: {{site.github.repository_url}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{site.github.latest_release.tag_name}}/examples/contour
 
 [2]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.1
 [3]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.2

--- a/site/content/resources/tagging.md
+++ b/site/content/resources/tagging.md
@@ -10,7 +10,7 @@ This document describes Contour's image tagging policy.
 `docker.io/projectcontour/contour:<SemVer>`
 
 Contour follows the [Semantic Versioning][1] standard for releases.
-Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{ site.latest }}`
+Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{< param latest_release_tag_name >}}`
 
 ### Latest
 


### PR DESCRIPTION
Does the following replacements:

```
{{site.github.repository_url}}              {{< param github_url >}}
{{site.footer_social_links.Slack.url}}      {{< param slack_url >}}
{{site.latest}}                             {{< param latest_release_tag_name >}}
{{site.github.latest_release.tag_name}}     {{< param latest_release_tag_name >}}
{{page.version}}                            {{< param version >}} (only for versions 1.9.0+)
```

Separately, going to file an issue to de-dupe `latest_release_tag_name` and `docs_latest` params, I think in practice they're always the same. I think we'll have to update our automation for this as well.