### PR TITLE
cmd/contour: Use ContourConfiguration for all config

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -31,7 +31,7 @@ jobs:
         steps: ${{ toJson(steps) }}
         channel: '#contour-ci-notifications'
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  e2e-contourconfiguration:
+  e2e:
     runs-on: ubuntu-latest
     # TODO uncomment the below once we're using the image
     # or its binary for testing.
@@ -44,7 +44,7 @@ jobs:
         # a Kubernetes version number.
         kubernetes_version: ["kubernetes:latest", "kubernetes:n-1", "kubernetes:n-2"]
         # run tests using the configuration crd as well as without
-        use_config_crd: [true, false]
+        config_type: ["ConfigmapConfiguration", "ContourConfiguration"]
         # include defines an additional variable (the specific node
         # image to use) for each kubernetes_version value.
         include:
@@ -54,6 +54,11 @@ jobs:
             node_image: "docker.io/kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4"
           - kubernetes_version: "kubernetes:n-2"
             node_image: "docker.io/kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+          - config_type: "ConfigmapConfiguration"
+            use_config_crd: "false"
+          - config_type: "ContourConfiguration"
+            use_config_crd: "false"
+
     steps:
       - uses: actions/checkout@v2
       # TODO uncomment the below once we're using the image

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -31,7 +31,7 @@ jobs:
         steps: ${{ toJson(steps) }}
         channel: '#contour-ci-notifications'
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  e2e:
+  e2e-configmap:
     runs-on: ubuntu-latest
     # TODO uncomment the below once we're using the image
     # or its binary for testing.
@@ -82,6 +82,66 @@ jobs:
         env:
           NODEIMAGE: ${{ matrix.node_image }}
           LOAD_PREBUILT_IMAGE: "true"
+        run: |
+          make e2e
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#contour-ci-notifications'
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+  e2e-contourconfiguration:
+    runs-on: ubuntu-latest
+    # TODO uncomment the below once we're using the image
+    # or its binary for testing.
+    # needs: [build-image]
+    strategy:
+      matrix:
+        # use stable kubernetes_version values since they're included
+        # in the name of the GitHub Actions job, and we don't want to
+        # have to update branch protection rules every time we change
+        # a Kubernetes version number.
+        kubernetes_version: ["kubernetes:latest", "kubernetes:n-1", "kubernetes:n-2"]
+        # include defines an additional variable (the specific node
+        # image to use) for each kubernetes_version value.
+        include:
+          - kubernetes_version: "kubernetes:latest"
+            node_image: "docker.io/kindest/node:v1.22.0@sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717"
+          - kubernetes_version: "kubernetes:n-1"
+            node_image: "docker.io/kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4"
+          - kubernetes_version: "kubernetes:n-2"
+            node_image: "docker.io/kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+    steps:
+      - uses: actions/checkout@v2
+      # TODO uncomment the below once we're using the image
+      # or its binary for testing.
+      # - name: Download image
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: image
+      #     path: image
+      - uses: actions/cache@v2
+        with:
+          # * Module download cache
+          # * Build cache (Linux)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-go-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.0'
+      - name: add deps to path
+        run: |
+          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: e2e tests
+        env:
+          NODEIMAGE: ${{ matrix.node_image }}
+          LOAD_PREBUILT_IMAGE: "true"
+          USE_CONTOUR_CONFIGURATION_CRD: "true"
         run: |
           make e2e
       - uses: act10ns/slack@v1

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -57,7 +57,7 @@ jobs:
           - config_type: "ConfigmapConfiguration"
             use_config_crd: "false"
           - config_type: "ContourConfiguration"
-            use_config_crd: "false"
+            use_config_crd: "true"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -31,65 +31,6 @@ jobs:
         steps: ${{ toJson(steps) }}
         channel: '#contour-ci-notifications'
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  e2e-configmap:
-    runs-on: ubuntu-latest
-    # TODO uncomment the below once we're using the image
-    # or its binary for testing.
-    # needs: [build-image]
-    strategy:
-      matrix:
-        # use stable kubernetes_version values since they're included
-        # in the name of the GitHub Actions job, and we don't want to
-        # have to update branch protection rules every time we change
-        # a Kubernetes version number.
-        kubernetes_version: ["kubernetes:latest", "kubernetes:n-1", "kubernetes:n-2"]
-        # include defines an additional variable (the specific node
-        # image to use) for each kubernetes_version value.
-        include:
-          - kubernetes_version: "kubernetes:latest"
-            node_image: "docker.io/kindest/node:v1.22.0@sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717"
-          - kubernetes_version: "kubernetes:n-1"
-            node_image: "docker.io/kindest/node:v1.21.2@sha256:9d07ff05e4afefbba983fac311807b3c17a5f36e7061f6cb7e2ba756255b2be4"
-          - kubernetes_version: "kubernetes:n-2"
-            node_image: "docker.io/kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
-    steps:
-      - uses: actions/checkout@v2
-      # TODO uncomment the below once we're using the image
-      # or its binary for testing.
-      # - name: Download image
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: image
-      #     path: image
-      - uses: actions/cache@v2
-        with:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.0'
-      - name: add deps to path
-        run: |
-          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-      - name: e2e tests
-        env:
-          NODEIMAGE: ${{ matrix.node_image }}
-          LOAD_PREBUILT_IMAGE: "true"
-        run: |
-          make e2e
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#contour-ci-notifications'
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
   e2e-contourconfiguration:
     runs-on: ubuntu-latest
     # TODO uncomment the below once we're using the image
@@ -102,6 +43,8 @@ jobs:
         # have to update branch protection rules every time we change
         # a Kubernetes version number.
         kubernetes_version: ["kubernetes:latest", "kubernetes:n-1", "kubernetes:n-2"]
+        # run tests using the configuration crd as well as without
+        use_config_crd: [true, false]
         # include defines an additional variable (the specific node
         # image to use) for each kubernetes_version value.
         include:
@@ -141,7 +84,7 @@ jobs:
         env:
           NODEIMAGE: ${{ matrix.node_image }}
           LOAD_PREBUILT_IMAGE: "true"
-          USE_CONTOUR_CONFIGURATION_CRD: "true"
+          USE_CONTOUR_CONFIGURATION_CRD: ${{ matrix.use_config_crd }}
         run: |
           make e2e
       - uses: act10ns/slack@v1

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -523,7 +523,11 @@ type NamespacedName struct {
 	Namespace string `json:"namespace"`
 }
 
