### PR TITLE
internal/dag: Add additional validation for fqdn

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -196,6 +196,8 @@ type AuthorizationPolicy struct {
 type VirtualHost struct {
 	// The fully qualified domain name of the root of the ingress tree
 	// all leaves of the DAG rooted at this object relate to the fqdn.
+	//
+	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	Fqdn string `json:"fqdn"`
 
 	// If present the fields describes TLS properties of the virtual

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -2151,6 +2151,7 @@ spec:
                     description: The fully qualified domain name of the root of the
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   rateLimitPolicy:
                     description: The policy for rate limiting on the virtual host.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -2347,6 +2347,7 @@ spec:
                     description: The fully qualified domain name of the root of the
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   rateLimitPolicy:
                     description: The policy for rate limiting on the virtual host.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -2344,6 +2344,7 @@ spec:
                     description: The fully qualified domain name of the root of the
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   rateLimitPolicy:
                     description: The policy for rate limiting on the virtual host.

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -15,13 +15,10 @@ package dag
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -133,16 +130,6 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 	if isBlank(host) {
 		validCond.AddError(contour_api_v1.ConditionTypeVirtualHostError, "FQDNNotSpecified",
 			"Spec.VirtualHost.Fqdn must be specified")
-		return
-	}
-	if strings.Contains(host, "*") {
-		validCond.AddErrorf(contour_api_v1.ConditionTypeVirtualHostError, "WildCardNotAllowed",
-			"Spec.VirtualHost.Fqdn %q cannot use wildcards", host)
-		return
-	}
-	if !validHTTPProxyFQDN(host) {
-		validCond.AddError(contour_api_v1.ConditionTypeVirtualHostError, "FQDNInvalid",
-			"Spec.VirtualHost.Fqdn must be be a valid DNS name")
 		return
 	}
 
@@ -1056,14 +1043,4 @@ func directResponse(statusCode uint32) *DirectResponse {
 	return &DirectResponse{
 		StatusCode: statusCode,
 	}
-}
-
-func validHTTPProxyFQDN(hostname string) bool {
-	if isIP := net.ParseIP(hostname) != nil; isIP {
-		return false
-	}
-	if errs := validation.IsDNS1123Subdomain(hostname); errs != nil {
-		return false
-	}
-	return true
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -697,37 +697,6 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
-	// proxyWildCardFQDN is invalid because it contains a wildcarded fqdn
-	proxyWildCardFQDN := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "roots",
-			Name:      "example",
-		},
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{
-				Fqdn: "example.*.com",
-			},
-			Routes: []contour_api_v1.Route{{
-				Conditions: []contour_api_v1.MatchCondition{{
-					Prefix: "/foo",
-				}},
-				Services: []contour_api_v1.Service{{
-					Name: "home",
-					Port: 8080,
-				}},
-			}},
-		},
-	}
-
-	run(t, "proxy invalid FQDN contains wildcard", testcase{
-		objs: []interface{}{proxyWildCardFQDN},
-		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
-			{Name: proxyWildCardFQDN.Name, Namespace: proxyWildCardFQDN.Namespace}: fixture.NewValidCondition().
-				WithGeneration(proxyWildCardFQDN.Generation).
-				WithError(contour_api_v1.ConditionTypeVirtualHostError, "WildCardNotAllowed", `Spec.VirtualHost.Fqdn "example.*.com" cannot use wildcards`),
-		},
-	})
-
 	// singleNameFQDN is valid
 	singleNameFQDN := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -728,6 +728,37 @@ func TestDAGStatus(t *testing.T) {
 		},
 	})
 
+	// singleNameFQDN is valid
+	singleNameFQDN := &contour_api_v1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "roots",
+			Name:      "example",
+		},
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "example",
+			},
+			Routes: []contour_api_v1.Route{{
+				Conditions: []contour_api_v1.MatchCondition{{
+					Prefix: "/foo",
+				}},
+				Services: []contour_api_v1.Service{{
+					Name: "home",
+					Port: 8080,
+				}},
+			}},
+		},
+	}
+
+	run(t, "proxy valid single FQDN", testcase{
+		objs: []interface{}{singleNameFQDN, fixture.ServiceRootsHome},
+		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
+			{Name: singleNameFQDN.Name, Namespace: singleNameFQDN.Namespace}: fixture.NewValidCondition().
+				WithGeneration(singleNameFQDN.Generation).
+				Valid(),
+		},
+	})
+
 	// proxyInvalidServiceInvalid is invalid because it references an invalid service
 	proxyInvalidServiceInvalid := &contour_api_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -242,6 +242,11 @@ func (f *Framework) Test(body TestBody) {
 	body()
 }
 
+// CreateHTTPProxy creates the provided HTTPProxy and returns any relevant error.
+func (f *Framework) CreateHTTPProxy(proxy *contourv1.HTTPProxy) error {
+	return f.Client.Create(context.TODO(), proxy)
+}
+
 // CreateHTTPProxyAndWaitFor creates the provided HTTPProxy in the Kubernetes API
 // and then waits for the specified condition to be true.
 func (f *Framework) CreateHTTPProxyAndWaitFor(proxy *contourv1.HTTPProxy, condition func(*contourv1.HTTPProxy) bool) (*contourv1.HTTPProxy, bool) {

--- a/test/e2e/httpproxy/fqdn_test.go
+++ b/test/e2e/httpproxy/fqdn_test.go
@@ -1,0 +1,84 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package httpproxy
+
+import (
+	. "github.com/onsi/ginkgo"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testWildcardSubdomainFQDN(namespace string) {
+	Specify("invalid wildcard subdomain fqdn", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "wildcard-subdomain",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "*.projectcontour.io",
+				},
+				Routes: []contourv1.Route{{
+					Services: []contourv1.Service{{
+						Name: "ingress-conformance-echo",
+						Port: 80,
+					}},
+				}},
+			},
+		}
+
+		// Creation should fail the kubebuilder CRD validations.
+		err := f.CreateHTTPProxy(p)
+		require.NotNil(t, err, "Expected invalid subdomain wildcard to be rejected.")
+	})
+}
+
+func testWildcardFQDN(namespace string) {
+	Specify("invalid wildcard fqdn", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "wildcard-subdomain",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "*",
+				},
+				Routes: []contourv1.Route{{
+					Services: []contourv1.Service{{
+						Name: "ingress-conformance-echo",
+						Port: 80,
+					}},
+				}},
+			},
+		}
+
+		// Creation should fail the kubebuilder CRD validations.
+		err := f.CreateHTTPProxy(p)
+		require.NotNil(t, err, "Expected invalid wildcard to be rejected.")
+	})
+}

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -110,6 +110,9 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-retry-policy-validation", testRetryPolicyValidation)
 
+	f.NamespacedTest("httpproxy-invalid-wildcard-subdomain-fqdn", testWildcardSubdomainFQDN)
+	f.NamespacedTest("httpproxy-invalid-wildcard-fqdn", testWildcardFQDN)
+
 	f.NamespacedTest("httpproxy-https-fallback-certificate", func(namespace string) {
 		Context("with fallback certificate", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
Adds additional validation for FQDN in HTTPProxy resources.

Fixes #3166

Signed-off-by: Steve Sloka <slokas@vmware.com>