### PR TITLE
internal/envoy: fix TCPProxy weights bug

### DIFF
--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -1339,6 +1339,7 @@ func TestTCPProxy(t *testing.T) {
 		accessLogPath = "/dev/stdout"
 	)
 
+	// c1 has no weight
 	c1 := &dag.Cluster{
 		Upstream: &dag.Service{
 			Weighted: dag.WeightedService{
@@ -1353,6 +1354,7 @@ func TestTCPProxy(t *testing.T) {
 			},
 		},
 	}
+	// c2 has a non-zero weight
 	c2 := &dag.Cluster{
 		Upstream: &dag.Service{
 			Weighted: dag.WeightedService{
@@ -1366,6 +1368,36 @@ func TestTCPProxy(t *testing.T) {
 			},
 		},
 		Weight: 20,
+	}
+	// c3 has a non-zero weight
+	c3 := &dag.Cluster{
+		Upstream: &dag.Service{
+			Weighted: dag.WeightedService{
+				ServiceName:      "example3",
+				ServiceNamespace: "default",
+				ServicePort: v1.ServicePort{
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
+			},
+		},
+		Weight: 40,
+	}
+	// c4 has no weight
+	c4 := &dag.Cluster{
+		Upstream: &dag.Service{
+			Weighted: dag.WeightedService{
+				Weight:           1,
+				ServiceName:      "example4",
+				ServiceNamespace: "default",
+				ServicePort: v1.ServicePort{
+					Protocol:   "TCP",
+					Port:       443,
+					TargetPort: intstr.FromInt(8443),
+				},
+			},
+		},
 	}
 
 	tests := map[string]struct {
@@ -1390,7 +1422,7 @@ func TestTCPProxy(t *testing.T) {
 				},
 			},
 		},
-		"multiple cluster": {
+		"multiple clusters, one has no weight specified": {
 			proxy: &dag.TCPProxy{
 				Clusters: []*dag.Cluster{c2, c1},
 			},
@@ -1403,10 +1435,62 @@ func TestTCPProxy(t *testing.T) {
 							WeightedClusters: &envoy_tcp_proxy_v3.TcpProxy_WeightedCluster{
 								Clusters: []*envoy_tcp_proxy_v3.TcpProxy_WeightedCluster_ClusterWeight{{
 									Name:   envoy.Clustername(c1),
-									Weight: 1,
+									Weight: 0,
 								}, {
 									Name:   envoy.Clustername(c2),
 									Weight: 20,
+								}},
+							},
+						},
+						AccessLog:   FileAccessLogEnvoy(accessLogPath, "", nil),
+						IdleTimeout: protobuf.Duration(9001 * time.Second),
+					}),
+				},
+			},
+		},
+		"multiple clusters, all have weights specified": {
+			proxy: &dag.TCPProxy{
+				Clusters: []*dag.Cluster{c2, c3},
+			},
+			want: &envoy_listener_v3.Filter{
+				Name: wellknown.TCPProxy,
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_tcp_proxy_v3.TcpProxy{
+						StatPrefix: statPrefix,
+						ClusterSpecifier: &envoy_tcp_proxy_v3.TcpProxy_WeightedClusters{
+							WeightedClusters: &envoy_tcp_proxy_v3.TcpProxy_WeightedCluster{
+								Clusters: []*envoy_tcp_proxy_v3.TcpProxy_WeightedCluster_ClusterWeight{{
+									Name:   envoy.Clustername(c2),
+									Weight: 20,
+								}, {
+									Name:   envoy.Clustername(c3),
+									Weight: 40,
+								}},
+							},
+						},
+						AccessLog:   FileAccessLogEnvoy(accessLogPath, "", nil),
+						IdleTimeout: protobuf.Duration(9001 * time.Second),
+					}),
+				},
+			},
+		},
+		"multiple clusters, none have weights specified": {
+			proxy: &dag.TCPProxy{
+				Clusters: []*dag.Cluster{c1, c4},
+			},
+			want: &envoy_listener_v3.Filter{
+				Name: wellknown.TCPProxy,
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_tcp_proxy_v3.TcpProxy{
+						StatPrefix: statPrefix,
+						ClusterSpecifier: &envoy_tcp_proxy_v3.TcpProxy_WeightedClusters{
+							WeightedClusters: &envoy_tcp_proxy_v3.TcpProxy_WeightedCluster{
+								Clusters: []*envoy_tcp_proxy_v3.TcpProxy_WeightedCluster_ClusterWeight{{
+									Name:   envoy.Clustername(c1),
+									Weight: 1,
+								}, {
+									Name:   envoy.Clustername(c4),
+									Weight: 1,
 								}},
 							},
 						},


### PR DESCRIPTION
Fixes a bug where when a TCPProxy had more than one
service defined, any service with a zero weight was
updated to have a weight of 1. The correct behavior
is that if all service have no weights, then they
should be evenly weighted, but if some have non-zero
weights and others have zero weights, they stay as-is.

Signed-off-by: Steve Kriss <krisss@vmware.com>