### PR TITLE
cmd/contour: remove legacy CRD validation code

### DIFF
--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -50,12 +50,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4643,12 +4643,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4640,12 +4640,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses


### PR DESCRIPTION
Removes the code that validates that Contour
CRDs have been created as v1. Contour has now
provided v1-only CRDs for many releases, and
the v1beta1 API version is dropped as of
Kubernetes 1.22.

Signed-off-by: Steve Kriss <krisss@vmware.com>