### PR TITLE
Add troubleshooting page

### DIFF
--- a/site/content/docs/main/README.md
+++ b/site/content/docs/main/README.md
@@ -14,7 +14,13 @@ RBAC must be enabled on your cluster.
 Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
+## Troubleshooting
+If you encounter issues review the [troubleshooting][5] page, [file an issue][6], or talk to us on the [#contour channel][7] on the Kubernetes slack server.
+
 [1]: https://www.envoyproxy.io/
 [2]: config/fundamentals.md
 [3]: /getting-started
 [4]: /resources/compatibility-matrix.md
+[5]: /docs/main/troubleshooting
+[6]: https://github.com/projectcontour/contour/issues
+[7]: https://kubernetes.slack.com/messages/contour

--- a/site/content/docs/main/README.md
+++ b/site/content/docs/main/README.md
@@ -15,7 +15,7 @@ Getting started with Contour is as simple as one command.
 See the [Getting Started][3] document.
 
 ## Troubleshooting
-If you encounter issues review the [troubleshooting][5] page, [file an issue][6], or talk to us on the [#contour channel][7] on the Kubernetes slack server.
+If you encounter issues review the [troubleshooting][5] page, [file an issue][6], or talk to us on the [#contour channel][7] on Kubernetes slack.
 
 [1]: https://www.envoyproxy.io/
 [2]: config/fundamentals.md

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -1,6 +1,6 @@
 ## Troubleshooting
 
-If you encounter issues, follow the guides below for help. For topics not covered here, you can [file an issue][0], or talk to us on the [#contour channel][1] on the Kubernetes Slack server.
+If you encounter issues, follow the guides below for help. For topics not covered here, you can [file an issue][0], or talk to us on the [#contour channel][1] on Kubernetes Slack.
 
 ### [Envoy Administration Access][2]
 Review the linked steps to learn how to access the administration interface for your Envoy instance.

--- a/site/content/docs/main/troubleshooting.md
+++ b/site/content/docs/main/troubleshooting.md
@@ -1,0 +1,38 @@
+## Troubleshooting
+
+If you encounter issues, follow the guides below for help. For topics not covered here, you can [file an issue][0], or talk to us on the [#contour channel][1] on the Kubernetes Slack server.
+
+### [Envoy Administration Access][2]
+Review the linked steps to learn how to access the administration interface for your Envoy instance.
+
+### [Contour Debug Logging][3]
+Learn how to enable debug logging to diagnose issues between Contour and the Kubernetes API.
+
+### [Envoy Debug Logging][4]
+Learn how to enable debug logging to diagnose TLS connection issues.
+
+### [Visualize the Contour Graph][5]
+Learn how to visualize Contour's internal object graph in [DOT][9] format, or as a png file.
+
+### [Show Contour xDS Resources][6]
+Review the linked steps to view the [xDS][10] resource data exchanged by Contour and Envoy.
+
+### [Profiling Contour][7]
+Learn how to profile Contour by using [net/http/pprof][11] handlers. 
+
+### [Contour Operator][8]
+Follow the linked guide to learn how to troubleshoot issues with [Contour Operator][12].
+
+[0]: {{< param github_url >}}/issues
+[1]: {{< param slack_url >}}
+[2]: /docs/{{< param latest_version >}}/troubleshooting/envoy-admin-interface/
+[3]: /docs/{{< param latest_version >}}/troubleshooting/contour-debug-log/
+[4]: /docs/{{< param latest_version >}}/troubleshooting/envoy-debug-log/
+[5]: /docs/{{< param latest_version >}}/troubleshooting/contour-graph/
+[6]: /docs/{{< param latest_version >}}/troubleshooting/contour-xds-resources/
+[7]: /docs/{{< param latest_version >}}/troubleshooting/profiling-contour/
+[8]: /docs/{{< param latest_version >}}/troubleshooting/operator/
+[9]: https://en.wikipedia.org/wiki/Dot
+[10]: https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+[11]: https://golang.org/pkg/net/http/pprof/
+[12]: https://github.com/projectcontour/contour-operator

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -126,7 +126,7 @@ We've also got [a FAQ][4] for short-answer questions and conceptual stuff that d
 
 ## Troubleshooting
 
-If you encounter issues, review the [troubleshooting][17] page, [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
+If you encounter issues, review the [troubleshooting][17] page, [file an issue][6], or talk to us on the [#contour channel][12] on Kubernetes Slack.
 
 [0]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes
 [1]: /docs/{{< param latest_version >}}/deploy-options

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -126,7 +126,7 @@ We've also got [a FAQ][4] for short-answer questions and conceptual stuff that d
 
 ## Troubleshooting
 
-If you encounter issues, review the Troubleshooting section of [the docs][3], [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
+If you encounter issues, review the [troubleshooting][17] page, [file an issue][6], or talk to us on the [#contour channel][12] on the Kubernetes Slack server.
 
 [0]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes
 [1]: /docs/{{< param latest_version >}}/deploy-options
@@ -142,3 +142,4 @@ If you encounter issues, review the Troubleshooting section of [the docs][3], [f
 [14]: https://github.com/projectcontour/contour-operator/blob/main/README.md
 [15]: https://github.com/bitnami/charts/tree/master/bitnami/contour
 [16]: https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice
+[17]: /docs/main/troubleshooting


### PR DESCRIPTION
site/content/docs: Add troubleshooting page
Created a troubleshooting page and added a troubleshooting section to the main Docs page.

Updates #3816 
Signed-off-by: johnnycase <johneverettcase@gmail.com>
