### PR TITLE
site: repair broken links in blog post

### DIFF
--- a/site/content/posts/2019-09-5-contour-v015.md
+++ b/site/content/posts/2019-09-5-contour-v015.md
@@ -13,7 +13,7 @@ slug: contour-v015
 
 In the previous release of Contour, a split deployment model was improved to secure communication between Envoy and Contour. Now, with our latest release, Contour v0.15, leader election is available to ensure that all instances of Envoy take their configuration from a single Contour instance.
 
-![img][4]
+![img](/img/posts/leader-election.png)
 *Overview of leader election.*
 
 ## Leader Election
@@ -24,7 +24,7 @@ In leader election mode, only one Contour pod in a deployment, the leader, will 
 
 Leader election is currently opt in. In future versions of Contour, we plan to make leader election mode the default.
 
-For more information, please consult the [documentation on upgrading]().
+For more information, please consult the [documentation on upgrading][1].
 
 ## Contour Configuration File
 
@@ -75,25 +75,21 @@ data:
 
 Version 0.15 includes several fixes. It patches several CVEs related to HTTP/2 by upgrading Envoy to v1.11.1. To help with the number and frequency of configuration updates sent to Envoy, Contour now ignores unrelated Secrets and Services that are not referenced by an active Ingress or IngressRoute object.
 
-We recommend reading the full release notes for [Contour v0.15][1] as well as digging into the [upgrade guide][2], which outlines some key changes to be aware of when moving from v0.14 to v0.15.
+We recommend reading the full release notes for [Contour v0.15][2] as well as digging into the [upgrade guide][3], which outlines some key changes to be aware of when moving from v0.14 to v0.15.
 
 ## Future Plans
 
 The Contour project is very community driven and the team would love to hear your feedback! Many features (including IngressRoute) were driven by users who needed a better way to solve their problems. We’re working hard to add features to Contour, especially in expanding how we approach routing. 
 
-If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted][3] and work with the team on how to resolve them.
+If you are interested in contributing, a great place to start is to comment on one of the issues labeled with [Help Wanted][4] and work with the team on how to resolve them.
 
 We’re immensely grateful for all the community contributions that help make Contour even better! For version v0.15, special thanks go out to:
 
-- [@DylanGraham][7]
-- [@so0k][8]
-- [@mattalberts][9]
+- [@DylanGraham](https://github.com/DylanGraham)
+- [@so0k](https://github.com/so0k)
+- [@mattalberts](https://github.com/mattalberts)
 
-[1]: {{< param github_url >}}/releases/tag/v0.15.0
-[2]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md
-[3]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
-[4]: {% link img/posts/leader-election.png %}
-[5]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md#enabling-leader-election
-[7]: https://github.com/DylanGraham
-[8]: https://github.com/so0k
-[9]: https://github.com/mattalberts
+[1]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md#enabling-leader-election
+[2]: {{< param github_url >}}/releases/tag/v0.15.0
+[3]: {{< param github_url >}}/blob/v0.15.0/docs/upgrading.md
+[4]: {{< param github_url >}}/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22


### PR DESCRIPTION
Fixes: 
- Repairs image local reference. 
- Repairs "envoy documentation on upgrading" link. 
- Repairs github links to community contributors listed in special thanks section.

Signed-off-by: Michelle Zelechoski <zelechom@oregonstate.edu>