### PR TITLE
design: Add configuration & deployment crd design

### DIFF
--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -1,0 +1,250 @@
+# Contour Configuration CRD
+
+Currently, Contour gets its configuration from two different places, one is the configuration file represented as a Kubernetes configmap.
+The other are flags which are passed to Contour.
+
+Contour's configmap configuration file has grown to the point where moving to a CRD will enable a better user experience as well as allowing Contour to react to changes in its configuration faster.
+
+This design proposes two new CRDs, one that represents a `ContourConfig` and another which represents a `ContourDeployment`.
+The Contour configuration mirrors how the configmap functions today. 
+A Contour Deployment is managed by a controller (aka Operator) which uses the details of the CRD spec to deploy a fully managed instance of Contour inside a cluster.
+
+## Benefits
+- Eliminates the need to translate from a CRD to a configmap (Like the Operator does today)
+- Allows for a place to surface information about configuration errors - the CRD status, in addition to the Contour log files
+- Allows the Operator workflow to match a non-operator workflow (i.e. you start with a Contour configuration CRD)
+- Provides better validation to avoid errors in the configuration file
+
+## Contour Configuration
+
+The Contour configuration file wil be migrated into a Contour Configuration CRD named `Contour`.
+The current config file looks like this:
+
+```yaml
+server:
+  xds-server-type: contour
+gateway:
+  controllerName: projectcontour.io/projectcontour/contour
+incluster: true
+kubeconfig: /path/to/.kube/config
+disableAllowChunkedLength: false
+disablePermitInsecure: false
+tls:
+  minimum-protocol-version: "1.2"
+  cipher-suites:
+  - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+  - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+  - 'ECDHE-ECDSA-AES256-GCM-SHA384'
+  - 'ECDHE-RSA-AES256-GCM-SHA384'
+fallback-certificate:
+  name: fallback-secret-name
+  namespace: projectcontour
+envoy-client-certificate:
+  name: envoy-client-cert-secret-name
+  namespace: projectcontour
+leaderelection:
+  configmap-name: leader-elect
+  configmap-namespace: projectcontour
+enableExternalNameService: false
+accesslog-format: envoy
+accesslog-format-string: "...\n"
+json-fields:
+  - <Fields Omitted)
+default-http-versions:
+  - "HTTP/2"
+  - "HTTP/1.1"
+timeouts:
+  request-timeout: infinity
+  connection-idle-timeout: 60s
+  stream-idle-timeout: 5m
+  max-connection-duration: infinity
+  delayed-close-timeout: 1s
+  connection-shutdown-grace-period: 5s
+cluster:
+  dns-lookup-family: auto
+network:
+  num-trusted-hops: 0
+  admin-port: 9001
+rateLimitService:
+  extensionService: projectcontour/ratelimit
+  domain: contour
+  failOpen: false
+  enableXRateLimitHeaders: false
+policy:
+  request-headers:
+    set:
+  response-headers:
+    set:
+```
+
+The contents of this file has grown over time and some fields need to be better categorized. 
+The new ContourConfiguration CRD will move the logging options into a `logging` struct. 
+All other fields will stay the same where they currently exist in the configmap.
+
+### New fields:
+
+Some fields will be moved around and others added to complete the configuration:
+- logging: The logging configuration bits are now moved into a common struct
+- envoy: This manages the Envoy configuration of how it should be deployed and exposed from the cluster
+- ingressClassName: Adds the `ingress-class-name` flag to the configuration file
+
+## New CRD Spec
+
+```yaml
+apiVersion: projectcontour.io/v1alpha1
+kind: ContourConfiguration
+metadata:
+  name: contour
+spec:
+  server:
+    xds-server-type: contour
+  ingressClassName: contour
+  envoy:  
+    networkPublishing:
+    nodePlacement:
+      nodeSelector:
+      tolerations:
+  gateway:
+      controllerName: projectcontour.io/projectcontour/contour
+  incluster: true
+  kubeconfig: /path/to/.kube/config
+  disableAllowChunkedLength: false
+  disablePermitInsecure: false
+  tls:
+    minimum-protocol-version: "1.2"
+    cipher-suites:
+      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+      - 'ECDHE-ECDSA-AES256-GCM-SHA384'
+      - 'ECDHE-RSA-AES256-GCM-SHA384'
+  fallback-certificate:
+    name: fallback-secret-name
+    namespace: projectcontour
+  envoy-client-certificate:
+    name: envoy-client-cert-secret-name
+    namespace: projectcontour
+  leaderelection:
+    configmap-name: leader-elect
+    configmap-namespace: projectcontour
+  enableExternalNameService: false
+  logging: 
+    accesslog-format: envoy
+    accesslog-format-string: "...\n"
+    json-fields:
+      - <Fields Omitted)
+  default-http-versions:
+    - "HTTP/2"
+    - "HTTP/1.1"
+  timeouts:
+    request-timeout: infinity
+    connection-idle-timeout: 60s
+    stream-idle-timeout: 5m
+    max-connection-duration: infinity
+    delayed-close-timeout: 1s
+    connection-shutdown-grace-period: 5s
+  cluster:
+    dns-lookup-family: auto
+  network:
+    num-trusted-hops: 0
+    admin-port: 9001
+  rateLimitService:
+    extensionService: projectcontour/ratelimit
+    domain: contour
+    failOpen: false
+    enableXRateLimitHeaders: false
+  policy:
+    request-headers:
+      set:
+    response-headers:
+      set:
+status:
+```
+
+## Contour Deployment
+
+A managed version of Contour was made available with the `Contour Operator`.
+Since Contour will manage Envoy instances, the Operator will now manage instances of Contour.
+The details of how an instance of Contour should be deployed within a cluster will be defined in the second CRD named `ContourDeployment`. 
+
+A controller will watch for these objects to be created and take action on them accordingly to make desired state in the cluster match the configuration on the spec. 
+
+```yaml
+apiVersion: projectcontour.io/v1alpha1
+kind: ContourDeployment
+metadata:
+  name: contour
+spec:
+  replicas: 2
+  nodePlacement:
+    nodeSelector:
+    tolerations:
+  configuration:
+    server:
+      xds-server-type: contour
+    ingressClassName: contour
+    envoy:
+      networkPublishing:
+      nodePlacement:
+        nodeSelector:
+        tolerations:
+    gateway:
+        controllerName: projectcontour.io/projectcontour/contour
+    incluster: true
+    kubeconfig: /path/to/.kube/config
+    disableAllowChunkedLength: false
+    disablePermitInsecure: false
+    tls:
+      minimum-protocol-version: "1.2"
+      cipher-suites:
+      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+      - 'ECDHE-ECDSA-AES256-GCM-SHA384'
+      - 'ECDHE-RSA-AES256-GCM-SHA384'
+    fallback-certificate:
+      name: fallback-secret-name
+      namespace: projectcontour
+    envoy-client-certificate:
+      name: envoy-client-cert-secret-name
+      namespace: projectcontour
+    leaderelection:
+      configmap-name: leader-elect
+      configmap-namespace: projectcontour
+    enableExternalNameService: false
+    logging: 
+      accesslog-format: envoy
+      accesslog-format-string: "...\n"
+      json-fields:
+        - <Fields Omitted)
+    default-http-versions:
+      - "HTTP/2"
+      - "HTTP/1.1"
+    timeouts:
+      request-timeout: infinity
+      connection-idle-timeout: 60s
+      stream-idle-timeout: 5m
+      max-connection-duration: infinity
+      delayed-close-timeout: 1s
+      connection-shutdown-grace-period: 5s
+    cluster:
+      dns-lookup-family: auto
+    network:
+      num-trusted-hops: 0
+      admin-port: 9001
+    rateLimitService:
+      extensionService: projectcontour/ratelimit
+      domain: contour
+      failOpen: false
+      enableXRateLimitHeaders: false
+    policy:
+      request-headers:
+        set:
+      response-headers:
+        set:
+status:
+```
+
+## Versioning
+
+Initially, the CRDs will use the `v1alpha1` api group to allow for changes to the specs before they are released as a full `v1` spec. 
+It's possible that we find issues along the way developing the new controllers and migrating to this new configuration method. 
+Having a way to change the spec should we need to will be helpful on the path to a full v1 version. 

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -56,7 +56,7 @@ spec:
   debug:
     address: 127.0.0.1
     port: 6060
