### PR TITLE
internal: program 502/503 routes for misconfigured services and includes

### DIFF
--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -580,8 +580,8 @@ func TestDAGStatus(t *testing.T) {
 			}},
 			Routes: []contour_api_v1.Route{{
 				Services: []contour_api_v1.Service{{
-					Name: "green",
-					Port: 80,
+					Name: "kuard",
+					Port: 8080,
 				}},
 			}},
 		},
@@ -1184,11 +1184,10 @@ func TestDAGStatus(t *testing.T) {
 		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
 			{Name: proxyInvalidDuplicateIncludeCondtionHeaders.Name,
 				Namespace: proxyInvalidDuplicateIncludeCondtionHeaders.Namespace}: fixture.NewValidCondition().
-				WithGeneration(proxyInvalidDuplicateIncludeCondtionHeaders.Generation).Valid(),
+				WithGeneration(proxyInvalidDuplicateIncludeCondtionHeaders.Generation).WithError(contour_api_v1.ConditionTypeRouteError, "HeaderMatchConditionsNotValid", "cannot specify duplicate header 'exact match' conditions in the same route"),
 			{Name: proxyValidDelegatedRoots.Name,
 				Namespace: proxyValidDelegatedRoots.Namespace}: fixture.NewValidCondition().
-				WithGeneration(proxyValidDelegatedRoots.Generation).
-				WithError(contour_api_v1.ConditionTypeRouteError, "HeaderMatchConditionsNotValid", "cannot specify duplicate header 'exact match' conditions in the same route"),
+				WithGeneration(proxyValidDelegatedRoots.Generation).Orphaned(),
 		},
 	})
 


### PR DESCRIPTION
This change implements

* Handle specific configuration errors as non-fatal, so that traffic will be served for the valid parts of the HTTPProxy.
* Program 502/503 direct responses for the faulty parts.

See design/httpproxy-conflict.md for more details, but note that this change addresses only missing includes and missing service references, while the design document covers wider concept of misconfigured proxies.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>