### PR TITLE
examples: Add ingress-status-address to Contour configuration file

### DIFF
--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -55,7 +55,11 @@ data:
     # This is not recommended without understanding the security implications.
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
     # enableExternalNameService: false
-    ## 
+    ##
+    # Address to be placed in status.loadbalancer field of Ingress objects.
+    # May be either a literal IP address or a host name.
+    # The value will be placed directly into the relevant field inside the status.loadBalancer struct.
+    # ingress-status-address: local.projectcontour.io
     ### Logging options
     # Default setting
     accesslog-format: envoy

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -93,6 +93,10 @@ data:
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
     # enableExternalNameService: false
     ##
+    # Address to be placed in status.loadbalancer field of Ingress objects.
+    # May be either a literal IP address or a host name.
+    # The value will be placed directly into the relevant field inside the status.loadBalancer struct.
+    # ingress-status-address: local.projectcontour.io
     ### Logging options
     # Default setting
     accesslog-format: envoy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -90,6 +90,10 @@ data:
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
     # enableExternalNameService: false
     ##
+    # Address to be placed in status.loadbalancer field of Ingress objects.
+    # May be either a literal IP address or a host name.
+    # The value will be placed directly into the relevant field inside the status.loadBalancer struct.
+    # ingress-status-address: local.projectcontour.io
     ### Logging options
     # Default setting
     accesslog-format: envoy


### PR DESCRIPTION
Adds the ingress-status-address to the example configuration file
to make it complete with the other examples.

Signed-off-by: Steve Sloka <slokas@vmware.com>