### PR TITLE
Bump Envoy to v1.20.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.19.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.20.0
 GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.20.0
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.20.1
 GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4075-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4075-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Bump Envoy to v1.20.0. See [release notes](https://www.envoyproxy.io/docs/envoy/v1.20.0/version_history/current).

--- a/changelogs/unreleased/4075-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4075-sunjayBhatia-small.md
@@ -1,1 +1,1 @@
-Bump Envoy to v1.20.0. See [release notes](https://www.envoyproxy.io/docs/envoy/v1.20.0/version_history/current).
+Bump Envoy to v1.20.1. See [release notes](https://www.envoyproxy.io/docs/envoy/v1.20.1/version_history/current).

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.20.0
+        image: docker.io/envoyproxy/envoy:v1.20.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.19.1
+        image: docker.io/envoyproxy/envoy:v1.20.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5133,7 +5133,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.20.0
+        image: docker.io/envoyproxy/envoy:v1.20.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5133,7 +5133,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.19.1
+        image: docker.io/envoyproxy/envoy:v1.20.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5130,7 +5130,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.20.0
+        image: docker.io/envoyproxy/envoy:v1.20.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5130,7 +5130,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.19.1
+        image: docker.io/envoyproxy/envoy:v1.20.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ go 1.15
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/bombsimon/logrusr v1.0.0
-	github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957
+	github.com/envoyproxy/go-control-plane v0.9.10-0.20211006050637-f76d23b38f14
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.15
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/bombsimon/logrusr v1.0.0
+	github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/envoyproxy/go-control-plane v0.9.10-0.20210806072310-abdc764d71d2
+	github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,9 @@ github.com/cloudflare/cloudflare-go v0.20.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe h1:QJDJubh0OEcpeGjC7/8uF9tt4e39U/Ya1uyK+itnNPQ=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
@@ -265,8 +266,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20210806072310-abdc764d71d2 h1:/iuhlbooXa+EfHt42+/MMeiVb2B16sSfqF+vHEyByqk=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20210806072310-abdc764d71d2/go.mod h1:+baROYa9cKpDyN21rZlsSq5zgBrZOrMTNu78Lm3fFJQ=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957 h1:5rgf1K46LZ5+/ST/83YtprIm8JxeUsgyq+mlOvI8L5s=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=

--- a/go.sum
+++ b/go.sum
@@ -180,7 +180,6 @@ github.com/cloudflare/cloudflare-go v0.20.0/go.mod h1:sPWL/lIC6biLEdyGZwBQ1rGQKF
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe h1:QJDJubh0OEcpeGjC7/8uF9tt4e39U/Ya1uyK+itnNPQ=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
@@ -266,8 +265,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957 h1:5rgf1K46LZ5+/ST/83YtprIm8JxeUsgyq+mlOvI8L5s=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20211004210356-4dc61ebae957/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20211006050637-f76d23b38f14 h1:+i20cKEgdzKq9kPay5sCQFs54hCTXCO+sCAMH5HQIDc=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20211006050637-f76d23b38f14/go.mod h1:kO0EGgHDqkmaTB0bvNfdXEVQsUOD+poi+ry4urQS1qc=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=

--- a/internal/xds/v3/snapshotter.go
+++ b/internal/xds/v3/snapshotter.go
@@ -36,17 +36,11 @@ type snapshotter struct {
 	envoy_cache_v3.SnapshotCache
 }
 
-func (s *snapshotter) Generate(version string, resources map[envoy_types.ResponseType][]envoy_types.Resource) error {
+func (s *snapshotter) Generate(version string, resources map[envoy_resource_v3.Type][]envoy_types.Resource) error {
 	// Create a snapshot with all xDS resources.
 	snapshot, err := envoy_cache_v3.NewSnapshot(
 		version,
-		map[envoy_resource_v3.Type][]envoy_types.Resource{
-			envoy_resource_v3.EndpointType: resources[envoy_types.Endpoint],
-			envoy_resource_v3.ClusterType:  resources[envoy_types.Cluster],
-			envoy_resource_v3.RouteType:    resources[envoy_types.Route],
-			envoy_resource_v3.ListenerType: resources[envoy_types.Listener],
-			envoy_resource_v3.SecretType:   resources[envoy_types.Secret],
-		},
+		resources,
 	)
 	if err != nil {
 		return err

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.19.1][13]         | 1.22, 1.21, 1.20    | [main][50]       | v1alpha2            |
+| main            | [1.20.1][14]         | 1.22, 1.21, 1.20    | [main][50]       | v1alpha2            |
 | 1.19.1          | [1.19.1][13]         | 1.22, 1.21, 1.20    | [1.19.1][65]       | v1alpha1            |
 | 1.19.0          | [1.19.1][13]         | 1.22, 1.21, 1.20    | [1.19.0][64]       | v1alpha1            |
 | 1.18.3          | [1.19.1][13]         | 1.21, 1.20, 1.19    | [1.18.3][66]     | v1alpha1            |
@@ -107,6 +107,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [11]: https://www.envoyproxy.io/docs/envoy/v1.17.4/version_history/current
 [12]: https://www.envoyproxy.io/docs/envoy/v1.18.4/version_history/current
 [13]: https://www.envoyproxy.io/docs/envoy/v1.19.1/version_history/current
+[14]: https://www.envoyproxy.io/docs/envoy/v1.20.1/version_history/current
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.20.0"
+      envoy: "1.20.1"
       kubernetes:
         - "1.22"
         - "1.21"

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.19.1"
+      envoy: "1.20.0"
       kubernetes:
         - "1.22"
         - "1.21"


### PR DESCRIPTION
See release notes:
https://www.envoyproxy.io/docs/envoy/v1.20.0/version_history/current

Also bumps go-control-plane to latest

Deprecation of existing headermatch usage will need to be handled in the release after this is
merged. The "string match" header matching method is preferred but was
added in 1.20.1 and it was not present in 1.19.x, we will need to
release a version with Envoy 1.20.x compatibility and the subsequent
release will need to move to the "string match" method (rather than the
individual regex/exact/etc. methods.