### PR TITLE
fixes build_main job with invalid syntax

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -28,9 +28,9 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         make multiarch-build
         docker logout
-     - uses: act10ns/slack@v1
-       with:
-         status: ${{ job.status }}
-         steps: ${{ toJson(steps) }}
-         channel: '#contour-ci-notifications'
+   - uses: act10ns/slack@v1
+     with:
+       status: ${{ job.status }}
+       steps: ${{ toJson(steps) }}
+       channel: '#contour-ci-notifications'
        if: failure()


### PR DESCRIPTION
The main build was broken with bad syntax after adding the Slack notifications. 

![image](https://user-images.githubusercontent.com/1048184/125966180-38e236f4-73c3-49ff-b159-ca74f454098e.png)

Signed-off-by: Steve Sloka <slokas@vmware.com>