### PR TITLE
only run label check workflow for PRs

### DIFF
--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -1,10 +1,7 @@
 name: Release Note Label Check
 
-# Trigger the workflow on push or pull request
+# Trigger the workflow on pull requests only
 on: 
-  push:
-    branches-ignore:
-      - "main"
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 


### PR DESCRIPTION
The label check workflow is only relevant
for PRs. This disables it for all push
builds, not just for pushes to "main", to
avoid failures on other branches.

Signed-off-by: Steve Kriss <krisss@vmware.com>