### PR TITLE
hack: Change ginkgo install var to use CI

### DIFF
--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -10,6 +10,10 @@ readonly KIND_VERS="v0.11.1"
 readonly SONOBUOY_VERS="0.19.0"
 readonly KUBEBUILDER_VERS="3.1.0"
 
+# The CI env variable is set by Github Actions when running jobs.
+# This is used to know how to configure specific GithubAction jobs.
+readonly CI="false"
+
 # Envtest Binaries Manager is required for newer versions. See the following for details:
 # https://github.com/projectcontour/contour/issues/3832
 readonly KUBEBUILDER_TOOLS_VERS="1.19.2"
@@ -50,7 +54,7 @@ esac
 echo "Installing Kubernetes toolchain..."
 
 # Install ginkgo CLI
-if [[ ${OS} == "linux" ]]; then
+if [[ ${CI} == "true" ]]; then
   go get github.com/onsi/ginkgo/...
   mv /home/runner/go/bin/ginkgo ${DESTDIR}/ginkgo
 fi

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -54,7 +54,7 @@ esac
 echo "Installing Kubernetes toolchain..."
 
 # Install ginkgo CLI
-if [[ ${CI} == "true" ]]; then
+if [[ ${GITHUB_ACTIONS} == "true" ]]; then
   go get github.com/onsi/ginkgo/...
   mv /home/runner/go/bin/ginkgo ${DESTDIR}/ginkgo
 fi

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -10,10 +10,6 @@ readonly KIND_VERS="v0.11.1"
 readonly SONOBUOY_VERS="0.19.0"
 readonly KUBEBUILDER_VERS="3.1.0"
 
-# The CI env variable is set by Github Actions when running jobs.
-# This is used to know how to configure specific GithubAction jobs.
-readonly CI="false"
-
 # Envtest Binaries Manager is required for newer versions. See the following for details:
 # https://github.com/projectcontour/contour/issues/3832
 readonly KUBEBUILDER_TOOLS_VERS="1.19.2"
@@ -54,7 +50,7 @@ esac
 echo "Installing Kubernetes toolchain..."
 
 # Install ginkgo CLI
-if [[ ${GITHUB_ACTIONS} == "true" ]]; then
+if [[ ${GITHUB_ACTIONS} == "true" && ${OS} == "linux" ]]; then
   go get github.com/onsi/ginkgo/...
   mv /home/runner/go/bin/ginkgo ${DESTDIR}/ginkgo
 fi


### PR DESCRIPTION
The install-kubernetes-toolchain.sh installs a few dependencies in order to
build, test, and lint Contour code. The env var to install gingkgo was using
OSType=Linux which breaks on a local linux machine.

This changes that variable to use "CI" which is setup by Github Actions to let the
script know if it's running in Github Actions or not.

Signed-off-by: Steve Sloka <slokas@vmware.com>