### PR TITLE
ContourConfiguration status

### DIFF
--- a/apis/projectcontour/v1alpha1/helpers.go
+++ b/apis/projectcontour/v1alpha1/helpers.go
@@ -26,3 +26,15 @@ func (status *ExtensionServiceStatus) GetConditionFor(condType string) *contour_
 
 	return nil
 }
+
+// GetConditionFor returns the a pointer to the condition for a given type,
+// or nil if there are none currently present.
+func (status *ContourConfigurationStatus) GetConditionFor(condType string) *contour_api_v1.DetailedCondition {
+	for i, cond := range status.Conditions {
+		if cond.Type == condType {
+			return &status.Conditions[i]
+		}
+	}
+
+	return nil
+}

--- a/changelogs/unreleased/4074-stevesloka-minor.md
+++ b/changelogs/unreleased/4074-stevesloka-minor.md
@@ -1,0 +1,4 @@
+Refactors the LeaderElection into cmd/contour/contour.go to allow for identifying
+if a leader has been elected or not to set proper status on the ContourConfiguration
+CRD. If the instance of Contour running is not the leader, leader election is disabled, 
+or the ContourConfiguration is not being used, then setting status never happens.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -14,15 +14,23 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
 
 	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/build"
 	"github.com/projectcontour/contour/internal/envoy"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/workgroup"
 	"github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/leaderelection"
 )
 
 func main() {
@@ -126,7 +134,46 @@ func main() {
 			log.WithError(err).Fatal("unable to initialize Server dependencies required to start Contour")
 		}
 
-		if err := serve.doServe(); err != nil {
+		// Get the ContourConfiguration CRD if specified
+		contourConfiguration, err := getContourConfiguration(serveCtx, serve.clients)
+		if err != nil {
+			log.WithError(err).Fatal("error processing Contour Configuration")
+		}
+
+		// Set up workgroup runner.
+		var contourGroup workgroup.Group
+
+		// Register leadership election.
+		var isLeader chan struct{}
+		var le *leaderelection.LeaderElector
+		var leaderChanged chan string
+		if contourConfiguration.Spec.LeaderElection.DisableLeaderElection {
+			isLeader = disableLeaderElection(log)
+		} else {
+			isLeader, leaderChanged, le = setupLeadershipElection(&contourGroup, log, contourConfiguration.Spec.LeaderElection, serve.clients)
+		}
+
+		// Start up Contour Group
+		go func() {
+			if err := contourGroup.Run(context.Background()); err != nil {
+				log.WithError(err).Fatal("error running Contour Group")
+			}
+		}()
+
+		if !contourConfiguration.Spec.LeaderElection.DisableLeaderElection {
+			// wait for leader to be elected or found
+			<-leaderChanged
+		}
+
+		// If ContourConfiguration is specified and LeaderElection is disabled, or we're the leader set status on the object.
+		if len(serveCtx.contourConfigurationName) > 0 && (contourConfiguration.Spec.LeaderElection.DisableLeaderElection || le.IsLeader()) {
+			// Set valid status on the ContourConfiguration object
+			if err := serve.sh.SetValidContourConfigurationStatus(contourConfiguration); err != nil {
+				log.WithError(err).Fatal("could not set status on the ContourConfiguration object")
+			}
+		}
+
+		if err := serve.doServe(contourConfiguration, isLeader); err != nil {
 			log.WithError(err).Fatal("Contour server failed")
 		}
 	case version.FullCommand():
@@ -136,4 +183,38 @@ func main() {
 		os.Exit(2)
 	}
 
+}
+
+// getContourConfiguration returns a specified ContourConfiguration or converts a ServeContext into a ContourConfiguration.
+func getContourConfiguration(serveCtx *serveContext, clients *k8s.Clients) (*contour_api_v1alpha1.ContourConfiguration, error) {
+	if len(serveCtx.contourConfigurationName) > 0 {
+		// Determine the name/namespace of the configuration resource utilizing the environment
+		// variable "CONTOUR_NAMESPACE" which should exist on the Contour deployment.
+		//
+		// If the env variable is not present, it will default to "projectcontour".
+		contourNamespace, found := os.LookupEnv("CONTOUR_NAMESPACE")
+		if !found {
+			contourNamespace = "projectcontour"
+		}
+
+		namespacedName := types.NamespacedName{Name: serveCtx.contourConfigurationName, Namespace: contourNamespace}
+		client := clients.DynamicClient().Resource(contour_api_v1alpha1.ContourConfigurationGVR).Namespace(namespacedName.Namespace)
+
+		// ensure the specified ContourConfiguration exists
+		res, err := client.Get(context.Background(), namespacedName.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("error getting contour configuration %s; %v", namespacedName, err)
+		}
+
+		var contourConfig contour_api_v1alpha1.ContourConfiguration
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(res.Object, &contourConfig); err != nil {
+			return nil, fmt.Errorf("error converting contour configuration %s; %v", namespacedName, err)
+		}
+
+		return &contourConfig, nil
+	}
+	// No contour configuration passed, so convert the ServeContext into a ContourConfigurationSpec.
+	return &contour_api_v1alpha1.ContourConfiguration{
+		Spec: *serveCtx.convertToContourConfigurationSpec(),
+	}, nil
 }

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -259,7 +259,7 @@ func parseDefaultHTTPVersions(versions []contour_api_v1alpha1.HTTPVersionType) [
 	return parsed
 }
 
-func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha1.ContourConfigurationSpec {
+func (ctx *serveContext) convertToContourConfigurationSpec() *contour_api_v1alpha1.ContourConfigurationSpec {
 	ingress := &contour_api_v1alpha1.IngressConfig{}
 	if len(ctx.ingressClassName) > 0 {
 		ingress.ClassName = pointer.StringPtr(ctx.ingressClassName)
@@ -487,5 +487,5 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 		},
 	}
 
-	return contourConfiguration
+	return &contourConfiguration
 }

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -26,14 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/projectcontour/contour/pkg/config"
-	"k8s.io/utils/pointer"
-
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"k8s.io/utils/pointer"
 )
 
 func TestServeContextProxyRootNamespaces(t *testing.T) {
@@ -430,11 +429,11 @@ func TestConvertServeContext(t *testing.T) {
 
 	cases := map[string]struct {
 		serveContext  *serveContext
-		contourConfig contour_api_v1alpha1.ContourConfigurationSpec
+		contourConfig *contour_api_v1alpha1.ContourConfigurationSpec
 	}{
 		"default ServeContext": {
 			serveContext: defaultContext,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -548,7 +547,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"headers policy": {
 			serveContext: headersPolicyContext,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -665,7 +664,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"ingress": {
 			serveContext: ingressContext,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -776,7 +775,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"gatewayapi": {
 			serveContext: gatewayContext,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -889,7 +888,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"client certificate": {
 			serveContext: clientCertificate,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -1003,7 +1002,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"httpproxy": {
 			serveContext: httpProxy,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -1117,7 +1116,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"ratelimit": {
 			serveContext: rateLimit,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -1236,7 +1235,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"default http versions": {
 			serveContext: defaultHTTPVersions,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",
@@ -1349,7 +1348,7 @@ func TestConvertServeContext(t *testing.T) {
 		},
 		"access log": {
 			serveContext: accessLog,
-			contourConfig: contour_api_v1alpha1.ContourConfigurationSpec{
+			contourConfig: &contour_api_v1alpha1.ContourConfigurationSpec{
 				XDSServer: contour_api_v1alpha1.XDSServerConfig{
 					Type:    contour_api_v1alpha1.ContourServerType,
 					Address: "127.0.0.1",

--- a/test/e2e/contourconfiguration/contourconfiguration_test.go
+++ b/test/e2e/contourconfiguration/contourconfiguration_test.go
@@ -1,0 +1,95 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package contourconfiguration
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+var f = e2e.NewFramework(false)
+
+func TestInfra(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ContourConfiguration tests")
+}
+
+var _ = BeforeSuite(func() {
+	require.NoError(f.T(), f.Deployment.EnsureResourcesForLocalContour())
+})
+
+var _ = AfterSuite(func() {
+	// Delete resources individually instead of deleting the entire contour
+	// namespace as a performance optimization, because deleting non-empty
+	// namespaces can take up to a couple of minutes to complete.
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
+	gexec.CleanupBuildArtifacts()
+})
+
+var (
+	contourCmd            *gexec.Session
+	contourConfiguration  *contour_api_v1alpha1.ContourConfiguration
+	contourConfigFile     string
+	additionalContourArgs []string
+)
+
+var _ = Describe("ContourConfiguration Status", func() {
+
+	AfterEach(func() {
+		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+	})
+
+	f.Test(testContourConfigurationStatus)
+})
+
+func testContourConfigurationStatus() {
+
+	contourConfiguration = e2e.DefaultContourConfiguration()
+
+	Specify("default ContourConfiguration status is Valid=true", func() {
+		var err error
+		// Set the "config" to nil to disable running those tests since they don't apply.
+		contourCmd, contourConfigFile, err = f.Deployment.StartLocalContour(nil, contourConfiguration, additionalContourArgs...)
+		require.NoError(f.T(), err)
+
+		// Verify Status on Contour
+		require.True(f.T(), f.WaitForContourConfigurationStatus(contourConfiguration, contourConfigurationValid))
+	})
+}
+
+// contourConfigurationValid returns true if the config has a .status.conditions
+// entry of Valid: true".
+func contourConfigurationValid(config *contour_api_v1alpha1.ContourConfiguration) bool {
+	if config == nil {
+		return false
+	}
+
+	for _, cond := range config.Status.Conditions {
+		if cond.Type == "Valid" && cond.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/contourconfiguration/contourconfiguration_test.go
+++ b/test/e2e/contourconfiguration/contourconfiguration_test.go
@@ -18,6 +18,7 @@ package contourconfiguration
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -67,6 +68,10 @@ var _ = Describe("ContourConfiguration Status", func() {
 func testValidContourConfigurationStatus() {
 
 	Specify("leader election enabled", func() {
+		if useContourConfiguration, variableFound := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); variableFound && useContourConfiguration == "false" {
+			Skip("configmap configuration not supported")
+		}
+
 		var err error
 
 		contourConfiguration := e2e.DefaultContourConfiguration()
@@ -100,6 +105,9 @@ func testValidContourConfigurationStatus() {
 	})
 
 	Specify("leader election disabled", func() {
+		if useContourConfiguration, variableFound := os.LookupEnv("USE_CONTOUR_CONFIGURATION_CRD"); variableFound && useContourConfiguration == "false" {
+			Skip("configmap configuration not supported")
+		}
 		var err error
 
 		contourConfiguration := e2e.DefaultContourConfiguration()

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -583,11 +583,6 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 			},
 		}
 
-		// Disable leader election.
-		contourConfiguration.Spec.LeaderElection = contour_api_v1alpha1.LeaderElectionConfig{
-			DisableLeaderElection: true,
-		}
-
 		if err := d.client.Create(context.TODO(), contourConfiguration); err != nil {
 			return nil, "", fmt.Errorf("could not create ContourConfiguration: %v", err)
 		}

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -599,7 +599,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 		}, additionalArgs...)
 
 		configReferenceName = contourConfiguration.Name
-	} else {
+	} else if config != nil {
 
 		configFile, err := ioutil.TempFile("", "contour-config-*.yaml")
 		if err != nil {
@@ -626,6 +626,8 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 		}, additionalArgs...)
 
 		configReferenceName = configFile.Name()
+	} else {
+		return nil, "", errors.New("no valid configurations specified")
 	}
 
 	session, err := gexec.Start(exec.Command(d.contourBin, contourServeArgs...), d.cmdOutputWriter, d.cmdOutputWriter) // nolint:gosec

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -378,6 +378,9 @@ func DefaultContourConfiguration() *contour_api_v1alpha1.ContourConfiguration {
 				Address: "0.0.0.0",
 				Port:    8000,
 			},
+			LeaderElection: contour_api_v1alpha1.LeaderElectionConfig{
+				DisableLeaderElection: true,
+			},
 		},
 	}
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -422,6 +422,26 @@ func (f *Framework) DeleteGatewayClass(gwc *gatewayv1alpha1.GatewayClass, waitFo
 	return nil
 }
 
+// WaitForContourConfigurationStatus waits for a Valid=true condition to exist on the object.
+func (f *Framework) WaitForContourConfigurationStatus(config *contourv1alpha1.ContourConfiguration, condition func(configuration *contourv1alpha1.ContourConfiguration) bool) bool {
+	res := &contourv1alpha1.ContourConfiguration{}
+
+	if err := wait.PollImmediate(f.RetryInterval, f.RetryTimeout, func() (bool, error) {
+		if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(config), res); err != nil {
+			// if there was an error, we want to keep
+			// retrying, so just return false, not an
+			// error.
+			return false, nil
+		}
+
+		return condition(res), nil
+	}); err != nil {
+		// return the last response for logging/debugging purposes
+		return false
+	}
+	return true
+}
+
 // GetEchoResponseBody decodes an HTTP response body that is
 // expected to have come from ingress-conformance-echo into an
 // EchoResponseBody, or fails the test if it encounters an error.

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -19,11 +19,10 @@ package infra
 import (
 	"testing"
 
-	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Follow up to #4048 to wire up a way to set status on the ContourConfiguration object. Future refactoring will enable the ability to add more validations and setting status accordingly. This only sets a "valid" status on the object relying on Kubebuilder annotations for all current validations. 
