### PR TITLE
test/e2e: Nil check before assertion on succeeded request

### DIFF
--- a/test/e2e/gateway/gateway_allow_type_test.go
+++ b/test/e2e/gateway/gateway_allow_type_test.go
@@ -81,6 +81,7 @@ func testGatewayAllowType(namespace string) {
 			Path:      "/gateway-in-allowed-list",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body := f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo-blue", body.Service)
@@ -132,6 +133,7 @@ func testGatewayAllowType(namespace string) {
 			Path:      "/gateway-not-in-allowed-list",
 			Condition: e2e.HasStatusCode(404),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 404 response code, got %d", res.StatusCode)
 
 		// This route allows gateways in the same namespace, and the actual
@@ -174,6 +176,7 @@ func testGatewayAllowType(namespace string) {
 			Path:      "/gateway-in-same-namespace",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// This route allows gateways in the same namespace, and the actual
@@ -219,6 +222,7 @@ func testGatewayAllowType(namespace string) {
 			Path:      "/gateway-not-in-same-namespace",
 			Condition: e2e.HasStatusCode(404),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 404 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -78,6 +78,7 @@ func testHostRewrite(namespace string) {
 			Host:      string(route.Spec.Hostnames[0]),
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body := f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo", body.Service)

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -109,6 +109,7 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body := f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo-header-filter", body.Service)
@@ -130,6 +131,7 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body = f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo-header-nofilter", body.Service)
@@ -223,6 +225,7 @@ func testRequestHeaderModifierRule(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body := f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo-header-filter", body.Service)
@@ -244,6 +247,7 @@ func testRequestHeaderModifierRule(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		body = f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "echo-header-nofilter", body.Service)

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -109,6 +109,7 @@ func testTLSWildcardHost(namespace string) {
 				},
 				Condition: e2e.HasStatusCode(tc.wantStatus),
 			})
+			require.NotNil(t, res, "request never succeeded")
 			require.Truef(t, ok, "expected %d response code, got %d", tc.wantStatus, res.StatusCode)
 		}
 	})

--- a/test/e2e/httpproxy/dynamic_headers_test.go
+++ b/test/e2e/httpproxy/dynamic_headers_test.go
@@ -150,6 +150,7 @@ func testDynamicHeaders(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		body := f.GetEchoResponseBody(res.Body)

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -231,6 +231,7 @@ func testExternalAuth(namespace string) {
 			Path:      "/first",
 			Condition: e2e.HasStatusCode(401),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
 
 		// The `testserver` authorization server will accept any request with
@@ -242,6 +243,7 @@ func testExternalAuth(namespace string) {
 			Path:      "/first/allow",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		body := f.GetEchoResponseBody(res.Body)
@@ -254,6 +256,7 @@ func testExternalAuth(namespace string) {
 			Path:      "/second",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// The default route should not authorize by default.
@@ -262,6 +265,7 @@ func testExternalAuth(namespace string) {
 			Path:      "/matches-default-route",
 			Condition: e2e.HasStatusCode(401),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
 
 		// The `testserver` authorization server will accept any request with
@@ -273,6 +277,7 @@ func testExternalAuth(namespace string) {
 			Path:      "/matches-default-route/allow",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		body = f.GetEchoResponseBody(res.Body)

--- a/test/e2e/httpproxy/external_name_test.go
+++ b/test/e2e/httpproxy/external_name_test.go
@@ -90,6 +90,7 @@ func testExternalNameServiceInsecure(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }
@@ -160,6 +161,7 @@ func testExternalNameServiceTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -63,6 +63,7 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		require.NoError(t, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -96,6 +97,7 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -104,6 +106,7 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 	})
 }
@@ -156,6 +159,7 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Add a global rate limit policy on the first route.
@@ -190,6 +194,7 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -198,6 +203,7 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 
 		// Make a request against the route that doesn't have rate limiting
@@ -207,6 +213,7 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 			Path:      "/unlimited",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
 	})
 }
@@ -250,6 +257,7 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Add a global rate limit policy on the virtual host.
@@ -283,6 +291,7 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -291,6 +300,7 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 	})
 }
@@ -347,6 +357,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Add a global rate limit policy on the first route.
@@ -380,6 +391,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -388,6 +400,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 
 		// Make a request against the route that doesn't have rate limiting
