### PR TITLE
use unix socket for Envoy admin webpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ e2e: | setup-kind-cluster run-e2e cleanup-kind ## Run E2E tests against a real k
 .PHONY: run-e2e
 run-e2e:
 	CONTOUR_E2E_LOCAL_HOST=$(CONTOUR_E2E_LOCAL_HOST) \
-		ginkgo -tags=e2e -mod=readonly -skipPackage=upgrade -keepGoing -randomizeSuites -randomizeAllSpecs -slowSpecThreshold=15 -r -v ./test/e2e
+		ginkgo -tags=e2e -mod=readonly -skipPackage=upgrade -keepGoing -randomizeSuites -randomizeAllSpecs -slowSpecThreshold=15 -r -v ./test/e2e/infra
 
 .PHONY: cleanup-kind
 cleanup-kind:

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ e2e: | setup-kind-cluster run-e2e cleanup-kind ## Run E2E tests against a real k
 .PHONY: run-e2e
 run-e2e:
 	CONTOUR_E2E_LOCAL_HOST=$(CONTOUR_E2E_LOCAL_HOST) \
-		ginkgo -tags=e2e -mod=readonly -skipPackage=upgrade -keepGoing -randomizeSuites -randomizeAllSpecs -slowSpecThreshold=15 -r -v ./test/e2e/infra
+		ginkgo -tags=e2e -mod=readonly -skipPackage=upgrade -keepGoing -randomizeSuites -randomizeAllSpecs -slowSpecThreshold=15 -r -v ./test/e2e
 
 .PHONY: cleanup-kind
 cleanup-kind:

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -26,7 +26,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
 	bootstrap.Arg("path", "Configuration file ('-' for standard output).").Required().StringVar(&config.Path)
 	bootstrap.Flag("resources-dir", "Directory where configuration files will be written to.").StringVar(&config.ResourcesDir)
-	bootstrap.Flag("admin-address", "Envoy admin interface address.").StringVar(&config.AdminAddress)
+	bootstrap.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&config.AdminAddress)
 	bootstrap.Flag("admin-port", "Envoy admin interface port.").IntVar(&config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address.").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port.").IntVar(&config.XDSGRPCPort)

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -27,7 +27,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Arg("path", "Configuration file ('-' for standard output).").Required().StringVar(&config.Path)
 	bootstrap.Flag("resources-dir", "Directory where configuration files will be written to.").StringVar(&config.ResourcesDir)
 	bootstrap.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&config.AdminAddress)
-	bootstrap.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").Hidden().IntVar(&config.AdminPort)
+	bootstrap.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").IntVar(&config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address.").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port.").IntVar(&config.XDSGRPCPort)
 	bootstrap.Flag("envoy-cafile", "CA Filename for Envoy secure xDS gRPC communication.").Envar("ENVOY_CAFILE").StringVar(&config.GrpcCABundle)

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -27,7 +27,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Arg("path", "Configuration file ('-' for standard output).").Required().StringVar(&config.Path)
 	bootstrap.Flag("resources-dir", "Directory where configuration files will be written to.").StringVar(&config.ResourcesDir)
 	bootstrap.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&config.AdminAddress)
-	bootstrap.Flag("admin-port", "Envoy admin interface port.").IntVar(&config.AdminPort)
+	bootstrap.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").Hidden().IntVar(&config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address.").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port.").IntVar(&config.XDSGRPCPort)
 	bootstrap.Flag("envoy-cafile", "CA Filename for Envoy secure xDS gRPC communication.").Envar("ENVOY_CAFILE").StringVar(&config.GrpcCABundle)

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -26,7 +26,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap := app.Command("bootstrap", "Generate bootstrap configuration.")
 	bootstrap.Arg("path", "Configuration file ('-' for standard output).").Required().StringVar(&config.Path)
 	bootstrap.Flag("resources-dir", "Directory where configuration files will be written to.").StringVar(&config.ResourcesDir)
-	bootstrap.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&config.AdminAddress)
+	bootstrap.Flag("admin-address", "Path to Envoy admin unix domain socket.").Default("/admin/admin.sock").StringVar(&config.AdminAddress)
 	bootstrap.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").IntVar(&config.AdminPort)
 	bootstrap.Flag("xds-address", "xDS gRPC API address.").StringVar(&config.XDSAddress)
 	bootstrap.Flag("xds-port", "xDS gRPC API port.").IntVar(&config.XDSGRPCPort)

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -18,6 +18,7 @@ import (
 
 	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/projectcontour/contour/internal/build"
+	"github.com/projectcontour/contour/internal/envoy"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -70,9 +71,11 @@ func main() {
 	case sdmShutdown.FullCommand():
 		sdmShutdownCtx.shutdownHandler()
 	case bootstrap.FullCommand():
-		err := bootstrapCtx.XDSResourceVersion.Validate()
-		if err != nil {
+		if err := bootstrapCtx.XDSResourceVersion.Validate(); err != nil {
 			log.WithError(err).Fatal("failed to parse bootstrap args")
+		}
+		if err := envoy.ValidAdminAddress(bootstrapCtx.AdminAddress); err != nil {
+			log.WithField("flag", "--admin-address").WithError(err).Fatal("failed to parse bootstrap args")
 		}
 		if err := envoy_v3.WriteBootstrap(bootstrapCtx); err != nil {
 			log.WithError(err).Fatal("failed to write bootstrap configuration")

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -354,7 +354,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		// The enableDebugListener boolean is defaulted to true which matches Contour's current behavior.
 		// Future iterations can allow for this to be customized by the user if they desire to disable the
 		// Envoy admin interface entirely.
-		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, ctx.Config.Network.EnvoyAdminPort, true),
+		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, ctx.Config.Network.EnvoyAdminPort),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -351,9 +351,6 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	endpointHandler := xdscache_v3.NewEndpointsTranslator(log.WithField("context", "endpointstranslator"))
 
 	resources := []xdscache.ResourceCache{
-		// The enableDebugListener boolean is defaulted to true which matches Contour's current behavior.
-		// Future iterations can allow for this to be customized by the user if they desire to disable the
-		// Envoy admin interface entirely.
 		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, ctx.Config.Network.EnvoyAdminPort),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -351,7 +351,10 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	endpointHandler := xdscache_v3.NewEndpointsTranslator(log.WithField("context", "endpointstranslator"))
 
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort),
+		// The enableDebugListener boolean is defaulted to true which matches Contour's current behavior.
+		// Future iterations can allow for this to be customized by the user if they desire to disable the
+		// Envoy admin interface entirely.
+		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, true),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -354,7 +354,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		// The enableDebugListener boolean is defaulted to true which matches Contour's current behavior.
 		// Future iterations can allow for this to be customized by the user if they desire to disable the
 		// Envoy admin interface entirely.
-		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, true),
+		xdscache_v3.NewListenerCache(listenerConfig, ctx.statsAddr, ctx.statsPort, ctx.Config.Network.EnvoyAdminPort, true),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -308,7 +308,7 @@ func registerShutdown(cmd *kingpin.CmdClause, log logrus.FieldLogger) (*kingpin.
 	ctx.FieldLogger = log.WithField("context", "shutdown")
 
 	shutdown := cmd.Command("shutdown", "Initiate an shutdown sequence which configures Envoy to begin draining connections.")
-	shutdown.Flag("admin-port", "Envoy admin interface port.").IntVar(&ctx.adminPort)
+	shutdown.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").IntVar(&ctx.adminPort)
 	shutdown.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&ctx.adminAddress)
 	shutdown.Flag("check-interval", "Time to poll Envoy for open connections.").DurationVar(&ctx.checkInterval)
 	shutdown.Flag("check-delay", "Time to wait before polling Envoy for open connections.").Default("60s").DurationVar(&ctx.checkDelay)

