### PR TITLE
Update ExternalName Service documentation after security advisory

### DIFF
--- a/site/content/docs/main/config/client-authorization.md
+++ b/site/content/docs/main/config/client-authorization.md
@@ -65,24 +65,6 @@ The `.spec.validation` field should specify the expected server name
 from the authorization server's TLS certificate, and the trusted CA bundle
 that can be used to validate the TLS chain of trust.
 
-### Side-car Authorization Server
-
-Instead of running the authorization server as a separate set of Pods it can
-also be run as a side-car alongside each Envoy Pod, accessed over localhost.
-To achieve this, create a Service of type ExternalName that resolves to the
-localhost IP - for example:
-```
-kind: Service
-apiVersion: v1
-metadata:
-  name: localhost
-spec:
-  type: ExternalName
-  externalName: localhost
-selector: {}
-```
-and set the `.spec.services[].name` field to the name of the Service.
-
 ## Authorizing Virtual Hosts
 
 The [.spec.virtualhost.authorization][5] field in the Contour `HTTPProxy`

--- a/site/content/docs/main/config/external-service-routing.md
+++ b/site/content/docs/main/config/external-service-routing.md
@@ -1,7 +1,21 @@
 # External Service Routing
 
-HTTPProxy supports routing traffic to `ExternalName` service types.
+HTTPProxy supports routing traffic to `ExternalName` service types, but this is disabled by default, as it can lead
+to inadvertent exposure of the Envoy Admin UI, allowing remote shutdown and restart of Envoy.
+Please see [this security advisory](https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc) for all the details.
+It can also be used to expose services in namespaces a user does not have access to, using an ExternalName of `service.namespace.svc.cluster.local`.
+Please see [this Kubernetes security advisory](https://github.com/kubernetes/kubernetes/issues/103675) for more details.
+
+We do *not* recommend enabling ExternalName Services without a strong use case, and understanding of the security implications.
+
+However, To enable ExternalName processing, you must set the `enableExternalNameService` configuration file setting to `true`.
+This will allow the following configuration to be valid.
+
+## ExternalName Support
+
 Contour looks at the `spec.externalName` field of the service and configures the route to use that DNS name instead of utilizing EDS.
+
+Note that hostnames of `localhost` or some other synonyms will be rejected (because of the aforementioned security issues).
 
 There's nothing specific in the HTTPProxy object that needs to be configured other than referencing a service of type `ExternalName`.
 HTTPProxy supports the `requestHeadersPolicy` field to rewrite the `Host` header after first handling a request and before proxying to an upstream service.


### PR DESCRIPTION
Fixes #3918.

Signed-off-by: Nick Young <ynick@vmware.com>