@@ -397,6 +410,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 			Path:      "/unlimited",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/host_header_rewrite_test.go
@@ -66,6 +66,7 @@ func testHostHeaderRewrite(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		assert.Equal(t, "rewritten.com", f.GetEchoResponseBody(res.Body).Host)

--- a/test/e2e/httpproxy/http_health_checks_test.go
+++ b/test/e2e/httpproxy/http_health_checks_test.go
@@ -61,6 +61,7 @@ func testHTTPHealthChecks(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// set the health check policy to always fail
@@ -82,6 +83,7 @@ func testHTTPHealthChecks(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(503),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 503 response code, got %d", res.StatusCode)
 
 		// set the health check policy to always pass
@@ -103,6 +105,7 @@ func testHTTPHealthChecks(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/https_fallback_certificate_test.go
@@ -67,6 +67,7 @@ func testHTTPSFallbackCertificate(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected a 200 response code, got %d", res.StatusCode)
 
 		assert.Equal(t, "echo", f.GetEchoResponseBody(res.Body).Service)
@@ -80,6 +81,7 @@ func testHTTPSFallbackCertificate(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected a 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/https_misdirected_request_test.go
@@ -64,6 +64,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		assert.Equal(t, "echo", f.GetEchoResponseBody(res.Body).Service)
@@ -77,6 +78,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(421),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 421 (Misdirected Request) response code, got %d", res.StatusCode)
 
 		// The virtual host name is port-insensitive, so verify that we can
@@ -88,6 +90,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Verify that the hostname match is case-insensitive.
@@ -100,6 +103,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/https_sni_enforcement_test.go
@@ -65,6 +65,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 			Path:      "/https-sni-enforcement",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		assert.Equal(t, "echo-one", f.GetEchoResponseBody(res.Body).Service)
@@ -104,6 +105,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 			Path:      "/https-sni-enforcement",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		assert.Equal(t, "echo-two", f.GetEchoResponseBody(res.Body).Service)
@@ -118,6 +120,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(421),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 421 (Misdirected Request) response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/local_rate_limiting_test.go
+++ b/test/e2e/httpproxy/local_rate_limiting_test.go
@@ -63,6 +63,7 @@ func testLocalRateLimitingVirtualHost(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Add a local rate limit policy on the virtual host.
@@ -87,6 +88,7 @@ func testLocalRateLimitingVirtualHost(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -95,6 +97,7 @@ func testLocalRateLimitingVirtualHost(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 	})
 }
@@ -147,6 +150,7 @@ func testLocalRateLimitingRoute(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Add a local rate limit policy on the first route.
@@ -171,6 +175,7 @@ func testLocalRateLimitingRoute(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// Make another request against the proxy, confirm a 429 response
@@ -179,6 +184,7 @@ func testLocalRateLimitingRoute(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(429),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 429 response code, got %d", res.StatusCode)
 
 		// Make a request against the route that doesn't have rate limiting
@@ -188,6 +194,7 @@ func testLocalRateLimitingRoute(namespace string) {
 			Path:      "/unlimited",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code for non-rate-limited route, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/httpproxy/merge_slash_test.go
+++ b/test/e2e/httpproxy/merge_slash_test.go
@@ -64,6 +64,7 @@ func testMergeSlash(namespace string) {
 			Path:      "/anything/this//has//lots////of/slashes",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		assert.Contains(t, f.GetEchoResponseBody(res.Body).Path, "/this/has/lots/of/slashes")

--- a/test/e2e/httpproxy/pod_restart_test.go
+++ b/test/e2e/httpproxy/pod_restart_test.go
@@ -64,6 +64,7 @@ func testPodRestart(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		body := f.GetEchoResponseBody(res.Body)
@@ -93,6 +94,7 @@ func testPodRestart(namespace string) {
 			Host:      p.Spec.VirtualHost.Fqdn,
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 
 		// should be a different pod than the original request

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -78,6 +78,7 @@ func testTCPRouteHTTPSTermination(namespace string) {
 			},
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/infra/admin_test.go
+++ b/test/e2e/infra/admin_test.go
@@ -50,6 +50,7 @@ func testAdminInterface() {
 				Path:      prefix,
 				Condition: e2e.HasStatusCode(code),
 			})
+			require.NotNil(t, res, "request never succeeded")
 			require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		}
 	})

--- a/test/e2e/infra/metrics_test.go
+++ b/test/e2e/infra/metrics_test.go
@@ -30,6 +30,7 @@ func testMetrics() {
 			Path:      "/stats",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }
@@ -42,6 +43,7 @@ func testReady() {
 			Path:      "/ready",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res, "request never succeeded")
 		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 	})
 }

--- a/test/e2e/ingress/tls_wildcard_host_test.go
+++ b/test/e2e/ingress/tls_wildcard_host_test.go
@@ -121,6 +121,7 @@ func testTLSWildcardHost(namespace string) {
 				},
 				Condition: e2e.HasStatusCode(tc.wantStatus),
 			})
+			require.NotNil(t, res, "request never succeeded")
 			require.Truef(t, ok, "expected %d response code, got %d", tc.wantStatus, res.StatusCode)
 		}
 	})

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -121,6 +121,7 @@ func checkRoutability(host string) {
 		Path:      "/echo",
 		Condition: e2e.HasStatusCode(200),
 	})
+	require.NotNil(f.T(), res, "request never succeeded")
 	require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
 }
 


### PR DESCRIPTION
Log message uses status code from response which might be nil