### PR TITLE
Add path based logging (#3994)

### DIFF
--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -543,6 +543,9 @@ type ListenerParameters struct {
 // Parameters contains the configuration file parameters for the
 // Contour ingress controller.
 type Parameters struct {
+	// Path for file based logging.
+	ContourLogFile string `yaml:"contour-log-file,omitempty"`
+
 	// Enable debug logging
 	Debug bool
 


### PR DESCRIPTION
Adds an optional flag to configure file-based logging for the controller.

Closes #3994.