--- a/cmd/contour/shutdownmanager_test.go
+++ b/cmd/contour/shutdownmanager_test.go
@@ -62,13 +62,6 @@ func TestShutdownManager_HealthzHandler(t *testing.T) {
 	}
 }
 
-func TestShutdownManager_NewShutDownContextCheckDefaultAdminPort(t *testing.T) {
-	shutdownContext := newShutdownContext()
-	if (*shutdownContext).adminPort != 9001 {
-		t.Errorf("TestShutdownManager_NewShutDownContextWithoutAdminPort failed: expected shutdown port %d, got %d", 9001, (*shutdownContext).adminPort)
-	}
-}
-
 func TestShutdownManager_ShutdownReadyHandler_Success(t *testing.T) {
 	// Create a request to pass to our handler
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -114,6 +114,8 @@ data:
     #   Configure the number of additional ingress proxy hops from the
     #   right side of the x-forwarded-for HTTP header to trust.
     #   num-trusted-hops: 0
+    #   Configure the port used to access the Envoy Admin interface.
+    #   admin-port: 9001
     #
     # Configure an optional global rate limit service.
     # rateLimitService:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -45,6 +45,9 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 10
         name: shutdown-manager
+        volumeMounts:
+          - name: envoy-admin
+            mountPath: /admin
       - args:
         - -c
         - /config/envoy.json
@@ -89,6 +92,8 @@ spec:
           - name: envoycert
             mountPath: /certs
             readOnly: true
+          - name: envoy-admin
+            mountPath: /admin
         lifecycle:
           preStop:
             httpGet:
@@ -117,6 +122,8 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
+        - name: envoy-admin
+          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:
@@ -126,6 +133,8 @@ spec:
       serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
+        - name: envoy-admin
+          emptyDir: {}
         - name: envoy-config
           emptyDir: {}
         - name: envoycert

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -104,16 +104,17 @@ spec:
       - args:
         - bootstrap
         - /config/envoy.json
-        - --xds-address=contour
+        - --xds-address=10.52.131.186
         - --xds-port=8001
         - --xds-resource-version=v3
         - --resources-dir=/config/resources
-        - --envoy-cafile=/certs/ca.crt
-        - --envoy-cert-file=/certs/tls.crt
-        - --envoy-key-file=/certs/tls.key
+#        - --envoy-cafile=/certs/ca.crt
+#        - --envoy-cert-file=/certs/tls.crt
+#        - --envoy-key-file=/certs/tls.key
+        - --admin-address=/admin/admin.sock
         command:
         - contour
-        image: docker.io/projectcontour/contour:main
+        image: stevesloka/contour:socket
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:
@@ -122,8 +123,6 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
-        - name: envoy-admin
-          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -104,16 +104,16 @@ spec:
       - args:
         - bootstrap
         - /config/envoy.json
-        - --xds-address=10.52.131.186
+        - --xds-address=contour
         - --xds-port=8001
         - --xds-resource-version=v3
         - --resources-dir=/config/resources
-#        - --envoy-cafile=/certs/ca.crt
-#        - --envoy-cert-file=/certs/tls.crt
-#        - --envoy-key-file=/certs/tls.key
+        - --envoy-cafile=/certs/ca.crt
+        - --envoy-cert-file=/certs/tls.crt
+        - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: stevesloka/contour:socket
+        image: docker.io/projectcontour/contour:main
         imagePullPolicy: Always
         name: envoy-initconfig
         volumeMounts:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -111,7 +111,6 @@ spec:
 #        - --envoy-cafile=/certs/ca.crt
 #        - --envoy-cert-file=/certs/tls.crt
 #        - --envoy-key-file=/certs/tls.key
-        - --admin-address=/admin/admin.sock
         command:
         - contour
         image: stevesloka/contour:socket

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3097,6 +3097,9 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 10
         name: shutdown-manager
+        volumeMounts:
+          - name: envoy-admin
+            mountPath: /admin
       - args:
         - -c
         - /config/envoy.json
@@ -3141,6 +3144,8 @@ spec:
           - name: envoycert
             mountPath: /certs
             readOnly: true
+          - name: envoy-admin
+            mountPath: /admin
         lifecycle:
           preStop:
             httpGet:
@@ -3169,6 +3174,8 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
+        - name: envoy-admin
+          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:
@@ -3178,6 +3185,8 @@ spec:
       serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
+        - name: envoy-admin
+          emptyDir: {}
         - name: envoy-config
           emptyDir: {}
         - name: envoycert

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -151,6 +151,8 @@ data:
     #   Configure the number of additional ingress proxy hops from the
     #   right side of the x-forwarded-for HTTP header to trust.
     #   num-trusted-hops: 0
+    #   Configure the port used to access the Envoy Admin interface.
+    #   admin-port: 9001
     #
     # Configure an optional global rate limit service.
     # rateLimitService:
@@ -3174,8 +3176,6 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
-        - name: envoy-admin
-          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3094,6 +3094,9 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 10
         name: shutdown-manager
+        volumeMounts:
+          - name: envoy-admin
+            mountPath: /admin
       - args:
         - -c
         - /config/envoy.json
@@ -3138,6 +3141,8 @@ spec:
           - name: envoycert
             mountPath: /certs
             readOnly: true
+          - name: envoy-admin
+            mountPath: /admin
         lifecycle:
           preStop:
             httpGet:
@@ -3166,6 +3171,8 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
+        - name: envoy-admin
+          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:
@@ -3175,6 +3182,8 @@ spec:
       serviceAccountName: envoy
       terminationGracePeriodSeconds: 300
       volumes:
+        - name: envoy-admin
+          emptyDir: {}
         - name: envoy-config
           emptyDir: {}
         - name: envoycert

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -148,6 +148,8 @@ data:
     #   Configure the number of additional ingress proxy hops from the
     #   right side of the x-forwarded-for HTTP header to trust.
     #   num-trusted-hops: 0
+    #   Configure the port used to access the Envoy Admin interface.
+    #   admin-port: 9001
     #
     # Configure an optional global rate limit service.
     # rateLimitService:
@@ -3171,8 +3173,6 @@ spec:
         - name: envoycert
           mountPath: /certs
           readOnly: true
-        - name: envoy-admin
-          mountPath: /admin
         env:
         - name: CONTOUR_NAMESPACE
           valueFrom:

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -42,7 +42,7 @@ type BootstrapConfig struct {
 	// Defaults to /dev/null.
 	AdminAccessLogPath string
 
-	// AdminAddress is the TCP address that the administration server will listen on.
+	// AdminAddress is the Unix Socket address that the administration server will listen on.
 	// Defaults to /admin/admin.sock.
 	AdminAddress string
 

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -47,6 +46,7 @@ type BootstrapConfig struct {
 	// Defaults to 127.0.0.1.
 	AdminAddress string
 
+	// Deprecated
 	// AdminPort is the port that the administration server will listen on.
 	// Defaults to 9001.
 	AdminPort int
@@ -111,10 +111,8 @@ func (c *BootstrapConfig) GetDNSLookupFamily() string {
 // is supported for this address to mitigate security.
 func ValidAdminAddress(address string) error {
 	// Value of "localhost" is invalid.
-	if address == "localhost" ||
-		net.ParseIP(address) != nil ||
-		!strings.Contains(address, "/") {
-		return fmt.Errorf("invalid value %q, must be a unix socket name", address)
+	if address == "localhost" || net.ParseIP(address) != nil {
+		return fmt.Errorf("invalid value %q, cannot be `localhost` or an ip address", address)
 	}
 	return nil
 }

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -43,12 +43,11 @@ type BootstrapConfig struct {
 	AdminAccessLogPath string
 
 	// AdminAddress is the TCP address that the administration server will listen on.
-	// Defaults to 127.0.0.1.
+	// Defaults to /admin/admin.sock.
 	AdminAddress string
 
 	// Deprecated
 	// AdminPort is the port that the administration server will listen on.
-	// Defaults to 9001.
 	AdminPort int
 
 	// XDSAddress is the TCP address of the gRPC XDS management server.

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -28,9 +28,9 @@ func TestValidAdminAddress(t *testing.T) {
 		want    error
 	}{
 		{name: "valid socket name", address: "/admin/admin.sock", want: nil},
-		{name: "ip address invalid", address: "127.0.0.1", want: fmt.Errorf("invalid value %q, must be a unix socket name", "127.0.0.1")},
-		{name: "localhost invalid", address: "localhost", want: fmt.Errorf("invalid value %q, must be a unix socket name", "localhost")},
-		{name: "must have a /", address: "admin.sock", want: fmt.Errorf("invalid value %q, must be a unix socket name", "admin.sock")},
+		{name: "valid socket name", address: "admin.sock", want: nil},
+		{name: "ip address invalid", address: "127.0.0.1", want: fmt.Errorf("invalid value %q, cannot be `localhost` or an ip address", "127.0.0.1")},
+		{name: "localhost invalid", address: "localhost", want: fmt.Errorf("invalid value %q, cannot be `localhost` or an ip address", "localhost")},
 	}
 
 	for _, tc := range tests {

--- a/internal/envoy/bootstrap_test.go
+++ b/internal/envoy/bootstrap_test.go
@@ -1,0 +1,42 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidAdminAddress(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		address string
+		want    error
+	}{
+		{name: "valid socket name", address: "/admin/admin.sock", want: nil},
+		{name: "ip address invalid", address: "127.0.0.1", want: fmt.Errorf("invalid value %q, must be a unix socket name", "127.0.0.1")},
+		{name: "localhost invalid", address: "localhost", want: fmt.Errorf("invalid value %q, must be a unix socket name", "localhost")},
+		{name: "must have a /", address: "admin.sock", want: fmt.Errorf("invalid value %q, must be a unix socket name", "admin.sock")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidAdminAddress(tc.address)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -198,7 +198,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 				Name:                 "service-stats",
 				AltStatName:          strings.Join([]string{c.Namespace, "service-stats", strconv.Itoa(c.GetAdminPort())}, "_"),
 				ConnectTimeout:       protobuf.Duration(250 * time.Millisecond),
-				ClusterDiscoveryType: ClusterDiscoveryTypeForAddress(c.GetAdminAddress(), envoy_cluster_v3.Cluster_LOGICAL_DNS),
+				ClusterDiscoveryType: ClusterDiscoveryTypeForAddress(c.GetAdminAddress(), envoy_cluster_v3.Cluster_STATIC),
 				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
 				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
 					ClusterName: "service-stats",

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -203,14 +203,14 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
 					ClusterName: "service-stats",
 					Endpoints: Endpoints(
-						SocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
+						UnixSocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
 					),
 				},
 			}},
 		},
 		Admin: &envoy_bootstrap_v3.Admin{
 			AccessLogPath: c.GetAdminAccessLogPath(),
-			Address:       SocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
+			Address:       UnixSocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
 		},
 	}
 }

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -166,146 +166,10 @@ func TestBootstrap(t *testing.T) {
   }
 }`,
 		},
-		"--admin-address=8.8.8.8 --admin-port=9200": {
-			config: envoy.BootstrapConfig{
-				Path:         "envoy.json",
-				AdminAddress: "8.8.8.8",
-				AdminPort:    9200,
-				Namespace:    "testing-ns",
-			},
-			wantedBootstrapConfig: `{
-  "static_resources": {
-    "clusters": [
-      {
-        "name": "contour",
-        "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STATIC",
-        "connect_timeout": "5s",
-        "load_assignment": {
-          "cluster_name": "contour",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 8001
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "circuit_breakers": {
-          "thresholds": [
-            {
-              "priority": "HIGH",
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            },
-            {
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            }
-          ]
-        },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {	
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",	
-            "explicit_http_config": {	
-              "http2_protocol_options": {}	
-            }	
-          }	
-        },
-        "upstream_connection_options": {
-          "tcp_keepalive": {
-            "keepalive_probes": 3,
-            "keepalive_time": 30,
-            "keepalive_interval": 5
-          }
-        }
-      },
-      {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9200",
-        "type": "STATIC",
-        "connect_timeout": "0.250s",
-        "load_assignment": {
-          "cluster_name": "service-stats",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "8.8.8.8",
-                        "port_value": 9200
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  },
-  "dynamic_resources": {
-    "lds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-        "transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-      "resource_api_version": "V3"
-    },
-    "cds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-		"transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-      "resource_api_version": "V3"
-    }
-  },
-  "admin": {
-    "access_log_path": "/dev/null",
-    "address": {
-      "socket_address": {
-        "address": "8.8.8.8",
-        "port_value": 9200
-      }
-    }
-  }
-}`,
-		},
-		"--admin-address=someaddr --admin-port=9200": {
+		"--admin-address=someaddr": {
 			config: envoy.BootstrapConfig{
 				Path:         "envoy.json",
 				AdminAddress: "someaddr",
-				AdminPort:    9200,
 				Namespace:    "testing-ns",
 			},
 			wantedBootstrapConfig: `{
@@ -370,7 +234,7 @@ func TestBootstrap(t *testing.T) {
       },
       {
         "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9200",
+        "alt_stat_name": "testing-ns_service-stats_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
@@ -381,9 +245,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "someaddr",
-                        "port_value": 9200
+                     "pipe": {
+                        "path": "someaddr",
+                        "mode": "420"
                       }
                     }
                   }
@@ -428,144 +292,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "someaddr",
-        "port_value": 9200
-      }
-    }
-  }
-}`,
-		},
-		"--admin-address=::1 --admin-port=9200": {
-			config: envoy.BootstrapConfig{
-				Path:         "envoy.json",
-				AdminAddress: "::1",
-				AdminPort:    9200,
-				Namespace:    "testing-ns",
-			},
-			wantedBootstrapConfig: `{
-  "static_resources": {
-    "clusters": [
-      {
-        "name": "contour",
-        "alt_stat_name": "testing-ns_contour_8001",
-        "type": "STATIC",
-        "connect_timeout": "5s",
-        "load_assignment": {
-          "cluster_name": "contour",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 8001
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "circuit_breakers": {
-          "thresholds": [
-            {
-              "priority": "HIGH",
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            },
-            {
-              "max_connections": 100000,
-              "max_pending_requests": 100000,
-              "max_requests": 60000000,
-              "max_retries": 50
-            }
-          ]
-        },
-        "typed_extension_protocol_options": {
-          "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
-            "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-            "explicit_http_config": {
-              "http2_protocol_options": {}
-            }
-          }
-        },
-        "upstream_connection_options": {
-          "tcp_keepalive": {
-            "keepalive_probes": 3,
-            "keepalive_time": 30,
-            "keepalive_interval": 5
-          }
-        }
-      },
-      {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9200",
-        "type": "STATIC",
-        "connect_timeout": "0.250s",
-        "load_assignment": {
-          "cluster_name": "service-stats",
-          "endpoints": [
-            {
-              "lb_endpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "::1",
-                        "port_value": 9200
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  },
-  "dynamic_resources": {
-    "lds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-		"transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-      "resource_api_version": "V3"
-    },
-    "cds_config": {
-      "api_config_source": {
-        "api_type": "GRPC",
-		"transport_api_version": "V3",
-        "grpc_services": [
-          {
-            "envoy_grpc": {
-              "cluster_name": "contour"
-            }
-          }
-        ]
-      },
-      "resource_api_version": "V3"
-    }
-  },
-  "admin": {
-    "access_log_path": "/dev/null",
-    "address": {
-      "socket_address": {
-        "address": "::1",
-        "port_value": 9200
+      "pipe": {
+        "path": "someaddr",
+        "mode": "420"
       }
     }
   }

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -111,9 +111,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -158,9 +158,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+   	 "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -371,7 +371,7 @@ func TestBootstrap(t *testing.T) {
       {
         "name": "service-stats",
         "alt_stat_name": "testing-ns_service-stats_9200",
-        "type": "LOGICAL_DNS",
+        "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
           "cluster_name": "service-stats",
@@ -650,9 +650,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -697,9 +697,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/var/log/admin.log",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -785,9 +785,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -832,9 +832,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -920,9 +920,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -967,9 +967,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -1055,9 +1055,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -1102,9 +1102,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -1192,9 +1192,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -1239,9 +1239,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -1357,9 +1357,9 @@ func TestBootstrap(t *testing.T) {
                 {
                   "endpoint": {
                     "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 9001
+                      "pipe": {
+                        "path": "/admin/admin.sock",
+                        "mode": "420"
                       }
                     }
                   }
@@ -1404,9 +1404,9 @@ func TestBootstrap(t *testing.T) {
   "admin": {
     "access_log_path": "/dev/null",
     "address": {
-      "socket_address": {
-        "address": "127.0.0.1",
-        "port_value": 9001
+      "pipe": {
+        "path": "/admin/admin.sock",
+        "mode": "420"
       }
     }
   }
@@ -1518,14 +1518,14 @@ func TestBootstrap(t *testing.T) {
                     "lb_endpoints": [
                       {
                         "endpoint": {
-                          "address": {
-                            "socket_address": {
-                              "address": "127.0.0.1",
-                              "port_value": 9001
-                            }
-                          }
-                        }
-                      }
+                        "address": {
+						  "pipe": {
+							"path": "/admin/admin.sock",
+							"mode": "420"
+						  }
+						}
+                       }
+					 }
                     ]
                   }
                 ]
@@ -1566,10 +1566,10 @@ func TestBootstrap(t *testing.T) {
         "admin": {
           "access_log_path": "/dev/null",
           "address": {
-            "socket_address": {
-              "address": "127.0.0.1",
-              "port_value": 9001
-            }
+           "pipe": {
+		    "path": "/admin/admin.sock",
+			   "mode": "420"
+			}
           }
         }
     }`,

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -545,6 +545,17 @@ func SocketAddress(address string, port int) *envoy_core_v3.Address {
 			},
 		}
 	}
+	// Check if the address is a socket.
+	if strings.Contains(address, "/") {
+		return &envoy_core_v3.Address{
+			Address: &envoy_core_v3.Address_Pipe{
+				Pipe: &envoy_core_v3.Pipe{
+					Path: address,
+					Mode: 0644,
+				},
+			},
+		}
+	}
 	return &envoy_core_v3.Address{
 		Address: &envoy_core_v3.Address_SocketAddress{
 			SocketAddress: &envoy_core_v3.SocketAddress{

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -529,6 +529,18 @@ func TCPProxy(statPrefix string, proxy *dag.TCPProxy, accesslogger []*accesslog.
 	}
 }
 
+// UnixSocketAddress creates a new Unix Socket envoy_core_v3.Address.
+func UnixSocketAddress(address string, port int) *envoy_core_v3.Address {
+	return &envoy_core_v3.Address{
+		Address: &envoy_core_v3.Address_Pipe{
+			Pipe: &envoy_core_v3.Pipe{
+				Path: address,
+				Mode: 0644,
+			},
+		},
+	}
+}
+
 // SocketAddress creates a new TCP envoy_core_v3.Address.
 func SocketAddress(address string, port int) *envoy_core_v3.Address {
 	if address == "::" {
@@ -541,17 +553,6 @@ func SocketAddress(address string, port int) *envoy_core_v3.Address {
 					PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
 						PortValue: uint32(port),
 					},
-				},
-			},
-		}
-	}
-	// Check if the address is a socket.
-	if strings.Contains(address, "/") {
-		return &envoy_core_v3.Address{
-			Address: &envoy_core_v3.Address_Pipe{
-				Pipe: &envoy_core_v3.Pipe{
-					Path: address,
-					Mode: 0644,
 				},
 			},
 		}

--- a/internal/envoy/v3/stats.go
+++ b/internal/envoy/v3/stats.go
@@ -57,6 +57,51 @@ func StatsListener(address string, port int) *envoy_listener_v3.Listener {
 	}
 }
 
+// EnvoyAdminListener returns a *envoy_listener_v3.Listener configured to serve
+// Envoy Admin endpoints.
+func EnvoyAdminListener(port int) *envoy_listener_v3.Listener {
+	return &envoy_listener_v3.Listener{
+		Name:    "envoy-admin",
+		Address: SocketAddress("127.0.0.1", port),
+		FilterChains: FilterChains(
+			&envoy_listener_v3.Filter{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
+						StatPrefix: "envoy-admin",
+						RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
+							RouteConfig: &envoy_route_v3.RouteConfiguration{
+								VirtualHosts: []*envoy_route_v3.VirtualHost{{
+									Name:    "backend",
+									Domains: []string{"*"},
+									Routes: []*envoy_route_v3.Route{
+										serviceStatsRoute("/certs"),
+										serviceStatsRoute("/clusters"),
+										serviceStatsRoute("/listeners"),
+										serviceStatsRoute("/config_dump"),
+										serviceStatsRoute("/memory"),
+										serviceStatsRoute("/ready"),
+										serviceStatsRoute("/runtime"),
+										serviceStatsRoute("/server_info"),
+										serviceStatsRoute("/stats"),
+										serviceStatsRoute("/stats/prometheus"),
+										serviceStatsRoute("/stats/recentlookups"),
+									},
+								}},
+							},
+						},
+						HttpFilters: []*http.HttpFilter{{
+							Name: wellknown.Router,
+						}},
+						NormalizePath: protobuf.Bool(true),
+					}),
+				},
+			},
+		),
+		SocketOptions: TCPKeepaliveSocketOptions(),
+	}
+}
+
 // AdminListener returns a *envoy_listener_v3.Listener configured to serve Envoy
 // debug routes from the admin webpage.
 func AdminListener(address string, port int) *envoy_listener_v3.Listener {

--- a/internal/envoy/v3/stats.go
+++ b/internal/envoy/v3/stats.go
@@ -38,33 +38,9 @@ func StatsListener(address string, port int) *envoy_listener_v3.Listener {
 								VirtualHosts: []*envoy_route_v3.VirtualHost{{
 									Name:    "backend",
 									Domains: []string{"*"},
-									Routes: []*envoy_route_v3.Route{{
-										Match: &envoy_route_v3.RouteMatch{
-											PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
-												Prefix: "/ready",
-											},
-										},
-										Action: &envoy_route_v3.Route_Route{
-											Route: &envoy_route_v3.RouteAction{
-												ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
-													Cluster: "service-stats",
-												},
-											},
-										},
-									}, {
-										Match: &envoy_route_v3.RouteMatch{
-											PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
-												Prefix: "/stats",
-											},
-										},
-										Action: &envoy_route_v3.Route_Route{
-											Route: &envoy_route_v3.RouteAction{
-												ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
-													Cluster: "service-stats",
-												},
-											},
-										},
-									},
+									Routes: []*envoy_route_v3.Route{
+										serviceStatsRoute("/ready"),
+										serviceStatsRoute("/stats"),
 									},
 								}},
 							},
@@ -78,5 +54,67 @@ func StatsListener(address string, port int) *envoy_listener_v3.Listener {
 			},
 		),
 		SocketOptions: TCPKeepaliveSocketOptions(),
+	}
+}
+
+// AdminListener returns a *envoy_listener_v3.Listener configured to serve Envoy
+// debug routes from the admin webpage.
+func AdminListener(address string, port int) *envoy_listener_v3.Listener {
+	return &envoy_listener_v3.Listener{
+		Name:    "envoy-admin",
+		Address: SocketAddress(address, port),
+		FilterChains: FilterChains(
+			&envoy_listener_v3.Filter{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
+						StatPrefix: "envoy-admin",
+						RouteSpecifier: &http.HttpConnectionManager_RouteConfig{
+							RouteConfig: &envoy_route_v3.RouteConfiguration{
+								VirtualHosts: []*envoy_route_v3.VirtualHost{{
+									Name:    "backend",
+									Domains: []string{"*"},
+									Routes: []*envoy_route_v3.Route{
+										serviceStatsRoute("/certs"),
+										serviceStatsRoute("/clusters"),
+										serviceStatsRoute("/listeners"),
+										serviceStatsRoute("/config_dump"),
+										serviceStatsRoute("/memory"),
+										serviceStatsRoute("/ready"),
+										serviceStatsRoute("/runtime"),
+										serviceStatsRoute("/server_info"),
+										serviceStatsRoute("/stats"),
+										serviceStatsRoute("/stats/prometheus"),
+										serviceStatsRoute("/stats/recentlookups"),
+									},
+								}},
+							},
+						},
+						HttpFilters: []*http.HttpFilter{{
+							Name: wellknown.Router,
+						}},
+						NormalizePath: protobuf.Bool(true),
+					}),
+				},
+			},
+		),
+		SocketOptions: TCPKeepaliveSocketOptions(),
+	}
+}
+
+func serviceStatsRoute(prefix string) *envoy_route_v3.Route {
+	return &envoy_route_v3.Route{
+		Match: &envoy_route_v3.RouteMatch{
+			PathSpecifier: &envoy_route_v3.RouteMatch_Prefix{
+				Prefix: prefix,
+			},
+		},
+		Action: &envoy_route_v3.Route_Route{
+			Route: &envoy_route_v3.RouteAction{
+				ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+					Cluster: "service-stats",
+				},
+			},
+		},
 	}
 }

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -108,7 +108,7 @@ func authzResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c *Contou
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
 
-			staticListener()),
+			statsListener()),
 	}).Status(p).IsValid()
 }
 
@@ -135,7 +135,7 @@ func authzInvalidResponseTimeout(t *testing.T, rh cache.ResourceEventHandler, c 
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl:   listenerType,
-		Resources: resources(t, staticListener()),
+		Resources: resources(t, statsListener()),
 	}).Status(p).HasError(contour_api_v1.ConditionTypeAuthError, "AuthResponseTimeoutInvalid", `Spec.Virtualhost.Authorization.ResponseTimeout is invalid: unable to parse timeout string "invalid-timeout": time: invalid duration "invalid-timeout"`)
 }
 
@@ -194,7 +194,7 @@ func authzFailOpen(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 				},
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener()),
+			statsListener()),
 	}).Status(p).IsValid()
 }
 
@@ -220,7 +220,7 @@ func authzFallbackIncompat(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl:   listenerType,
-		Resources: resources(t, staticListener()),
+		Resources: resources(t, statsListener()),
 	}).Status(p).HasError(contour_api_v1.ConditionTypeTLSError, "TLSIncompatibleFeatures", "Spec.Virtualhost.TLS fallback & client authorization are incompatible")
 }
 
@@ -450,7 +450,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl:   listenerType,
-		Resources: resources(t, staticListener()),
+		Resources: resources(t, statsListener()),
 	}).Status(invalid).HasError(contour_api_v1.ConditionTypeAuthError, "AuthBadResourceVersion", `Spec.Virtualhost.Authorization.extensionRef specifies an unsupported resource version "foo/bar"`)
 
 	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = contour_api_v1.ExtensionServiceReference{
@@ -464,7 +464,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl:   listenerType,
-		Resources: resources(t, staticListener()),
+		Resources: resources(t, statsListener()),
 	}).Status(invalid).HasError(contour_api_v1.ConditionTypeAuthError, "ExtensionServiceNotFound", `Spec.Virtualhost.Authorization.ServiceRef extension service "missing/extension" not found`)
 
 	invalid.Spec.VirtualHost.Authorization.ExtensionServiceRef = contour_api_v1.ExtensionServiceReference{
@@ -509,7 +509,7 @@ func authzInvalidReference(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 				},
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener()),
+			statsListener()),
 	}).Status(invalid).IsValid()
 }
 

--- a/internal/featuretests/v3/backendcavalidation_test.go
+++ b/internal/featuretests/v3/backendcavalidation_test.go
@@ -70,7 +70,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -111,7 +111,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -161,7 +161,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -102,7 +102,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPS,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	}).Status(proxy).IsValid()
@@ -148,7 +148,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPSSkipVerify,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	}).Status(proxy).IsValid()
@@ -198,7 +198,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPSSkipVerifyWithCA,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	}).Status(proxy).IsValid()

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -408,8 +408,12 @@ func tcpproxy(statPrefix, cluster string) *envoy_listener_v3.Filter {
 	}
 }
 
-func staticListener() *envoy_listener_v3.Listener {
+func statsListener() *envoy_listener_v3.Listener {
 	return envoy_v3.StatsListener("0.0.0.0", 8002)
+}
+
+func envoyAdminListener(port int) *envoy_listener_v3.Listener {
+	return envoy_v3.EnvoyAdminListener(port)
 }
 
 func defaultHTTPListener() *envoy_listener_v3.Listener {

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -82,7 +82,7 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	}
 
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort),
+		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, false),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -82,11 +82,17 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	}
 
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, 9001, false),
+		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, 0),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},
 		et,
+	}
+
+	for _, opt := range opts {
+		if opt, ok := opt.([]xdscache.ResourceCache); ok {
+			resources = opt
+		}
 	}
 
 	registry := prometheus.NewRegistry()

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -82,7 +82,7 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	}
 
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, false),
+		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, 9001, false),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/internal/featuretests/v3/globalratelimit_test.go
+++ b/internal/featuretests/v3/globalratelimit_test.go
@@ -98,7 +98,7 @@ func globalRateLimitFilterExists(t *testing.T, rh cache.ResourceEventHandler, c 
 		TypeUrl: listenerType,
 		Resources: resources(t,
 			httpListener,
-			staticListener()),
+			statsListener()),
 	}).Status(p).IsValid()
 }
 

--- a/internal/featuretests/v3/localratelimit_test.go
+++ b/internal/featuretests/v3/localratelimit_test.go
@@ -60,7 +60,7 @@ func filterExists(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 		TypeUrl: listenerType,
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener()),
+			statsListener()),
 	}).Status(p).IsValid()
 }
 

--- a/internal/featuretests/v3/rootnamespaces_test.go
+++ b/internal/featuretests/v3/rootnamespaces_test.go
@@ -46,7 +46,7 @@ func TestRootNamespaces(t *testing.T) {
 	// assert that there is only a static listener
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -81,7 +81,7 @@ func TestRootNamespaces(t *testing.T) {
 	// assert that hp1 has no effect on the listener set.
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -119,7 +119,7 @@ func TestRootNamespaces(t *testing.T) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -352,7 +352,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -438,7 +438,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/tcpproxy_test.go
+++ b/internal/featuretests/v3/tcpproxy_test.go
@@ -89,7 +89,7 @@ func TestTCPProxy(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -173,7 +173,7 @@ func TestTCPProxyDelegation(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -246,7 +246,7 @@ func TestTCPProxyTLSPassthrough(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -319,7 +319,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -411,7 +411,7 @@ func TestTCPProxyAndHTTPService(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -501,7 +501,7 @@ func TestTCPProxyAndHTTPServicePermitInsecure(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -589,7 +589,7 @@ func TestTCPProxyTLSPassthroughAndHTTPService(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -678,7 +678,7 @@ func TestTCPProxyTLSPassthroughAndHTTPServicePermitInsecure(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -754,7 +754,7 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 		Resources: resources(t,
 			// ingress_http and ingress_https should be missing
 			// as hp1 is not valid.
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -800,7 +800,7 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 		Resources: resources(t,
 			// ingress_http and ingress_https should be missing
 			// as hp2 is not valid.
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/tlscertificatedelegation_test.go
+++ b/internal/featuretests/v3/tlscertificatedelegation_test.go
@@ -33,7 +33,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	// assert that there is only a static listener
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -83,7 +83,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	// assert there are no listeners
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -123,7 +123,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPS,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -149,7 +149,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPS,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -173,7 +173,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -197,7 +197,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -232,7 +232,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	// assert there are no listeners
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -257,7 +257,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 		Resources: resources(t,
 			defaultHTTPListener(),
 			ingressHTTPS,
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -125,7 +125,7 @@ func TestTLSRoute(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -174,7 +174,7 @@ func TestTLSRoute(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -252,7 +252,7 @@ func TestTLSRoute(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -324,7 +324,7 @@ func TestTLSRoute(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/featuretests/v3/wildcardhost_test.go
+++ b/internal/featuretests/v3/wildcardhost_test.go
@@ -69,7 +69,7 @@ func TestIngressWildcardHostHTTP(t *testing.T) {
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			defaultHTTPListener(),
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})
@@ -178,7 +178,7 @@ func TestIngressWildcardHostHTTPSWildcardSecret(t *testing.T) {
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
-			staticListener(),
+			statsListener(),
 		),
 		TypeUrl: listenerType,
 	})

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -14,6 +14,7 @@
 package v3
 
 import (
+	"fmt"
 	"path"
 	"sort"
 	"sync"
@@ -291,6 +292,8 @@ type ListenerCache struct {
 func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adminPort int, enableDebugListener bool) *ListenerCache {
 	stats := envoy_v3.StatsListener(statsAddress, statsPort)
 	admin := envoy_v3.AdminListener("127.0.0.1", adminPort)
+
+	fmt.Println("---admin port: ", adminPort)
 
 	listenerCache := &ListenerCache{
 		Config: config,

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -14,7 +14,6 @@
 package v3
 
 import (
-	"fmt"
 	"path"
 	"sort"
 	"sync"
@@ -289,11 +288,9 @@ type ListenerCache struct {
 }
 
 // NewListenerCache returns an instance of a ListenerCache
-func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adminPort int, enableDebugListener bool) *ListenerCache {
+func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adminPort int) *ListenerCache {
 	stats := envoy_v3.StatsListener(statsAddress, statsPort)
 	admin := envoy_v3.AdminListener("127.0.0.1", adminPort)
-
-	fmt.Println("---admin port: ", adminPort)
 
 	listenerCache := &ListenerCache{
 		Config: config,
@@ -302,9 +299,9 @@ func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adm
 		},
 	}
 
-	// If enabled, allow the read-only options from the
+	// If the port is not zero, allow the read-only options from the
 	// Envoy admin webpage to be served.
-	if enableDebugListener {
+	if adminPort > 0 {
 		listenerCache.staticValues[admin.Name] = admin
 	}
 

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -288,14 +288,24 @@ type ListenerCache struct {
 }
 
 // NewListenerCache returns an instance of a ListenerCache
-func NewListenerCache(config ListenerConfig, address string, port int) *ListenerCache {
+func NewListenerCache(config ListenerConfig, address string, port int, enableDebugListener bool) *ListenerCache {
 	stats := envoy_v3.StatsListener(address, port)
-	return &ListenerCache{
+	admin := envoy_v3.AdminListener("127.0.0.1", 9001)
+
+	listenerCache := &ListenerCache{
 		Config: config,
 		staticValues: map[string]*envoy_listener_v3.Listener{
 			stats.Name: stats,
 		},
 	}
+
+	// If enabled, allow the read-only options from the
+	// Envoy admin webpage to be served.
+	if enableDebugListener {
+		listenerCache.staticValues[admin.Name] = admin
+	}
+
+	return listenerCache
 }
 
 // Update replaces the contents of the cache with the supplied map.

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -288,9 +288,9 @@ type ListenerCache struct {
 }
 
 // NewListenerCache returns an instance of a ListenerCache
-func NewListenerCache(config ListenerConfig, address string, port int, enableDebugListener bool) *ListenerCache {
-	stats := envoy_v3.StatsListener(address, port)
-	admin := envoy_v3.AdminListener("127.0.0.1", 9001)
+func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adminPort int, enableDebugListener bool) *ListenerCache {
+	stats := envoy_v3.StatsListener(statsAddress, statsPort)
+	admin := envoy_v3.AdminListener("127.0.0.1", adminPort)
 
 	listenerCache := &ListenerCache{
 		Config: config,

--- a/internal/xdscache/v3/server_test.go
+++ b/internal/xdscache/v3/server_test.go
@@ -193,7 +193,7 @@ func TestGRPC(t *testing.T) {
 			et = NewEndpointsTranslator(fixture.NewTestLogger(t))
 
 			resources := []xdscache.ResourceCache{
-				NewListenerCache(ListenerConfig{}, "", 0, false),
+				NewListenerCache(ListenerConfig{}, "", 0, 9001, false),
 				&SecretCache{},
 				&RouteCache{},
 				&ClusterCache{},

--- a/internal/xdscache/v3/server_test.go
+++ b/internal/xdscache/v3/server_test.go
@@ -193,7 +193,7 @@ func TestGRPC(t *testing.T) {
 			et = NewEndpointsTranslator(fixture.NewTestLogger(t))
 
 			resources := []xdscache.ResourceCache{
-				NewListenerCache(ListenerConfig{}, "", 0),
+				NewListenerCache(ListenerConfig{}, "", 0, false),
 				&SecretCache{},
 				&RouteCache{},
 				&ClusterCache{},

--- a/internal/xdscache/v3/server_test.go
+++ b/internal/xdscache/v3/server_test.go
@@ -193,7 +193,7 @@ func TestGRPC(t *testing.T) {
 			et = NewEndpointsTranslator(fixture.NewTestLogger(t))
 
 			resources := []xdscache.ResourceCache{
-				NewListenerCache(ListenerConfig{}, "", 0, 9001, false),
+				NewListenerCache(ListenerConfig{}, "", 0, 0),
 				&SecretCache{},
 				&RouteCache{},
 				&ClusterCache{},

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -525,10 +525,10 @@ type NetworkParameters struct {
 	//
 	// See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
 	// for more information.
-	XffNumTrustedHops uint32 `yaml:"num-trusted-hops"`
+	XffNumTrustedHops uint32 `yaml:"num-trusted-hops,omitempty"`
 
 	// Configure the port used to access the Envoy Admin interface.
-	EnvoyAdminPort int `yaml:"admin-port"`
+	EnvoyAdminPort int `yaml:"admin-port,omitempty"`
 }
 
 // ListenerParameters hold various configurable listener values.

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -528,6 +528,7 @@ type NetworkParameters struct {
 	XffNumTrustedHops uint32 `yaml:"num-trusted-hops,omitempty"`
 
 	// Configure the port used to access the Envoy Admin interface.
+	// If configured to port "0" then the admin interface is disabled.
 	EnvoyAdminPort int `yaml:"admin-port,omitempty"`
 }
 

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -526,6 +526,9 @@ type NetworkParameters struct {
 	// See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
 	// for more information.
 	XffNumTrustedHops uint32 `yaml:"num-trusted-hops"`
+
+	// Configure the port used to access the Envoy Admin interface.
+	EnvoyAdminPort int `yaml:"admin-port"`
 }
 
 // ListenerParameters hold various configurable listener values.
@@ -739,6 +742,7 @@ func Defaults() Parameters {
 		},
 		Network: NetworkParameters{
 			XffNumTrustedHops: 0,
+			EnvoyAdminPort:    9001,
 		},
 		Listener: ListenerParameters{
 			ConnectionBalancer: "",

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -86,7 +86,6 @@ default-http-versions: []
 cluster:
   dns-lookup-family: auto
 network:
-  num-trusted-hops: 0
   admin-port: 9001
 `
 	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(data)))

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -85,6 +85,9 @@ envoy-service-name: envoy
 default-http-versions: []
 cluster:
   dns-lookup-family: auto
+network:
+  num-trusted-hops: 0
+  admin-port: 9001
 `
 	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(data)))
 
@@ -510,6 +513,7 @@ default-http-versions:
 	}, `
 network:
   num-trusted-hops: 1
+  admin-port: 9001
 `)
 }
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -443,7 +443,7 @@ func (d *Deployment) EnsureResourcesForLocalContour() error {
 		return err
 	}
 
-	// Add bootstrap ConfigMap as volume on Envoy pods (also removes cert volume).
+	// Add bootstrap ConfigMap as volume and add envoy admin volume on Envoy pods (also removes cert volume).
 	d.EnvoyDaemonSet.Spec.Template.Spec.Volumes = []v1.Volume{{
 		Name: "envoy-config",
 		VolumeSource: v1.VolumeSource{

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -73,6 +73,9 @@ type Framework struct {
 	// are part of a full Contour deployment manifest.
 	Deployment *Deployment
 
+	// Kubectl provides helpers for managing kubectl port-forward helpers.
+	Kubectl *Kubectl
+
 	t ginkgo.GinkgoTInterface
 }
 
@@ -122,6 +125,16 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 		httpsURLBase = "https://127.0.0.1:9443"
 	}
 
+	httpURLMetricsBase := os.Getenv("CONTOUR_E2E_HTTP_URL_METRICS_BASE")
+	if httpURLMetricsBase == "" {
+		httpURLMetricsBase = "http://127.0.0.1:8002"
+	}
+
+	httpURLAdminBase := os.Getenv("CONTOUR_E2E_HTTP_URL_ADMIN_BASE")
+	if httpURLAdminBase == "" {
+		httpURLAdminBase = "http://127.0.0.1:19001"
+	}
+
 	var (
 		kubeConfig  string
 		contourHost string
@@ -156,6 +169,11 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 		localContourPort: contourPort,
 		contourBin:       contourBin,
 	}
+
+	kubectl := &Kubectl{
+		cmdOutputWriter: ginkgo.GinkgoWriter,
+	}
+
 	require.NoError(t, deployment.UnmarshalResources())
 
 	return &Framework{
@@ -177,11 +195,13 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 			},
 		},
 		HTTP: &HTTP{
-			HTTPURLBase:   httpURLBase,
-			HTTPSURLBase:  httpsURLBase,
-			RetryInterval: time.Second,
-			RetryTimeout:  60 * time.Second,
-			t:             t,
+			HTTPURLBase:        httpURLBase,
+			HTTPSURLBase:       httpsURLBase,
+			HTTPURLMetricsBase: httpURLMetricsBase,
+			HTTPURLAdminBase:   httpURLAdminBase,
+			RetryInterval:      time.Second,
+			RetryTimeout:       60 * time.Second,
+			t:                  t,
 		},
 		Certs: &Certs{
 			client:        crClient,
@@ -190,6 +210,7 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 			t:             t,
 		},
 		Deployment: deployment,
+		Kubectl:    kubectl,
 		t:          t,
 	}
 }
@@ -201,6 +222,7 @@ func (f *Framework) T() ginkgo.GinkgoTInterface {
 }
 
 type NamespacedTestBody func(string)
+type TestBody func()
 
 func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody) {
 	ginkgo.Context("with namespace: "+namespace, func() {
@@ -213,6 +235,10 @@ func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody) {
 
 		body(namespace)
 	})
+}
+
+func (f *Framework) Test(body TestBody) {
+	body()
 }
 
 // CreateHTTPProxyAndWaitFor creates the provided HTTPProxy in the Kubernetes API

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -36,6 +36,16 @@ type HTTP struct {
 	// HTTPS requests, formatted as "https://<ip>:<port>".
 	HTTPSURLBase string
 
+	// HTTPURLMetricsBase holds the IP address and port for making
+	// (insecure) HTTP requests to the Envoy metrics listener,
+	// formatted as "http://<ip>:<port>".
+	HTTPURLMetricsBase string
+
+	// HTTPURLAdminBase holds the IP address and port for making
+	// (insecure) HTTP requests to the Envoy admin listener,
+	// formatted as "http://<ip>:<port>".
+	HTTPURLAdminBase string
+
 	// RetryInterval is how often to retry polling operations.
 	RetryInterval time.Duration
 
@@ -69,6 +79,42 @@ func (h *HTTP) RequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
 	require.NoError(h.t, err, "error creating HTTP request")
 
 	req.Host = opts.Host
+	for _, opt := range opts.RequestOpts {
+		opt(req)
+	}
+
+	makeRequest := func() (*http.Response, error) {
+		return http.DefaultClient.Do(req)
+	}
+
+	return h.requestUntil(makeRequest, opts.Condition)
+}
+
+// MetricsRequestUntil repeatedly makes HTTP requests with the provided
+// parameters until "condition" returns true or the timeout is reached.
+// It always returns the last HTTP response received.
+func (h *HTTP) MetricsRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
+	req, err := http.NewRequest("GET", h.HTTPURLMetricsBase+opts.Path, nil)
+	require.NoError(h.t, err, "error creating HTTP request")
+
+	for _, opt := range opts.RequestOpts {
+		opt(req)
+	}
+
+	makeRequest := func() (*http.Response, error) {
+		return http.DefaultClient.Do(req)
+	}
+
+	return h.requestUntil(makeRequest, opts.Condition)
+}
+
+// AdminRequestUntil repeatedly makes HTTP requests with the provided
+// parameters until "condition" returns true or the timeout is reached.
+// It always returns the last HTTP response received.
+func (h *HTTP) AdminRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
+	req, err := http.NewRequest("GET", h.HTTPURLAdminBase+opts.Path, nil)
+	require.NoError(h.t, err, "error creating HTTP request")
+
 	for _, opt := range opts.RequestOpts {
 		opt(req)
 	}

--- a/test/e2e/infra/admin_test.go
+++ b/test/e2e/infra/admin_test.go
@@ -1,0 +1,52 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package infra
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdminInterface() {
+	Specify("requests to admin listener are served", func() {
+		t := f.T()
+
+		cases := []string{
+			"/certs",
+			"/clusters",
+			"/listeners",
+			"/config_dump",
+			"/memory",
+			"/ready",
+			"/runtime",
+			"/server_info",
+			"/stats",
+			"/stats/prometheus",
+			"/stats/recentlookups",
+		}
+
+		for _, prefix := range cases {
+			t.Logf("Querying admin prefix %q", prefix)
+
+			res, ok := f.HTTP.AdminRequestUntil(&e2e.HTTPRequestOpts{
+				Path:      prefix,
+				Condition: e2e.HasStatusCode(200),
+			})
+			require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+		}
+	})
+}

--- a/test/e2e/infra/admin_test.go
+++ b/test/e2e/infra/admin_test.go
@@ -25,26 +25,29 @@ func testAdminInterface() {
 	Specify("requests to admin listener are served", func() {
 		t := f.T()
 
-		cases := []string{
-			"/certs",
-			"/clusters",
-			"/listeners",
-			"/config_dump",
-			"/memory",
-			"/ready",
-			"/runtime",
-			"/server_info",
-			"/stats",
-			"/stats/prometheus",
-			"/stats/recentlookups",
+		cases := map[string]int{
+			"/certs":               200,
+			"/clusters":            200,
+			"/listeners":           200,
+			"/config_dump":         200,
+			"/memory":              200,
+			"/ready":               200,
+			"/runtime":             200,
+			"/server_info":         200,
+			"/stats":               200,
+			"/stats/prometheus":    200,
+			"/stats/recentlookups": 200,
+			"/quitquitquit":        404,
+			"/healthcheck/ok":      404,
+			"/healthcheck/fail":    404,
 		}
 
-		for _, prefix := range cases {
+		for prefix, code := range cases {
 			t.Logf("Querying admin prefix %q", prefix)
 
 			res, ok := f.HTTP.AdminRequestUntil(&e2e.HTTPRequestOpts{
 				Path:      prefix,
-				Condition: e2e.HasStatusCode(200),
+				Condition: e2e.HasStatusCode(code),
 			})
 			require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		}

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -1,0 +1,92 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package infra
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/projectcontour/contour/pkg/config"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+var f = e2e.NewFramework(false)
+
+func TestInfra(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infra tests")
+}
+
+var _ = BeforeSuite(func() {
+	require.NoError(f.T(), f.Deployment.EnsureResourcesForLocalContour())
+})
+
+var _ = AfterSuite(func() {
+	// Delete resources individually instead of deleting the entire contour
+	// namespace as a performance optimization, because deleting non-empty
+	// namespaces can take up to a couple of minutes to complete.
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
+	gexec.CleanupBuildArtifacts()
+})
+
+var _ = Describe("Infra", func() {
+	var (
+		contourCmd            *gexec.Session
+		kubectlCmd            *gexec.Session
+		contourConfig         *config.Parameters
+		contourConfigFile     string
+		additionalContourArgs []string
+	)
+
+	BeforeEach(func() {
+		// Contour config file contents, can be modified in nested
+		// BeforeEach.
+		contourConfig = &config.Parameters{}
+
+		// Default contour serve command line arguments can be appended to in
+		// nested BeforeEach.
+		additionalContourArgs = []string{}
+	})
+
+	// JustBeforeEach is called after each of the nested BeforeEach are
+	// called, so it is a final setup step before running a test.
+	// A nested BeforeEach may have modified Contour config, so we wait
+	// until here to start Contour.
+	JustBeforeEach(func() {
+		var err error
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		require.NoError(f.T(), err)
+
+		// Wait for Envoy to be healthy.
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+
+		kubectlCmd, err = f.Kubectl.StartKubectlPortForward(19001, 9001, "projectcontour", "daemonset/envoy", additionalContourArgs...)
+		require.NoError(f.T(), err)
+	})
+
+	AfterEach(func() {
+		require.NoError(f.T(), f.Kubectl.StopKubectlPortForward(kubectlCmd))
+		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+	})
+
+	f.Test(testMetrics)
+	f.Test(testReady)
+
+	f.Test(testAdminInterface)
+})

--- a/test/e2e/infra/metrics_test.go
+++ b/test/e2e/infra/metrics_test.go
@@ -1,0 +1,46 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package infra
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func testMetrics() {
+	Specify("requests to default metrics listener are served", func() {
+		t := f.T()
+
+		res, ok := f.HTTP.MetricsRequestUntil(&e2e.HTTPRequestOpts{
+			Path:      "/stats",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	})
+}
+
+func testReady() {
+	Specify("requests to default ready listener are served", func() {
+		t := f.T()
+
+		res, ok := f.HTTP.MetricsRequestUntil(&e2e.HTTPRequestOpts{
+			Path:      "/ready",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	})
+}

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1,0 +1,53 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+type Kubectl struct {
+	// Command output is written to this writer.
+	cmdOutputWriter io.Writer
+}
+
+func (k *Kubectl) StartKubectlPortForward(localPort, containerPort int, namespace, object string, additionalArgs ...string) (*gexec.Session, error) {
+	args := append([]string{
+		"port-forward",
+		"-n",
+		namespace,
+		object,
+		fmt.Sprintf("%d:%d", localPort, containerPort),
+	}, additionalArgs...)
+
+	session, err := gexec.Start(exec.Command("kubectl", args...), k.cmdOutputWriter, k.cmdOutputWriter) // nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+func (k *Kubectl) StopKubectlPortForward(cmd *gexec.Session) error {
+	// Default timeout of 1s produces test flakes,
+	// a minute should be more than enough to avoid them.
+	cmd.Terminate().Wait(time.Minute)
+	return nil
+}

--- a/test/scripts/kind-expose-port.yaml
+++ b/test/scripts/kind-expose-port.yaml
@@ -10,3 +10,6 @@ nodes:
   - containerPort: 443
     hostPort: 9443
     listenAddress: "0.0.0.0"
+  - containerPort: 8002
+    hostPort: 8002
+    listenAddress: "0.0.0.0"


### PR DESCRIPTION
- Moves the Envoy admin interface to use a unix socket
- Creates new listener from Contour to expose read only information
  from Envoy admin page over port 9001
- Updates shutdown-manager to use new unix socket to begin Envoy
  draining procedure

Signed-off-by: Steve Sloka <slokas@vmware.com>