-func (n NamespacedName) NamespacedNameOf() *types.NamespacedName {
+func (n *NamespacedName) NamespacedNameOf() *types.NamespacedName {
+	if n == nil {
+		return nil
+	}
+
 	if len(strings.TrimSpace(n.Name)) == 0 && len(strings.TrimSpace(n.Namespace)) == 0 {
 		return nil
 	}

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -14,11 +14,8 @@
 package v1alpha1
 
 import (
-	"strings"
-
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // ContourConfigurationSpec represents a configuration of a Contour controller.
@@ -82,7 +79,7 @@ type ContourConfigurationSpec struct {
 	// +optional
 	Policy *PolicyConfig `json:"policy,omitempty"`
 
-	// Metrics defines the endpoints Envoy use to serve to metrics.
+	// Metrics defines the endpoints Contour uses to serve to metrics.
 	// +optional
 	// +kubebuilder:default={address: "0.0.0.0", port: 8000}
 	Metrics MetricsConfig `json:"metrics"`
@@ -524,21 +521,6 @@ type HeadersPolicy struct {
 type NamespacedName struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
-}
-
-func (n *NamespacedName) NamespacedNameOf() *types.NamespacedName {
-	if n == nil {
-		return nil
-	}
-
-	if len(strings.TrimSpace(n.Name)) == 0 && len(strings.TrimSpace(n.Namespace)) == 0 {
-		return nil
-	}
-
-	return &types.NamespacedName{
-		Namespace: n.Namespace,
-		Name:      n.Name,
-	}
 }
 
 // ContourConfigurationStatus defines the observed state of a ContourConfiguration resource.

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -49,7 +49,7 @@ type ContourConfigurationSpec struct {
 	// Envoy contains parameters for Envoy as well
 	// as how to optionally configure a managed Envoy fleet.
 	// +optional
-	// +kubebuilder:default={listener: {useProxyProtocol: false, disableAllowChunkedLength: false, connectionBalancer: "", tls: { minimumProtocolVersion: "1.2", cipherSuites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]";"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]";"ECDHE-ECDSA-AES256-GCM-SHA384";"ECDHE-RSA-AES256-GCM-SHA384" }}, service: {name: "envoy", namespace: "projectcontour"}, http: {address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout"}, https: {address: "0.0.0.0", port: 8443, accessLog: "/dev/stdout"}, metrics: {address: "0.0.0.0", port: 8002}, logging: { accessLogFormat: "envoy"}, defaultHTTPVersions: "http/1.1";"http/2", cluster: {dnsLookupFamily: "auto"}, network: { adminPort: 9001}}
+	// +kubebuilder:default={listener: {useProxyProtocol: false, disableAllowChunkedLength: false, connectionBalancer: "", tls: { minimumProtocolVersion: "1.2", cipherSuites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]";"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]";"ECDHE-ECDSA-AES256-GCM-SHA384";"ECDHE-RSA-AES256-GCM-SHA384" }}, service: {name: "envoy", namespace: "projectcontour"}, http: {address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout"}, https: {address: "0.0.0.0", port: 8443, accessLog: "/dev/stdout"}, metrics: {address: "0.0.0.0", port: 8002}, logging: { accessLogFormat: "envoy"}, defaultHTTPVersions: "HTTP/1.1";"HTTP/2", cluster: {dnsLookupFamily: "auto"}, network: { adminPort: 9001}}
 	Envoy EnvoyConfig `json:"envoy"`
 
 	// Gateway contains parameters for the gateway-api Gateway that Contour
@@ -172,11 +172,11 @@ type MetricsConfig struct {
 }
 
 // HTTPVersionType is the name of a supported HTTP version.
-// +kubebuilder:validation:Enum="http/1.1";"http/2"
+// +kubebuilder:validation:Enum="HTTP/1.1";"HTTP/2"
 type HTTPVersionType string
 
-const HTTPVersion1 HTTPVersionType = "http/1.1"
-const HTTPVersion2 HTTPVersionType = "http/2"
+const HTTPVersion1 HTTPVersionType = "HTTP/1.1"
+const HTTPVersion2 HTTPVersionType = "HTTP/2"
 
 // EnvoyConfig defines how Envoy is to be Configured from Contour.
 type EnvoyConfig struct {

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -504,6 +504,7 @@ type PolicyConfig struct {
 	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeaders,omitempty"`
 
+	// ApplyToIngress determines if the Policies will apply to ingress objects
 	// +optional
 	ApplyToIngress bool `json:"applyToIngress"`
 }

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -506,6 +506,9 @@ type PolicyConfig struct {
 	// ResponseHeadersPolicy defines the response headers set/removed on all routes
 	// +optional
 	ResponseHeadersPolicy *HeadersPolicy `json:"responseHeaders,omitempty"`
+
+	// +optional
+	ApplyToIngress bool `json:"applyToIngress"`
 }
 
 type HeadersPolicy struct {

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -14,8 +14,11 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ContourConfigurationSpec represents a configuration of a Contour controller.
@@ -254,7 +257,7 @@ type DebugConfig struct {
 	// +kubebuilder:default=0
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=9
-	KubernetesDebugLogLevel int `json:"kubernetesLogLevel"`
+	KubernetesDebugLogLevel uint `json:"kubernetesLogLevel"`
 }
 
 // EnvoyListenerConfig hold various configurable Envoy listener values.
@@ -282,21 +285,6 @@ type EnvoyListenerConfig struct {
 
 // +kubebuilder:validation:Enum="[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]";"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]";"ECDHE-ECDSA-AES128-GCM-SHA256";"ECDHE-RSA-AES128-GCM-SHA256";"ECDHE-ECDSA-AES128-SHA";"ECDHE-RSA-AES128-SHA";"AES128-GCM-SHA256";"AES128-SHA";"ECDHE-ECDSA-AES256-GCM-SHA384";"ECDHE-RSA-AES256-GCM-SHA384";"ECDHE-ECDSA-AES256-SHA";"ECDHE-RSA-AES256-SHA";"AES256-GCM-SHA384";"AES256-SHA"
 type TLSCipherType string
-
-const CIPHER1 TLSCipherType = "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
-const CIPHER2 TLSCipherType = "[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]"
-const CIPHER3 TLSCipherType = "ECDHE-ECDSA-AES128-GCM-SHA256"
-const CIPHER4 TLSCipherType = "ECDHE-RSA-AES128-GCM-SHA256"
-const CIPHER5 TLSCipherType = "ECDHE-ECDSA-AES128-SHA"
-const CIPHER6 TLSCipherType = "ECDHE-RSA-AES128-SHA"
-const CIPHER7 TLSCipherType = "AES128-GCM-SHA256"
-const CIPHER8 TLSCipherType = "AES128-SHA"
-const CIPHER9 TLSCipherType = "ECDHE-ECDSA-AES256-GCM-SHA384"
-const CIPHER10 TLSCipherType = "ECDHE-RSA-AES256-GCM-SHA384"
-const CIPHER11 TLSCipherType = "ECDHE-ECDSA-AES256-SHA"
-const CIPHER12 TLSCipherType = "ECDHE-RSA-AES256-SHA"
-const CIPHER13 TLSCipherType = "AES256-GCM-SHA384"
-const CIPHER14 TLSCipherType = "AES256-SHA"
 
 // EnvoyTLS describes tls parameters for Envoy listneners.
 type EnvoyTLS struct {
@@ -533,6 +521,17 @@ type HeadersPolicy struct {
 type NamespacedName struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+}
+
+func (n NamespacedName) NamespacedNameOf() *types.NamespacedName {
+	if len(strings.TrimSpace(n.Name)) == 0 && len(strings.TrimSpace(n.Namespace)) == 0 {
+		return nil
+	}
+
+	return &types.NamespacedName{
+		Namespace: n.Namespace,
+		Name:      n.Name,
+	}
 }
 
 // ContourConfigurationStatus defines the observed state of a ContourConfiguration resource.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -120,7 +120,13 @@ func main() {
 			log.WithError(err).Fatal("invalid configuration")
 		}
 
-		if err := doServe(log, serveCtx); err != nil {
+		// Build out serve deps.
+		serve, err := NewServe(log, serveCtx)
+		if err != nil {
+			log.WithError(err).Fatal("unable to create serve deps")
+		}
+
+		if err := serve.doServe(); err != nil {
 			log.WithError(err).Fatal("Contour server failed")
 		}
 	case version.FullCommand():

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -121,9 +121,9 @@ func main() {
 		}
 
 		// Build out serve deps.
-		serve, err := NewServe(log, serveCtx)
+		serve, err := NewServer(log, serveCtx)
 		if err != nil {
-			log.WithError(err).Fatal("unable to create serve deps")
+			log.WithError(err).Fatal("unable to initialize Server dependencies required to start Contour")
 		}
 
 		if err := serve.doServe(); err != nil {

--- a/cmd/contour/leadership.go
+++ b/cmd/contour/leadership.go
@@ -103,11 +103,11 @@ func newLeaderElector(
 	if err != nil {
 		log.WithError(err).Fatalf("could not parse LeaseDuration: %q", conf.LeaseDuration)
 	}
-	renewDeadline, _ := time.ParseDuration(conf.RenewDeadline)
+	renewDeadline, err := time.ParseDuration(conf.RenewDeadline)
 	if err != nil {
 		log.WithError(err).Fatalf("could not parse RenewDeadline: %q", conf.RenewDeadline)
 	}
-	retryPeriod, _ := time.ParseDuration(conf.RetryPeriod)
+	retryPeriod, err := time.ParseDuration(conf.RetryPeriod)
 	if err != nil {
 		log.WithError(err).Fatalf("could not parse RetryPeriod: %q", conf.RetryPeriod)
 	}

--- a/cmd/contour/leadership.go
+++ b/cmd/contour/leadership.go
@@ -99,9 +99,18 @@ func newLeaderElector(
 
 	rl := newResourceLock(log, conf, clients)
 
-	leaseDuration, _ := time.ParseDuration(conf.LeaseDuration) // TODO;
+	leaseDuration, err := time.ParseDuration(conf.LeaseDuration)
+	if err != nil {
+		log.WithError(err).Fatalf("could not parse LeaseDuration: %q", conf.LeaseDuration)
+	}
 	renewDeadline, _ := time.ParseDuration(conf.RenewDeadline)
+	if err != nil {
+		log.WithError(err).Fatalf("could not parse RenewDeadline: %q", conf.RenewDeadline)
+	}
 	retryPeriod, _ := time.ParseDuration(conf.RetryPeriod)
+	if err != nil {
+		log.WithError(err).Fatalf("could not parse RetryPeriod: %q", conf.RetryPeriod)
+	}
 
 	// Make the leader elector, ready to be used in the Workgroup.
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{

--- a/cmd/contour/leadership.go
+++ b/cmd/contour/leadership.go
@@ -16,11 +16,13 @@ package main
 import (
 	"context"
 	"os"
+	"time"
+
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 
 	"github.com/google/uuid"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/workgroup"
-	"github.com/projectcontour/contour/pkg/config"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -40,15 +42,15 @@ func disableLeaderElection(log logrus.FieldLogger) chan struct{} {
 func setupLeadershipElection(
 	g *workgroup.Group,
 	log logrus.FieldLogger,
-	conf *config.LeaderElectionParameters,
+	conf contour_api_v1alpha1.LeaderElectionConfig,
 	clients *k8s.Clients, updateNow func(),
 ) chan struct{} {
 	le, leader, deposed := newLeaderElector(log, conf, clients)
 
 	g.AddContext(func(electionCtx context.Context) error {
 		log.WithFields(logrus.Fields{
-			"configmapname":      conf.Name,
-			"configmapnamespace": conf.Namespace,
+			"configmapname":      conf.Configmap.Name,
+			"configmapnamespace": conf.Configmap.Namespace,
 		}).Info("started leader election")
 
 		le.Run(electionCtx)
@@ -85,7 +87,7 @@ func setupLeadershipElection(
 // channels by which to observe elections and depositions.
 func newLeaderElector(
 	log logrus.FieldLogger,
-	conf *config.LeaderElectionParameters,
+	conf contour_api_v1alpha1.LeaderElectionConfig,
 	clients *k8s.Clients,
 ) (*leaderelection.LeaderElector, chan struct{}, chan struct{}) {
 	log = log.WithField("context", "leaderelection")
@@ -97,12 +99,16 @@ func newLeaderElector(
 
 	rl := newResourceLock(log, conf, clients)
 
+	leaseDuration, _ := time.ParseDuration(conf.LeaseDuration) // TODO;
+	renewDeadline, _ := time.ParseDuration(conf.RenewDeadline)
+	retryPeriod, _ := time.ParseDuration(conf.RetryPeriod)
+
 	// Make the leader elector, ready to be used in the Workgroup.
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:          rl,
-		LeaseDuration: conf.LeaseDuration,
-		RenewDeadline: conf.RenewDeadline,
-		RetryPeriod:   conf.RetryPeriod,
+		LeaseDuration: leaseDuration,
+		RenewDeadline: renewDeadline,
+		RetryPeriod:   retryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
 				log.WithFields(logrus.Fields{
@@ -126,7 +132,7 @@ func newLeaderElector(
 
 // newResourceLock creates a new resourcelock.Interface based on the Pod's name,
 // or a uuid if the name cannot be determined.
-func newResourceLock(log logrus.FieldLogger, conf *config.LeaderElectionParameters, clients *k8s.Clients) resourcelock.Interface {
+func newResourceLock(log logrus.FieldLogger, conf contour_api_v1alpha1.LeaderElectionConfig, clients *k8s.Clients) resourcelock.Interface {
 	resourceLockID, found := os.LookupEnv("POD_NAME")
 	if !found {
 		resourceLockID = uuid.New().String()
@@ -138,8 +144,8 @@ func newResourceLock(log logrus.FieldLogger, conf *config.LeaderElectionParamete
 		// cycle (ie nine months).
 		// Figure out the resource lock ID
 		resourcelock.ConfigMapsResourceLock,
-		conf.Namespace,
-		conf.Name,
+		conf.Configmap.Namespace,
+		conf.Configmap.Name,
 		clients.ClientSet().CoreV1(),
 		clients.ClientSet().CoordinationV1(),
 		resourcelock.ResourceLockConfig{
@@ -148,8 +154,8 @@ func newResourceLock(log logrus.FieldLogger, conf *config.LeaderElectionParamete
 	)
 	if err != nil {
 		log.WithError(err).
-			WithField("name", conf.Name).
-			WithField("namespace", conf.Namespace).
+			WithField("name", conf.Configmap.Name).
+			WithField("namespace", conf.Configmap.Namespace).
 			WithField("identity", resourceLockID).
 			Fatal("failed to create new resource lock")
 	}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -223,7 +223,13 @@ func (s *Server) doServe() error {
 		//
 		// If the env variable is not present, it will return "" and still fail the lookup
 		// of the ContourConfiguration in the cluster.
-		namespacedName := types.NamespacedName{Name: s.ctx.contourConfigurationName, Namespace: os.Getenv("CONTOUR_NAMESPACE")}
+
+		contourNamespace := os.Getenv("CONTOUR_NAMESPACE")
+		if len(contourNamespace) == 0 {
+			contourNamespace = "projectcontour"
+		}
+
+		namespacedName := types.NamespacedName{Name: s.ctx.contourConfigurationName, Namespace: contourNamespace}
 		client := s.clients.DynamicClient().Resource(contour_api_v1alpha1.ContourConfigurationGVR).Namespace(namespacedName.Namespace)
 
 		// ensure the specified ContourConfiguration exists

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -706,17 +706,18 @@ func (s *Serve) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Contou
 }
 
 type dagBuilderConfig struct {
-	ingressClassName          string
-	rootNamespaces            []string
-	gatewayAPIConfigured      bool
-	disablePermitInsecure     bool
-	enableExternalNameService bool
-	dnsLookupFamily           contour_api_v1alpha1.ClusterDNSFamilyType
-	requestHP                 *contour_api_v1alpha1.HeadersPolicy
-	responseHP                *contour_api_v1alpha1.HeadersPolicy
-	clients                   *k8s.Clients
-	clientCert                *types.NamespacedName
-	fallbackCert              *types.NamespacedName
+	ingressClassName           string
+	rootNamespaces             []string
+	gatewayAPIConfigured       bool
+	disablePermitInsecure      bool
+	enableExternalNameService  bool
+	dnsLookupFamily            contour_api_v1alpha1.ClusterDNSFamilyType
+	requestHP                  *contour_api_v1alpha1.HeadersPolicy
+	responseHP                 *contour_api_v1alpha1.HeadersPolicy
+	applyHeaderPolicyToIngress bool
+	clients                    *k8s.Clients
+	clientCert                 *types.NamespacedName
+	fallbackCert               *types.NamespacedName
 }
 
 func (s *Serve) getDAGBuilder(dbc dagBuilderConfig) dag.Builder {
@@ -748,6 +749,13 @@ func (s *Serve) getDAGBuilder(dbc dagBuilderConfig) dag.Builder {
 			responseHeadersPolicy.Remove = make([]string, 0, len(dbc.responseHP.Remove))
 			responseHeadersPolicy.Remove = append(responseHeadersPolicy.Remove, dbc.responseHP.Remove...)
 		}
+	}
+
+	var requestHeadersPolicyIngress dag.HeadersPolicy
+	var responseHeadersPolicyIngress dag.HeadersPolicy
+	if dbc.applyHeaderPolicyToIngress {
+		requestHeadersPolicyIngress = requestHeadersPolicy
+		responseHeadersPolicyIngress = responseHeadersPolicy
 	}
 
 	s.log.Debugf("EnableExternalNameService is set to %t", dbc.enableExternalNameService)

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -345,6 +345,15 @@ func (s *Server) doServe() error {
 		ingressClassName = *contourConfiguration.Ingress.ClassName
 	}
 
+	var clientCert *types.NamespacedName
+	var fallbackCert *types.NamespacedName
+	if contourConfiguration.Envoy.ClientCertificate != nil {
+		clientCert = &types.NamespacedName{Name: contourConfiguration.Envoy.ClientCertificate.Name, Namespace: contourConfiguration.Envoy.ClientCertificate.Namespace}
+	}
+	if contourConfiguration.HTTPProxy.FallbackCertificate != nil {
+		fallbackCert = &types.NamespacedName{Name: contourConfiguration.HTTPProxy.FallbackCertificate.Name, Namespace: contourConfiguration.HTTPProxy.FallbackCertificate.Namespace}
+	}
+
 	// Build the core Kubernetes event handler.
 	contourHandler := &contour.EventHandler{
 		HoldoffDelay:    100 * time.Millisecond,
@@ -359,8 +368,8 @@ func (s *Server) doServe() error {
 			dnsLookupFamily:           contourConfiguration.Envoy.Cluster.DNSLookupFamily,
 			headersPolicy:             contourConfiguration.Policy,
 			clients:                   s.clients,
-			clientCert:                &types.NamespacedName{Name: contourConfiguration.Envoy.ClientCertificate.Name, Namespace: contourConfiguration.Envoy.ClientCertificate.Namespace},
-			fallbackCert:              &types.NamespacedName{Name: contourConfiguration.HTTPProxy.FallbackCertificate.Name, Namespace: contourConfiguration.HTTPProxy.FallbackCertificate.Namespace},
+			clientCert:                clientCert,
+			fallbackCert:              fallbackCert,
 		}),
 		FieldLogger: s.log.WithField("context", "contourEventHandler"),
 	}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -760,13 +760,6 @@ func (s *Serve) getDAGBuilder(dbc dagBuilderConfig) dag.Builder {
 
 	s.log.Debugf("EnableExternalNameService is set to %t", dbc.enableExternalNameService)
 
-	var requestHeadersPolicyIngress dag.HeadersPolicy
-	var responseHeadersPolicyIngress dag.HeadersPolicy
-	if ctx.Config.Policy.ApplyToIngress {
-		requestHeadersPolicyIngress = requestHeadersPolicy
-		responseHeadersPolicyIngress = responseHeadersPolicy
-	}
-
 	// Get the appropriate DAG processors.
 	dagProcessors := []dag.Processor{
 		&dag.IngressProcessor{

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -946,6 +946,27 @@ func convertServeContext(ctx *serveContext) contour_api_v1alpha1.ContourConfigur
 		},
 	}
 
+	var clientCertificate *contour_api_v1alpha1.NamespacedName
+	if len(ctx.Config.TLS.ClientCertificate.Name) > 0 {
+		clientCertificate = &contour_api_v1alpha1.NamespacedName{
+			Name:      ctx.Config.TLS.ClientCertificate.Name,
+			Namespace: ctx.Config.TLS.ClientCertificate.Namespace,
+		}
+	}
+
+	var accessLogFormatString *string
+	if len(ctx.Config.AccessLogFormatString) > 0 {
+		accessLogFormatString = pointer.StringPtr(ctx.Config.AccessLogFormatString)
+	}
+
+	var fallbackCertificate *contour_api_v1alpha1.NamespacedName
+	if len(ctx.Config.TLS.FallbackCertificate.Name) > 0 {
+		fallbackCertificate = &contour_api_v1alpha1.NamespacedName{
+			Name:      ctx.Config.TLS.FallbackCertificate.Name,
+			Namespace: ctx.Config.TLS.FallbackCertificate.Namespace,
+		}
+	}
+
 	// Convert serveContext to a ContourConfiguration
 	contourConfiguration := contour_api_v1alpha1.ContourConfigurationSpec{
 		Ingress: ingress,
@@ -987,13 +1008,10 @@ func convertServeContext(ctx *serveContext) contour_api_v1alpha1.ContourConfigur
 				Address: ctx.statsAddr,
 				Port:    ctx.statsPort,
 			},
-			ClientCertificate: &contour_api_v1alpha1.NamespacedName{
-				Name:      ctx.Config.TLS.ClientCertificate.Name,
-				Namespace: ctx.Config.TLS.ClientCertificate.Namespace,
-			},
+			ClientCertificate: clientCertificate,
 			Logging: contour_api_v1alpha1.EnvoyLogging{
 				AccessLogFormat:       accessLogFormat,
-				AccessLogFormatString: pointer.StringPtr(ctx.Config.AccessLogFormatString),
+				AccessLogFormatString: accessLogFormatString,
 				AccessLogFields:       accessLogFields,
 			},
 			DefaultHTTPVersions: defaultHTTPVersions,
@@ -1010,10 +1028,7 @@ func convertServeContext(ctx *serveContext) contour_api_v1alpha1.ContourConfigur
 		HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
 			DisablePermitInsecure: ctx.Config.DisablePermitInsecure,
 			RootNamespaces:        ctx.proxyRootNamespaces(),
-			FallbackCertificate: &contour_api_v1alpha1.NamespacedName{
-				Name:      ctx.Config.TLS.FallbackCertificate.Name,
-				Namespace: ctx.Config.TLS.FallbackCertificate.Namespace,
-			},
+			FallbackCertificate:   fallbackCertificate,
 		},
 		LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
 			LeaseDuration: ctx.Config.LeaderElection.LeaseDuration.String(),

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -41,7 +41,10 @@ func TestGetDAGBuilder(t *testing.T) {
 	}
 
 	t.Run("all default options", func(t *testing.T) {
-		got := getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily}, logrus.StandardLogger())
+		serve := &Serve{
+			log: logrus.StandardLogger(),
+		}
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily})
 		commonAssertions(t, &got)
 		assert.Empty(t, got.Source.ConfiguredSecretRefs)
 	})
@@ -49,7 +52,10 @@ func TestGetDAGBuilder(t *testing.T) {
 	t.Run("client cert specified", func(t *testing.T) {
 		clientCert := &types.NamespacedName{Namespace: "client-ns", Name: "client-name"}
 
-		got := getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert}, logrus.StandardLogger())
+		serve := &Serve{
+			log: logrus.StandardLogger(),
+		}
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert})
 		commonAssertions(t, &got)
 		assert.ElementsMatch(t, got.Source.ConfiguredSecretRefs, []*types.NamespacedName{clientCert})
 	})
@@ -57,7 +63,10 @@ func TestGetDAGBuilder(t *testing.T) {
 	t.Run("fallback cert specified", func(t *testing.T) {
 		fallbackCert := &types.NamespacedName{Namespace: "fallback-ns", Name: "fallback-name"}
 
-		got := getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, fallbackCert: fallbackCert}, logrus.StandardLogger())
+		serve := &Serve{
+			log: logrus.StandardLogger(),
+		}
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, fallbackCert: fallbackCert})
 		commonAssertions(t, &got)
 		assert.ElementsMatch(t, got.Source.ConfiguredSecretRefs, []*types.NamespacedName{fallbackCert})
 	})
@@ -66,7 +75,10 @@ func TestGetDAGBuilder(t *testing.T) {
 		clientCert := &types.NamespacedName{Namespace: "client-ns", Name: "client-name"}
 		fallbackCert := &types.NamespacedName{Namespace: "fallback-ns", Name: "fallback-name"}
 
-		got := getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert, fallbackCert: fallbackCert}, logrus.StandardLogger())
+		serve := &Serve{
+			log: logrus.StandardLogger(),
+		}
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert, fallbackCert: fallbackCert})
 		commonAssertions(t, &got)
 		assert.ElementsMatch(t, got.Source.ConfiguredSecretRefs, []*types.NamespacedName{clientCert, fallbackCert})
 	})
@@ -89,7 +101,10 @@ func TestGetDAGBuilder(t *testing.T) {
 			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 		}
 
-		got := getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, requestHP: requestHP, responseHP: responseHP}, logrus.StandardLogger())
+		serve := &Serve{
+			log: logrus.StandardLogger(),
+		}
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, requestHP: requestHP, responseHP: responseHP})
 		commonAssertions(t, &got)
 
 		httpProxyProcessor := mustGetHTTPProxyProcessor(t, &got)

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -37,7 +37,7 @@ func TestGetDAGBuilder(t *testing.T) {
 	}
 
 	t.Run("all default options", func(t *testing.T) {
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily})
@@ -48,7 +48,7 @@ func TestGetDAGBuilder(t *testing.T) {
 	t.Run("client cert specified", func(t *testing.T) {
 		clientCert := &types.NamespacedName{Namespace: "client-ns", Name: "client-name"}
 
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert})
@@ -59,7 +59,7 @@ func TestGetDAGBuilder(t *testing.T) {
 	t.Run("fallback cert specified", func(t *testing.T) {
 		fallbackCert := &types.NamespacedName{Namespace: "fallback-ns", Name: "fallback-name"}
 
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, fallbackCert: fallbackCert})
@@ -71,7 +71,7 @@ func TestGetDAGBuilder(t *testing.T) {
 		clientCert := &types.NamespacedName{Namespace: "client-ns", Name: "client-name"}
 		fallbackCert := &types.NamespacedName{Namespace: "fallback-ns", Name: "fallback-name"}
 
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, clientCert: clientCert, fallbackCert: fallbackCert})
@@ -97,7 +97,7 @@ func TestGetDAGBuilder(t *testing.T) {
 			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 		}
 
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, requestHP: requestHP, responseHP: responseHP})
@@ -134,7 +134,7 @@ func TestGetDAGBuilder(t *testing.T) {
 			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 		}
 
-		serve := &Serve{
+		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -133,9 +133,14 @@ func mustGetHTTPProxyProcessor(t *testing.T, builder *dag.Builder) *dag.HTTPProx
 func TestConvertServeContext(t *testing.T) {
 
 	defaultContext := newServeContext()
-	defaultContext.caFile = "/certs/ca.crt"
-	defaultContext.contourKey = "/certs/cert.key"
-	defaultContext.contourCert = "/certs/cert.crt"
+	defaultContext.ServerConfig = ServerConfig{
+		xdsAddr:     "127.0.0.1",
+		xdsPort:     8001,
+		caFile:      "/certs/ca.crt",
+		contourCert: "/certs/cert.crt",
+		contourKey:  "/certs/cert.key",
+	}
+
 	defaultContext.ingressClassName = "coolclass"
 	defaultContext.Config.IngressStatusAddress = "1.2.3.4"
 	defaultContext.Config.GatewayConfig = &config.GatewayParameters{

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -81,33 +81,35 @@ func TestGetDAGBuilder(t *testing.T) {
 
 	t.Run("request and response headers policy specified", func(t *testing.T) {
 
-		requestHP := &contour_api_v1alpha1.HeadersPolicy{
-			Set: map[string]string{
-				"req-set-key-1": "req-set-val-1",
-				"req-set-key-2": "req-set-val-2",
+		policy := &contour_api_v1alpha1.PolicyConfig{
+			RequestHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+				Set: map[string]string{
+					"req-set-key-1": "req-set-val-1",
+					"req-set-key-2": "req-set-val-2",
+				},
+				Remove: []string{"req-remove-key-1", "req-remove-key-2"},
 			},
-			Remove: []string{"req-remove-key-1", "req-remove-key-2"},
-		}
-
-		responseHP := &contour_api_v1alpha1.HeadersPolicy{
-			Set: map[string]string{
-				"res-set-key-1": "res-set-val-1",
-				"res-set-key-2": "res-set-val-2",
+			ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+				Set: map[string]string{
+					"res-set-key-1": "res-set-val-1",
+					"res-set-key-2": "res-set-val-2",
+				},
+				Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 			},
-			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
+			ApplyToIngress: false,
 		}
 
 		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
-		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, requestHP: requestHP, responseHP: responseHP})
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, headersPolicy: policy})
 		commonAssertions(t, &got)
 
 		httpProxyProcessor := mustGetHTTPProxyProcessor(t, &got)
-		assert.EqualValues(t, requestHP.Set, httpProxyProcessor.RequestHeadersPolicy.Set)
-		assert.ElementsMatch(t, requestHP.Remove, httpProxyProcessor.RequestHeadersPolicy.Remove)
-		assert.EqualValues(t, responseHP.Set, httpProxyProcessor.ResponseHeadersPolicy.Set)
-		assert.ElementsMatch(t, responseHP.Remove, httpProxyProcessor.ResponseHeadersPolicy.Remove)
+		assert.EqualValues(t, policy.RequestHeadersPolicy.Set, httpProxyProcessor.RequestHeadersPolicy.Set)
+		assert.ElementsMatch(t, policy.RequestHeadersPolicy.Remove, httpProxyProcessor.RequestHeadersPolicy.Remove)
+		assert.EqualValues(t, policy.ResponseHeadersPolicy.Set, httpProxyProcessor.ResponseHeadersPolicy.Set)
+		assert.ElementsMatch(t, policy.ResponseHeadersPolicy.Remove, httpProxyProcessor.ResponseHeadersPolicy.Remove)
 
 		ingressProcessor := mustGetIngressProcessor(t, &got)
 		assert.EqualValues(t, map[string]string(nil), ingressProcessor.RequestHeadersPolicy.Set)
@@ -118,34 +120,36 @@ func TestGetDAGBuilder(t *testing.T) {
 
 	t.Run("request and response headers policy specified for ingress", func(t *testing.T) {
 
-		requestHP := &contour_api_v1alpha1.HeadersPolicy{
-			Set: map[string]string{
-				"req-set-key-1": "req-set-val-1",
-				"req-set-key-2": "req-set-val-2",
+		policy := &contour_api_v1alpha1.PolicyConfig{
+			RequestHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+				Set: map[string]string{
+					"req-set-key-1": "req-set-val-1",
+					"req-set-key-2": "req-set-val-2",
+				},
+				Remove: []string{"req-remove-key-1", "req-remove-key-2"},
 			},
-			Remove: []string{"req-remove-key-1", "req-remove-key-2"},
-		}
-
-		responseHP := &contour_api_v1alpha1.HeadersPolicy{
-			Set: map[string]string{
-				"res-set-key-1": "res-set-val-1",
-				"res-set-key-2": "res-set-val-2",
+			ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+				Set: map[string]string{
+					"res-set-key-1": "res-set-val-1",
+					"res-set-key-2": "res-set-val-2",
+				},
+				Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 			},
-			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
+			ApplyToIngress: false,
 		}
 
 		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
 		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
-			requestHP: requestHP, responseHP: responseHP, applyHeaderPolicyToIngress: true})
+			headersPolicy: policy, applyHeaderPolicyToIngress: true})
 		commonAssertions(t, &got)
 
 		ingressProcessor := mustGetIngressProcessor(t, &got)
-		assert.EqualValues(t, requestHP.Set, ingressProcessor.RequestHeadersPolicy.Set)
-		assert.ElementsMatch(t, requestHP.Remove, ingressProcessor.RequestHeadersPolicy.Remove)
-		assert.EqualValues(t, responseHP.Set, ingressProcessor.ResponseHeadersPolicy.Set)
-		assert.ElementsMatch(t, responseHP.Remove, ingressProcessor.ResponseHeadersPolicy.Remove)
+		assert.EqualValues(t, policy.RequestHeadersPolicy.Set, ingressProcessor.RequestHeadersPolicy.Set)
+		assert.ElementsMatch(t, policy.RequestHeadersPolicy.Remove, ingressProcessor.RequestHeadersPolicy.Remove)
+		assert.EqualValues(t, policy.ResponseHeadersPolicy.Set, ingressProcessor.ResponseHeadersPolicy.Set)
+		assert.ElementsMatch(t, policy.ResponseHeadersPolicy.Remove, ingressProcessor.ResponseHeadersPolicy.Remove)
 	})
 
 	// TODO(3453): test additional properties of the DAG builder (processor fields, cache fields, Gateway tests (requires a client fake))

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -16,10 +16,6 @@ package main
 import (
 	"testing"
 
-	"github.com/projectcontour/contour/pkg/config"
-
-	"k8s.io/utils/pointer"
-
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 
 	"github.com/projectcontour/contour/internal/dag"
@@ -121,30 +117,35 @@ func TestGetDAGBuilder(t *testing.T) {
 	})
 
 	t.Run("request and response headers policy specified for ingress", func(t *testing.T) {
-		ctx := newServeContext()
-		ctx.Config.Policy.RequestHeadersPolicy.Set = map[string]string{
-			"req-set-key-1": "req-set-val-1",
-			"req-set-key-2": "req-set-val-2",
+
+		requestHP := &contour_api_v1alpha1.HeadersPolicy{
+			Set: map[string]string{
+				"req-set-key-1": "req-set-val-1",
+				"req-set-key-2": "req-set-val-2",
+			},
+			Remove: []string{"req-remove-key-1", "req-remove-key-2"},
 		}
-		ctx.Config.Policy.RequestHeadersPolicy.Remove = []string{"req-remove-key-1", "req-remove-key-2"}
-		ctx.Config.Policy.ResponseHeadersPolicy.Set = map[string]string{
-			"res-set-key-1": "res-set-val-1",
-			"res-set-key-2": "res-set-val-2",
+
+		responseHP := &contour_api_v1alpha1.HeadersPolicy{
+			Set: map[string]string{
+				"res-set-key-1": "res-set-val-1",
+				"res-set-key-2": "res-set-val-2",
+			},
+			Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 		}
-		ctx.Config.Policy.ResponseHeadersPolicy.Remove = []string{"res-remove-key-1", "res-remove-key-2"}
-		ctx.Config.Policy.ApplyToIngress = true
 
 		serve := &Serve{
 			log: logrus.StandardLogger(),
 		}
-		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily})
+		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+			requestHP: requestHP, responseHP: responseHP, applyHeaderPolicyToIngress: true})
 		commonAssertions(t, &got)
 
 		ingressProcessor := mustGetIngressProcessor(t, &got)
-		assert.EqualValues(t, ctx.Config.Policy.RequestHeadersPolicy.Set, ingressProcessor.RequestHeadersPolicy.Set)
-		assert.ElementsMatch(t, ctx.Config.Policy.RequestHeadersPolicy.Remove, ingressProcessor.RequestHeadersPolicy.Remove)
-		assert.EqualValues(t, ctx.Config.Policy.ResponseHeadersPolicy.Set, ingressProcessor.ResponseHeadersPolicy.Set)
-		assert.ElementsMatch(t, ctx.Config.Policy.ResponseHeadersPolicy.Remove, ingressProcessor.ResponseHeadersPolicy.Remove)
+		assert.EqualValues(t, requestHP.Set, ingressProcessor.RequestHeadersPolicy.Set)
+		assert.ElementsMatch(t, requestHP.Remove, ingressProcessor.RequestHeadersPolicy.Remove)
+		assert.EqualValues(t, responseHP.Set, ingressProcessor.ResponseHeadersPolicy.Set)
+		assert.ElementsMatch(t, responseHP.Remove, ingressProcessor.ResponseHeadersPolicy.Remove)
 	})
 
 	// TODO(3453): test additional properties of the DAG builder (processor fields, cache fields, Gateway tests (requires a client fake))
@@ -161,159 +162,6 @@ func mustGetHTTPProxyProcessor(t *testing.T, builder *dag.Builder) *dag.HTTPProx
 
 	require.FailNow(t, "HTTPProxyProcessor not found in list of DAG builder's processors")
 	return nil
-}
-
-func TestConvertServeContext(t *testing.T) {
-
-	defaultContext := newServeContext()
-	defaultContext.ServerConfig = ServerConfig{
-		xdsAddr:     "127.0.0.1",
-		xdsPort:     8001,
-		caFile:      "/certs/ca.crt",
-		contourCert: "/certs/cert.crt",
-		contourKey:  "/certs/cert.key",
-	}
-
-	defaultContext.ingressClassName = "coolclass"
-	defaultContext.Config.IngressStatusAddress = "1.2.3.4"
-	defaultContext.Config.GatewayConfig = &config.GatewayParameters{
-		ControllerName: "projectcontour.io/projectcontour/contour",
-	}
-	defaultContext.Config.TLS.ClientCertificate = config.NamespacedName{
-		Name:      "cert",
-		Namespace: "secretplace",
-	}
-
-	cases := map[string]struct {
-		serveContext  *serveContext
-		contourConfig contour_api_v1alpha1.ContourConfigurationSpec
-	}{
-		"default ServeContext": {
-			serveContext: defaultContext,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
-				XDSServer: contour_api_v1alpha1.XDSServerConfig{
-					Type:    contour_api_v1alpha1.ContourServerType,
-					Address: "127.0.0.1",
-					Port:    8001,
-					TLS: &contour_api_v1alpha1.TLS{
-						CAFile:   "/certs/ca.crt",
-						CertFile: "/certs/cert.crt",
-						KeyFile:  "/certs/cert.key",
-						Insecure: false,
-					},
-				},
-				Ingress: &contour_api_v1alpha1.IngressConfig{
-					ClassName:     pointer.StringPtr("coolclass"),
-					StatusAddress: pointer.StringPtr("1.2.3.4"),
-				},
-				Debug: contour_api_v1alpha1.DebugConfig{
-					Address:                 "127.0.0.1",
-					Port:                    6060,
-					DebugLogLevel:           contour_api_v1alpha1.InfoLog,
-					KubernetesDebugLogLevel: 0,
-				},
-				Health: contour_api_v1alpha1.HealthConfig{
-					Address: "0.0.0.0",
-					Port:    8000,
-				},
-				Envoy: contour_api_v1alpha1.EnvoyConfig{
-					Service: contour_api_v1alpha1.NamespacedName{
-						Name:      "envoy",
-						Namespace: "projectcontour",
-					},
-					HTTPListener: contour_api_v1alpha1.EnvoyListener{
-						Address:   "0.0.0.0",
-						Port:      8080,
-						AccessLog: "/dev/stdout",
-					},
-					HTTPSListener: contour_api_v1alpha1.EnvoyListener{
-						Address:   "0.0.0.0",
-						Port:      8443,
-						AccessLog: "/dev/stdout",
-					},
-					Metrics: contour_api_v1alpha1.MetricsConfig{
-						Address: "0.0.0.0",
-						Port:    8002,
-					},
-					ClientCertificate: &contour_api_v1alpha1.NamespacedName{
-						Name:      "cert",
-						Namespace: "secretplace",
-					},
-					Logging: contour_api_v1alpha1.EnvoyLogging{
-						AccessLogFormat:       contour_api_v1alpha1.EnvoyAccessLog,
-						AccessLogFormatString: nil,
-						AccessLogFields: contour_api_v1alpha1.AccessLogFields([]string{
-							"@timestamp",
-							"authority",
-							"bytes_received",
-							"bytes_sent",
-							"downstream_local_address",
-							"downstream_remote_address",
-							"duration",
-							"method",
-							"path",
-							"protocol",
-							"request_id",
-							"requested_server_name",
-							"response_code",
-							"response_flags",
-							"uber_trace_id",
-							"upstream_cluster",
-							"upstream_host",
-							"upstream_local_address",
-							"upstream_service_time",
-							"user_agent",
-							"x_forwarded_for",
-						}),
-					},
-					DefaultHTTPVersions: nil,
-					Timeouts: &contour_api_v1alpha1.TimeoutParameters{
-						ConnectionIdleTimeout: pointer.StringPtr("60s"),
-					},
-					Cluster: contour_api_v1alpha1.ClusterParameters{
-						DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
-					},
-					Network: contour_api_v1alpha1.NetworkParameters{
-						EnvoyAdminPort: 9001,
-					},
-				},
-				Gateway: &contour_api_v1alpha1.GatewayConfig{
-					ControllerName: "projectcontour.io/projectcontour/contour",
-				},
-				HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
-					DisablePermitInsecure: false,
-					FallbackCertificate:   nil,
-				},
-				LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
-					LeaseDuration: "15s",
-					RenewDeadline: "10s",
-					RetryPeriod:   "2s",
-					Configmap: contour_api_v1alpha1.NamespacedName{
-						Name:      "leader-elect",
-						Namespace: "projectcontour",
-					},
-					DisableLeaderElection: false,
-				},
-				EnableExternalNameService: false,
-				RateLimitService:          nil,
-				Policy: &contour_api_v1alpha1.PolicyConfig{
-					RequestHeadersPolicy:  &contour_api_v1alpha1.HeadersPolicy{},
-					ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{},
-				},
-				Metrics: contour_api_v1alpha1.MetricsConfig{
-					Address: "0.0.0.0",
-					Port:    8000,
-				},
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			converted := tc.serveContext.convertToContourConfigurationSpec()
-			assert.Equal(t, tc.contourConfig, converted)
-		})
-	}
 }
 
 func mustGetIngressProcessor(t *testing.T, builder *dag.Builder) *dag.IngressProcessor {

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -16,6 +16,8 @@ package main
 import (
 	"testing"
 
+	"k8s.io/utils/pointer"
+
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 
 	"github.com/projectcontour/contour/internal/dag"
@@ -109,6 +111,142 @@ func mustGetHTTPProxyProcessor(t *testing.T, builder *dag.Builder) *dag.HTTPProx
 
 	require.FailNow(t, "HTTPProxyProcessor not found in list of DAG builder's processors")
 	return nil
+}
+
+func TestConvertServeContext(t *testing.T) {
+
+	defaultContext := newServeContext()
+	defaultContext.caFile = "/certs/ca.crt"
+	defaultContext.contourKey = "/certs/cert.key"
+	defaultContext.contourCert = "/certs/cert.crt"
+	defaultContext.ingressClassName = "coolclass"
+	defaultContext.Config.IngressStatusAddress = "1.2.3.4"
+
+	cases := map[string]struct {
+		serveContext  *serveContext
+		contourConfig contour_api_v1alpha1.ContourConfigurationSpec
+	}{
+		"default ServeContext": {
+			serveContext: defaultContext,
+			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+				XDSServer: contour_api_v1alpha1.XDSServerConfig{
+					Type:    contour_api_v1alpha1.ContourServerType,
+					Address: "127.0.0.1",
+					Port:    8001,
+					TLS: &contour_api_v1alpha1.TLS{
+						CAFile:   "/certs/ca.crt",
+						CertFile: "/certs/cert.crt",
+						KeyFile:  "/certs/cert.key",
+						Insecure: false,
+					},
+				},
+				Ingress: &contour_api_v1alpha1.IngressConfig{
+					ClassName:     pointer.StringPtr("coolclass"),
+					StatusAddress: pointer.StringPtr("1.2.3.4"),
+				},
+				Debug: contour_api_v1alpha1.DebugConfig{
+					Address:                 "127.0.0.1",
+					Port:                    6060,
+					DebugLogLevel:           contour_api_v1alpha1.InfoLog,
+					KubernetesDebugLogLevel: 0,
+				},
+				Health: contour_api_v1alpha1.HealthConfig{
+					Address: "0.0.0.0",
+					Port:    8000,
+				},
+				Envoy: contour_api_v1alpha1.EnvoyConfig{
+					Service: contour_api_v1alpha1.NamespacedName{
+						Name:      "envoy",
+						Namespace: "projectcontour",
+					},
+					HTTPListener: contour_api_v1alpha1.EnvoyListener{
+						Address:   "0.0.0.0",
+						Port:      8080,
+						AccessLog: "/dev/stdout",
+					},
+					HTTPSListener: contour_api_v1alpha1.EnvoyListener{
+						Address:   "0.0.0.0",
+						Port:      8443,
+						AccessLog: "/dev/stdout",
+					},
+					Metrics: contour_api_v1alpha1.MetricsConfig{
+						Address: "0.0.0.0",
+						Port:    8002,
+					},
+					ClientCertificate: nil,
+					Logging: contour_api_v1alpha1.EnvoyLogging{
+						AccessLogFormat:       contour_api_v1alpha1.EnvoyAccessLog,
+						AccessLogFormatString: nil,
+						AccessLogFields: contour_api_v1alpha1.AccessLogFields([]string{
+							"@timestamp",
+							"authority",
+							"bytes_received",
+							"bytes_sent",
+							"downstream_local_address",
+							"downstream_remote_address",
+							"duration",
+							"method",
+							"path",
+							"protocol",
+							"request_id",
+							"requested_server_name",
+							"response_code",
+							"response_flags",
+							"uber_trace_id",
+							"upstream_cluster",
+							"upstream_host",
+							"upstream_local_address",
+							"upstream_service_time",
+							"user_agent",
+							"x_forwarded_for",
+						}),
+					},
+					DefaultHTTPVersions: nil,
+					Timeouts: &contour_api_v1alpha1.TimeoutParameters{
+						ConnectionIdleTimeout: pointer.StringPtr("60s"),
+					},
+					Cluster: contour_api_v1alpha1.ClusterParameters{
+						DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+					},
+					Network: contour_api_v1alpha1.NetworkParameters{
+						EnvoyAdminPort: 9001,
+					},
+				},
+				Gateway: nil,
+				HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
+					DisablePermitInsecure: false,
+					FallbackCertificate:   nil,
+				},
+				LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
+					LeaseDuration: "15s",
+					RenewDeadline: "10s",
+					RetryPeriod:   "2s",
+					Configmap: contour_api_v1alpha1.NamespacedName{
+						Name:      "leader-elect",
+						Namespace: "projectcontour",
+					},
+					DisableLeaderElection: false,
+				},
+				EnableExternalNameService: false,
+				RateLimitService:          nil,
+				Policy: &contour_api_v1alpha1.PolicyConfig{
+					RequestHeadersPolicy:  &contour_api_v1alpha1.HeadersPolicy{},
+					ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{},
+				},
+				Metrics: contour_api_v1alpha1.MetricsConfig{
+					Address: "0.0.0.0",
+					Port:    8000,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			converted := convertServeContext(tc.serveContext)
+			assert.Equal(t, tc.contourConfig, converted)
+		})
+	}
 }
 
 func mustGetIngressProcessor(t *testing.T, builder *dag.Builder) *dag.IngressProcessor {

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -277,7 +277,7 @@ func TestConvertServeContext(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			converted := convertServeContext(tc.serveContext)
+			converted := tc.serveContext.convertToContourConfigurationSpec()
 			assert.Equal(t, tc.contourConfig, converted)
 		})
 	}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -303,7 +303,12 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 
 	var defaultHTTPVersions []contour_api_v1alpha1.HTTPVersionType
 	for _, version := range ctx.Config.DefaultHTTPVersions {
-		defaultHTTPVersions = append(defaultHTTPVersions, contour_api_v1alpha1.HTTPVersionType(version))
+		switch version {
+		case config.HTTPVersion1:
+			defaultHTTPVersions = append(defaultHTTPVersions, contour_api_v1alpha1.HTTPVersion1)
+		case config.HTTPVersion2:
+			defaultHTTPVersions = append(defaultHTTPVersions, contour_api_v1alpha1.HTTPVersion2)
+		}
 	}
 
 	timeoutParams := &contour_api_v1alpha1.TimeoutParameters{}

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -159,7 +159,7 @@ func grpcOptions(log logrus.FieldLogger, contourXDSConfig *contour_api_v1alpha1.
 	return opts
 }
 
-// tlsconfig returns a new *tls.Config. If the context is not properly configured
+// tlsconfig returns a new *tls.Config. If the TLS parameters passed are not properly configured
 // for tls communication, tlsconfig returns nil.
 func tlsconfig(log logrus.FieldLogger, contourXDSTLS *contour_api_v1alpha1.TLS) *tls.Config {
 	err := verifyTLSFlags(contourXDSTLS)

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -254,7 +254,6 @@ func parseDefaultHTTPVersions(versions []contour_api_v1alpha1.HTTPVersionType) [
 	var parsed []envoy_v3.HTTPVersionType
 	for k := range wanted {
 		parsed = append(parsed, k)
-
 	}
 
 	return parsed

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
 	"github.com/projectcontour/contour/pkg/config"
@@ -30,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type serveContext struct {
@@ -230,14 +230,14 @@ func (ctx *serveContext) proxyRootNamespaces() []string {
 
 // parseDefaultHTTPVersions parses a list of supported HTTP versions
 //  (of the form "HTTP/xx") into a slice of unique version constants.
-func parseDefaultHTTPVersions(versions []config.HTTPVersionType) []envoy_v3.HTTPVersionType {
+func parseDefaultHTTPVersions(versions []contour_api_v1alpha1.HTTPVersionType) []envoy_v3.HTTPVersionType {
 	wanted := map[envoy_v3.HTTPVersionType]struct{}{}
 
 	for _, v := range versions {
 		switch v {
-		case config.HTTPVersion1:
+		case contour_api_v1alpha1.HTTPVersion1:
 			wanted[envoy_v3.HTTPVersion1] = struct{}{}
-		case config.HTTPVersion2:
+		case contour_api_v1alpha1.HTTPVersion2:
 			wanted[envoy_v3.HTTPVersion2] = struct{}{}
 		}
 	}
@@ -249,15 +249,4 @@ func parseDefaultHTTPVersions(versions []config.HTTPVersionType) []envoy_v3.HTTP
 	}
 
 	return parsed
-}
-
-func namespacedNameOf(n config.NamespacedName) *types.NamespacedName {
-	if len(strings.TrimSpace(n.Name)) == 0 && len(strings.TrimSpace(n.Namespace)) == 0 {
-		return nil
-	}
-
-	return &types.NamespacedName{
-		Namespace: n.Namespace,
-		Name:      n.Name,
-	}
 }

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/projectcontour/contour/internal/k8s"
+	"k8s.io/utils/pointer"
+
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
@@ -255,4 +258,229 @@ func parseDefaultHTTPVersions(versions []contour_api_v1alpha1.HTTPVersionType) [
 	}
 
 	return parsed
+}
+
+func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha1.ContourConfigurationSpec {
+	ingress := &contour_api_v1alpha1.IngressConfig{}
+	if len(ctx.ingressClassName) > 0 {
+		ingress.ClassName = pointer.StringPtr(ctx.ingressClassName)
+	}
+	if len(ctx.Config.IngressStatusAddress) > 0 {
+		ingress.StatusAddress = pointer.StringPtr(ctx.Config.IngressStatusAddress)
+	}
+
+	debugLogLevel := contour_api_v1alpha1.InfoLog
+	switch ctx.Config.Debug {
+	case true:
+		debugLogLevel = contour_api_v1alpha1.DebugLog
+	case false:
+		debugLogLevel = contour_api_v1alpha1.InfoLog
+	}
+
+	var gatewayConfig *contour_api_v1alpha1.GatewayConfig
+	if ctx.Config.GatewayConfig != nil {
+		gatewayConfig = &contour_api_v1alpha1.GatewayConfig{
+			ControllerName: ctx.Config.GatewayConfig.ControllerName,
+		}
+	}
+
+	var cipherSuites []contour_api_v1alpha1.TLSCipherType
+	for _, suite := range ctx.Config.TLS.CipherSuites {
+		cipherSuites = append(cipherSuites, contour_api_v1alpha1.TLSCipherType(suite))
+	}
+
+	var accessLogFormat contour_api_v1alpha1.AccessLogType
+	switch ctx.Config.AccessLogFormat {
+	case config.EnvoyAccessLog:
+		accessLogFormat = contour_api_v1alpha1.EnvoyAccessLog
+	case config.JSONAccessLog:
+		accessLogFormat = contour_api_v1alpha1.JSONAccessLog
+	}
+
+	var accessLogFields contour_api_v1alpha1.AccessLogFields
+	for _, alf := range ctx.Config.AccessLogFields {
+		accessLogFields = append(accessLogFields, alf)
+	}
+
+	var defaultHTTPVersions []contour_api_v1alpha1.HTTPVersionType
+	for _, version := range ctx.Config.DefaultHTTPVersions {
+		defaultHTTPVersions = append(defaultHTTPVersions, contour_api_v1alpha1.HTTPVersionType(version))
+	}
+
+	timeoutParams := &contour_api_v1alpha1.TimeoutParameters{}
+	if len(ctx.Config.Timeouts.RequestTimeout) > 0 {
+		timeoutParams.RequestTimeout = pointer.StringPtr(ctx.Config.Timeouts.RequestTimeout)
+	}
+	if len(ctx.Config.Timeouts.ConnectionIdleTimeout) > 0 {
+		timeoutParams.ConnectionIdleTimeout = pointer.StringPtr(ctx.Config.Timeouts.ConnectionIdleTimeout)
+	}
+	if len(ctx.Config.Timeouts.StreamIdleTimeout) > 0 {
+		timeoutParams.StreamIdleTimeout = pointer.StringPtr(ctx.Config.Timeouts.StreamIdleTimeout)
+	}
+	if len(ctx.Config.Timeouts.MaxConnectionDuration) > 0 {
+		timeoutParams.MaxConnectionDuration = pointer.StringPtr(ctx.Config.Timeouts.MaxConnectionDuration)
+	}
+	if len(ctx.Config.Timeouts.DelayedCloseTimeout) > 0 {
+		timeoutParams.DelayedCloseTimeout = pointer.StringPtr(ctx.Config.Timeouts.DelayedCloseTimeout)
+	}
+	if len(ctx.Config.Timeouts.ConnectionShutdownGracePeriod) > 0 {
+		timeoutParams.ConnectionShutdownGracePeriod = pointer.StringPtr(ctx.Config.Timeouts.ConnectionShutdownGracePeriod)
+	}
+
+	var dnsLookupFamily contour_api_v1alpha1.ClusterDNSFamilyType
+	switch ctx.Config.Cluster.DNSLookupFamily {
+	case config.AutoClusterDNSFamily:
+		dnsLookupFamily = contour_api_v1alpha1.AutoClusterDNSFamily
+	case config.IPv6ClusterDNSFamily:
+		dnsLookupFamily = contour_api_v1alpha1.IPv6ClusterDNSFamily
+	case config.IPv4ClusterDNSFamily:
+		dnsLookupFamily = contour_api_v1alpha1.IPv4ClusterDNSFamily
+	}
+
+	var rateLimitService *contour_api_v1alpha1.RateLimitServiceConfig
+	if ctx.Config.RateLimitService.ExtensionService != "" {
+		rateLimitService = &contour_api_v1alpha1.RateLimitServiceConfig{
+			ExtensionService: contour_api_v1alpha1.NamespacedName{
+				Name:      k8s.NamespacedNameFrom(ctx.Config.RateLimitService.ExtensionService).Name,
+				Namespace: k8s.NamespacedNameFrom(ctx.Config.RateLimitService.ExtensionService).Namespace,
+			},
+			Domain:                  ctx.Config.RateLimitService.Domain,
+			FailOpen:                ctx.Config.RateLimitService.FailOpen,
+			EnableXRateLimitHeaders: ctx.Config.RateLimitService.EnableXRateLimitHeaders,
+		}
+	}
+
+	policy := &contour_api_v1alpha1.PolicyConfig{
+		RequestHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+			Set:    ctx.Config.Policy.RequestHeadersPolicy.Set,
+			Remove: ctx.Config.Policy.RequestHeadersPolicy.Remove,
+		},
+		ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+			Set:    ctx.Config.Policy.ResponseHeadersPolicy.Set,
+			Remove: ctx.Config.Policy.ResponseHeadersPolicy.Remove,
+		},
+	}
+
+	var clientCertificate *contour_api_v1alpha1.NamespacedName
+	if len(ctx.Config.TLS.ClientCertificate.Name) > 0 {
+		clientCertificate = &contour_api_v1alpha1.NamespacedName{
+			Name:      ctx.Config.TLS.ClientCertificate.Name,
+			Namespace: ctx.Config.TLS.ClientCertificate.Namespace,
+		}
+	}
+
+	var accessLogFormatString *string
+	if len(ctx.Config.AccessLogFormatString) > 0 {
+		accessLogFormatString = pointer.StringPtr(ctx.Config.AccessLogFormatString)
+	}
+
+	var fallbackCertificate *contour_api_v1alpha1.NamespacedName
+	if len(ctx.Config.TLS.FallbackCertificate.Name) > 0 {
+		fallbackCertificate = &contour_api_v1alpha1.NamespacedName{
+			Name:      ctx.Config.TLS.FallbackCertificate.Name,
+			Namespace: ctx.Config.TLS.FallbackCertificate.Namespace,
+		}
+	}
+
+	// Convert serveContext to a ContourConfiguration
+	contourConfiguration := contour_api_v1alpha1.ContourConfigurationSpec{
+		Ingress: ingress,
+		Debug: contour_api_v1alpha1.DebugConfig{
+			Address:                 ctx.debugAddr,
+			Port:                    ctx.debugPort,
+			DebugLogLevel:           debugLogLevel,
+			KubernetesDebugLogLevel: ctx.KubernetesDebug,
+		},
+		Health: contour_api_v1alpha1.HealthConfig{
+			Address: ctx.healthAddr,
+			Port:    ctx.healthPort,
+		},
+		Envoy: contour_api_v1alpha1.EnvoyConfig{
+			Listener: contour_api_v1alpha1.EnvoyListenerConfig{
+				UseProxyProto:             ctx.useProxyProto,
+				DisableAllowChunkedLength: ctx.Config.DisableAllowChunkedLength,
+				ConnectionBalancer:        ctx.Config.Listener.ConnectionBalancer,
+				TLS: contour_api_v1alpha1.EnvoyTLS{
+					MinimumProtocolVersion: ctx.Config.TLS.MinimumProtocolVersion,
+					CipherSuites:           cipherSuites,
+				},
+			},
+			Service: contour_api_v1alpha1.NamespacedName{
+				Name:      ctx.Config.EnvoyServiceName,
+				Namespace: ctx.Config.EnvoyServiceNamespace,
+			},
+			HTTPListener: contour_api_v1alpha1.EnvoyListener{
+				Address:   ctx.httpAddr,
+				Port:      ctx.httpPort,
+				AccessLog: ctx.httpAccessLog,
+			},
+			HTTPSListener: contour_api_v1alpha1.EnvoyListener{
+				Address:   ctx.httpsAddr,
+				Port:      ctx.httpsPort,
+				AccessLog: ctx.httpsAccessLog,
+			},
+			Metrics: contour_api_v1alpha1.MetricsConfig{
+				Address: ctx.statsAddr,
+				Port:    ctx.statsPort,
+			},
+			ClientCertificate: clientCertificate,
+			Logging: contour_api_v1alpha1.EnvoyLogging{
+				AccessLogFormat:       accessLogFormat,
+				AccessLogFormatString: accessLogFormatString,
+				AccessLogFields:       accessLogFields,
+			},
+			DefaultHTTPVersions: defaultHTTPVersions,
+			Timeouts:            timeoutParams,
+			Cluster: contour_api_v1alpha1.ClusterParameters{
+				DNSLookupFamily: dnsLookupFamily,
+			},
+			Network: contour_api_v1alpha1.NetworkParameters{
+				XffNumTrustedHops: ctx.Config.Network.XffNumTrustedHops,
+				EnvoyAdminPort:    ctx.Config.Network.EnvoyAdminPort,
+			},
+		},
+		Gateway: gatewayConfig,
+		HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
+			DisablePermitInsecure: ctx.Config.DisablePermitInsecure,
+			RootNamespaces:        ctx.proxyRootNamespaces(),
+			FallbackCertificate:   fallbackCertificate,
+		},
+		LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
+			LeaseDuration: ctx.Config.LeaderElection.LeaseDuration.String(),
+			RenewDeadline: ctx.Config.LeaderElection.RenewDeadline.String(),
+			RetryPeriod:   ctx.Config.LeaderElection.RetryPeriod.String(),
+			Configmap: contour_api_v1alpha1.NamespacedName{
+				Name:      ctx.Config.LeaderElection.Name,
+				Namespace: ctx.Config.LeaderElection.Namespace,
+			},
+			DisableLeaderElection: ctx.DisableLeaderElection,
+		},
+		EnableExternalNameService: ctx.Config.EnableExternalNameService,
+		RateLimitService:          rateLimitService,
+		Policy:                    policy,
+		Metrics: contour_api_v1alpha1.MetricsConfig{
+			Address: ctx.metricsAddr,
+			Port:    ctx.metricsPort,
+		},
+	}
+
+	xdsServerType := contour_api_v1alpha1.ContourServerType
+	switch ctx.Config.Server.XDSServerType {
+	case config.EnvoyServerType:
+		xdsServerType = contour_api_v1alpha1.EnvoyServerType
+	}
+
+	contourConfiguration.XDSServer = contour_api_v1alpha1.XDSServerConfig{
+		Type:    xdsServerType,
+		Address: ctx.xdsAddr,
+		Port:    ctx.xdsPort,
+		TLS: &contour_api_v1alpha1.TLS{
+			CAFile:   ctx.caFile,
+			CertFile: ctx.contourCert,
+			KeyFile:  ctx.contourKey,
+			Insecure: ctx.PermitInsecureGRPC,
+		},
+	}
+
+	return contourConfiguration
 }

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -359,6 +359,7 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 			Set:    ctx.Config.Policy.ResponseHeadersPolicy.Set,
 			Remove: ctx.Config.Policy.ResponseHeadersPolicy.Remove,
 		},
