### PR TITLE
site: use a single param for latest version

### DIFF
--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -97,18 +97,10 @@ func updateConfigForSite(filePath string, vers string) error {
 
 	rn := yaml.MustParse(string(data))
 
-	// Set params.docs_latest to the provided version.
+	// Set params.latest_version to the provided version.
 	if _, err := rn.Pipe(
 		yaml.Lookup("params"),
-		yaml.FieldSetter{Name: "docs_latest", StringValue: vers},
-	); err != nil {
-		return err
-	}
-
-	// Set params.latest_release_tag_name to the provided version.
-	if _, err := rn.Pipe(
-		yaml.Lookup("params"),
-		yaml.FieldSetter{Name: "latest_release_tag_name", StringValue: vers},
+		yaml.FieldSetter{Name: "latest_version", StringValue: vers},
 	); err != nil {
 		return err
 	}

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -28,14 +28,13 @@ params:
   twitter_url: "https://twitter.com/projectcontour"
   github_url: "https://github.com/projectcontour/contour"
   slack_url: "https://kubernetes.slack.com/messages/contour"
-  latest_release_tag_name: v1.16.0
+  latest_version: v1.16.0
   use_advanced_docs: true
   docs_right_sidebar: true
   docs_search: true
   docs_search_index_name: projectcontour
   docs_search_api_key: 5e2fa46757e313755936b88feae652d1
   docs_versioning: true
-  docs_latest: v1.16.0
   docs_versions:
     - main
     - v1.16.0

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -129,9 +129,9 @@ We've also got [a FAQ][4] for short-answer questions and conceptual stuff that d
 If you encounter issues, review the Troubleshooting section of [the docs][3], [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
 
 [0]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes
-[1]: /docs/{{< param docs_latest >}}/deploy-options
-[2]: /docs/{{< param docs_latest >}}/config/fundamentals
-[3]: /docs/{{< param docs_latest >}}
+[1]: /docs/{{< param latest_version >}}/deploy-options
+[2]: /docs/{{< param latest_version >}}/config/fundamentals
+[3]: /docs/{{< param latest_version >}}
 [4]: {{< ref "resources/faq.md" >}}
 [6]: {{< param github_url >}}/issues
 [9]: https://github.com/kubernetes-up-and-running/kuard

--- a/site/content/guides/cert-manager.md
+++ b/site/content/guides/cert-manager.md
@@ -636,7 +636,7 @@ __Note:__ For HTTPProxy resources this happens automatically without the need fo
 [4]: https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
 [5]: https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
 [6]: https://letsencrypt.org/getting-started/
-[7]: /docs/{{< param docs_latest >}}/deploy-options/#get-your-hostname-or-ip-address
+[7]: /docs/{{< param latest_version >}}/deploy-options/#get-your-hostname-or-ip-address
 [8]: /img/cert-manager/httpbinhomepage.png
 [9]: /img/cert-manager/httpbin.png
 [10]: {{< param github_url >}}/issues/950

--- a/site/content/guides/deploy-aws-nlb.md
+++ b/site/content/guides/deploy-aws-nlb.md
@@ -43,6 +43,6 @@ You can now test your NLB.
   - Notice that Envoy fills out `X-Forwarded-For`, because it was the first to see the traffic directly from the browser.
 
 [1]: https://aws.amazon.com/blogs/aws/new-network-load-balancer-effortless-scaling-to-millions-of-requests-per-second/
-[2]: /docs/{{< param docs_latest >}}/deploy-options/#testing-your-installation
+[2]: /docs/{{< param latest_version >}}/deploy-options/#testing-your-installation
 [3]: https://github.com/kubernetes/kubernetes/issues/52173
-[4]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}
+[4]: {{< param github_url >}}/tree/{{< param latest_version >}}

--- a/site/content/guides/external-authorization.md
+++ b/site/content/guides/external-authorization.md
@@ -373,8 +373,8 @@ authorization:
 [1]: https://github.com/projectcontour/contour-authserver
 [2]: https://httpd.apache.org/docs/current/misc/password_encryptions.html
 [3]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
-[4]: /docs/{{< param docs_latest >}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
-[5]: /docs/{{< param docs_latest >}}/config/api/#projectcontour.io/v1.HTTPProxy
+[4]: /docs/{{< param latest_version >}}/config/api/#projectcontour.io/v1alpha1.ExtensionService
+[5]: /docs/{{< param latest_version >}}/config/api/#projectcontour.io/v1.HTTPProxy
 [6]: https://cert-manager.io/
 [7]: https://httpd.apache.org/docs/current/programs/htpasswd.html
 [8]: https://kubernetes-sigs.github.io/kustomize/

--- a/site/content/guides/global-rate-limiting.md
+++ b/site/content/guides/global-rate-limiting.md
@@ -424,12 +424,12 @@ For more information, see the [Contour rate limiting documentation][7] and the [
 The YAML used in this guide is available [in the Contour repository][9].
 
 [1]: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/global_rate_limiting
-[2]: /docs/{{< param docs_latest >}}/deploy-options/#kind
+[2]: /docs/{{< param latest_version >}}/deploy-options/#kind
 [3]: https://projectcontour.io/getting-started/#option-1-quickstart
 [4]: https://github.com/envoyproxy/ratelimit
 [5]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto
 [6]: https://github.com/envoyproxy/ratelimit#configuration
-[7]: /docs/{{< param docs_latest >}}/config/rate-limiting/
-[8]: /docs/{{< param docs_latest >}}/config/api/
+[7]: /docs/{{< param latest_version >}}/config/rate-limiting/
+[8]: /docs/{{< param latest_version >}}/config/api/
 [9]: {{< param github_url>}}/tree/main/examples/ratelimit
 [10]: https://github.com/lyft/goruntime

--- a/site/content/guides/ingressroute-to-httpproxy.md
+++ b/site/content/guides/ingressroute-to-httpproxy.md
@@ -552,4 +552,4 @@ No change.
 
 Status reporting on HTTPProxy objects is similar in scope and function to IngressRoute status.
 
-[1]: /docs/{{< param docs_latest >}}/httpproxy
+[1]: /docs/{{< param latest_version >}}/httpproxy

--- a/site/content/guides/structured-logs.md
+++ b/site/content/guides/structured-logs.md
@@ -84,4 +84,4 @@ json-fields:
 [2]: https://github.com/projectcontour/contour/blob/main/pkg/config/accesslog.go#L49-L93
 [3]: https://github.com/projectcontour/contour/blob/main/pkg/config/accesslog.go#L97-L102
 [4]: https://github.com/projectcontour/contour/blob/main/pkg/config/accesslog.go#L4
-[5]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour/01-contour-config.yaml
+[5]: {{< param github_url >}}/tree/{{< param latest_version >}}/examples/contour/01-contour-config.yaml

--- a/site/content/guides/tls.md
+++ b/site/content/guides/tls.md
@@ -23,7 +23,7 @@ For example, for a cert with common name foo.bar.com, requests to Foo.bar.com wo
 Similarly, for cert with wildcard name \*.bar.com, only requests to lower case name will match.
 Here is the [known issue][4] reported on Envoy.
 
-[1]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour/03-contour.yaml/#L45
+[1]: {{< param github_url >}}/tree/{{< param latest_version >}}/examples/contour/03-contour.yaml/#L45
 [2]: /guides/proxy-proto
 [3]: /guides/cert-manager
 [4]: https://github.com/envoyproxy/envoy/issues/6199

--- a/site/content/resources/faq.md
+++ b/site/content/resources/faq.md
@@ -54,6 +54,6 @@ To test whether Contour is correctly deployed you can deploy the kuard example s
 $ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
 ```
 
-[1]: /docs/{{< param docs_latest >}}/config/fundamentals
+[1]: /docs/{{< param latest_version >}}/config/fundamentals
 [2]: /guides/cert-manager
-[3]: /docs/{{< param docs_latest >}}/configuration
+[3]: /docs/{{< param latest_version >}}/configuration

--- a/site/content/resources/support.md
+++ b/site/content/resources/support.md
@@ -10,7 +10,7 @@ This document describes which versions of Contour are supported by the Contour t
 Only the latest stable release is supported.
 
 The latest stable release is identified by the [Docker tag `:latest`][1].
-`:latest` is an alias for {{< param latest_release_tag_name >}} which is the current stable release.
+`:latest` is an alias for {{< param latest_version >}} which is the current stable release.
 
 When required we may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
 At that point the patch release will become the :latest stable release.

--- a/site/themes/contour/layouts/_default/versions.html
+++ b/site/themes/contour/layouts/_default/versions.html
@@ -7,7 +7,7 @@
             </button>
             <div class="dropdown-menu" id="dropdown-menu" aria-labelledby="dropdownMenuButton">
                 {{ $original_version := printf "/%s/" .CurrentSection.Params.version }}
-                {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.docs_latest | relURL }}
+                {{ $latest_url := replace .Params.url .CurrentSection.Params.version .Site.Params.latest_version | relURL }}
                 {{ $currentUrl := .Permalink }}
                 {{ range .Site.Params.docs_versions }}
                     {{ $new_version := printf "/%s/" . }}
@@ -16,7 +16,7 @@
                 {{ end }}
             </div>
         {{ else }}
-            <span>{{ .Site.Params.Docs_latest }}</span>
+            <span>{{ .Site.Params.latest_version }}</span>
         {{ end }}
     </div>
 {{ end }}

--- a/site/themes/contour/layouts/index.redirects
+++ b/site/themes/contour/layouts/index.redirects
@@ -1,4 +1,4 @@
-{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
+{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.latest_version "") }}
 /docs                          /docs/{{ $latest }}     301!
 /docs/latest                   /docs/{{ $latest }}
 /docs/latest/*                 /docs/{{ $latest }}/:splat

--- a/site/themes/contour/layouts/partials/getting-started.html
+++ b/site/themes/contour/layouts/partials/getting-started.html
@@ -1,4 +1,4 @@
-{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
+{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.latest_version "") }}
 <div class="getting-started">
 	<div class="wrapper clearfix">
 		<div class="left-side">

--- a/site/themes/contour/layouts/partials/header.html
+++ b/site/themes/contour/layouts/partials/header.html
@@ -1,4 +1,4 @@
-{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.docs_latest "") }}
+{{ $latest := (cond (.Site.Params.docs_versioning) .Site.Params.latest_version "") }}
 <header>
 	<div class="wrapper">
 		<a href="{{ .Site.BaseURL }}"><img class="image" src="/img/Contour.svg" alt="Logo" /></a>


### PR DESCRIPTION
Replaces docs_latest and latest_release_tag_name with
a latest_version param.

Closes #3786.

Signed-off-by: Steve Kriss <krisss@vmware.com>