### PR TITLE
Makefile: fix order of generates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ lint-flags:
 
 .PHONY: generate
 generate: ## Re-generate generated code and documentation
-generate: generate-rbac generate-crd-deepcopy generate-crd-yaml generate-deployment generate-api-docs generate-metrics-docs generate-uml generate-gateway-crd-yaml
+generate: generate-rbac generate-crd-deepcopy generate-crd-yaml generate-gateway-crd-yaml generate-deployment generate-api-docs generate-metrics-docs generate-uml
 
 .PHONY: generate-rbac
 generate-rbac:


### PR DESCRIPTION
Moves generate-gateway-crd-yaml to before
generate-deployment so any Gateway API
CRD updates are included in the example
Gateway deployment.

Signed-off-by: Steve Kriss <krisss@vmware.com>