### PR TITLE
test/e2e: replace httpbin with ingress echoserver

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -190,10 +190,6 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 				client: crClient,
 				t:      t,
 			},
-			HTTPBin: &HTTPBin{
-				client: crClient,
-				t:      t,
-			},
 		},
 		HTTP: &HTTP{
 			HTTPURLBase:        httpURLBase,

--- a/test/e2e/httpproxy/http_health_checks_test.go
+++ b/test/e2e/httpproxy/http_health_checks_test.go
@@ -32,7 +32,7 @@ func testHTTPHealthChecks(namespace string) {
 	Specify("HTTP healthchecks are configurable", func() {
 		t := f.T()
 
-		f.Fixtures.HTTPBin.Deploy(namespace, "httpbin")
+		f.Fixtures.Echo.Deploy(namespace, "echo")
 
 		p := &contourv1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -47,7 +47,7 @@ func testHTTPHealthChecks(namespace string) {
 					{
 						Services: []contourv1.Service{
 							{
-								Name: "httpbin",
+								Name: "echo",
 								Port: 80,
 							},
 						},


### PR DESCRIPTION
Removes usages of httpbin and replaces it with
the ingress echoserver now that the latter supports
returning specified status codes.

Updates #3584.

Signed-off-by: Steve Kriss <krisss@vmware.com>