### PR TITLE
E2E tests: performance improvements

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -33,7 +33,9 @@ jobs:
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
   e2e:
     runs-on: ubuntu-latest
-    needs: [build-image]
+    # TODO uncomment the below once we're using the image
+    # or its binary for testing.
+    # needs: [build-image]
     strategy:
       matrix:
         # use stable kubernetes_version values since they're included
@@ -52,11 +54,13 @@ jobs:
             node_image: "docker.io/kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"
     steps:
       - uses: actions/checkout@v2
-      - name: Download image
-        uses: actions/download-artifact@v2
-        with:
-          name: image
-          path: image
+      # TODO uncomment the below once we're using the image
+      # or its binary for testing.
+      # - name: Download image
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: image
+      #     path: image
       - uses: actions/cache@v2
         with:
           # * Module download cache

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -43,7 +43,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	f.DeleteNamespace(f.Deployment.Namespace.Name, true)
+	// Delete resources individually instead of deleting the entire contour
+	// namespace as a performance optimization, because deleting non-empty
+	// namespaces can take up to a couple minutes to complete.
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
 	gexec.CleanupBuildArtifacts()
 })
 

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -44,7 +44,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	f.DeleteNamespace(f.Deployment.Namespace.Name, true)
+	// Delete resources individually instead of deleting the entire contour
+	// namespace as a performance optimization, because deleting non-empty
+	// namespaces can take up to a couple minutes to complete.
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
 	gexec.CleanupBuildArtifacts()
 })
 

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -43,7 +43,10 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	f.DeleteNamespace(f.Deployment.Namespace.Name, true)
+	// Delete resources individually instead of deleting the entire contour
+	// namespace as a performance optimization, because deleting non-empty
+	// namespaces can take up to a couple minutes to complete.
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
 	gexec.CleanupBuildArtifacts()
 })
 


### PR DESCRIPTION
Replaces projectcontour namespace deletion with per-resource
deletion after each E2E suite runs, to speed up the cleanup
phase. Also removes the dependency between build-image and
running the E2E's in the GitHub Actions workflow since the
image is not currently being used by the E2E's.

Signed-off-by: Steve Kriss <krisss@vmware.com>