### PR TITLE
site: Fixup codespell errors

### DIFF
--- a/.codespell.skip
+++ b/.codespell.skip
@@ -9,3 +9,4 @@
 *.svg
 ./site/themes/contour/static/fonts/README.md
 ./vendor
+./site/public

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -203,7 +203,7 @@ jobs:
       - name: Codespell
         uses: codespell-project/actions-codespell@master
         with:
-          skip: .git,*.png,*.woff,*.woff2,*.eot,*.ttf,*.jpg,*.ico,*.svg,./site/themes/contour/static/fonts/README.md
+          skip: .git,*.png,*.woff,*.woff2,*.eot,*.ttf,*.jpg,*.ico,*.svg,./site/themes/contour/static/fonts/README.md,./vendor,./site/public
           ignore_words_file: './.codespell.ignorewords'
           check_filenames: true
           check_hidden: true

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -393,7 +393,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.10.0/configuration.md
+++ b/site/content/docs/v1.10.0/configuration.md
@@ -188,7 +188,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.10.1/configuration.md
+++ b/site/content/docs/v1.10.1/configuration.md
@@ -188,7 +188,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.11.0/configuration.md
+++ b/site/content/docs/v1.11.0/configuration.md
@@ -188,7 +188,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.12.0/configuration.md
+++ b/site/content/docs/v1.12.0/configuration.md
@@ -189,7 +189,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.13.0/configuration.md
+++ b/site/content/docs/v1.13.0/configuration.md
@@ -345,7 +345,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.13.1/configuration.md
+++ b/site/content/docs/v1.13.1/configuration.md
@@ -345,7 +345,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.14.0/configuration.md
+++ b/site/content/docs/v1.14.0/configuration.md
@@ -404,7 +404,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.14.1/configuration.md
+++ b/site/content/docs/v1.14.1/configuration.md
@@ -403,7 +403,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.15.0/configuration.md
+++ b/site/content/docs/v1.15.0/configuration.md
@@ -404,7 +404,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.15.1/configuration.md
+++ b/site/content/docs/v1.15.1/configuration.md
@@ -391,7 +391,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/docs/v1.16.0/configuration.md
+++ b/site/content/docs/v1.16.0/configuration.md
@@ -393,7 +393,7 @@ the configuration file to match the environment in which Envoy is deployed.
 
 ### Flags
 
-There are flags that can be passed to `contour boostrap` that help configure how Envoy
+There are flags that can be passed to `contour bootstrap` that help configure how Envoy
 connects to Contour:
 
 | Flag | Default  | Description |

--- a/site/content/guides/xds-migration.md
+++ b/site/content/guides/xds-migration.md
@@ -22,7 +22,7 @@ Envoy gets configured with a bootstrap configuration file which Contour provides
 This file configures the dynamic xDS resources, Listener Discovery Service (LDS) and Cluster Discovery Service (CDS), to point to Contour's xDS gRPC server endpoint.
 
 The bootstrap configuration file has two settings in the LDS/CDS entries which tell Contour what Resource & Transport version they would like to use. 
-In Contour v1.10.0, there's a new flag, `--xds-resource-version`, on the `contour boostrap` command which is used in the `initContainer` that allows users to specify the xDS resource version.
+In Contour v1.10.0, there's a new flag, `--xds-resource-version`, on the `contour bootstrap` command which is used in the `initContainer` that allows users to specify the xDS resource version.
 
 Setting this flag to `v3` will configure Envoy to request the `v3` xDS Resource API version and will become the default in Contour v1.11.0.    
 


### PR DESCRIPTION
Found a bunch of codespell errors happening locally which ironically did
not show up in the CI build tests.

```
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: MAPE ==> MAP
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CAcL ==> calc
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACH ==> CATCH, CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACL ==> CALC
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/css/style.css.map:52: CACE ==> CACHE
./site/public/docs/v1.16.0/configuration/index.html:1397: boostrap ==> bootstrap
./site/public/docs/v1.12.0/configuration/index.html:1023: boostrap ==> bootstrap
./site/public/docs/v1.15.0/configuration/index.html:1556: boostrap ==> bootstrap
./site/public/docs/v1.11.0/configuration/index.html:1016: boostrap ==> bootstrap
./site/public/docs/v1.15.1/configuration/index.html:1382: boostrap ==> bootstrap
./site/public/docs/v1.10.1/configuration/index.html:1009: boostrap ==> bootstrap
./site/public/docs/v1.14.0/configuration/index.html:1556: boostrap ==> bootstrap
./site/public/docs/v1.10.0/configuration/index.html:1009: boostrap ==> bootstrap
./site/public/docs/v1.14.1/configuration/index.html:1556: boostrap ==> bootstrap
./site/public/docs/v1.13.1/configuration/index.html:1438: boostrap ==> bootstrap
./site/public/docs/main/configuration/index.html:1397: boostrap ==> bootstrap
./site/public/docs/v1.13.0/configuration/index.html:1438: boostrap ==> bootstrap
./site/public/guides/xds-migration/index.html:74: boostrap ==> bootstrap
./site/public/fonts/README.md:7: millenium ==> millennium

```

Signed-off-by: Steve Sloka <slokas@vmware.com>