### PR TITLE
test/e2e: increase timeout for Contour process exiting

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -508,6 +508,8 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, additionalArgs
 }
 
 func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile string) error {
-	contourCmd.Terminate().Wait()
+	// Default timeout of 1s produces test flakes,
+	// a minute should be more than enough to avoid them.
+	contourCmd.Terminate().Wait(time.Minute)
 	return os.RemoveAll(configFile)
 }


### PR DESCRIPTION
Increases the timeout for waiting for the Contour process
to exit from 1s (default) to 1m, to avoid test flakes.

Updates #3892.

Signed-off-by: Steve Kriss <krisss@vmware.com>