### PR TITLE
internal/validation: allow GatewayClass.Spec.ParametersRef to be specified

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -92,6 +92,7 @@ var _ = AfterSuite(func() {
 
 // isAdmitted returns true if gc status is "Admitted=true".
 func isGatewayClassAdmitted(gc *gatewayv1alpha1.GatewayClass) bool {
+
 	for _, c := range gc.Status.Conditions {
 		if c.Type == string(gatewayv1alpha1.GatewayClassConditionStatusAdmitted) &&
 			c.Status == metav1.ConditionTrue {

--- a/internal/validation/gatewayclass.go
+++ b/internal/validation/gatewayclass.go
@@ -73,9 +73,5 @@ func validateGatewayClassSpec(ctx context.Context, cli client.Client, gc *gatewa
 		}
 	}
 
-	ref := gc.Spec.ParametersRef
-	if ref != nil {
-		errs = append(errs, field.NotSupported(path.Child("parametersRef"), ref, []string{"nil"}))
-	}
 	return errs
 }

--- a/internal/validation/gatewayclass_test.go
+++ b/internal/validation/gatewayclass_test.go
@@ -115,18 +115,22 @@ func TestGatewayClass(t *testing.T) {
 			},
 			expect: true,
 		},
-		"invalid gatewayclass params": {
+		"gatewayclass paramsRef specified": {
 			mutateNew: func(gc *gatewayapi_v1alpha1.GatewayClass) {
-				gc.Name = "invalid-gatewayclass-params"
+				gc.Name = "gatewayclass-params-specified"
 				gc.Spec.ParametersRef = &gatewayapi_v1alpha1.ParametersReference{
 					Group: "foo",
 					Kind:  "bar",
 					Name:  "baz",
 				}
 			},
-			errType:  field.ErrorTypeNotSupported,
-			errField: "spec.parametersRef",
-			expect:   false,
+			expect: true,
+		},
+		"gatewayclass paramsRef not specified": {
+			mutateNew: func(gc *gatewayapi_v1alpha1.GatewayClass) {
+				gc.Name = "gatewayclass-params-not-specified"
+			},
+			expect: true,
 		},
 	}
 


### PR DESCRIPTION
The field parametersRef on a GatewayClass should be able to be defined.

Fixes #3874

Signed-off-by: Steve Sloka <slokas@vmware.com>