### PR TITLE
docs: GatewayConfig updates

### DIFF
--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -183,11 +183,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | Field Name | Type| Default  | Description |
 |------------|-----|----------|-------------|
 | controllerName | string |  | Gateway Class controller name (i.e. projectcontour.io/projectcontour/contour).  |
-| name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
-| namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
-
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration
 

--- a/site/content/docs/v1.17.0/configuration.md
+++ b/site/content/docs/v1.17.0/configuration.md
@@ -183,7 +183,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
 Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration

--- a/site/content/docs/v1.17.0/configuration.md
+++ b/site/content/docs/v1.17.0/configuration.md
@@ -183,9 +183,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
-
 ### Policy Configuration
 
 The Policy configuration block can be used to configure default policy values

--- a/site/content/docs/v1.17.1/configuration.md
+++ b/site/content/docs/v1.17.1/configuration.md
@@ -184,9 +184,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
-
 ### Policy Configuration
 
 The Policy configuration block can be used to configure default policy values

--- a/site/content/docs/v1.17.1/configuration.md
+++ b/site/content/docs/v1.17.1/configuration.md
@@ -184,7 +184,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
 Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration

--- a/site/content/docs/v1.17.2/configuration.md
+++ b/site/content/docs/v1.17.2/configuration.md
@@ -185,7 +185,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
 Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration

--- a/site/content/docs/v1.17.2/configuration.md
+++ b/site/content/docs/v1.17.2/configuration.md
@@ -185,9 +185,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
-
 ### Policy Configuration
 
 The Policy configuration block can be used to configure default policy values

--- a/site/content/docs/v1.18.0/configuration.md
+++ b/site/content/docs/v1.18.0/configuration.md
@@ -185,7 +185,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
 Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration

--- a/site/content/docs/v1.18.0/configuration.md
+++ b/site/content/docs/v1.18.0/configuration.md
@@ -185,9 +185,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
-
 ### Policy Configuration
 
 The Policy configuration block can be used to configure default policy values

--- a/site/content/docs/v1.18.1/configuration.md
+++ b/site/content/docs/v1.18.1/configuration.md
@@ -186,9 +186,6 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
-Please use the `controllerName` field going forward to configure which Gateway Contour should process._
-
 ### Policy Configuration
 
 The Policy configuration block can be used to configure default policy values

--- a/site/content/docs/v1.18.1/configuration.md
+++ b/site/content/docs/v1.18.1/configuration.md
@@ -186,7 +186,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 | name (Deprecated) | string | contour | DEPRECATED: This field specifies the name of a Gateway.  |
 | namespace (Deprecated) | string | projectcontour | DEPRECATED: This field specifies the namespace of a Gateway.  |
 
-_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.18.
+_NOTE: The fields `name` and `namespace` have been deprecated and will be removed in Contour v1.19.
 Please use the `controllerName` field going forward to configure which Gateway Contour should process._
 
 ### Policy Configuration


### PR DESCRIPTION
Updates GatewayConfig docs to drop namespace
and name going forward, and update older
versions' docs to name the correct version
in which they are removed.

Signed-off-by: Steve Kriss <krisss@vmware.com>