### PR TITLE
Fix helm quick start for ingressClassName

### DIFF
--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -213,7 +213,14 @@ $ kubectl get po,svc,ing -l app=kuard
 You should see the following:
 - 3 instances of pods/kuard, each with status **Running** and 1/1 **Ready**
 - 1 service/kuard CLUSTER-IP listed on port 80
-- 1 ingress on port 80
+- 1 Ingress on port 80
+
+The Helm install configures Contour to filter Ingress and HTTPProxy objects based on the `contour` IngressClass name.
+To ensure Contour reconciles the created Ingress, edit the `spec` to add an `ingressClassName` field as below:
+```yaml
+spec:
+  ingressClassName: contour
+```
 
 Verify web access by browsing to [127.0.0.1](http://127.0.0.1). You can refresh multiple times to cycle through each pod workload.  
 


### PR DESCRIPTION
the bitnami helm chart is now setting the `contour` ingressclassname by
default, this notes that correctly

see:
- https://github.com/bitnami/charts/blob/c3e887d475de6b4cd2ac8d3e699f9466ead95d49/bitnami/contour/values.yaml#L264
- https://github.com/bitnami/charts/pull/7381

Signed-off-by: Sunjay Bhatia <sunjayb@vmware.com>