### PR TITLE
hack/release: include contour-gateway.yaml in release commit

### DIFF
--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -62,7 +62,8 @@ if git status -s examples/contour 2>&1 | grep -E -q '^\s+[MADRCU]'; then
         examples/contour/03-contour.yaml \
         examples/contour/03-envoy.yaml \
         examples/contour/02-job-certgen.yaml \
-        examples/render/contour.yaml
+        examples/render/contour.yaml \
+        examples/render/contour-gateway.yaml
 fi
 
 git tag -F - "$NEWVERS" <<EOF


### PR DESCRIPTION
When generating a release tag, includes contour-gateway.yaml
in the commit.

Signed-off-by: Steve Kriss <krisss@vmware.com>