### PR TITLE
site: replace latest_release_tag_name with latest_version

### DIFF
--- a/site/content/guides/proxy-proto.md
+++ b/site/content/guides/proxy-proto.md
@@ -44,7 +44,7 @@ spec:
 ...
 spec:
   containers:
-  - image: docker.io/projectcontour/contour:{{< param latest_release_tag_name >}}
+  - image: docker.io/projectcontour/contour:{{< param latest_version >}}
     imagePullPolicy: Always
     name: contour
     command: ["contour"]

--- a/site/content/posts/2019-07-23-contour-v014.md
+++ b/site/content/posts/2019-07-23-contour-v014.md
@@ -60,8 +60,8 @@ We’re immensely grateful for all the community contributions that help make Co
 
 [1]: {% link img/posts/post-contour-split-deployment.png %}
 [2]: {% link docs/v1.0.0/grpc-tls-howto.md %}
-[3]: {{< param github_url >}}/blob/{{< param latest_release_tag_name >}}/examples/contour
-[4]: {{< param github_url >}}/blob/{{< param latest_release_tag_name >}}/examples/contour/02-job-certgen.yaml
+[3]: {{< param github_url >}}/blob/{{< param latest_version >}}/examples/contour
+[4]: {{< param github_url >}}/blob/{{< param latest_version >}}/examples/contour/02-job-certgen.yaml
 [5]: https://github.com/kubernetes-sigs/kind
 [6]: {% post_url 2019-07-11-kindly-running-contour %}
 [7]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -93,7 +93,7 @@ If you are providing your own Envoy it must be compiled with the following exten
 __Note:__ This list of extensions was last verified to be complete with Envoy v1.16.1.
 
 
-[1]: {{< param github_url >}}/tree/{{< param latest_release_tag_name >}}/examples/contour
+[1]: {{< param github_url >}}/tree/{{< param latest_version >}}/examples/contour
 
 [2]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.1
 [3]: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.2

--- a/site/content/resources/tagging.md
+++ b/site/content/resources/tagging.md
@@ -10,7 +10,7 @@ This document describes Contour's image tagging policy.
 `docker.io/projectcontour/contour:<SemVer>`
 
 Contour follows the [Semantic Versioning][1] standard for releases.
-Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{< param latest_release_tag_name >}}`
+Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{< param latest_version >}}`
 
 ### Latest
 


### PR DESCRIPTION
Follow-up to #3788, replaces some additional instances of
latest_release_tag_name with latest_version.

Updates #3786.

Signed-off-by: Steve Kriss <krisss@vmware.com>