### PR TITLE
internal/dag: Add tests for Gateway status

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -58,7 +58,7 @@ type matchConditions struct {
 // Run translates Service APIs into DAG objects and
 // adds them to the DAG.
 func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
-	var errs field.ErrorList
+	var gatewayErrors field.ErrorList
 	path := field.NewPath("spec")
 
 	p.dag = dag
@@ -81,7 +81,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 	}
 
 	if len(p.source.gateway.Spec.Addresses) > 0 {
-		errs = append(errs, &field.Error{Type: field.ErrorTypeNotSupported, Field: path.String(), BadValue: p.source.gateway.Spec.Addresses, Detail: "Spec.Addresses is not supported"})
+		gatewayErrors = append(gatewayErrors, &field.Error{Type: field.ErrorTypeNotSupported, Field: path.String(), BadValue: p.source.gateway.Spec.Addresses, Detail: "Spec.Addresses is not supported"})
 	}
 
 	for _, listener := range p.source.gateway.Spec.Listeners {
@@ -239,7 +239,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			}
 		}
 
-		validGateway := len(errs) == 0
+		validGateway := len(gatewayErrors) == 0
 
 		// Process all the HTTPRoutes that match this Gateway.
 		for _, matchingRoute := range matchingHTTPRoutes {
@@ -252,7 +252,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		}
 	}
 
-	p.computeGateway(p.source.gateway, errs)
+	p.computeGateway(p.source.gateway, gatewayErrors)
 }
 
 func (p *GatewayAPIProcessor) validGatewayTLS(listener gatewayapi_v1alpha1.Listener) *Secret {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -81,8 +81,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 	}
 
 	if len(p.source.gateway.Spec.Addresses) > 0 {
-		p.Error("Spec.Addresses is unsupported")
-		errs = append(errs, field.NotSupported(path, p.source.gateway.Spec.Addresses, []string{}))
+		errs = append(errs, &field.Error{Type: field.ErrorTypeNotSupported, Field: path.String(), BadValue: p.source.gateway.Spec.Addresses, Detail: "Spec.Addresses is not supported"})
 	}
 
 	for _, listener := range p.source.gateway.Spec.Listeners {

--- a/internal/status/gatewayconditions.go
+++ b/internal/status/gatewayconditions.go
@@ -28,6 +28,8 @@ type GatewayReasonType string
 const ReasonValidGateway = "Valid"
 const ReasonInvalidGateway = "Invalid"
 
+const MessageValidGateway = "Valid Gateway"
+
 type GatewayConditionsUpdate struct {
 	FullName           types.NamespacedName
 	Conditions         map[gatewayapi_v1alpha1.GatewayConditionType]metav1.Condition


### PR DESCRIPTION
Adds tests for the Gatewaay status that results from a DAG build.

Fixes #3867

Signed-off-by: Steve Sloka <slokas@vmware.com>