### PR TITLE
pkg/config: Mark Gateway.Name & Gateway.Namespace as deprecated

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -764,6 +764,12 @@ func getDAGBuilder(ctx *serveContext, clients *k8s.Clients, clientCert, fallback
 	}
 
 	if ctx.Config.GatewayConfig != nil {
+
+		// Log warning that the Name/Namespace fields in the configuration file are deprecated.
+		if len(ctx.Config.GatewayConfig.Name) > 0 || len(ctx.Config.GatewayConfig.Namespace) > 0 {
+			log.WithField("context", "configurationFile").Warn("Gateway.Name & Gateway.Namespace have been deprecated and will be removed in Contour v1.18. Please use Gateway.ControllerName instead.")
+		}
+
 		builder.Source.ConfiguredGateway = types.NamespacedName{
 			Name:      ctx.Config.GatewayConfig.Name,
 			Namespace: ctx.Config.GatewayConfig.Namespace,

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -295,8 +295,10 @@ type GatewayParameters struct {
 	// If unset, the gatewayclass controller will not be started.
 	ControllerName *string `yaml:"controllerName,omitempty"`
 	// Name is the Gateway name that Contour should reconcile.
+	// Deprecated: Name is deprecated and will be removed in Contour v1.18. Configure "ControllerName" instead.
 	Name string `yaml:"name,omitempty"`
 	// Namespace is the Gateway namespace that Contour should reconcile.
+	// Deprecated: Namespace is deprecated will be removed in Contour v1.18. Configure "ControllerName" instead.
 	Namespace string `yaml:"namespace,omitempty"`
 }
 

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -180,8 +180,11 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | controllerName | string |  | Gateway Class controller name (i.e. projectcontour.io/projectcontour/contour).  |
-| name | string | contour | This field specifies the name of a Gateway.  |
-| namespace | string | projectcontour | This field specifies the namespace of a Gateway.  |
+| name | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
+| namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
+
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration
 

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -180,7 +180,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | controllerName | string |  | Gateway Class controller name (i.e. projectcontour.io/projectcontour/contour).  |
-| name | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
+| name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
 _NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.


### PR DESCRIPTION
The fields in the Gateway configuration, Name & Namespace, are deprecated and will be removed in Contour v1.18.

Updates #3617

Signed-off-by: Steve Sloka <slokas@vmware.com>