### PR TITLE
drop obsolete DynamicClientHandler

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -396,7 +396,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	}
 
 	// Build the core Kubernetes event handler.
-	eventHandler := &contour.EventHandler{
+	contourHandler := &contour.EventHandler{
 		HoldoffDelay:    100 * time.Millisecond,
 		HoldoffMaxDelay: 500 * time.Millisecond,
 		Observer:        dag.ComposeObservers(append(xdscache.ObserversOf(resources), snapshotHandler)...),
@@ -404,9 +404,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		FieldLogger:     log.WithField("context", "contourEventHandler"),
 	}
 
-	// Wrap eventHandler in an EventRecorder which tracks API server events.
-	recordingHandler := &contour.EventRecorder{
-		Next:    eventHandler,
+	// Wrap contourHandler in an EventRecorder which tracks API server events.
+	eventHandler := &contour.EventRecorder{
+		Next:    contourHandler,
 		Counter: contourMetrics.EventHandlerOperations,
 	}
 
@@ -422,13 +422,13 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on DefaultResources.
 	for _, r := range k8s.DefaultResources() {
-		if err := informOnResource(clients, r, recordingHandler, mgr.GetCache()); err != nil {
+		if err := informOnResource(clients, r, eventHandler, mgr.GetCache()); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
 
 	for _, r := range k8s.IngressV1Resources() {
-		if err := informOnResource(clients, r, recordingHandler, mgr.GetCache()); err != nil {
+		if err := informOnResource(clients, r, eventHandler, mgr.GetCache()); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
@@ -440,7 +440,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			gatewayClassControllerName := ctx.Config.GatewayConfig.ControllerName
 			if _, err := controller.NewGatewayClassController(
 				mgr,
-				recordingHandler,
+				eventHandler,
 				sh.Writer(),
 				log.WithField("context", "gatewayclass-controller"),
 				gatewayClassControllerName,
@@ -449,23 +449,23 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			}
 
 			// Create and register the NewGatewayController controller with the manager.
-			if _, err := controller.NewGatewayController(mgr, recordingHandler,
+			if _, err := controller.NewGatewayController(mgr, eventHandler,
 				log.WithField("context", "gateway-controller"), gatewayClassControllerName); err != nil {
 				log.WithError(err).Fatal("failed to create gateway-controller")
 			}
 
 			// Create and register the NewHTTPRouteController controller with the manager.
-			if _, err := controller.NewHTTPRouteController(mgr, recordingHandler, log.WithField("context", "httproute-controller")); err != nil {
+			if _, err := controller.NewHTTPRouteController(mgr, eventHandler, log.WithField("context", "httproute-controller")); err != nil {
 				log.WithError(err).Fatal("failed to create httproute-controller")
 			}
 
 			// Create and register the NewTLSRouteController controller with the manager.
-			if _, err := controller.NewTLSRouteController(mgr, recordingHandler, log.WithField("context", "tlsroute-controller")); err != nil {
+			if _, err := controller.NewTLSRouteController(mgr, eventHandler, log.WithField("context", "tlsroute-controller")); err != nil {
 				log.WithError(err).Fatal("failed to create tlsroute-controller")
 			}
 
 			// Inform on Namespaces.
-			if err := informOnResource(clients, k8s.NamespacesResource(), recordingHandler, mgr.GetCache()); err != nil {
+			if err := informOnResource(clients, k8s.NamespacesResource(), eventHandler, mgr.GetCache()); err != nil {
 				log.WithError(err).WithField("resource", k8s.NamespacesResource()).Fatal("failed to create informer")
 			}
 		} else {
@@ -475,11 +475,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on secrets, filtering by root namespaces.
 	for _, r := range k8s.SecretsResources() {
-		var handler cache.ResourceEventHandler = recordingHandler
+		var handler cache.ResourceEventHandler = eventHandler
 
 		// If root namespaces are defined, filter for secrets in only those namespaces.
 		if len(informerNamespaces) > 0 {
-			handler = k8s.NewNamespaceFilter(informerNamespaces, recordingHandler)
+			handler = k8s.NewNamespaceFilter(informerNamespaces, eventHandler)
 		}
 
 		if err := informOnResource(clients, r, handler, mgr.GetCache()); err != nil {
@@ -498,7 +498,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	}
 
 	// Register our event handler with the workgroup.
-	g.Add(eventHandler.Start())
+	g.Add(contourHandler.Start())
 
 	// Create metrics service and register with workgroup.
 	metricsvc := httpsvc.Service{
@@ -540,39 +540,39 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			Port:        ctx.debugPort,
 			FieldLogger: log.WithField("context", "debugsvc"),
 		},
-		Builder: &eventHandler.Builder,
+		Builder: &contourHandler.Builder,
 	}
 	g.Add(debugsvc.Start)
 
 	// Register leadership election.
 	if ctx.DisableLeaderElection {
-		eventHandler.IsLeader = disableLeaderElection(log)
+		contourHandler.IsLeader = disableLeaderElection(log)
 	} else {
-		eventHandler.IsLeader = setupLeadershipElection(&g, log, &ctx.Config.LeaderElection, clients, eventHandler.UpdateNow)
+		contourHandler.IsLeader = setupLeadershipElection(&g, log, &ctx.Config.LeaderElection, clients, contourHandler.UpdateNow)
 	}
 
 	// Once we have the leadership detection channel, we can
 	// push DAG rebuild metrics onto the observer stack.
-	eventHandler.Observer = &contour.RebuildMetricsObserver{
+	contourHandler.Observer = &contour.RebuildMetricsObserver{
 		Metrics:      contourMetrics,
-		IsLeader:     eventHandler.IsLeader,
-		NextObserver: eventHandler.Observer,
+		IsLeader:     contourHandler.IsLeader,
+		NextObserver: contourHandler.Observer,
 	}
 
 	// Finish setting up the StatusUpdateHandler and
 	// add it to the work group.
-	sh.LeaderElected = eventHandler.IsLeader
+	sh.LeaderElected = contourHandler.IsLeader
 	g.Add(sh.Start)
 
 	// Now we have the statusUpdateHandler, we can create the event handler's StatusUpdater, which will take the
 	// status updates from the DAG, and send them to the status update handler.
-	eventHandler.StatusUpdater = sh.Writer()
+	contourHandler.StatusUpdater = sh.Writer()
 
 	// Set up ingress load balancer status writer.
 	lbsw := loadBalancerStatusWriter{
 		log:              log.WithField("context", "loadBalancerStatusWriter"),
 		cache:            mgr.GetCache(),
-		isLeader:         eventHandler.IsLeader,
+		isLeader:         contourHandler.IsLeader,
 		lbStatus:         make(chan corev1.LoadBalancerStatus, 1),
 		ingressClassName: ctx.ingressClassName,
 		statusUpdater:    sh.Writer(),

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -404,15 +404,10 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		FieldLogger:     log.WithField("context", "contourEventHandler"),
 	}
 
-	// Wrap eventHandler in a converter for objects from the dynamic client.
-	// and an EventRecorder which tracks API server events.
-	dynamicHandler := k8s.DynamicClientHandler{
-		Next: &contour.EventRecorder{
-			Next:    eventHandler,
-			Counter: contourMetrics.EventHandlerOperations,
-		},
-		Converter: converter,
-		Logger:    log.WithField("context", "dynamicHandler"),
+	// Wrap eventHandler in an EventRecorder which tracks API server events.
+	recordingHandler := &contour.EventRecorder{
+		Next:    eventHandler,
+		Counter: contourMetrics.EventHandlerOperations,
 	}
 
 	// Start setting up StatusUpdateHandler since we need it in
@@ -427,13 +422,13 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on DefaultResources.
 	for _, r := range k8s.DefaultResources() {
-		if err := informOnResource(clients, r, &dynamicHandler, mgr.GetCache()); err != nil {
+		if err := informOnResource(clients, r, recordingHandler, mgr.GetCache()); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
 
 	for _, r := range k8s.IngressV1Resources() {
-		if err := informOnResource(clients, r, &dynamicHandler, mgr.GetCache()); err != nil {
+		if err := informOnResource(clients, r, recordingHandler, mgr.GetCache()); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
 	}
@@ -445,7 +440,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			gatewayClassControllerName := ctx.Config.GatewayConfig.ControllerName
 			if _, err := controller.NewGatewayClassController(
 				mgr,
-				&dynamicHandler,
+				recordingHandler,
 				sh.Writer(),
 				log.WithField("context", "gatewayclass-controller"),
 				gatewayClassControllerName,
@@ -454,23 +449,23 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 			}
 
 			// Create and register the NewGatewayController controller with the manager.
-			if _, err := controller.NewGatewayController(mgr, &dynamicHandler,
+			if _, err := controller.NewGatewayController(mgr, recordingHandler,
 				log.WithField("context", "gateway-controller"), gatewayClassControllerName); err != nil {
 				log.WithError(err).Fatal("failed to create gateway-controller")
 			}
 
 			// Create and register the NewHTTPRouteController controller with the manager.
-			if _, err := controller.NewHTTPRouteController(mgr, &dynamicHandler, log.WithField("context", "httproute-controller")); err != nil {
+			if _, err := controller.NewHTTPRouteController(mgr, recordingHandler, log.WithField("context", "httproute-controller")); err != nil {
 				log.WithError(err).Fatal("failed to create httproute-controller")
 			}
 
 			// Create and register the NewTLSRouteController controller with the manager.
-			if _, err := controller.NewTLSRouteController(mgr, &dynamicHandler, log.WithField("context", "tlsroute-controller")); err != nil {
+			if _, err := controller.NewTLSRouteController(mgr, recordingHandler, log.WithField("context", "tlsroute-controller")); err != nil {
 				log.WithError(err).Fatal("failed to create tlsroute-controller")
 			}
 
 			// Inform on Namespaces.
-			if err := informOnResource(clients, k8s.NamespacesResource(), &dynamicHandler, mgr.GetCache()); err != nil {
+			if err := informOnResource(clients, k8s.NamespacesResource(), recordingHandler, mgr.GetCache()); err != nil {
 				log.WithError(err).WithField("resource", k8s.NamespacesResource()).Fatal("failed to create informer")
 			}
 		} else {
@@ -480,11 +475,11 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on secrets, filtering by root namespaces.
 	for _, r := range k8s.SecretsResources() {
-		var handler cache.ResourceEventHandler = &dynamicHandler
+		var handler cache.ResourceEventHandler = recordingHandler
 
 		// If root namespaces are defined, filter for secrets in only those namespaces.
 		if len(informerNamespaces) > 0 {
-			handler = k8s.NewNamespaceFilter(informerNamespaces, &dynamicHandler)
+			handler = k8s.NewNamespaceFilter(informerNamespaces, recordingHandler)
 		}
 
 		if err := informOnResource(clients, r, handler, mgr.GetCache()); err != nil {
@@ -494,13 +489,9 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 
 	// Inform on endpoints.
 	for _, r := range k8s.EndpointsResources() {
-		if err := informOnResource(clients, r, &k8s.DynamicClientHandler{
-			Next: &contour.EventRecorder{
-				Next:    endpointHandler,
-				Counter: contourMetrics.EventHandlerOperations,
-			},
-			Converter: converter,
-			Logger:    log.WithField("context", "endpointstranslator"),
+		if err := informOnResource(clients, r, &contour.EventRecorder{
+			Next:    endpointHandler,
+			Counter: contourMetrics.EventHandlerOperations,
 		}, mgr.GetCache()); err != nil {
 			log.WithError(err).WithField("resource", r).Fatal("failed to create informer")
 		}
@@ -594,18 +585,14 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 		log.WithField("loadbalancer-address", lbAddr).Info("Using supplied information for Ingress status")
 		lbsw.lbStatus <- parseStatusFlag(lbAddr)
 	} else {
-		dynamicServiceHandler := k8s.DynamicClientHandler{
-			Next: &k8s.ServiceStatusLoadBalancerWatcher{
-				ServiceName: ctx.Config.EnvoyServiceName,
-				LBStatus:    lbsw.lbStatus,
-				Log:         log.WithField("context", "serviceStatusLoadBalancerWatcher"),
-			},
-			Converter: converter,
-			Logger:    log.WithField("context", "serviceStatusLoadBalancerWatcher"),
+		serviceHandler := &k8s.ServiceStatusLoadBalancerWatcher{
+			ServiceName: ctx.Config.EnvoyServiceName,
+			LBStatus:    lbsw.lbStatus,
+			Log:         log.WithField("context", "serviceStatusLoadBalancerWatcher"),
 		}
 
 		for _, r := range k8s.ServicesResources() {
-			var handler cache.ResourceEventHandler = &dynamicServiceHandler
+			var handler cache.ResourceEventHandler = serviceHandler
 
 			if ctx.Config.EnvoyServiceNamespace != "" {
 				handler = k8s.NewNamespaceFilter([]string{ctx.Config.EnvoyServiceNamespace}, handler)

--- a/internal/k8s/converter.go
+++ b/internal/k8s/converter.go
@@ -16,57 +16,9 @@ package k8s
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 )
-
-// DynamicClientHandler converts *unstructured.Unstructured from the
-// k8s dynamic client to the types registered with the supplied Converter
-// and forwards them to the next Handler in the chain.
-type DynamicClientHandler struct {
-
-	// Next is the next handler in the chain.
-	Next cache.ResourceEventHandler
-
-	// Converter is the registered converter.
-	Converter Converter
-
-	Logger logrus.FieldLogger
-}
-
-func (d *DynamicClientHandler) OnAdd(obj interface{}) {
-	obj, err := d.Converter.FromUnstructured(obj)
-	if err != nil {
-		d.Logger.Error(err)
-		return
-	}
-	d.Next.OnAdd(obj)
-}
-
-func (d *DynamicClientHandler) OnUpdate(oldObj, newObj interface{}) {
-	oldObj, err := d.Converter.FromUnstructured(oldObj)
-	if err != nil {
-		d.Logger.Error(err)
-		return
-	}
-	newObj, err = d.Converter.FromUnstructured(newObj)
-	if err != nil {
-		d.Logger.Error(err)
-		return
-	}
-	d.Next.OnUpdate(oldObj, newObj)
-}
-
-func (d *DynamicClientHandler) OnDelete(obj interface{}) {
-	obj, err := d.Converter.FromUnstructured(obj)
-	if err != nil {
-		d.Logger.Error(err)
-		return
-	}
-	d.Next.OnDelete(obj)
-}
 
 type Converter interface {
 	FromUnstructured(obj interface{}) (interface{}, error)

--- a/internal/k8s/converter_test.go
+++ b/internal/k8s/converter_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/tools/cache"
 	gatewayapi_v1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
@@ -326,5 +325,3 @@ func TestConvertUnstructured(t *testing.T) {
 	})
 
 }
-
-var _ cache.ResourceEventHandler = &DynamicClientHandler{}


### PR DESCRIPTION
The DynamicClientHandler is no longer needed since we are
not using dynamic informers anymore. It has been silently
performing no-ops for awhile. This PR removes it.

Signed-off-by: Steve Kriss <krisss@vmware.com>