-    debug: false 
+    logLevel: Info 
     kubernetes-debug: 0
   health:
     address: 0.0.0.0

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -119,7 +119,9 @@ spec:
       controllerName: projectcontour.io/projectcontour/contour
   httpproxy:
     disablePermitInsecure: false
-    rootNamespaces: foo,bar
+    rootNamespaces: 
+      - foo
+      - bar
     fallbackCertificate:
       name: fallback-secret-name
       namespace: projectcontour
@@ -192,6 +194,11 @@ Once Contour begins using a Configuration CRD, it will add a finalizer to it suc
 Should the Configuration CRD be deleted while it is in use, Contour will default back to reasonable defaults and log the issue.
 
 When config in the CRD changes we will gracefully stop the dependent ingress/gateway controllers and restart them with new config, or dynamically update some in-memory data that the controllers use.
+
+If the configuration changes, Contour will first validate the new Configuration.
+If that new change set results in the object being invalid, Contour won't restart its controllers but set status and still try and serve the old configuration.
+Should a new Contour instance start up, or the existing be restarted and the configuration is still invalid, then it will not become ready and not serve any xDS traffic.
+As soon as the configuration does become valid, Contour will start up its controllers and begin processing as normal.
 
 ## Versioning
 

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -200,8 +200,11 @@ When config in the CRD changes we will gracefully stop the dependent ingress/gat
 Contour will first validate the new Configuration, ff that new change set results in the object being invalid, Contour will stop its Controller and will become not ready, and not serve any xDS traffic.
 As soon as the configuration does become valid, Contour will start up its controllers and begin processing as normal.
 
