### PR TITLE
test/e2e: change Gateways to RouteSelectSame

### DIFF
--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Gateway API", func() {
 							Routes: gatewayv1alpha1.RouteBindingSelector{
 								Kind: "HTTPRoute",
 								Namespaces: &gatewayv1alpha1.RouteNamespaces{
-									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectSame),
 								},
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"app": "filter"},
@@ -178,7 +178,7 @@ var _ = Describe("Gateway API", func() {
 							Routes: gatewayv1alpha1.RouteBindingSelector{
 								Kind: "HTTPRoute",
 								Namespaces: &gatewayv1alpha1.RouteNamespaces{
-									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectSame),
 								},
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"type": "insecure"},
@@ -198,7 +198,7 @@ var _ = Describe("Gateway API", func() {
 							Routes: gatewayv1alpha1.RouteBindingSelector{
 								Kind: "HTTPRoute",
 								Namespaces: &gatewayv1alpha1.RouteNamespaces{
-									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectSame),
 								},
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"type": "secure"},
@@ -224,32 +224,6 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-httproute-tls-wildcard-host", testWithHTTPSGateway("*.wildcardhost.gateway.projectcontour.io", testTLSWildcardHost))
 	})
 
-	Describe("TLSRoute: Gateway", func() {
-		gatewayClass := getGatewayClass()
-		gw := &gatewayv1alpha1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "tls",
-			},
-			Spec: gatewayv1alpha1.GatewaySpec{
-				GatewayClassName: gatewayClass.Name,
-				Listeners: []gatewayv1alpha1.Listener{{
-					Protocol: gatewayv1alpha1.TLSProtocolType,
-					TLS: &gatewayv1alpha1.GatewayTLSConfig{
-						Mode: tlsModeTypePtr(gatewayv1alpha1.TLSModePassthrough),
-					},
-					Port: gatewayv1alpha1.PortNumber(443),
-					Routes: gatewayv1alpha1.RouteBindingSelector{
-						Kind: "TLSRoute",
-						Namespaces: &gatewayv1alpha1.RouteNamespaces{
-							From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
-						},
-					},
-				}},
-			},
-		}
-		f.NamespacedTest("gateway-tlsroute", testWithGateway(gw, gatewayClass, testTLSRoutePassthrough))
-	})
-
 	Describe("TLSRoute Gateway: Mode: Passthrough", func() {
 		gatewayClass := getGatewayClass()
 		gw := &gatewayv1alpha1.Gateway{
@@ -268,7 +242,7 @@ var _ = Describe("Gateway API", func() {
 						Routes: gatewayv1alpha1.RouteBindingSelector{
 							Kind: "TLSRoute",
 							Namespaces: &gatewayv1alpha1.RouteNamespaces{
-								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+								From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectSame),
 							},
 						},
 					},
@@ -280,10 +254,11 @@ var _ = Describe("Gateway API", func() {
 
 	Describe("TLSRoute Gateway: Mode: Terminate", func() {
 
-		testWithTLSGateway := func(hostname string, gatewayClass *gatewayv1alpha1.GatewayClass, body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
+		testWithTLSGateway := func(hostname string, body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
+			gatewayClass := getGatewayClass()
 			gw := &gatewayv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "tls-passthrough",
+					Name: "tls-terminate",
 				},
 				Spec: gatewayv1alpha1.GatewaySpec{
 					GatewayClassName: gatewayClass.Name,
@@ -302,7 +277,7 @@ var _ = Describe("Gateway API", func() {
 							Routes: gatewayv1alpha1.RouteBindingSelector{
 								Kind: "TLSRoute",
 								Namespaces: &gatewayv1alpha1.RouteNamespaces{
-									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectAll),
+									From: routeSelectTypePtr(gatewayv1alpha1.RouteSelectSame),
 								},
 							},
 						},
@@ -320,9 +295,7 @@ var _ = Describe("Gateway API", func() {
 			})
 		}
 
-		gatewayClass := getGatewayClass()
-
-		f.NamespacedTest("gateway-tlsroute-mode-terminate", testWithTLSGateway("tlsroute.gatewayapi.projectcontour.io", gatewayClass, testTLSRouteTerminate))
+		f.NamespacedTest("gateway-tlsroute-mode-terminate", testWithTLSGateway("tlsroute.gatewayapi.projectcontour.io", testTLSRouteTerminate))
 	})
 })
 


### PR DESCRIPTION
Changes Gateways to use RouteSelectSame to only select
routes in the same namespace as the Gateway, to avoid
inadvertent test pollution across namespaces.

Also removes a duplicate test.

(Hopefully) closes #3892.

Signed-off-by: Steve Kriss <krisss@vmware.com>