### PR TITLE
internal/status: set RouteGatewayStatus controller field dynamically

### DIFF
--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -53,9 +53,13 @@ func (b *Builder) Build() *DAG {
 	if b.Source.gateway != nil {
 		gatewayNSName = k8s.NamespacedNameOf(b.Source.gateway)
 	}
+	var gatewayController string
+	if b.Source.gatewayclass != nil {
+		gatewayController = b.Source.gatewayclass.Spec.Controller
+	}
 
 	dag := DAG{
-		StatusCache: status.NewCache(gatewayNSName),
+		StatusCache: status.NewCache(gatewayNSName, gatewayController),
 	}
 
 	for _, p := range b.Processors {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2591,6 +2591,13 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				}),
 			}
 
+			// Since we're using a single static GatewayClass,
+			// set the expected controller string here for all
+			// test cases.
+			for _, u := range tc.wantRouteConditions {
+				u.GatewayController = builder.Source.gatewayclass.Spec.Controller
+			}
+
 			if diff := cmp.Diff(tc.wantRouteConditions, gotRouteUpdates, ops...); diff != "" {
 				t.Fatalf("expected route status: %v, got %v", tc.wantRouteConditions, diff)
 			}
@@ -3551,6 +3558,13 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				cmpopts.SortSlices(func(i, j metav1.Condition) bool {
 					return i.Message < j.Message
 				}),
+			}
+
+			// Since we're using a single static GatewayClass,
+			// set the expected controller string here for all
+			// test cases.
+			for _, u := range tc.wantRouteConditions {
+				u.GatewayController = builder.Source.gatewayclass.Spec.Controller
 			}
 
 			if diff := cmp.Diff(tc.wantRouteConditions, gotRouteUpdates, ops...); diff != "" {

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -33,13 +33,14 @@ type ConditionType string
 const ValidCondition ConditionType = "Valid"
 
 // NewCache creates a new Cache for holding status updates.
-func NewCache(gateway types.NamespacedName) Cache {
+func NewCache(gateway types.NamespacedName, gatewayController string) Cache {
 	return Cache{
-		proxyUpdates:   make(map[types.NamespacedName]*ProxyUpdate),
-		gatewayRef:     gateway,
-		gatewayUpdates: make(map[types.NamespacedName]*GatewayConditionsUpdate),
-		routeUpdates:   make(map[types.NamespacedName]*RouteConditionsUpdate),
-		entries:        make(map[string]map[types.NamespacedName]CacheEntry),
+		gatewayRef:        gateway,
+		gatewayController: gatewayController,
+		proxyUpdates:      make(map[types.NamespacedName]*ProxyUpdate),
+		gatewayUpdates:    make(map[types.NamespacedName]*GatewayConditionsUpdate),
+		routeUpdates:      make(map[types.NamespacedName]*RouteConditionsUpdate),
+		entries:           make(map[string]map[types.NamespacedName]CacheEntry),
 	}
 }
 
@@ -52,9 +53,10 @@ type CacheEntry interface {
 // It holds a per-Kind cache, and is intended to be accessed with a
 // KindAccessor.
 type Cache struct {
-	proxyUpdates map[types.NamespacedName]*ProxyUpdate
+	gatewayRef        types.NamespacedName
+	gatewayController string
 
-	gatewayRef     types.NamespacedName
+	proxyUpdates   map[types.NamespacedName]*ProxyUpdate
 	gatewayUpdates map[types.NamespacedName]*GatewayConditionsUpdate
 	routeUpdates   map[types.NamespacedName]*RouteConditionsUpdate
 

--- a/internal/status/cache_test.go
+++ b/internal/status/cache_test.go
@@ -52,7 +52,7 @@ func TestCacheAcquisition(t *testing.T) {
 	httpRoute := &gatewayapi_v1alpha1.HTTPRoute{
 		ObjectMeta: fixture.ObjectMeta("test/httproute"),
 	}
-	cache := NewCache(types.NamespacedName{Name: "contour", Namespace: "projectcontour"})
+	cache := NewCache(types.NamespacedName{Name: "contour", Namespace: "projectcontour"}, "")
 
 	// Initial acquisition should be nil.
 	assert.Nil(t, cache.Get(proxy))

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -48,6 +48,7 @@ type RouteConditionsUpdate struct {
 	Conditions         map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition
 	ExistingConditions map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition
 	GatewayRef         types.NamespacedName
+	GatewayController  string
 	Resource           string
 	Generation         int64
 	TransitionTime     metav1.Time
@@ -82,6 +83,7 @@ func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation 
 		Conditions:         make(map[gatewayapi_v1alpha1.RouteConditionType]metav1.Condition),
 		ExistingConditions: c.getRouteGatewayConditions(gateways),
 		GatewayRef:         c.gatewayRef,
+		GatewayController:  c.gatewayController,
 		Generation:         generation,
 		TransitionTime:     metav1.NewTime(clock.Now()),
 		Resource:           resource,
@@ -136,13 +138,9 @@ func (routeUpdate *RouteConditionsUpdate) Mutate(obj interface{}) interface{} {
 
 	gatewayStatuses = append(gatewayStatuses, gatewayapi_v1alpha1.RouteGatewayStatus{
 		GatewayRef: gatewayapi_v1alpha1.RouteStatusGatewayReference{
-			Name:      routeUpdate.GatewayRef.Name,
-			Namespace: routeUpdate.GatewayRef.Namespace,
-
-			// TODO(3689) the value of this field should probably come from
-			// the GatewayClass. Plumb that through once Contour handles
-			// GatewayClasses.
-			Controller: pointer.String("projectcontour.io/contour"),
+			Name:       routeUpdate.GatewayRef.Name,
+			Namespace:  routeUpdate.GatewayRef.Namespace,
+			Controller: pointer.String(routeUpdate.GatewayController),
 		},
 		Conditions: conditionsToWrite,
 	})


### PR DESCRIPTION
Sets the RouteGatewayStatus Controller field to the value
of the relevant GatewayClass's Controller, rather than a
static string value.

Closes #3689.

Signed-off-by: Steve Kriss <krisss@vmware.com>