### PR TITLE
site: Remove mention of HTTPProxy API being beta.

### DIFF
--- a/site/content/docs/main/config/fundamentals.md
+++ b/site/content/docs/main/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.0.0/httpproxy.md
+++ b/site/content/docs/v1.0.0/httpproxy.md
@@ -51,7 +51,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.0.1/httpproxy.md
+++ b/site/content/docs/v1.0.1/httpproxy.md
@@ -51,7 +51,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.1.0/httpproxy.md
+++ b/site/content/docs/v1.1.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.10.0/config/fundamentals.md
+++ b/site/content/docs/v1.10.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.10.1/config/fundamentals.md
+++ b/site/content/docs/v1.10.1/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.11.0/config/fundamentals.md
+++ b/site/content/docs/v1.11.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.12.0/config/fundamentals.md
+++ b/site/content/docs/v1.12.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.13.0/config/fundamentals.md
+++ b/site/content/docs/v1.13.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.13.1/config/fundamentals.md
+++ b/site/content/docs/v1.13.1/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.14.0/config/fundamentals.md
+++ b/site/content/docs/v1.14.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.14.1/config/fundamentals.md
+++ b/site/content/docs/v1.14.1/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.14.2/config/fundamentals.md
+++ b/site/content/docs/v1.14.2/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.15.0/config/fundamentals.md
+++ b/site/content/docs/v1.15.0/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.15.1/config/fundamentals.md
+++ b/site/content/docs/v1.15.1/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.15.2/config/fundamentals.md
+++ b/site/content/docs/v1.15.2/config/fundamentals.md
@@ -53,7 +53,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.16.0/config/fundamentals.md
+++ b/site/content/docs/v1.16.0/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.16.1/config/fundamentals.md
+++ b/site/content/docs/v1.16.1/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.17.0/config/fundamentals.md
+++ b/site/content/docs/v1.17.0/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.17.1/config/fundamentals.md
+++ b/site/content/docs/v1.17.1/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.17.2/config/fundamentals.md
+++ b/site/content/docs/v1.17.2/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.18.0/config/fundamentals.md
+++ b/site/content/docs/v1.18.0/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.18.1/config/fundamentals.md
+++ b/site/content/docs/v1.18.1/config/fundamentals.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 ```
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 

--- a/site/content/docs/v1.2.0/httpproxy.md
+++ b/site/content/docs/v1.2.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.2.1/httpproxy.md
+++ b/site/content/docs/v1.2.1/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.3.0/httpproxy.md
+++ b/site/content/docs/v1.3.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.4.0/httpproxy.md
+++ b/site/content/docs/v1.4.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.5.0/httpproxy.md
+++ b/site/content/docs/v1.5.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.5.1/httpproxy.md
+++ b/site/content/docs/v1.5.1/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.6.0/httpproxy.md
+++ b/site/content/docs/v1.6.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.6.1/httpproxy.md
+++ b/site/content/docs/v1.6.1/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.7.0/httpproxy.md
+++ b/site/content/docs/v1.7.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.8.0/httpproxy.md
+++ b/site/content/docs/v1.8.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.8.1/httpproxy.md
+++ b/site/content/docs/v1.8.1/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.8.2/httpproxy.md
+++ b/site/content/docs/v1.8.2/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.

--- a/site/content/docs/v1.9.0/httpproxy.md
+++ b/site/content/docs/v1.9.0/httpproxy.md
@@ -55,7 +55,7 @@ spec:
           port: 80
 {% endhighlight %}
 
-**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields. Note that the HTTPProxy API is currently considered beta.
+**Lines 1-5**: As with all other Kubernetes objects, an HTTPProxy needs apiVersion, kind, and metadata fields.
 
 **Lines 7-8**: The presence of the `virtualhost` field indicates that this is a root HTTPProxy that is the top level entry point for this domain.
 The `fqdn` field specifies the fully qualified domain name that will be used to match against `Host:` HTTP headers.


### PR DESCRIPTION
Removes mention that the HTTPProxy API is beta when it's really fully GA in v1.0.

//cc @jedsalazar

Signed-off-by: Steve Sloka <slokas@vmware.com>