### PR TITLE
Add metadata name to complete the minimum runnable example

### DIFF
--- a/site/content/docs/main/config/cors.md
+++ b/site/content/docs/main/config/cors.md
@@ -10,7 +10,7 @@ In this example, cross-domain requests will be allowed for any domain (note the 
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: cors_example
+  name: cors-example
 spec:
   virtualhost:
     fqdn: www.example.com
@@ -33,7 +33,7 @@ spec:
     - conditions:
       - prefix: /
       services:
-        - name: cors_example
+        - name: cors-example
           port: 80
 ```
 
@@ -43,7 +43,7 @@ In the following example, cross-domain requests are restricted to `https://clien
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: cors_example
+  name: cors-example
 spec:
   virtualhost:
     fqdn: www.example.com
@@ -66,7 +66,7 @@ spec:
     - conditions:
       - prefix: /
       services:
-        - name: cors_example
+        - name: cors-example
           port: 80
 ```
 


### PR DESCRIPTION
Adding the name provides a runnable example for the docs, as without it there is an error that `the resource name may not be empty`.