-Contour will initially start implementing this dynamic nature by restarting all Controllers when the config file changes.
-It's possible later on that this could be better optimized to keep the last working configuration, as well as only restarting specific controllers.
+### Initial Implementation
+
+Contour will initially start implementation by restarting the Contour pod and allowing Kubernetes to restart itself when the config file changes.
+Should the configuration be invalid, Contour will start up, set status on the ContourConfig CRD and then crash.
+Kubernetes will crash-loop until the configuration is valid, however, due to the nature of the exponential backoff, updates to the Configuration CRD will not be realized until the next restart loop, or Contour is restarted manually. 
 
 ## Versioning
 

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -57,7 +57,7 @@ spec:
     address: 127.0.0.1
     port: 6060
     logLevel: Info 
-    kubernetes-debug: 0
+    kubernetesLogLevel: 0
   health:
     address: 0.0.0.0
     port: 8000

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -79,14 +79,14 @@ spec:
     service:
       name: contour
       namespace: projectcontour
-      http: 
-          address: 0.0.0.0
-          port: 80
-          accessLog: /dev/STDOUT
-      https:
-          address: 0.0.0.0
-          port: 443
-          accessLog: /dev/STDOUT
+    http: 
+      address: 0.0.0.0
+      port: 80
+      accessLog: /dev/STDOUT
+    https:
+      address: 0.0.0.0
+      port: 443
+      accessLog: /dev/STDOUT
     metrics:
       address: 0.0.0.0
       port: 8002

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -69,13 +69,13 @@ spec:
       useProxyProtocol: false
       disableAllowChunkedLength: false
       connectionBalancer: exact
-    tls:
-      minimumProtocolVersion: "1.2"
-      cipherSuites:
-        - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-        - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-        - 'ECDHE-ECDSA-AES256-GCM-SHA384'
-        - 'ECDHE-RSA-AES256-GCM-SHA384'
+      tls:
+        minimumProtocolVersion: "1.2"
+        cipherSuites:
+          - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+          - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+          - 'ECDHE-ECDSA-AES256-GCM-SHA384'
+          - 'ECDHE-RSA-AES256-GCM-SHA384'
     service:
       name: contour
       namespace: projectcontour

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -93,6 +93,9 @@ spec:
     clientCertificate:
       name: envoy-client-cert-secret-name
       namespace: projectcontour
+    network:
+      numTrustedHops: 0
+      adminPort: 9001
     managed:
       networkPublishing:
       nodePlacement:
@@ -131,9 +134,6 @@ spec:
       namespace: projectcontour
     disableLeaderElection: false
   enableExternalNameService: false
-  network:
-    numTrustedHops: 0
-    adminPort: 9001
   rateLimitService:
     extensionService: projectcontour/ratelimit
     domain: contour

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -65,8 +65,10 @@ spec:
     address: 0.0.0.0
     port: 8002    
   envoy:
-    useProxyProtocol: false
-    disableAllowChunkedLength: false
+    listener:
+      useProxyProtocol: false
+      disableAllowChunkedLength: false
+      connectionBalancer: exact
     tls:
       minimumProtocolVersion: "1.2"
       cipherSuites:
@@ -74,7 +76,9 @@ spec:
         - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
         - 'ECDHE-ECDSA-AES256-GCM-SHA384'
         - 'ECDHE-RSA-AES256-GCM-SHA384'
-    services:
+    service:
+      name: contour
+      namespace: projectcontour
       http: 
           address: 0.0.0.0
           port: 80

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -16,24 +16,12 @@ A Contour Deployment is managed by a controller (aka Operator) which uses the de
 - Provides better validation to avoid errors in the configuration file
 - Dynamic restarting of Contour when configuration changes
 
