### PR TITLE
remove BackendPolicy informers, caching and RBAC

### DIFF
--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -82,7 +82,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes
@@ -96,7 +95,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies/status
   - gatewayclasses/status
   - gateways/status
   - httproutes/status

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -2849,7 +2849,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes
@@ -2863,7 +2862,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies/status
   - gatewayclasses/status
   - gateways/status
   - httproutes/status

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -2846,7 +2846,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies
   - gatewayclasses
   - gateways
   - httproutes
@@ -2860,7 +2859,6 @@ rules:
 - apiGroups:
   - networking.x-k8s.io
   resources:
-  - backendpolicies/status
   - gatewayclasses/status
   - gateways/status
   - httproutes/status

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -62,7 +62,6 @@ type KubernetesCache struct {
 	tlsroutes                 map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute
 	tcproutes                 map[types.NamespacedName]*gatewayapi_v1alpha1.TCPRoute
 	udproutes                 map[types.NamespacedName]*gatewayapi_v1alpha1.UDPRoute
-	backendpolicies           map[types.NamespacedName]*gatewayapi_v1alpha1.BackendPolicy
 	extensions                map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
@@ -82,7 +81,6 @@ func (kc *KubernetesCache) init() {
 	kc.tcproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.TCPRoute)
 	kc.udproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.UDPRoute)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha1.TLSRoute)
-	kc.backendpolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha1.BackendPolicy)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
 
@@ -208,13 +206,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *gatewayapi_v1alpha1.TLSRoute:
 		kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
-	case *gatewayapi_v1alpha1.BackendPolicy:
-		m := k8s.NamespacedNameOf(obj)
-		// TODO(youngnick): Remove this once gateway-api actually have behavior
-		// other than being added to the cache.
-		kc.WithField("experimental", "gateway-api").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Adding BackendPolicy")
-		kc.backendpolicies[k8s.NamespacedNameOf(obj)] = obj
-		return true
 	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 		return true
@@ -303,14 +294,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.tlsroutes[m]
 		delete(kc.tlsroutes, m)
-		return ok
-	case *gatewayapi_v1alpha1.BackendPolicy:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.backendpolicies[m]
-		// TODO(youngnick): Remove this once gateway-api actually have behavior
-		// other than being removed from the cache.
-		kc.WithField("experimental", "gateway-api").WithField("name", m.Name).WithField("namespace", m.Namespace).Debug("Removing BackendPolicy")
-		delete(kc.backendpolicies, m)
 		return ok
 	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -891,15 +891,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert gateway-api BackendPolicy": {
-			obj: &gatewayapi_v1alpha1.BackendPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backendpolicy",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
 		"insert extension service": {
 			obj: &contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
@@ -1198,21 +1189,6 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &gatewayapi_v1alpha1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tlsroute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"remove gateway-api BackendPolicy": {
-			cache: cache(&gatewayapi_v1alpha1.BackendPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backendpolicy",
-					Namespace: "default",
-				},
-			}),
-			obj: &gatewayapi_v1alpha1.BackendPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backendpolicy",
 					Namespace: "default",
 				},
 			},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -48,8 +48,8 @@ func IngressV1Resources() []schema.GroupVersionResource {
 	}
 }
 
-// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gatewayclasses;gateways;httproutes;backendpolicies;tlsroutes;tcproutes;udproutes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;backendpolicies/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;tcproutes;udproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="networking.x-k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
 
 // GatewayAPIResources returns a list of Gateway API group/version resources.
 func GatewayAPIResources() []schema.GroupVersionResource {
@@ -65,10 +65,6 @@ func GatewayAPIResources() []schema.GroupVersionResource {
 		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
 		Version:  gatewayapi_v1alpha1.GroupVersion.Version,
 		Resource: "httproutes",
-	}, {
-		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
-		Version:  gatewayapi_v1alpha1.GroupVersion.Version,
-		Resource: "backendpolicies",
 	}, {
 		Group:    gatewayapi_v1alpha1.GroupVersion.Group,
 		Version:  gatewayapi_v1alpha1.GroupVersion.Version,


### PR DESCRIPTION
The upcoming v1alpha2 release of Gateway API drops
BackendPolicy. Contour currently sets up an informer
for it but does not do any further processing based
on it. As such, this PR fully removes all code for it.

Signed-off-by: Steve Kriss <krisss@vmware.com>