### PR TITLE
[Release 1.15] Use exact kind node image

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -20,11 +20,11 @@ jobs:
         include:
             # TODO: Move to upstream image once available (#3610).
           - kubernetes_version: "kubernetes:latest"
-            node_image: "stevesloka/kind-node:v1.21.0"
+            node_image: "docker.io/kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
           - kubernetes_version: "kubernetes:n-1"
-            node_image: "docker.io/kindest/node:v1.20.2"
+            node_image: "docker.io/kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
           - kubernetes_version: "kubernetes:n-2"
-            node_image: "docker.io/kindest/node:v1.19.7"
+            node_image: "docker.io/kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"
     steps:
       - uses: actions/checkout@v2
       - name: add deps to path

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 readonly KUSTOMIZE_VERS="v3.8.6"
-readonly KUBECTL_VERS="v1.20.4"
+readonly KUBECTL_VERS="v1.21.1"
 readonly KIND_VERS="v0.11.1"
 readonly SONOBUOY_VERS="0.19.0"
 

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 readonly KUSTOMIZE_VERS="v3.8.6"
 readonly KUBECTL_VERS="v1.20.4"
-readonly KIND_VERS="v0.10.0"
+readonly KIND_VERS="v0.11.1"
 readonly SONOBUOY_VERS="0.19.0"
 
 readonly PROGNAME=$(basename $0)

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -38,20 +38,11 @@ case "$#" in
     ;;
 esac
 
-# TODO: Remove once upstream images are available (#3610).
-# Install latest version of kind.
-go get sigs.k8s.io/kind@master
+download \
+   "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERS}/kind-${OS}-amd64" \
+   "${DESTDIR}/kind"
 
-# Move the $GOPATH/bin/kind binary to local since Github actions
-# have their own version installed.
-mv /home/runner/go/bin/kind ${DESTDIR}/kind
-
-# Uncomment this once v0.11 of Kind is released.
-#download \
-#    "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERS}/kind-${OS}-amd64" \
-#    "${DESTDIR}/kind"
-#
-#chmod +x  "${DESTDIR}/kind"
+chmod +x  "${DESTDIR}/kind"
 
 download \
     "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERS}/bin/${OS}/amd64/kubectl" \


### PR DESCRIPTION
Using just a tag, kind cluster does not start up properly

Also bumps kind CLI version since we need k8s 1.21 images