-## Contour Configuration
-
-The contents of current configuration file has grown over time and some fields need to be better categorized. 
-The new `ContourConfiguration` CRD will move the logging options into a `logging` struct. 
-All other fields will stay the same where they currently exist in the configmap.
-Any field that was not previously `camelCased` will be renamed to match.
-
-### New fields:
-
-Some fields will be moved around and others added to complete the configuration:
-- logging: The logging configuration bits are now moved into a common struct
-- ingress: There are some ingress configuration items that are now moved into a common struct.
-- envoy: This manages the Envoy configuration of how it should be deployed and exposed from the cluster
-- ingressClassName: Adds the `ingress-class-name` flag to the configuration file
-- incluster (Removed)
-- kubeconfig (Removed)
-
 ## New CRD Spec
+
+The contents of current configuration file has grown over time and some fields need to be better categorized.
+- Any field that was not previously `camelCased` will be renamed to match.
+- All the non-startup required command flags have been moved to the configuration CRD.
+- New groupings of similar fields have been created to make the file flow better.
 
 ```yaml
 apiVersion: projectcontour.io/v1alpha1

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -150,6 +150,7 @@ Contour will provide a new command or external tool (similar to ir2proxy) which 
 A managed version of Contour was made available with the `Contour Operator`.
 Since Contour will manage Envoy instances, the Operator will now manage instances of Contour.
 The details of how an instance of Contour should be deployed within a cluster will be defined in the second CRD named `ContourDeployment`. 
+The `spec.confguration` of this object will be the same struct defined in the `ContourConfiguration`. 
 
 A controller will watch for these objects to be created and take action on them accordingly to make desired state in the cluster match the configuration on the spec. 
 
@@ -164,65 +165,7 @@ spec:
     nodeSelector:
     tolerations:
   configuration:
-    server:
-      xds-server-type: contour
-    ingressClassName: contour
-    envoy:
-      networkPublishing:
-      nodePlacement:
-        nodeSelector:
-        tolerations:
-    gateway:
-        controllerName: projectcontour.io/projectcontour/contour
-    disableAllowChunkedLength: false
-    disablePermitInsecure: false
-    tls:
-      minimum-protocol-version: "1.2"
-      cipher-suites:
-      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-      - 'ECDHE-ECDSA-AES256-GCM-SHA384'
-      - 'ECDHE-RSA-AES256-GCM-SHA384'
-    fallback-certificate:
-      name: fallback-secret-name
-      namespace: projectcontour
-    envoy-client-certificate:
-      name: envoy-client-cert-secret-name
-      namespace: projectcontour
-    leaderelection:
-      configmap-name: leader-elect
-      configmap-namespace: projectcontour
-    enableExternalNameService: false
-    logging: 
-      accesslog-format: envoy
-      accesslog-format-string: "...\n"
-      json-fields:
-        - <Fields Omitted)
-    default-http-versions:
-      - "HTTP/2"
-      - "HTTP/1.1"
-    timeouts:
-      request-timeout: infinity
-      connection-idle-timeout: 60s
-      stream-idle-timeout: 5m
-      max-connection-duration: infinity
-      delayed-close-timeout: 1s
-      connection-shutdown-grace-period: 5s
-    cluster:
-      dns-lookup-family: auto
-    network:
-      num-trusted-hops: 0
-      admin-port: 9001
-    rateLimitService:
-      extensionService: projectcontour/ratelimit
-      domain: contour
-      failOpen: false
-      enableXRateLimitHeaders: false
-    policy:
-      request-headers:
-        set:
-      response-headers:
-        set:
+    <same config as above>
 status:
 ```
 
@@ -230,6 +173,7 @@ status:
 
 Contour will require a new flag (`--contour-config`), which will allow for customizing the name of the `ContourConfiguration` CRD that is it to use.
 It will default to one named `contour`, but could be overridden if desired.
+The ContourConfiguration referenced must also be in the same namespace as Contour is running, it's not valid to reference a configuration from another namespace.
 The current flag `--config-path`/`-c` will continue to point to the Configmap file, but over time could eventually be deprecated and the short code `-c` be used for the CRD location (i.e. `--contour-config`) for simplicity.
 The Contour configuration CRD will still remain optional.
 In its absence, Contour will operate with reasonable defaults.


### PR DESCRIPTION
Adds design doc for migrating the Contour conifgmap to a ContourConfiguration
along with a new ContourDeployment CRD which is managed by an additional controller.

Signed-off-by: Steve Sloka <slokas@vmware.com>