### PR TITLE
Deprecate the static cluster `service-stats` 

### DIFF
--- a/cmd/contour/shutdownmanager_test.go
+++ b/cmd/contour/shutdownmanager_test.go
@@ -193,14 +193,14 @@ func TestParseOpenConnections(t *testing.T) {
 
 // nolint:revive
 const (
-	VALIDHTTP = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_version{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
+	VALIDHTTP = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_version{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
 # TYPE envoy_http_downstream_cx_ssl_active gauge
 envoy_http_downstream_cx_ssl_active{envoy_http_conn_manager_prefix="admin"} 0
 # TYPE envoy_server_total_connections gauge
@@ -220,14 +220,14 @@ envoy_server_hot_restart_epoch{} 0
 # TYPE envoy_http_downstream_cx_active gauge
 envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="ingress_http"} 4
 `
-	VALIDHTTPS = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_version{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
+	VALIDHTTPS = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_version{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
 # TYPE envoy_http_downstream_cx_ssl_active gauge
 envoy_http_downstream_cx_ssl_active{envoy_http_conn_manager_prefix="admin"} 0
 # TYPE envoy_server_total_connections gauge
@@ -247,14 +247,14 @@ envoy_server_hot_restart_epoch{} 0
 # TYPE envoy_http_downstream_cx_active gauge
 envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="ingress_http"} 4
 `
-	VALIDBOTH = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_version{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
+	VALIDBOTH = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_version{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
 # TYPE envoy_http_downstream_cx_ssl_active gauge
 envoy_http_downstream_cx_ssl_active{envoy_http_conn_manager_prefix="admin"} 0
 # TYPE envoy_server_total_connections gauge
@@ -276,14 +276,14 @@ envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="ingress_http"} 4
 envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="ingress_https"} 4
 `
 
-	MISSING_STATS = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_version{envoy_cluster_name="projectcontour_service-stats_9001"} 0
-envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_service-stats_9001"} 0
+	MISSING_STATS = `envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_max_host_weight{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_version{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="projectcontour_envoy-admin_9001"} 0
 # TYPE envoy_http_downstream_cx_ssl_active gauge
 envoy_http_downstream_cx_ssl_active{envoy_http_conn_manager_prefix="admin"} 0
 # TYPE envoy_server_total_connections gauge

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -195,13 +195,13 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 					}},
 				},
 			}, {
-				Name:                 "service-stats",
-				AltStatName:          strings.Join([]string{c.Namespace, "service-stats", strconv.Itoa(c.GetAdminPort())}, "_"),
+				Name:                 "envoy-admin",
+				AltStatName:          strings.Join([]string{c.Namespace, "envoy-admin", strconv.Itoa(c.GetAdminPort())}, "_"),
 				ConnectTimeout:       protobuf.Duration(250 * time.Millisecond),
 				ClusterDiscoveryType: ClusterDiscoveryTypeForAddress(c.GetAdminAddress(), envoy_cluster_v3.Cluster_STATIC),
 				LbPolicy:             envoy_cluster_v3.Cluster_ROUND_ROBIN,
 				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
-					ClusterName: "service-stats",
+					ClusterName: "envoy-admin",
 					Endpoints: Endpoints(
 						UnixSocketAddress(c.GetAdminAddress(), c.GetAdminPort()),
 					),

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -99,12 +99,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -233,12 +233,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -367,12 +367,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -502,12 +502,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -637,12 +637,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -772,12 +772,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -909,12 +909,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -1074,12 +1074,12 @@ func TestBootstrap(t *testing.T) {
         }
       },
       {
-        "name": "service-stats",
-        "alt_stat_name": "testing-ns_service-stats_9001",
+        "name": "envoy-admin",
+        "alt_stat_name": "testing-ns_envoy-admin_9001",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "load_assignment": {
-          "cluster_name": "service-stats",
+          "cluster_name": "envoy-admin",
           "endpoints": [
             {
               "lb_endpoints": [
@@ -1236,12 +1236,12 @@ func TestBootstrap(t *testing.T) {
               }
             },
             {
-              "name": "service-stats",
-              "alt_stat_name": "testing-ns_service-stats_9001",
+              "name": "envoy-admin",
+              "alt_stat_name": "testing-ns_envoy-admin_9001",
               "type": "STATIC",
               "connect_timeout": "0.250s",
               "load_assignment": {
-                "cluster_name": "service-stats",
+                "cluster_name": "envoy-admin",
                 "endpoints": [
                   {
                     "lb_endpoints": [

--- a/internal/envoy/v3/stats.go
+++ b/internal/envoy/v3/stats.go
@@ -157,7 +157,7 @@ func serviceStatsRoute(prefix string) *envoy_route_v3.Route {
 		Action: &envoy_route_v3.Route_Route{
 			Route: &envoy_route_v3.RouteAction{
 				ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
-					Cluster: "service-stats",
+					Cluster: "envoy-admin",
 				},
 			},
 		},

--- a/internal/envoy/v3/stats_test.go
+++ b/internal/envoy/v3/stats_test.go
@@ -55,7 +55,7 @@ func TestStatsListener(t *testing.T) {
 												Action: &envoy_route_v3.Route_Route{
 													Route: &envoy_route_v3.RouteAction{
 														ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
-															Cluster: "service-stats",
+															Cluster: "envoy-admin",
 														},
 													},
 												},
@@ -68,7 +68,7 @@ func TestStatsListener(t *testing.T) {
 												Action: &envoy_route_v3.Route_Route{
 													Route: &envoy_route_v3.RouteAction{
 														ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
-															Cluster: "service-stats",
+															Cluster: "envoy-admin",
 														},
 													},
 												},


### PR DESCRIPTION
Rename to `envoy-admin` which better represents the backend cluster.

Fixes #3959

Signed-off-by: Steve Sloka <slokas@vmware.com>