### PR TITLE
move Envoy from daemonset to deployment

### DIFF
--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -1,16 +1,19 @@
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: envoy
   name: envoy
   namespace: projectcontour
 spec:
-  updateStrategy:
+  replicas: 2
+  strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 10%
   selector:
     matchLabels:
       app: envoy
@@ -23,6 +26,16 @@ spec:
       labels:
         app: envoy
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - envoy
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /bin/contour

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4892,17 +4892,20 @@ spec:
 
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: envoy
   name: envoy
   namespace: projectcontour
 spec:
-  updateStrategy:
+  replicas: 2
+  strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 10%
   selector:
     matchLabels:
       app: envoy
@@ -4915,6 +4918,16 @@ spec:
       labels:
         app: envoy
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - envoy
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /bin/contour

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4889,17 +4889,20 @@ spec:
 
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: envoy
   name: envoy
   namespace: projectcontour
 spec:
-  updateStrategy:
+  replicas: 2
+  strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      # This value of maxSurge means that during a rolling update
+      # the new ReplicaSet will be created first.
+      maxSurge: 10%
   selector:
     matchLabels:
       app: envoy
@@ -4912,6 +4915,16 @@ spec:
       labels:
         app: envoy
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - envoy
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /bin/contour

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Gateway API", func() {
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
-		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 
 		f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassValid)
 		f.CreateGatewayAndWaitFor(contourGateway, gatewayValid)

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
-		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -81,7 +81,7 @@ var _ = Describe("HTTPProxy", func() {
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
-		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -75,9 +75,9 @@ var _ = Describe("Infra", func() {
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
-		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 
-		kubectlCmd, err = f.Kubectl.StartKubectlPortForward(19001, 9001, "projectcontour", "daemonset/envoy", additionalContourArgs...)
+		kubectlCmd, err = f.Kubectl.StartKubectlPortForward(19001, 9001, "projectcontour", "deployment/envoy", additionalContourArgs...)
 		require.NoError(f.T(), err)
 	})
 

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Ingress", func() {
 		require.NoError(f.T(), err)
 
 		// Wait for Envoy to be healthy.
-		require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+		require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -102,8 +102,8 @@ var _ = Describe("upgrading Contour", func() {
 			By("waiting for contour deployment to be updated")
 			require.NoError(f.T(), f.Deployment.WaitForContourDeploymentUpdated())
 
-			By("waiting for envoy daemonset to be updated")
-			require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetUpdated())
+			By("waiting for envoy deployment to be updated")
+			require.NoError(f.T(), f.Deployment.WaitForEnvoyDeploymentUpdated())
 
 			By("ensuring app is still routable")
 			checkRoutability(appHost)
@@ -180,13 +180,13 @@ func updateContourDeploymentResources() {
 	f.Deployment.ContourDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
 	require.NoError(f.T(), f.Deployment.EnsureContourDeployment())
 
-	By("updating envoy daemonset")
+	By("updating envoy deployment")
 	// Update container image.
-	require.Len(f.T(), f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.InitContainers, 1)
-	f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.InitContainers[0].Image = contourUpgradeToImage
-	f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = v1.PullIfNotPresent
-	require.Len(f.T(), f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.Containers, 2)
-	f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.Containers[0].Image = contourUpgradeToImage
-	f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
-	require.NoError(f.T(), f.Deployment.EnsureEnvoyDaemonSet())
+	require.Len(f.T(), f.Deployment.EnvoyDeployment.Spec.Template.Spec.InitContainers, 1)
+	f.Deployment.EnvoyDeployment.Spec.Template.Spec.InitContainers[0].Image = contourUpgradeToImage
+	f.Deployment.EnvoyDeployment.Spec.Template.Spec.InitContainers[0].ImagePullPolicy = v1.PullIfNotPresent
+	require.Len(f.T(), f.Deployment.EnvoyDeployment.Spec.Template.Spec.Containers, 2)
+	f.Deployment.EnvoyDeployment.Spec.Template.Spec.Containers[0].Image = contourUpgradeToImage
+	f.Deployment.EnvoyDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
+	require.NoError(f.T(), f.Deployment.EnsureEnvoyDeployment())
 }


### PR DESCRIPTION
This is a WIP playground on what it might look like to move Envoy from a daemonset to a Deployment. 

Motivation around this is the inability to have Envoy pod react to a `kubectl drain <node>` or a scale up/down of nodes since daemonsets are not applied in those events. 

```
 If there are DaemonSet-managed pods, drain will not proceed without –ignore-daemonsets, and regardless it will not delete any DaemonSet-managed pods, because those pods would be immediately replaced by the DaemonSet controller, which ignores unschedulable markings.
```

Signed-off-by: Steve Sloka <slokas@vmware.com>