+		ApplyToIngress: ctx.Config.Policy.ApplyToIngress,
 	}
 
 	var clientCertificate *contour_api_v1alpha1.NamespacedName

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -26,6 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectcontour/contour/pkg/config"
+	"k8s.io/utils/pointer"
+
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -357,6 +360,160 @@ func TestParseHTTPVersions(t *testing.T) {
 				func(i, j int) bool { return testcase.parseVersions[i] < testcase.parseVersions[j] })
 
 			assert.Equal(t, testcase.parseVersions, vers)
+		})
+	}
+}
+
+func TestConvertServeContext(t *testing.T) {
+
+	defaultContext := newServeContext()
+	defaultContext.ServerConfig = ServerConfig{
+		xdsAddr:     "127.0.0.1",
+		xdsPort:     8001,
+		caFile:      "/certs/ca.crt",
+		contourCert: "/certs/cert.crt",
+		contourKey:  "/certs/cert.key",
+	}
+
+	defaultContext.ingressClassName = "coolclass"
+	defaultContext.Config.IngressStatusAddress = "1.2.3.4"
+	defaultContext.Config.GatewayConfig = &config.GatewayParameters{
+		ControllerName: "projectcontour.io/projectcontour/contour",
+	}
+	defaultContext.Config.TLS.ClientCertificate = config.NamespacedName{
+		Name:      "cert",
+		Namespace: "secretplace",
+	}
+
+	cases := map[string]struct {
+		serveContext  *serveContext
+		contourConfig contour_api_v1alpha1.ContourConfigurationSpec
+	}{
+		"default ServeContext": {
+			serveContext: defaultContext,
+			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+				XDSServer: contour_api_v1alpha1.XDSServerConfig{
+					Type:    contour_api_v1alpha1.ContourServerType,
+					Address: "127.0.0.1",
+					Port:    8001,
+					TLS: &contour_api_v1alpha1.TLS{
+						CAFile:   "/certs/ca.crt",
+						CertFile: "/certs/cert.crt",
+						KeyFile:  "/certs/cert.key",
+						Insecure: false,
+					},
+				},
+				Ingress: &contour_api_v1alpha1.IngressConfig{
+					ClassName:     pointer.StringPtr("coolclass"),
+					StatusAddress: pointer.StringPtr("1.2.3.4"),
+				},
+				Debug: contour_api_v1alpha1.DebugConfig{
+					Address:                 "127.0.0.1",
+					Port:                    6060,
+					DebugLogLevel:           contour_api_v1alpha1.InfoLog,
+					KubernetesDebugLogLevel: 0,
+				},
+				Health: contour_api_v1alpha1.HealthConfig{
+					Address: "0.0.0.0",
+					Port:    8000,
+				},
+				Envoy: contour_api_v1alpha1.EnvoyConfig{
+					Service: contour_api_v1alpha1.NamespacedName{
+						Name:      "envoy",
+						Namespace: "projectcontour",
+					},
+					HTTPListener: contour_api_v1alpha1.EnvoyListener{
+						Address:   "0.0.0.0",
+						Port:      8080,
+						AccessLog: "/dev/stdout",
+					},
+					HTTPSListener: contour_api_v1alpha1.EnvoyListener{
+						Address:   "0.0.0.0",
+						Port:      8443,
+						AccessLog: "/dev/stdout",
+					},
+					Metrics: contour_api_v1alpha1.MetricsConfig{
+						Address: "0.0.0.0",
+						Port:    8002,
+					},
+					ClientCertificate: &contour_api_v1alpha1.NamespacedName{
+						Name:      "cert",
+						Namespace: "secretplace",
+					},
+					Logging: contour_api_v1alpha1.EnvoyLogging{
+						AccessLogFormat:       contour_api_v1alpha1.EnvoyAccessLog,
+						AccessLogFormatString: nil,
+						AccessLogFields: contour_api_v1alpha1.AccessLogFields([]string{
+							"@timestamp",
+							"authority",
+							"bytes_received",
+							"bytes_sent",
+							"downstream_local_address",
+							"downstream_remote_address",
+							"duration",
+							"method",
+							"path",
+							"protocol",
+							"request_id",
+							"requested_server_name",
+							"response_code",
+							"response_flags",
+							"uber_trace_id",
+							"upstream_cluster",
+							"upstream_host",
+							"upstream_local_address",
+							"upstream_service_time",
+							"user_agent",
+							"x_forwarded_for",
+						}),
+					},
+					DefaultHTTPVersions: nil,
+					Timeouts: &contour_api_v1alpha1.TimeoutParameters{
+						ConnectionIdleTimeout: pointer.StringPtr("60s"),
+					},
+					Cluster: contour_api_v1alpha1.ClusterParameters{
+						DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+					},
+					Network: contour_api_v1alpha1.NetworkParameters{
+						EnvoyAdminPort: 9001,
+					},
+				},
+				Gateway: &contour_api_v1alpha1.GatewayConfig{
+					ControllerName: "projectcontour.io/projectcontour/contour",
+				},
+				HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
+					DisablePermitInsecure: false,
+					FallbackCertificate:   nil,
+				},
+				LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
+					LeaseDuration: "15s",
+					RenewDeadline: "10s",
+					RetryPeriod:   "2s",
+					Configmap: contour_api_v1alpha1.NamespacedName{
+						Name:      "leader-elect",
+						Namespace: "projectcontour",
+					},
+					DisableLeaderElection: false,
+				},
+				EnableExternalNameService: false,
+				RateLimitService:          nil,
+				Policy: &contour_api_v1alpha1.PolicyConfig{
+					RequestHeadersPolicy:  &contour_api_v1alpha1.HeadersPolicy{},
+					ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{},
+					ApplyToIngress:        false,
+				},
+				Metrics: contour_api_v1alpha1.MetricsConfig{
+					Address: "0.0.0.0",
+					Port:    8000,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			converted := tc.serveContext.convertToContourConfigurationSpec()
+			assert.Equal(t, tc.contourConfig, converted)
 		})
 	}
 }

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
-	"github.com/projectcontour/contour/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
@@ -326,25 +326,25 @@ func peekError(conn net.Conn) error {
 
 func TestParseHTTPVersions(t *testing.T) {
 	cases := map[string]struct {
-		versions      []config.HTTPVersionType
+		versions      []contour_api_v1alpha1.HTTPVersionType
 		parseVersions []envoy_v3.HTTPVersionType
 	}{
 		"empty": {
-			versions:      []config.HTTPVersionType{},
+			versions:      []contour_api_v1alpha1.HTTPVersionType{},
 			parseVersions: nil,
 		},
 		"http/1.1": {
-			versions:      []config.HTTPVersionType{config.HTTPVersion1},
+			versions:      []contour_api_v1alpha1.HTTPVersionType{contour_api_v1alpha1.HTTPVersion1},
 			parseVersions: []envoy_v3.HTTPVersionType{envoy_v3.HTTPVersion1},
 		},
 		"http/1.1+http/2": {
-			versions:      []config.HTTPVersionType{config.HTTPVersion1, config.HTTPVersion2},
+			versions:      []contour_api_v1alpha1.HTTPVersionType{contour_api_v1alpha1.HTTPVersion1, contour_api_v1alpha1.HTTPVersion2},
 			parseVersions: []envoy_v3.HTTPVersionType{envoy_v3.HTTPVersion1, envoy_v3.HTTPVersion2},
 		},
 		"http/1.1+http/2 duplicated": {
-			versions: []config.HTTPVersionType{
-				config.HTTPVersion1, config.HTTPVersion2,
-				config.HTTPVersion1, config.HTTPVersion2},
+			versions: []contour_api_v1alpha1.HTTPVersionType{
+				contour_api_v1alpha1.HTTPVersion1, contour_api_v1alpha1.HTTPVersion2,
+				contour_api_v1alpha1.HTTPVersion1, contour_api_v1alpha1.HTTPVersion2},
 			parseVersions: []envoy_v3.HTTPVersionType{envoy_v3.HTTPVersion1, envoy_v3.HTTPVersion2},
 		},
 	}

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -542,7 +542,8 @@ spec:
                 default:
                   address: 0.0.0.0
                   port: 8000
-                description: Metrics defines the endpoints Envoy use to serve to metrics.
+                description: Metrics defines the endpoints Contour uses to serve to
+                  metrics.
                 properties:
                   address:
                     description: Defines the metrics address interface.
@@ -1455,7 +1456,7 @@ spec:
                     default:
                       address: 0.0.0.0
                       port: 8000
-                    description: Metrics defines the endpoints Envoy use to serve
+                    description: Metrics defines the endpoints Contour uses to serve
                       to metrics.
                     properties:
                       address:

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -562,6 +562,8 @@ spec:
                   by the user
                 properties:
                   applyToIngress:
+                    description: ApplyToIngress determines if the Policies will apply
+                      to ingress objects
                     type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
@@ -1476,6 +1478,8 @@ spec:
                       by the user
                     properties:
                       applyToIngress:
+                        description: ApplyToIngress determines if the Policies will
+                          apply to ingress objects
                         type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -560,6 +560,8 @@ spec:
                 description: Policy specifies default policy applied if not overridden
                   by the user
                 properties:
+                  applyToIngress:
+                    type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
                       set/removed on all routes
@@ -1472,6 +1474,8 @@ spec:
                     description: Policy specifies default policy applied if not overridden
                       by the user
                     properties:
+                      applyToIngress:
+                        type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers
                           set/removed on all routes

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -81,8 +81,8 @@ spec:
                   cluster:
                     dnsLookupFamily: auto
                   defaultHTTPVersions:
-                  - http/1.1
-                  - http/2
+                  - HTTP/1.1
+                  - HTTP/2
                   http:
                     accessLog: /dev/stdout
                     address: 0.0.0.0
@@ -162,8 +162,8 @@ spec:
                       description: HTTPVersionType is the name of a supported HTTP
                         version.
                       enum:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       type: string
                     type: array
                   http:
@@ -988,8 +988,8 @@ spec:
                       cluster:
                         dnsLookupFamily: auto
                       defaultHTTPVersions:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       http:
                         accessLog: /dev/stdout
                         address: 0.0.0.0
@@ -1069,8 +1069,8 @@ spec:
                           description: HTTPVersionType is the name of a supported
                             HTTP version.
                           enum:
-                          - http/1.1
-                          - http/2
+                          - HTTP/1.1
+                          - HTTP/2
                           type: string
                         type: array
                       http:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -277,8 +277,8 @@ spec:
                   cluster:
                     dnsLookupFamily: auto
                   defaultHTTPVersions:
-                  - http/1.1
-                  - http/2
+                  - HTTP/1.1
+                  - HTTP/2
                   http:
                     accessLog: /dev/stdout
                     address: 0.0.0.0
@@ -358,8 +358,8 @@ spec:
                       description: HTTPVersionType is the name of a supported HTTP
                         version.
                       enum:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       type: string
                     type: array
                   http:
@@ -1184,8 +1184,8 @@ spec:
                       cluster:
                         dnsLookupFamily: auto
                       defaultHTTPVersions:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       http:
                         accessLog: /dev/stdout
                         address: 0.0.0.0
@@ -1265,8 +1265,8 @@ spec:
                           description: HTTPVersionType is the name of a supported
                             HTTP version.
                           enum:
-                          - http/1.1
-                          - http/2
+                          - HTTP/1.1
+                          - HTTP/2
                           type: string
                         type: array
                       http:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -738,7 +738,8 @@ spec:
                 default:
                   address: 0.0.0.0
                   port: 8000
-                description: Metrics defines the endpoints Envoy use to serve to metrics.
+                description: Metrics defines the endpoints Contour uses to serve to
+                  metrics.
                 properties:
                   address:
                     description: Defines the metrics address interface.
@@ -1651,7 +1652,7 @@ spec:
                     default:
                       address: 0.0.0.0
                       port: 8000
-                    description: Metrics defines the endpoints Envoy use to serve
+                    description: Metrics defines the endpoints Contour uses to serve
                       to metrics.
                     properties:
                       address:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -758,6 +758,8 @@ spec:
                   by the user
                 properties:
                   applyToIngress:
+                    description: ApplyToIngress determines if the Policies will apply
+                      to ingress objects
                     type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
@@ -1672,6 +1674,8 @@ spec:
                       by the user
                     properties:
                       applyToIngress:
+                        description: ApplyToIngress determines if the Policies will
+                          apply to ingress objects
                         type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -756,6 +756,8 @@ spec:
                 description: Policy specifies default policy applied if not overridden
                   by the user
                 properties:
+                  applyToIngress:
+                    type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
                       set/removed on all routes
@@ -1668,6 +1670,8 @@ spec:
                     description: Policy specifies default policy applied if not overridden
                       by the user
                     properties:
+                      applyToIngress:
+                        type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers
                           set/removed on all routes

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -755,6 +755,8 @@ spec:
                   by the user
                 properties:
                   applyToIngress:
+                    description: ApplyToIngress determines if the Policies will apply
+                      to ingress objects
                     type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
@@ -1669,6 +1671,8 @@ spec:
                       by the user
                     properties:
                       applyToIngress:
+                        description: ApplyToIngress determines if the Policies will
+                          apply to ingress objects
                         type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -274,8 +274,8 @@ spec:
                   cluster:
                     dnsLookupFamily: auto
                   defaultHTTPVersions:
-                  - http/1.1
-                  - http/2
+                  - HTTP/1.1
+                  - HTTP/2
                   http:
                     accessLog: /dev/stdout
                     address: 0.0.0.0
@@ -355,8 +355,8 @@ spec:
                       description: HTTPVersionType is the name of a supported HTTP
                         version.
                       enum:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       type: string
                     type: array
                   http:
@@ -1181,8 +1181,8 @@ spec:
                       cluster:
                         dnsLookupFamily: auto
                       defaultHTTPVersions:
-                      - http/1.1
-                      - http/2
+                      - HTTP/1.1
+                      - HTTP/2
                       http:
                         accessLog: /dev/stdout
                         address: 0.0.0.0
@@ -1262,8 +1262,8 @@ spec:
                           description: HTTPVersionType is the name of a supported
                             HTTP version.
                           enum:
-                          - http/1.1
-                          - http/2
+                          - HTTP/1.1
+                          - HTTP/2
                           type: string
                         type: array
                       http:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -735,7 +735,8 @@ spec:
                 default:
                   address: 0.0.0.0
                   port: 8000
-                description: Metrics defines the endpoints Envoy use to serve to metrics.
+                description: Metrics defines the endpoints Contour uses to serve to
+                  metrics.
                 properties:
                   address:
                     description: Defines the metrics address interface.
@@ -1648,7 +1649,7 @@ spec:
                     default:
                       address: 0.0.0.0
                       port: 8000
-                    description: Metrics defines the endpoints Envoy use to serve
+                    description: Metrics defines the endpoints Contour uses to serve
                       to metrics.
                     properties:
                       address:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -753,6 +753,8 @@ spec:
                 description: Policy specifies default policy applied if not overridden
                   by the user
                 properties:
+                  applyToIngress:
+                    type: boolean
                   requestHeaders:
                     description: RequestHeadersPolicy defines the request headers
                       set/removed on all routes
@@ -1665,6 +1667,8 @@ spec:
                     description: Policy specifies default policy applied if not overridden
                       by the user
                     properties:
+                      applyToIngress:
+                        type: boolean
                       requestHeaders:
                         description: RequestHeadersPolicy defines the request headers
                           set/removed on all routes

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -209,7 +209,8 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 		return true
-
+	case *contour_api_v1alpha1.ContourConfiguration:
+		return false
 	default:
 		// not an interesting object
 		kc.WithField("object", obj).Error("insert unknown object")
@@ -300,7 +301,8 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		_, ok := kc.extensions[m]
 		delete(kc.extensions, m)
 		return ok
-
+	case *contour_api_v1alpha1.ContourConfiguration:
+		return false
 	default:
 		// not interesting
 		kc.WithField("object", obj).Error("remove unknown object")

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/internal/timeout"
-	"github.com/projectcontour/contour/pkg/config"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -71,7 +70,7 @@ type HTTPProxyProcessor struct {
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
 	// in the IPv4 family.
 	// Note: This only applies to externalName clusters.
-	DNSLookupFamily config.ClusterDNSFamilyType
+	DNSLookupFamily contour_api_v1alpha1.ClusterDNSFamilyType
 
 	// ClientCertificate is the optional identifier of the TLS secret containing client certificate and
 	// private key to be used when establishing TLS connection to upstream cluster.

--- a/internal/envoy/v3/accesslog.go
+++ b/internal/envoy/v3/accesslog.go
@@ -20,8 +20,8 @@ import (
 	envoy_req_without_query_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/formatter/req_without_query/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/protobuf"
-	"github.com/projectcontour/contour/pkg/config"
 )
 
 // FileAccessLogEnvoy returns a new file based access log filter
@@ -57,7 +57,7 @@ func FileAccessLogEnvoy(path string, format string, extensions []string) []*envo
 
 // FileAccessLogJSON returns a new file based access log filter
 // that will log in JSON format
-func FileAccessLogJSON(path string, fields config.AccessLogFields, extensions []string) []*envoy_accesslog_v3.AccessLog {
+func FileAccessLogJSON(path string, fields contour_api_v1alpha1.AccessLogFields, extensions []string) []*envoy_accesslog_v3.AccessLog {
 
 	jsonformat := &_struct.Struct{
 		Fields: make(map[string]*_struct.Value),

--- a/internal/envoy/v3/accesslog_test.go
+++ b/internal/envoy/v3/accesslog_test.go
@@ -22,8 +22,8 @@ import (
 	envoy_req_without_query_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/formatter/req_without_query/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	_struct "github.com/golang/protobuf/ptypes/struct"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/protobuf"
-	"github.com/projectcontour/contour/pkg/config"
 )
 
 func TestFileAccessLog(t *testing.T) {
@@ -107,12 +107,12 @@ func TestFileAccessLog(t *testing.T) {
 func TestJSONFileAccessLog(t *testing.T) {
 	tests := map[string]struct {
 		path    string
-		headers config.AccessLogFields
+		headers contour_api_v1alpha1.AccessLogFields
 		want    []*envoy_accesslog_v3.AccessLog
 	}{
 		"only timestamp": {
 			path:    "/dev/stdout",
-			headers: config.AccessLogFields([]string{"@timestamp"}),
+			headers: contour_api_v1alpha1.AccessLogFields([]string{"@timestamp"}),
 			want: []*envoy_accesslog_v3.AccessLog{{
 				Name: wellknown.FileAccessLog,
 				ConfigType: &envoy_accesslog_v3.AccessLog_TypedConfig{
@@ -136,7 +136,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 		},
 		"custom fields should appear": {
 			path: "/dev/stdout",
-			headers: config.AccessLogFields([]string{
+			headers: contour_api_v1alpha1.AccessLogFields([]string{
 				"@timestamp",
 				"method",
 				"custom1=%REQ(X-CUSTOM-HEADER)%",

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -62,8 +62,6 @@ const (
 	routeType    = resource.RouteType
 	listenerType = resource.ListenerType
 	secretType   = resource.SecretType
-	statsAddress = "0.0.0.0"
-	statsPort    = 8002
 )
 
 func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Contour, func()) {
@@ -82,7 +80,7 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 	}
 
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, 0),
+		xdscache_v3.NewListenerCache(conf, "0.0.0.0", 8002, 0),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -36,7 +36,7 @@ func customAdminPort(t *testing.T, port int) []xdscache.ResourceCache {
 	et := xdscache_v3.NewEndpointsTranslator(log)
 	conf := xdscache_v3.ListenerConfig{}
 	return []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(conf, statsAddress, statsPort, port),
+		xdscache_v3.NewListenerCache(conf, "0.0.0.0", 8002, port),
 		&xdscache_v3.SecretCache{},
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -42,11 +42,6 @@ func DefaultResources() []schema.GroupVersionResource {
 		contour_api_v1alpha1.ExtensionServiceGVR,
 		contour_api_v1alpha1.ContourConfigurationGVR,
 		corev1.SchemeGroupVersion.WithResource("services"),
-	}
-}
-
-func IngressV1Resources() []schema.GroupVersionResource {
-	return []schema.GroupVersionResource{
 		networking_v1.SchemeGroupVersion.WithResource("ingresses"),
 		networking_v1.SchemeGroupVersion.WithResource("ingressclasses"),
 	}

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -24,6 +24,7 @@ import (
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/golang/protobuf/proto"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/dag"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
@@ -96,12 +97,12 @@ type ListenerConfig struct {
 	// AccessLogType defines if Envoy logs should be output as Envoy's default or JSON.
 	// Valid values: 'envoy', 'json'
 	// If not set, defaults to 'envoy'
-	AccessLogType config.AccessLogType
+	AccessLogType contour_api_v1alpha1.AccessLogType
 
 	// AccessLogFields sets the fields that should be shown in JSON logs.
 	// Valid entries are the keys from internal/envoy/accesslog.go:jsonheaders
 	// Defaults to a particular set of fields.
-	AccessLogFields config.AccessLogFields
+	AccessLogFields contour_api_v1alpha1.AccessLogFields
 
 	// AccessLogFormatString sets the format string to be used for text based access logs.
 	// Defaults to empty to defer to Envoy's default log format.
@@ -242,11 +243,11 @@ func (lvc *ListenerConfig) accesslogType() string {
 
 // accesslogFields returns the access log fields that should be configured
 // for Envoy, or a default set if not configured.
-func (lvc *ListenerConfig) accesslogFields() config.AccessLogFields {
+func (lvc *ListenerConfig) accesslogFields() contour_api_v1alpha1.AccessLogFields {
 	if lvc.AccessLogFields != nil {
 		return lvc.AccessLogFields
 	}
-	return config.DefaultFields
+	return contour_api_v1alpha1.DefaultFields
 }
 
 func (lvc *ListenerConfig) newInsecureAccessLog() []*envoy_accesslog_v3.AccessLog {
@@ -288,8 +289,8 @@ type ListenerCache struct {
 }
 
 // NewListenerCache returns an instance of a ListenerCache
-func NewListenerCache(config ListenerConfig, statsAddress string, statsPort, adminPort int) *ListenerCache {
-	stats := envoy_v3.StatsListener(statsAddress, statsPort)
+func NewListenerCache(config ListenerConfig, statsAddr string, statsPort, adminPort int) *ListenerCache {
+	stats := envoy_v3.StatsListener(statsAddr, statsPort)
 	admin := envoy_v3.AdminListener("127.0.0.1", adminPort)
 
 	listenerCache := &ListenerCache{

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -165,7 +165,7 @@ func NewListenerConfig(
 	httpsListener contour_api_v1alpha1.EnvoyListener,
 	accessLogType contour_api_v1alpha1.AccessLogType,
 	accessLogFields contour_api_v1alpha1.AccessLogFields,
-	accessLogFormatString string,
+	accessLogFormatString *string,
 	accessLogFormatterExtensions []string,
 	minimumTLSVersion string,
 	cipherSuites []string,
@@ -232,6 +232,11 @@ func NewListenerConfig(
 		}
 	}
 
+	accessLogFormatStringConverted := ""
+	if accessLogFormatString != nil {
+		accessLogFormatStringConverted = *accessLogFormatString
+	}
+
 	lc := ListenerConfig{
 		UseProxyProto: useProxyProto,
 		HTTPListeners: map[string]Listener{
@@ -252,7 +257,7 @@ func NewListenerConfig(
 		HTTPSAccessLog:                httpsListener.AccessLog,
 		AccessLogType:                 accessLogType,
 		AccessLogFields:               accessLogFields,
-		AccessLogFormatString:         accessLogFormatString,
+		AccessLogFormatString:         accessLogFormatStringConverted,
 		AccessLogFormatterExtensions:  accessLogFormatterExtensions,
 		MinimumTLSVersion:             minimumTLSVersion,
 		CipherSuites:                  cipherSuites,

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -169,12 +169,7 @@ func NewListenerConfig(
 	accessLogFormatterExtensions []string,
 	minimumTLSVersion string,
 	cipherSuites []string,
-	requestTimeout *string,
-	connectionIdleTimeout *string,
-	streamIdleTimeout *string,
-	delayedCloseTimeout *string,
-	maxConnectionDuration *string,
-	connectionShutdownGracePeriod *string,
+	timeoutParameters *contour_api_v1alpha1.TimeoutParameters,
 	defaultHTTPVersions []envoy_v3.HTTPVersionType,
 	allowChunkedLength bool,
 	xffNumTrustedHops uint32,
@@ -195,40 +190,42 @@ func NewListenerConfig(
 	var requestTimeoutSetting timeout.Setting
 	var err error
 
-	if connectionIdleTimeout != nil {
-		connectionIdleTimeoutSetting, err = timeout.Parse(*connectionIdleTimeout)
-		if err != nil {
-			log.Errorf("error parsing connection idle timeout: %w", err)
+	if timeoutParameters != nil {
+		if timeoutParameters.ConnectionIdleTimeout != nil {
+			connectionIdleTimeoutSetting, err = timeout.Parse(*timeoutParameters.ConnectionIdleTimeout)
+			if err != nil {
+				log.Errorf("error parsing connection idle timeout: %w", err)
+			}
 		}
-	}
-	if streamIdleTimeout != nil {
-		streamIdleTimeoutSetting, err = timeout.Parse(*streamIdleTimeout)
-		if err != nil {
-			log.Errorf("error parsing stream idle timeout: %w", err)
+		if timeoutParameters.StreamIdleTimeout != nil {
+			streamIdleTimeoutSetting, err = timeout.Parse(*timeoutParameters.StreamIdleTimeout)
+			if err != nil {
+				log.Errorf("error parsing stream idle timeout: %w", err)
+			}
 		}
-	}
-	if delayedCloseTimeout != nil {
-		delayedCloseTimeoutSetting, err = timeout.Parse(*delayedCloseTimeout)
-		if err != nil {
-			log.Errorf("error parsing delayed close timeout: %w", err)
+		if timeoutParameters.DelayedCloseTimeout != nil {
+			delayedCloseTimeoutSetting, err = timeout.Parse(*timeoutParameters.DelayedCloseTimeout)
+			if err != nil {
+				log.Errorf("error parsing delayed close timeout: %w", err)
+			}
 		}
-	}
-	if maxConnectionDuration != nil {
-		maxConnectionDurationSetting, _ = timeout.Parse(*maxConnectionDuration)
-		if err != nil {
-			log.Errorf("error parsing max connection duration: %w", err)
+		if timeoutParameters.MaxConnectionDuration != nil {
+			maxConnectionDurationSetting, _ = timeout.Parse(*timeoutParameters.MaxConnectionDuration)
+			if err != nil {
+				log.Errorf("error parsing max connection duration: %w", err)
+			}
 		}
-	}
-	if connectionShutdownGracePeriod != nil {
-		connectionShutdownGracePeriodSetting, _ = timeout.Parse(*connectionShutdownGracePeriod)
-		if err != nil {
-			log.Errorf("error parsing connection shutdown grace period: %w", err)
+		if timeoutParameters.ConnectionShutdownGracePeriod != nil {
+			connectionShutdownGracePeriodSetting, _ = timeout.Parse(*timeoutParameters.ConnectionShutdownGracePeriod)
+			if err != nil {
+				log.Errorf("error parsing connection shutdown grace period: %w", err)
+			}
 		}
-	}
-	if requestTimeout != nil {
-		requestTimeoutSetting, _ = timeout.Parse(*requestTimeout)
-		if err != nil {
-			log.Errorf("error parsing request timeout: %w", err)
+		if timeoutParameters.RequestTimeout != nil {
+			requestTimeoutSetting, _ = timeout.Parse(*timeoutParameters.RequestTimeout)
+			if err != nil {
+				log.Errorf("error parsing request timeout: %w", err)
+			}
 		}
 	}
 

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -4234,7 +4234,7 @@ use when outputting log information.</p>
 <code>kubernetesLogLevel</code>
 <br>
 <em>
-int
+uint
 </em>
 </td>
 <td>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -5409,6 +5409,18 @@ HeadersPolicy
 <p>ResponseHeadersPolicy defines the response headers set/removed on all routes</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>applyToIngress</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1alpha1.RateLimitServiceConfig">RateLimitServiceConfig

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -5419,6 +5419,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
+<p>ApplyToIngress determines if the Policies will apply to ingress objects</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3466,7 +3466,7 @@ MetricsConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>Metrics defines the endpoints Envoy use to serve to metrics.</p>
+<p>Metrics defines the endpoints Contour uses to serve to metrics.</p>
 </td>
 </tr>
 </table>
@@ -4045,7 +4045,7 @@ MetricsConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>Metrics defines the endpoints Envoy use to serve to metrics.</p>
+<p>Metrics defines the endpoints Contour uses to serve to metrics.</p>
 </td>
 </tr>
 </tbody>

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -639,7 +639,7 @@ func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile stri
 
 	// Look for the ENV variable to tell if this test run should use
 	// the ContourConfiguration file or the ContourConfiguration CRD.
-	if _, useContourConfiguration := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); useContourConfiguration {
+	if useContourConfiguration, variableFound := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); variableFound && useContourConfiguration == "true" {
 		cc := &contour_api_v1alpha1.ContourConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configFile,

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -568,7 +568,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 
 	// Look for the ENV variable to tell if this test run should use
 	// the ContourConfiguration file or the ContourConfiguration CRD.
-	if _, useContourConfiguration := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); useContourConfiguration {
+	if useContourConfiguration, variableFound := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); variableFound && useContourConfiguration == "true" {
 		port, _ := strconv.Atoi(d.localContourPort)
 
 		contourConfiguration.Name = randomString(14)
@@ -628,8 +628,6 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 		configReferenceName = configFile.Name()
 	}
 
-	// Set the CONTOUR_NAMESPACE env variable so Contour can lookup the Configuration CRD in the proper namespace.
-	//os.Setenv("CONTOUR_NAMESPACE", "projectcontour")
 	session, err := gexec.Start(exec.Command(d.contourBin, contourServeArgs...), d.cmdOutputWriter, d.cmdOutputWriter) // nolint:gosec
 	if err != nil {
 		return nil, "", err

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -18,11 +18,12 @@ package e2e
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -588,7 +589,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 		}
 
 		if err := d.client.Create(context.TODO(), contourConfiguration); err != nil {
-			fmt.Println("could not create ContourConfiguration: %v", err)
+			return nil, "", fmt.Errorf("could not create ContourConfiguration: %v", err)
 		}
 
 		contourServeArgs = append([]string{
@@ -649,7 +650,7 @@ func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile stri
 		}
 
 		if err := d.client.Delete(context.TODO(), cc); err != nil {
-			fmt.Errorf("could not delete ContourConfiguration: %v", err)
+			return fmt.Errorf("could not delete ContourConfiguration: %v", err)
 		}
 	}
 
@@ -660,11 +661,15 @@ func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile stri
 }
 
 func randomString(n int) string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
-
-	s := make([]rune, n)
-	for i := range s {
-		s[i] = letters[rand.Intn(len(letters))]
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return ""
+		}
+		ret[i] = letters[num.Int64()]
 	}
-	return string(s)
+
+	return string(ret)
 }

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -22,14 +22,16 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/onsi/gomega/gexec"
-	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/pkg/config"
 	"gopkg.in/yaml.v2"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -84,7 +86,7 @@ type Deployment struct {
 	// Ratelimit deployment.
 	RateLimitDeployment       *apps_v1.Deployment
 	RateLimitService          *v1.Service
-	RateLimitExtensionService *contourv1alpha1.ExtensionService
+	RateLimitExtensionService *contour_api_v1alpha1.ExtensionService
 }
 
 // UnmarshalResources unmarshals resources from rendered Contour manifest in
@@ -180,7 +182,7 @@ func (d *Deployment) UnmarshalResources() error {
 	}
 	defer rLESFile.Close()
 	decoder = apimachinery_util_yaml.NewYAMLToJSONDecoder(rLESFile)
-	d.RateLimitExtensionService = new(contourv1alpha1.ExtensionService)
+	d.RateLimitExtensionService = new(contour_api_v1alpha1.ExtensionService)
 
 	return decoder.Decode(d.RateLimitExtensionService)
 }
@@ -382,7 +384,7 @@ func (d *Deployment) EnsureRateLimitResources(namespace string, configContents s
 
 	extSvc := d.RateLimitExtensionService.DeepCopy()
 	extSvc.Namespace = setNamespace
-	return d.ensureResource(extSvc, new(contourv1alpha1.ExtensionService))
+	return d.ensureResource(extSvc, new(contour_api_v1alpha1.ExtensionService))
 }
 
 // Convenience method for deploying the pieces of the deployment needed for
@@ -436,6 +438,7 @@ func (d *Deployment) EnsureResourcesForLocalContour() error {
 		"--xds-resource-version=v3",
 		"--admin-address=/admin/admin.sock",
 	)
+
 	session, err := gexec.Start(bootstrapCmd, d.cmdOutputWriter, d.cmdOutputWriter)
 	if err != nil {
 		return err
@@ -555,40 +558,113 @@ func (d *Deployment) DeleteResourcesForLocalContour() error {
 // Starts local contour, applying arguments and marshaling config into config
 // file. Returns running Contour command and config file so we can clean them
 // up.
-func (d *Deployment) StartLocalContour(config *config.Parameters, additionalArgs ...string) (*gexec.Session, string, error) {
-	configFile, err := ioutil.TempFile("", "contour-config-*.yaml")
-	if err != nil {
-		return nil, "", err
-	}
-	defer configFile.Close()
+func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfiguration *contour_api_v1alpha1.ContourConfiguration, additionalArgs ...string) (*gexec.Session, string, error) {
 
-	content, err := yaml.Marshal(config)
-	if err != nil {
-		return nil, "", err
-	}
-	if err := os.WriteFile(configFile.Name(), content, 0600); err != nil {
-		return nil, "", err
+	var content []byte
+	var configReferenceName string
+	var contourServeArgs []string
+	var err error
+
+	// Look for the ENV variable to tell if this test run should use
+	// the ContourConfiguration file or the ContourConfiguration CRD.
+	if _, useContourConfiguration := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); useContourConfiguration {
+		port, _ := strconv.Atoi(d.localContourPort)
+
+		contourConfiguration.Name = randomString(14)
+
+		// Set the xds server to the defined testing port as well as enable insecure communication.
+		contourConfiguration.Spec.XDSServer = contour_api_v1alpha1.XDSServerConfig{
+			Type:    contour_api_v1alpha1.ContourServerType,
+			Address: "0.0.0.0",
+			Port:    port,
+			TLS: &contour_api_v1alpha1.TLS{
+				Insecure: true,
+			},
+		}
+
+		// Disable leader election.
+		contourConfiguration.Spec.LeaderElection = contour_api_v1alpha1.LeaderElectionConfig{
+			DisableLeaderElection: true,
+		}
+
+		if err := d.client.Create(context.TODO(), contourConfiguration); err != nil {
+			fmt.Println("could not create ContourConfiguration: %v", err)
+		}
+
+		contourServeArgs = append([]string{
+			"serve",
+			"--kubeconfig=" + d.kubeConfig,
+			"--contour-config-name=" + contourConfiguration.Name,
+		}, additionalArgs...)
+
+		configReferenceName = contourConfiguration.Name
+	} else {
+
+		configFile, err := ioutil.TempFile("", "contour-config-*.yaml")
+		if err != nil {
+			return nil, "", err
+		}
+		defer configFile.Close()
+
+		content, err = yaml.Marshal(config)
+		if err != nil {
+			return nil, "", err
+		}
+		if err := os.WriteFile(configFile.Name(), content, 0600); err != nil {
+			return nil, "", err
+		}
+
+		contourServeArgs = append([]string{
+			"serve",
+			"--xds-address=0.0.0.0",
+			"--xds-port=" + d.localContourPort,
+			"--insecure",
+			"--kubeconfig=" + d.kubeConfig,
+			"--config-path=" + configFile.Name(),
+			"--disable-leader-election",
+		}, additionalArgs...)
+
+		configReferenceName = configFile.Name()
 	}
 
-	contourServeArgs := append([]string{
-		"serve",
-		"--xds-address=0.0.0.0",
-		"--xds-port=" + d.localContourPort,
-		"--insecure",
-		"--kubeconfig=" + d.kubeConfig,
-		"--config-path=" + configFile.Name(),
-		"--disable-leader-election",
-	}, additionalArgs...)
+	// Set the CONTOUR_NAMESPACE env variable so Contour can lookup the Configuration CRD in the proper namespace.
+	//os.Setenv("CONTOUR_NAMESPACE", "projectcontour")
 	session, err := gexec.Start(exec.Command(d.contourBin, contourServeArgs...), d.cmdOutputWriter, d.cmdOutputWriter) // nolint:gosec
 	if err != nil {
 		return nil, "", err
 	}
-	return session, configFile.Name(), nil
+	return session, configReferenceName, nil
 }
 
 func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile string) error {
+
+	// Look for the ENV variable to tell if this test run should use
+	// the ContourConfiguration file or the ContourConfiguration CRD.
+	if _, useContourConfiguration := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); useContourConfiguration {
+		cc := &contour_api_v1alpha1.ContourConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configFile,
+				Namespace: "projectcontour",
+			},
+		}
+
+		if err := d.client.Delete(context.TODO(), cc); err != nil {
+			fmt.Errorf("could not delete ContourConfiguration: %v", err)
+		}
+	}
+
 	// Default timeout of 1s produces test flakes,
 	// a minute should be more than enough to avoid them.
 	contourCmd.Terminate().Wait(time.Minute)
 	return os.RemoveAll(configFile)
+}
+
+func randomString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
 }

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -306,7 +306,7 @@ func (e *EchoSecure) Deploy(ns, name string) func() {
 	}
 }
 
-var ContourConfigration = &contour_api_v1alpha1.ContourConfiguration{
+var ContourConfiguration = &contour_api_v1alpha1.ContourConfiguration{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "ingress",
 		Namespace: "projectcontour",

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -306,75 +306,78 @@ func (e *EchoSecure) Deploy(ns, name string) func() {
 	}
 }
 
-var ContourConfiguration = &contour_api_v1alpha1.ContourConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "ingress",
-		Namespace: "projectcontour",
-	},
-	Spec: contour_api_v1alpha1.ContourConfigurationSpec{
-		Debug: contour_api_v1alpha1.DebugConfig{
-			Address:                 "127.0.0.1",
-			Port:                    6060,
-			DebugLogLevel:           contour_api_v1alpha1.InfoLog,
-			KubernetesDebugLogLevel: 0,
+// DefaultContourConfiguration returns a default ContourConfiguration object.
+func DefaultContourConfiguration() *contour_api_v1alpha1.ContourConfiguration {
+	return &contour_api_v1alpha1.ContourConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ingress",
+			Namespace: "projectcontour",
 		},
-		Health: contour_api_v1alpha1.HealthConfig{
-			Address: "0.0.0.0",
-			Port:    8000,
-		},
-		Envoy: contour_api_v1alpha1.EnvoyConfig{
-			DefaultHTTPVersions: []contour_api_v1alpha1.HTTPVersionType{
-				"HTTP/1.1", "HTTP/2",
+		Spec: contour_api_v1alpha1.ContourConfigurationSpec{
+			Debug: contour_api_v1alpha1.DebugConfig{
+				Address:                 "127.0.0.1",
+				Port:                    6060,
+				DebugLogLevel:           contour_api_v1alpha1.InfoLog,
+				KubernetesDebugLogLevel: 0,
 			},
-			Listener: contour_api_v1alpha1.EnvoyListenerConfig{
-				UseProxyProto:             false,
-				DisableAllowChunkedLength: false,
-				ConnectionBalancer:        "",
-				TLS: contour_api_v1alpha1.EnvoyTLS{
-					MinimumProtocolVersion: "1.2",
-					CipherSuites: []contour_api_v1alpha1.TLSCipherType{
-						"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
-						"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
-						"ECDHE-ECDSA-AES256-GCM-SHA384",
-						"ECDHE-RSA-AES256-GCM-SHA384",
+			Health: contour_api_v1alpha1.HealthConfig{
+				Address: "0.0.0.0",
+				Port:    8000,
+			},
+			Envoy: contour_api_v1alpha1.EnvoyConfig{
+				DefaultHTTPVersions: []contour_api_v1alpha1.HTTPVersionType{
+					"HTTP/1.1", "HTTP/2",
+				},
+				Listener: contour_api_v1alpha1.EnvoyListenerConfig{
+					UseProxyProto:             false,
+					DisableAllowChunkedLength: false,
+					ConnectionBalancer:        "",
+					TLS: contour_api_v1alpha1.EnvoyTLS{
+						MinimumProtocolVersion: "1.2",
+						CipherSuites: []contour_api_v1alpha1.TLSCipherType{
+							"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
+							"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
+							"ECDHE-ECDSA-AES256-GCM-SHA384",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
 					},
 				},
+				Service: contour_api_v1alpha1.NamespacedName{
+					Name:      "envoy",
+					Namespace: "projectcontour",
+				},
+				HTTPListener: contour_api_v1alpha1.EnvoyListener{
+					Address:   "0.0.0.0",
+					Port:      8080,
+					AccessLog: "/dev/stdout",
+				},
+				HTTPSListener: contour_api_v1alpha1.EnvoyListener{
+					Address:   "0.0.0.0",
+					Port:      8443,
+					AccessLog: "/dev/stdout",
+				},
+				Metrics: contour_api_v1alpha1.MetricsConfig{
+					Address: "0.0.0.0",
+					Port:    8002,
+				},
+				Logging: contour_api_v1alpha1.EnvoyLogging{
+					AccessLogFormat: contour_api_v1alpha1.EnvoyAccessLog,
+				},
+				Cluster: contour_api_v1alpha1.ClusterParameters{
+					DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+				},
+				Network: contour_api_v1alpha1.NetworkParameters{
+					EnvoyAdminPort: 9001,
+				},
 			},
-			Service: contour_api_v1alpha1.NamespacedName{
-				Name:      "envoy",
-				Namespace: "projectcontour",
+			HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
+				DisablePermitInsecure: false,
 			},
-			HTTPListener: contour_api_v1alpha1.EnvoyListener{
-				Address:   "0.0.0.0",
-				Port:      8080,
-				AccessLog: "/dev/stdout",
-			},
-			HTTPSListener: contour_api_v1alpha1.EnvoyListener{
-				Address:   "0.0.0.0",
-				Port:      8443,
-				AccessLog: "/dev/stdout",
-			},
+			EnableExternalNameService: false,
 			Metrics: contour_api_v1alpha1.MetricsConfig{
 				Address: "0.0.0.0",
-				Port:    8002,
-			},
-			Logging: contour_api_v1alpha1.EnvoyLogging{
-				AccessLogFormat: contour_api_v1alpha1.EnvoyAccessLog,
-			},
-			Cluster: contour_api_v1alpha1.ClusterParameters{
-				DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
-			},
-			Network: contour_api_v1alpha1.NetworkParameters{
-				EnvoyAdminPort: 9001,
+				Port:    8000,
 			},
 		},
-		HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
-			DisablePermitInsecure: false,
-		},
-		EnableExternalNameService: false,
-		Metrics: contour_api_v1alpha1.MetricsConfig{
-			Address: "0.0.0.0",
-			Port:    8000,
-		},
-	},
+	}
 }

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -19,6 +19,8 @@ package e2e
 import (
 	"context"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+
 	"github.com/onsi/ginkgo"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -302,4 +304,77 @@ func (e *EchoSecure) Deploy(ns, name string) func() {
 		require.NoError(e.t, e.client.Delete(context.TODO(), service))
 		require.NoError(e.t, e.client.Delete(context.TODO(), deployment))
 	}
+}
+
+var ContourConfigration = &contour_api_v1alpha1.ContourConfiguration{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "ingress",
+		Namespace: "projectcontour",
+	},
+	Spec: contour_api_v1alpha1.ContourConfigurationSpec{
+		Debug: contour_api_v1alpha1.DebugConfig{
+			Address:                 "127.0.0.1",
+			Port:                    6060,
+			DebugLogLevel:           contour_api_v1alpha1.InfoLog,
+			KubernetesDebugLogLevel: 0,
+		},
+		Health: contour_api_v1alpha1.HealthConfig{
+			Address: "0.0.0.0",
+			Port:    8000,
+		},
+		Envoy: contour_api_v1alpha1.EnvoyConfig{
+			DefaultHTTPVersions: []contour_api_v1alpha1.HTTPVersionType{
+				"HTTP/1.1", "HTTP/2",
+			},
+			Listener: contour_api_v1alpha1.EnvoyListenerConfig{
+				UseProxyProto:             false,
+				DisableAllowChunkedLength: false,
+				ConnectionBalancer:        "",
+				TLS: contour_api_v1alpha1.EnvoyTLS{
+					MinimumProtocolVersion: "1.2",
+					CipherSuites: []contour_api_v1alpha1.TLSCipherType{
+						"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
+						"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
+						"ECDHE-ECDSA-AES256-GCM-SHA384",
+						"ECDHE-RSA-AES256-GCM-SHA384",
+					},
+				},
+			},
+			Service: contour_api_v1alpha1.NamespacedName{
+				Name:      "envoy",
+				Namespace: "projectcontour",
+			},
+			HTTPListener: contour_api_v1alpha1.EnvoyListener{
+				Address:   "0.0.0.0",
+				Port:      8080,
+				AccessLog: "/dev/stdout",
+			},
+			HTTPSListener: contour_api_v1alpha1.EnvoyListener{
+				Address:   "0.0.0.0",
+				Port:      8443,
+				AccessLog: "/dev/stdout",
+			},
+			Metrics: contour_api_v1alpha1.MetricsConfig{
+				Address: "0.0.0.0",
+				Port:    8002,
+			},
+			Logging: contour_api_v1alpha1.EnvoyLogging{
+				AccessLogFormat: contour_api_v1alpha1.EnvoyAccessLog,
+			},
+			Cluster: contour_api_v1alpha1.ClusterParameters{
+				DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+			},
+			Network: contour_api_v1alpha1.NetworkParameters{
+				EnvoyAdminPort: 9001,
+			},
+		},
+		HTTPProxy: contour_api_v1alpha1.HTTPProxyConfig{
+			DisablePermitInsecure: false,
+		},
+		EnableExternalNameService: false,
+		Metrics: contour_api_v1alpha1.MetricsConfig{
+			Address: "0.0.0.0",
+			Port:    8000,
+		},
+	},
 }

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Gateway API", func() {
 					}
 
 					// Update contour configuration to point to specified gateway.
-					contourConfiguration = e2e.ContourConfigration.DeepCopy()
+					contourConfiguration = e2e.ContourConfiguration.DeepCopy()
 					contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
 						ControllerName: gatewayClass.Spec.Controller,
 					}

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Gateway API", func() {
 					}
 
 					// Update contour configuration to point to specified gateway.
-					contourConfiguration = e2e.ContourConfiguration.DeepCopy()
+					contourConfiguration = e2e.DefaultContourConfiguration()
 					contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
 						ControllerName: gatewayClass.Spec.Controller,
 					}

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -22,6 +22,8 @@ import (
 	"math/big"
 	"testing"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -55,6 +57,7 @@ var _ = Describe("Gateway API", func() {
 	var (
 		contourCmd            *gexec.Session
 		contourConfig         *config.Parameters
+		contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
 		contourConfigFile     string
 		additionalContourArgs []string
 
@@ -73,6 +76,12 @@ var _ = Describe("Gateway API", func() {
 					gateway.Namespace = namespace
 					// Update contour config to point to specified gateway.
 					contourConfig.GatewayConfig = &config.GatewayParameters{
+						ControllerName: gatewayClass.Spec.Controller,
+					}
+
+					// Update contour configuration to point to specified gateway.
+					contourConfiguration = e2e.ContourConfigration.DeepCopy()
+					contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
 						ControllerName: gatewayClass.Spec.Controller,
 					}
 
@@ -104,7 +113,7 @@ var _ = Describe("Gateway API", func() {
 	// until here to start Contour.
 	JustBeforeEach(func() {
 		var err error
-		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, contourConfiguration, additionalContourArgs...)
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -56,7 +56,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 		}
 
 		// Update contour configuration to point to specified gateway.
-		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
+		contourConfiguration = e2e.DefaultContourConfiguration()
 		contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
 			ControllerName: controllerName,
 		}

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -56,7 +56,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 		}
 
 		// Update contour configuration to point to specified gateway.
-		contourConfiguration = e2e.ContourConfigration.DeepCopy()
+		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
 		contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
 			ControllerName: controllerName,
 		}

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"time"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/test/e2e"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/gexec"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -35,6 +38,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 	var (
 		contourCmd            *gexec.Session
 		contourConfig         *config.Parameters
+		contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
 		contourConfigFile     string
 		additionalContourArgs []string
 		controllerName        string
@@ -51,6 +55,12 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 			},
 		}
 
+		// Update contour configuration to point to specified gateway.
+		contourConfiguration = e2e.ContourConfigration.DeepCopy()
+		contourConfiguration.Spec.Gateway = &contour_api_v1alpha1.GatewayConfig{
+			ControllerName: controllerName,
+		}
+
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.
 		additionalContourArgs = []string{}
@@ -62,7 +72,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 	// until here to start Contour.
 	JustBeforeEach(func() {
 		var err error
-		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, contourConfiguration, additionalContourArgs...)
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -71,7 +71,7 @@ var _ = Describe("HTTPProxy", func() {
 
 		// Contour configuration crd, can be modified in nested
 		// BeforeEach.
-		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
+		contourConfiguration = e2e.DefaultContourConfiguration()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -71,7 +71,7 @@ var _ = Describe("HTTPProxy", func() {
 
 		// Contour configuration crd, can be modified in nested
 		// BeforeEach.
-		contourConfiguration = e2e.ContourConfigration.DeepCopy()
+		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"testing"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+
 	"github.com/davecgh/go-spew/spew"
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -57,6 +59,7 @@ var _ = Describe("HTTPProxy", func() {
 	var (
 		contourCmd            *gexec.Session
 		contourConfig         *config.Parameters
+		contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
 		contourConfigFile     string
 		additionalContourArgs []string
 	)
@@ -65,6 +68,10 @@ var _ = Describe("HTTPProxy", func() {
 		// Contour config file contents, can be modified in nested
 		// BeforeEach.
 		contourConfig = &config.Parameters{}
+
+		// Contour configuration crd, can be modified in nested
+		// BeforeEach.
+		contourConfiguration = e2e.ContourConfigration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.
@@ -77,7 +84,7 @@ var _ = Describe("HTTPProxy", func() {
 	// until here to start Contour.
 	JustBeforeEach(func() {
 		var err error
-		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, contourConfiguration, additionalContourArgs...)
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
@@ -122,6 +129,11 @@ var _ = Describe("HTTPProxy", func() {
 						Namespace: namespace,
 					},
 				}
+				contourConfiguration.Spec.HTTPProxy.FallbackCertificate = &contour_api_v1alpha1.NamespacedName{
+					Name:      "fallback-cert",
+					Namespace: namespace,
+				}
+
 				f.Certs.CreateSelfSignedCert(namespace, "fallback-cert", "fallback-cert", "fallback.projectcontour.io")
 			})
 
@@ -208,6 +220,11 @@ var _ = Describe("HTTPProxy", func() {
 						Name:      "backend-client-cert",
 					},
 				}
+
+				contourConfiguration.Spec.Envoy.ClientCertificate = &contour_api_v1alpha1.NamespacedName{
+					Name:      "backend-client-cert",
+					Namespace: namespace,
+				}
 			})
 
 			testBackendTLS(namespace)
@@ -226,6 +243,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
+				contourConfiguration.Spec.EnableExternalNameService = true
 			})
 			testExternalNameServiceInsecure(namespace)
 		})
@@ -235,6 +253,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
+				contourConfiguration.Spec.EnableExternalNameService = true
 			})
 			testExternalNameServiceTLS(namespace)
 		})
@@ -244,6 +263,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
+				contourConfiguration.Spec.EnableExternalNameService = true
 			})
 			testExternalNameServiceLocalhostInvalid(namespace)
 		})
@@ -261,6 +281,15 @@ var _ = Describe("HTTPProxy", func() {
 							ExtensionService: fmt.Sprintf("%s/%s", namespace, f.Deployment.RateLimitExtensionService.Name),
 							Domain:           "contour",
 							FailOpen:         false,
+						}
+						contourConfiguration.Spec.RateLimitService = &contour_api_v1alpha1.RateLimitServiceConfig{
+							ExtensionService: contour_api_v1alpha1.NamespacedName{
+								Name:      f.Deployment.RateLimitExtensionService.Name,
+								Namespace: namespace,
+							},
+							Domain:                  "contour",
+							FailOpen:                false,
+							EnableXRateLimitHeaders: false,
 						}
 						require.NoError(f.T(),
 							f.Deployment.EnsureRateLimitResources(

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Infra", func() {
 
 		// Contour configuration crd, can be modified in nested
 		// BeforeEach.
-		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
+		contourConfiguration = e2e.DefaultContourConfiguration()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -19,6 +19,8 @@ package infra
 import (
 	"testing"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -51,6 +53,7 @@ var _ = Describe("Infra", func() {
 		contourCmd            *gexec.Session
 		kubectlCmd            *gexec.Session
 		contourConfig         *config.Parameters
+		contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
 		contourConfigFile     string
 		additionalContourArgs []string
 	)
@@ -59,6 +62,10 @@ var _ = Describe("Infra", func() {
 		// Contour config file contents, can be modified in nested
 		// BeforeEach.
 		contourConfig = &config.Parameters{}
+
+		// Contour configuration crd, can be modified in nested
+		// BeforeEach.
+		contourConfiguration = e2e.ContourConfigration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.
@@ -71,7 +78,7 @@ var _ = Describe("Infra", func() {
 	// until here to start Contour.
 	JustBeforeEach(func() {
 		var err error
-		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, contourConfiguration, additionalContourArgs...)
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Infra", func() {
 
 		// Contour configuration crd, can be modified in nested
 		// BeforeEach.
-		contourConfiguration = e2e.ContourConfigration.DeepCopy()
+		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo"
@@ -55,6 +57,7 @@ var _ = Describe("Ingress", func() {
 	var (
 		contourCmd            *gexec.Session
 		contourConfig         *config.Parameters
+		contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
 		contourConfigFile     string
 		additionalContourArgs []string
 	)
@@ -63,6 +66,8 @@ var _ = Describe("Ingress", func() {
 		// Contour config file contents, can be modified in nested
 		// BeforeEach.
 		contourConfig = &config.Parameters{}
+
+		contourConfiguration = e2e.ContourConfigration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.
@@ -75,7 +80,7 @@ var _ = Describe("Ingress", func() {
 	// until here to start Contour.
 	JustBeforeEach(func() {
 		var err error
-		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, additionalContourArgs...)
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(contourConfig, contourConfiguration, additionalContourArgs...)
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
@@ -166,6 +171,10 @@ var _ = Describe("Ingress", func() {
 						Namespace: namespace,
 						Name:      "backend-client-cert",
 					},
+				}
+				contourConfiguration.Spec.Envoy.ClientCertificate = &contour_api_v1alpha1.NamespacedName{
+					Namespace: namespace,
+					Name:      "backend-client-cert",
 				}
 			})
 

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Ingress", func() {
 		// BeforeEach.
 		contourConfig = &config.Parameters{}
 
-		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
+		contourConfiguration = e2e.DefaultContourConfiguration()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Ingress", func() {
 		// BeforeEach.
 		contourConfig = &config.Parameters{}
 
-		contourConfiguration = e2e.ContourConfigration.DeepCopy()
+		contourConfiguration = e2e.ContourConfiguration.DeepCopy()
 
 		// Default contour serve command line arguments can be appended to in
 		// nested BeforeEach.


### PR DESCRIPTION
Convert the ServeContext to a ContourConfiguration and use
that for all config items which will allow for the ServeContext
to be deprecated and the optional ContourConfig CRD to be
specified.

Signed-off-by: Steve Sloka <slokas@vmware.com>