### PR TITLE
WIP: internal/dag: routes in tcpproxy should result in error

### DIFF
--- a/internal/featuretests/v3/tcpproxy_test.go
+++ b/internal/featuretests/v3/tcpproxy_test.go
@@ -78,6 +78,8 @@ func TestTCPProxy(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			defaultHTTPListener(),
+
 			&envoy_listener_v3.Listener{
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -94,10 +96,14 @@ func TestTCPProxy(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	// check that ingress_http is empty
+	// Check that ingress_http has single route for HTTPS upgrade.
 	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("kuard-tcp.example.com",
+					upgradeHTTPS(routePrefix("/")),
+				),
+			),
 		),
 		TypeUrl: routeType,
 	})
@@ -162,6 +168,8 @@ func TestTCPProxyDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			defaultHTTPListener(),
+
 			&envoy_listener_v3.Listener{
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -178,10 +186,14 @@ func TestTCPProxyDelegation(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	// check that ingress_http is empty
+	// Check that ingress_http has single route for HTTPS upgrade.
 	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("kuard-tcp.example.com",
+					upgradeHTTPS(routePrefix("/")),
+				),
+			),
 		),
 		TypeUrl: routeType,
 	})
@@ -230,6 +242,8 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			defaultHTTPListener(),
+
 			&envoy_listener_v3.Listener{
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -251,10 +265,14 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	// check that ingress_http is empty
+	// Check that ingress_http has single route for HTTPS upgrade.
 	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("kuard-tcp.example.com",
+					upgradeHTTPS(routePrefix("/")),
+				),
+			),
 		),
 		TypeUrl: routeType,
 	})
@@ -307,6 +325,8 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
+			defaultHTTPListener(),
+
 			&envoy_listener_v3.Listener{
 				Name:    "ingress_https",
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
@@ -334,10 +354,14 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 
-	// check that ingress_http is empty
+	// Check that ingress_http has single route for HTTPS upgrade.
 	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("k8s.run.ubisoft.org",
+					upgradeHTTPS(routePrefix("/")),
+				),
+			),
 		),
 		TypeUrl: routeType,
 	})


### PR DESCRIPTION
`HTTPProxy` spec says *"If TCPProxy is present, Routes is ignored"* but this has not been true.  Routes are processed and HTTPS upgrade is added for given routes in HTTP listener (and only HTTP listener).  In this case request for such route will get `301 Moved Permanently` response.

If routes field does not exist, then HTTP listener may be left unconfigured unless it is configured due to some other `HTTPProxy`.  User will get either connection refused or `404 Not Found` if connecting to insecure port and making request to virtualhost with `Spec.TCPProxy`.

The current behavior also has meant that user has needed to define routes (against documented behavior) if they need HTTPS upgrade for their tcpproxy.

This change is the first phase aiming to conform with the document.

This change will:

* Raise error condition if `Spec.Routes` are given (but continue processing them)
* Raise error condition if `Spec.Includes` are given (but continue processing them)
* Ensure that there will be also HTTP listener for the tcpproxy with a catch-all route `/` that will unconditionally trigger the HTTPS upgrade.

The last bullet implies that all tcpproxies will get `301 Moved Permanently` in the insecure listener. This may be undesirable if tcpproxy is handling some other protocol on top of TLS than HTTP, or even for HTTP use case if user wants to avoid the surface area of an insecure listener in Envoy.

Updates #3800

Signed-off-by: Tero Saarni <tero.saarni@est.tech>