### PR TITLE
Update documentation for transition to quarterly releases

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,19 +2,18 @@
 This document describes the versioning and release process of Contour. This document is a living document, contents will be updated according to each release.
 
 ## Releases
-Contour releases will be versioned using dotted triples, similar to [Semantic Version](http://semver.org/). For this specific document, we will refer to the respective components of this triple as `<major>.<minor>.<patch>`. The version number may have additional information, such as "-rc1,-rc2,-rc3" to mark release candidate builds for earlier access. Such releases will be considered as "pre-releases".
+Contour releases will be versioned using dotted triples, similar to [Semantic Version](http://semver.org/). The project refers to the respective components of this triple as `<major>.<minor>.<patch>`. The version number may have additional information, such as "-rc1,-rc2,-rc3" to mark release candidate builds for earlier access. Such releases will be considered as "pre-releases".
 
 ### Major and Minor Releases
 Major and minor releases of Contour will be branched from main when the release reaches to `RC (release candidate)` state. The release cadence is currently once a month, but is migrating to quarterly as of the October 2021 release (which will be Contour 1.20).
 
-If for any reason this release cadence has to be adjusted (for example due to open source events), we will communicate it clearly on Slack, Twitter, and distribution lists. There is no mandated timeline for major versions and there are currently no criteria for shipping a new major version (i.e. Contour 2.0.0). You can find additional resources on the [release process](https://projectcontour.io/resources/release-process/) portion of our website.
+If for any reason this release cadence has to be adjusted (for example due to open source events), the project will communicate it clearly on Slack, Twitter, and distribution lists. There is no mandated timeline for major versions and there are currently no criteria for shipping a new major version (i.e. Contour 2.0.0). You can find additional resources on the [release process](https://projectcontour.io/resources/release-process/) portion of our website.
 
 ### Patch releases
-Patch releases are based on the major/minor release branch. There is no specific release cadence for patch releases. However, we will create patch releases to address critical community and security issues (for example to address high severity security issues in Contour or in Envoy).
-We will issue patch releases for all supported versions of Contour.
+Patch releases are based on the major/minor release branch. There is no specific release cadence for patch releases. However, the project will create patch releases to address critical community and security issues (for example to address high severity security issues in Contour or in Envoy).The project will issue patch releases for all supported versions of Contour.
 
 ### Release Support Matrix
-Per the [Contour support policy](https://projectcontour.io/resources/support/), we are in the process of transitioning to supporting three Contour releases. Please see the support policy page to see what versions are currently supported.
+Per the [Contour support policy](https://projectcontour.io/resources/support/), the project is in the process of transitioning to supporting three Contour releases. Please see the support policy page to see what versions are currently supported.
 
 Also, please consult the [Contour Compatibility Matrix](https://projectcontour.io/resources/compatibility-matrix/) for details of what each version of Contour requires for each of its dependencies like Envoy, Kubernetes, and so on.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,14 +5,21 @@ This document describes the versioning and release process of Contour. This docu
 Contour releases will be versioned using dotted triples, similar to [Semantic Version](http://semver.org/). For this specific document, we will refer to the respective components of this triple as `<major>.<minor>.<patch>`. The version number may have additional information, such as "-rc1,-rc2,-rc3" to mark release candidate builds for earlier access. Such releases will be considered as "pre-releases".
 
 ### Major and Minor Releases
-Major and minor releases of Contour will be branched from main when the release reaches to `RC (release candidate)` state. The release cadence is around once a month, If for any reason this release cadence has to be adjusted (for example due to open source events), we will communicate it clearly on Slack, Twitter, and distribution lists. There is no mandated timeline for major versions and there are currently no criteria for shipping a new major version (i.e. Contour 2.0.0). You can find additional resources on the [release process](https://projectcontour.io/resources/release-process/) portion of our website.
+Major and minor releases of Contour will be branched from main when the release reaches to `RC (release candidate)` state. The release cadence is currently once a month, but is migrating to quarterly as of the October 2021 release (which will be Contour 1.20).
+
+If for any reason this release cadence has to be adjusted (for example due to open source events), we will communicate it clearly on Slack, Twitter, and distribution lists. There is no mandated timeline for major versions and there are currently no criteria for shipping a new major version (i.e. Contour 2.0.0). You can find additional resources on the [release process](https://projectcontour.io/resources/release-process/) portion of our website.
 
 ### Patch releases
-Patch releases are based on the major/minor release branch. There is no specific release cadence for patch releases as we already release monthly. However, we will create patch releases to address critical community and security issues (for example to address high severity security issues in Contour or in Envoy). We will patch release only the latest release of Contour. The Contour team only maintains a single release branch.
+Patch releases are based on the major/minor release branch. There is no specific release cadence for patch releases. However, we will create patch releases to address critical community and security issues (for example to address high severity security issues in Contour or in Envoy).
+We will issue patch releases for all supported versions of Contour.
 
 ### Release Support Matrix
-Per the [Contour support policy](https://projectcontour.io/resources/support/), we support only the latest Contour [release](https://github.com/projectcontour/contour/releases).
-* [Contour Compatibility Matrix](https://projectcontour.io/resources/compatibility-matrix/)
+Per the [Contour support policy](https://projectcontour.io/resources/support/), we are in the process of transitioning to supporting three Contour releases. Please see the support policy page to see what versions are currently supported.
+
+Also, please consult the [Contour Compatibility Matrix](https://projectcontour.io/resources/compatibility-matrix/) for details of what each version of Contour requires for each of its dependencies like Envoy, Kubernetes, and so on.
+
+Both of these details are also available in a machine-consumable (YAML) format via [versions.yaml](https://github.com/projectcontour/contour/blob/main/versions.yaml).
+
 
 ### Upgrade path 
 The upgrade path for Contour, including upgrade instructions, is documented [here](https://projectcontour.io/resources/upgrading/). Each Contour version also requires a specific release of Envoy, documented in the upgrading portion of our website.

--- a/site/content/docs/main/github.md
+++ b/site/content/docs/main/github.md
@@ -2,7 +2,7 @@ This document outlines how we use GitHub.
 
 ## Milestones
 
-Contour attempts to ship on a monthly-ish, generally every four to six weeks, basis.
+Contour attempts to ship on a quarterly basis.
 These releases are tracked with a milestone.
 The _current_ release is the milestone with the closest delivery date.
 

--- a/site/content/docs/v1.18.1/github.md
+++ b/site/content/docs/v1.18.1/github.md
@@ -2,7 +2,7 @@ This document outlines how we use GitHub.
 
 ## Milestones
 
-Contour attempts to ship on a monthly-ish, generally every four to six weeks, basis.
+Contour attempts to ship on a quarterly basis.
 These releases are tracked with a milestone.
 The _current_ release is the milestone with the closest delivery date.
 

--- a/site/content/resources/support.md
+++ b/site/content/resources/support.md
@@ -13,18 +13,18 @@ The first Contour version covered by the quarterly release cadence will be Conto
 
 At the time it is released, it will be the only supported version, and versions 1.21 and 1.22 will continue supporting back to Contour 1.20.
 
-When Contour 1.23 releases (nine months later), Contour 1.20 will fall out of support.
+When Contour 1.23 releases, Contour 1.20 will fall out of support.
 
 The following table illustrates how this will work. The given dates are estimates, not guarantees.
 They are our best guess as to when each version will be released.
 
 | Version |v1.19 |v1.20|v1.21|v1.22|v1.23|
 |---------|--------|-------|-------|-------|-------|
-|Q3 2021 (September 2021) | :heavy_check_mark: |
-|Q4 2021 (October 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |
-|Q1 2022 (January 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |
-|Q2 2022 (April 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |:heavy_check_mark: |
-|Q3 2022 (July 2021) | :negative_squared_cross_mark: | :negative_squared_cross_mark: |:heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
+|Q3 2021 | :heavy_check_mark: |
+|Q4 2021 | :negative_squared_cross_mark: | :heavy_check_mark: |
+|Q1 2022 | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |
+|Q2 2022 | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |:heavy_check_mark: |
+|Q3 2022 | :negative_squared_cross_mark: | :negative_squared_cross_mark: |:heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
 
 ## What does a release being "supported" mean?
 
@@ -45,8 +45,8 @@ If, later on, the supported versions are 1.21, 1.22, and 1.23, and 1.21.1, 1.22.
 The latest stable release is identified by the [Docker tag `:latest`][1].
 `:latest` is an alias for {{< param latest_version >}} which is the current stable release.
 
-When required the project may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
-At that point the patch release will become the :latest stable release.
+`:latest` is always guaranteed to point to the highest available `:<major>.<minor>.<patch>` release.
+When a new `:<major>.<minor>` release track is out the `:latest` tag will move along.
 
 For example, prior to a patch release version Contour 1.20.0 was the `:latest` stable release.
 If Contour 1.20.1 is released, the `:latest` tag will move to that version.

--- a/site/content/resources/support.md
+++ b/site/content/resources/support.md
@@ -5,20 +5,51 @@ layout: page
 
 This document describes which versions of Contour are supported by the Contour team.
 
-## Stable release
+## Supported releases
 
-Only the latest stable release is supported.
+Contour is in the process of changing both to quarterly releases and three supported releases.
 
+The first Contour version covered by the quarterly release cadence will be Contour v1.20, scheduled for late October 2021.
+
+At the time it is released, it will be the only supported version, and versions 1.21 and 1.22 will continue supporting back to Contour 1.20.
+
+When Contour 1.23 releases (nine months later), Contour 1.20 will fall out of support.
+
+The following table illustrates how this will work. The given dates are estimates, not guarantees.
+They are our best guess as to when each version will be released.
+
+| Version |v1.19 |v1.20|v1.21|v1.22|v1.23|
+|---------|--------|-------|-------|-------|-------|
+|Q3 2021 (September 2021) | :heavy_check_mark: |
+|Q4 2021 (October 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |
+|Q1 2022 (January 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |
+|Q2 2022 (April 2021) | :negative_squared_cross_mark: | :heavy_check_mark: |:heavy_check_mark: |:heavy_check_mark: |
+|Q3 2022 (July 2021) | :negative_squared_cross_mark: | :negative_squared_cross_mark: |:heavy_check_mark: |:heavy_check_mark: | :heavy_check_mark: |
+
+## What does a release being "supported" mean?
+
+In short, "supported" means that we will issue fixes for security and other critical bugs for that release's supported lifetime.
+
+However, we will require users to upgrade to the most recent patch release for a version to be supported.
+
+That is:
+- The latest patch version in each release is the supported version.
+- If you are not running the supported version from your release train, we will ask you to upgrade first if you have any problems.
+- When a new patch is cut, that will become the supported version for that release.
+
+So, if Contour 1.20.0 is the only supported version, and we release Contour 1.20.1, then the supported version will change to 1.20.1.
+
+If, later on, the supported versions are 1.21, 1.22, and 1.23, and we release 1.21.1, 1.22.1, and 1.23.1, then the patch releases will be the only supported versions.
+
+## Latest version and the `:latest` tag
 The latest stable release is identified by the [Docker tag `:latest`][1].
 `:latest` is an alias for {{< param latest_version >}} which is the current stable release.
 
 When required we may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
 At that point the patch release will become the :latest stable release.
 
-For example, prior to a patch release version Contour 1.0.0 was the `:latest` stable release.
-If Contour 1.0.1 is release, the `:latest` tag will move to that version.
-
-No support is offered for major, minor, or patch releases older than the `:latest` stable release.
+For example, prior to a patch release version Contour 1.20.0 was the `:latest` stable release.
+If Contour 1.20.1 is released, the `:latest` tag will move to that version.
 
 ### Additional Resources
 

--- a/site/content/resources/support.md
+++ b/site/content/resources/support.md
@@ -7,7 +7,7 @@ This document describes which versions of Contour are supported by the Contour t
 
 ## Supported releases
 
-Contour is in the process of changing both to quarterly releases and three supported releases.
+Contour is changing both to quarterly releases and three supported releases.
 
 The first Contour version covered by the quarterly release cadence will be Contour v1.20, scheduled for late October 2021.
 
@@ -28,24 +28,24 @@ They are our best guess as to when each version will be released.
 
 ## What does a release being "supported" mean?
 
-In short, "supported" means that we will issue fixes for security and other critical bugs for that release's supported lifetime.
+In short, "supported" means that Contour will issue fixes for security and other critical bugs for that release's supported lifetime.
 
-However, we will require users to upgrade to the most recent patch release for a version to be supported.
+However, the project will require users to upgrade to the most recent patch release for a version to be supported.
 
 That is:
 - The latest patch version in each release is the supported version.
-- If you are not running the supported version from your release train, we will ask you to upgrade first if you have any problems.
+- If you are not running the supported version from your release train, you'll need to upgrade first if you have any problems.
 - When a new patch is cut, that will become the supported version for that release.
 
-So, if Contour 1.20.0 is the only supported version, and we release Contour 1.20.1, then the supported version will change to 1.20.1.
+So, if Contour 1.20.0 is the only supported version, and Contour 1.20.1 is released, then the supported version will change to 1.20.1.
 
-If, later on, the supported versions are 1.21, 1.22, and 1.23, and we release 1.21.1, 1.22.1, and 1.23.1, then the patch releases will be the only supported versions.
+If, later on, the supported versions are 1.21, 1.22, and 1.23, and 1.21.1, 1.22.1, and 1.23.1 are released, then the patch releases will be the only supported versions.
 
 ## Latest version and the `:latest` tag
 The latest stable release is identified by the [Docker tag `:latest`][1].
 `:latest` is an alias for {{< param latest_version >}} which is the current stable release.
 
-When required we may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
+When required the project may release a patch release to address security issues, serious problems with no suitable workaround, or documentation issues.
 At that point the patch release will become the :latest stable release.
 
 For example, prior to a patch release version Contour 1.20.0 was the `:latest` stable release.

--- a/site/content/resources/tagging.md
+++ b/site/content/resources/tagging.md
@@ -7,20 +7,25 @@ This document describes Contour's image tagging policy.
 
 ## Released versions
 
-`docker.io/projectcontour/contour:<SemVer>`
+`ghcr.io/projectcontour/contour:<SemVer>`
 
 Contour follows the [Semantic Versioning][1] standard for releases.
 Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{< param latest_version >}}`
 
+`ghcr.io/projectcontour/contour:v<major>.<minor>`
+
+This tag will point to the latest available patch of the release train mentioned.
+That is, it's `:latest` where you're guaranteed to not have a minor version bump.
+
 ### Latest
 
-`docker.io/projectcontour/contour:latest`
+`ghcr.io/projectcontour/contour:latest`
 
 The `latest` tag follows the most recent stable version of Contour.
 
 ## Development
 
-`docker.io/projectcontour/contour:main`
+`ghcr.io/projectcontour/contour:main`
 
 The `main` tag follows the latest commit to land on the `main` branch.
 


### PR DESCRIPTION
This one should go in after #4021.

Signed-off-by: Nick Young <ynick@vmware.com>