### PR TITLE
Fix label sync, update labels, add new decision issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/decision.md
+++ b/.github/ISSUE_TEMPLATE/decision.md
@@ -1,0 +1,24 @@
+---
+name: Decision
+about: A binding record of a decision
+title: ''
+labels: kind/decision, lifecycle/needs-triage
+assignees: ''
+
+---
+<!--  Thanks for asking for a decision! Here are some tips for you:
+
+1. Decisions should be large ones, that cut across many parts of a repo
+   or the project as a whole. "Should we change Contour's support policy"
+   is an example of a decision that's relevant here, "Should we implement
+   this feature" is an example of a decision that's not.
+   If in doubt, ask in #contour on the Kubernetes Slack.
+2. Contour's maintainers have the binding votes, but non-binding votes are welcomed.
+-->
+
+**What do you want the project to decide?**
+<!-- A clear and concise description of what the decision is. -->
+
+
+**Anything else you would like to add:**
+<!-- Background or other information that will assist people in understanding why we need to decide this. -->

--- a/hack/release/sync-repo-labels.sh
+++ b/hack/release/sync-repo-labels.sh
@@ -7,7 +7,7 @@ readonly REPO=$(cd "${HERE}/../.." && pwd)
 readonly TOKEN=${TOKEN:-}
 
 readonly DOCKER=${DOCKER:-docker}
-readonly LABELS=${LABELS:-${REPO}/site/_data/github-labels.yaml}
+readonly LABELS=${LABELS:-${REPO}/site/data/github-labels.yaml}
 
 set -o errexit
 set -o nounset
@@ -55,5 +55,3 @@ labelsync \
     --skip projectcontour/toc \
     --config "${yaml}" \
     --token "${token}"
-
-# TODO(jpeach): add the -confirm flag to enable changes.

--- a/site/data/github-labels.yaml
+++ b/site/data/github-labels.yaml
@@ -127,6 +127,20 @@ default:
       name: area/operational
       target: both
       addedBy: label
+    - color: 0052cc
+      description: Issues or PRs about making Contour interoperate with service meshes. Contour is not a service mesh.
+      name: area/service-mesh
+      previously:
+        - name: "area/service mesh"
+      target: both
+      addedBy: label
+    - color: 0052cc
+      description: Issues or PRs about Contour's support for sticky sessions.
+      name: area/sticky-session
+      previously:
+        - name: "area/sticky session"
+      target: both
+      addedBy: label
 
 # Blocked.
     - color: "FF7B7B"
@@ -171,6 +185,11 @@ default:
       addedBy: anyone
       previously:
         - name: bug
+    - color: 8cff82
+      description: Categorizes issue as a decision to be voted on.
+      name: kind/decision
+      target: issue
+      addedBy: anyone
     - color: c7def8
       description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
       name: kind/cleanup
@@ -248,6 +267,14 @@ default:
       name: lifecycle/accepted
       target: both
       addedBy: anyone
+
+# Documentation
+    - color: 9F629C
+      description: Indicates that an issue or PR needs attention from a technical writer or a docs update.
+      name: doc-impact
+      target: both
+      addedBy: anyone
+
 
 # Priority.
     - color: fef2c0


### PR DESCRIPTION
I've fixed the permissions issues for the `contour-perf` repo, but there was also a bug from the site move (fixed as well).

Then I've updated the labels with some that had been manually created, and added the new "Decision" issue template.

Signed-off-by: Nick Young <ynick@vmware.com>