### PR TITLE
cmd/contour: Stub out --contour-config-name flag

### DIFF
--- a/apis/projectcontour/v1alpha1/register.go
+++ b/apis/projectcontour/v1alpha1/register.go
@@ -21,7 +21,6 @@ import (
 
 var ExtensionServiceGVR = GroupVersion.WithResource("extensionservices")
 var ContourConfigurationGVR = GroupVersion.WithResource("contourconfigurations")
-var ContourDeploymentGVR = GroupVersion.WithResource("contourdeployments")
 
 var (
 	// GroupVersion is group version used to register these objects
@@ -41,8 +40,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ExtensionServiceList{},
 		&ContourConfiguration{},
 		&ContourConfigurationList{},
-		&ContourDeployment{},
-		&ContourDeploymentList{},
 	)
 
 	metav1.AddToGroupVersion(scheme, GroupVersion)

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -75,7 +75,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve := app.Command("serve", "Serve xDS API traffic.")
 
 	// The precedence of configuration for contour serve is as follows:
-	// If ContourConfiguration file is specified, it takes precedence,
+	// If ContourConfiguration resource is specified, it takes precedence,
 	// otherwise config file, overridden by env vars, overridden by cli flags.
 	// however, as -c is a cli flag, we don't know its value til cli flags
 	// have been parsed. To correct this ordering we assign a post parse
@@ -223,7 +223,7 @@ func doServe(log logrus.FieldLogger, ctx *serveContext) error {
 	// Get the ContourConfiguration CRD if specified
 	if len(ctx.contourConfigurationName) > 0 {
 
-		// Determine the name/namespace of the configuration file utilizing the environment
+		// Determine the name/namespace of the configuration resource utilizing the environment
 		// variable "CONTOUR_NAMESPACE" which should exist on the Contour deployment.
 		//
 		// If the env variable is not present, it will return "" and still fail the lookup

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -34,6 +34,9 @@ import (
 )
 
 type serveContext struct {
+	// Name of the ContourConfiguration CRD to use for configuration.
+	contourConfigurationName string
+
 	Config config.Parameters
 
 	ServerConfig

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -106,6 +106,38 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
+  - contourconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
   - extensionservices
   verbs:
   - get

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -122,22 +122,6 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
-  - contourdeployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - projectcontour.io
-  resources:
-  - contourdeployments/status
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - projectcontour.io
-  resources:
   - extensionservices
   verbs:
   - get

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4715,22 +4715,6 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
-  - contourdeployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - projectcontour.io
-  resources:
-  - contourdeployments/status
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - projectcontour.io
-  resources:
   - extensionservices
   verbs:
   - get

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4699,6 +4699,38 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
+  - contourconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
   - extensionservices
   verbs:
   - get

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4696,6 +4696,38 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
+  - contourconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourconfigurations/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - projectcontour.io
+  resources:
+  - contourdeployments/status
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - projectcontour.io
+  resources:
   - extensionservices
   verbs:
   - get

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4712,22 +4712,6 @@ rules:
 - apiGroups:
   - projectcontour.io
   resources:
-  - contourdeployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - projectcontour.io
-  resources:
-  - contourdeployments/status
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - projectcontour.io
-  resources:
   - extensionservices
   verbs:
   - get

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -33,8 +33,6 @@ import (
 
 // +kubebuilder:rbac:groups="projectcontour.io",resources=contourconfigurations,verbs=get;list;watch
 // +kubebuilder:rbac:groups="projectcontour.io",resources=contourconfigurations/status,verbs=create;get;update
-// +kubebuilder:rbac:groups="projectcontour.io",resources=contourdeployments,verbs=get;list;watch
-// +kubebuilder:rbac:groups="projectcontour.io",resources=contourdeployments/status,verbs=create;get;update
 
 // DefaultResources ...
 func DefaultResources() []schema.GroupVersionResource {
@@ -43,7 +41,6 @@ func DefaultResources() []schema.GroupVersionResource {
 		contour_api_v1.TLSCertificateDelegationGVR,
 		contour_api_v1alpha1.ExtensionServiceGVR,
 		contour_api_v1alpha1.ContourConfigurationGVR,
-		contour_api_v1alpha1.ContourDeploymentGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 	}
 }

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -31,12 +31,19 @@ import (
 // +kubebuilder:rbac:groups="projectcontour.io",resources=extensionservices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="projectcontour.io",resources=extensionservices/status,verbs=create;get;update
 
+// +kubebuilder:rbac:groups="projectcontour.io",resources=contourconfigurations,verbs=get;list;watch
+// +kubebuilder:rbac:groups="projectcontour.io",resources=contourconfigurations/status,verbs=create;get;update
+// +kubebuilder:rbac:groups="projectcontour.io",resources=contourdeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="projectcontour.io",resources=contourdeployments/status,verbs=create;get;update
+
 // DefaultResources ...
 func DefaultResources() []schema.GroupVersionResource {
 	return []schema.GroupVersionResource{
 		contour_api_v1.HTTPProxyGVR,
 		contour_api_v1.TLSCertificateDelegationGVR,
 		contour_api_v1alpha1.ExtensionServiceGVR,
+		contour_api_v1alpha1.ContourConfigurationGVR,
+		contour_api_v1alpha1.ContourDeploymentGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
 	}
 }

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -19,6 +19,7 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | Flag Name         | Description        |
 |-------------------|--------------------|
 | `--config-path`       | Path to base configuration |
+| `--contour-config-name`       | Name of the ContourConfiguration file to use |
 | `--incluster`         | Use in cluster configuration |
 | `--kubeconfig=</path/to/file>` |    Path to kubeconfig (if not in running inside a cluster) |
 | `--xds-address=<ipaddr>` | xDS gRPC API address |

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -19,7 +19,7 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | Flag Name         | Description        |
 |-------------------|--------------------|
 | `--config-path`       | Path to base configuration |
-| `--contour-config-name`       | Name of the ContourConfiguration file to use |
+| `--contour-config-name`       | Name of the ContourConfiguration resource to use |
 | `--incluster`         | Use in cluster configuration |
 | `--kubeconfig=</path/to/file>` |    Path to kubeconfig (if not in running inside a cluster) |
 | `--xds-address=<ipaddr>` | xDS gRPC API address |


### PR DESCRIPTION
Stubs out the '--contour-config-name' flag on 'contour serve' command
which will take precendence over any other configuration items if
specified.

Signed-off-by: Steve Sloka <slokas@vmware.com>