### PR TITLE
update docs to reference GHCR image

### DIFF
--- a/site/content/guides/proxy-proto.md
+++ b/site/content/guides/proxy-proto.md
@@ -44,7 +44,7 @@ spec:
 ...
 spec:
   containers:
-  - image: docker.io/projectcontour/contour:{{< param latest_version >}}
+  - image: ghcr.io/projectcontour/contour:{{< param latest_version >}}
     imagePullPolicy: Always
     name: contour
     command: ["contour"]

--- a/site/content/resources/tagging.md
+++ b/site/content/resources/tagging.md
@@ -10,7 +10,7 @@ This document describes Contour's image tagging policy.
 `ghcr.io/projectcontour/contour:<SemVer>`
 
 Contour follows the [Semantic Versioning][1] standard for releases.
-Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `docker.io/projectcontour/contour:{{< param latest_version >}}`
+Each tag in the github.com/projectcontour/contour repository has a matching image. eg. `ghcr.io/projectcontour/contour:{{< param latest_version >}}`
 
 `ghcr.io/projectcontour/contour:v<major>.<minor>`
 


### PR DESCRIPTION
Fixes a couple of spots that hadn't been updated
to use the new ghcr.io/projectcontour/contour
image.

Signed-off-by: Steve Kriss <krisss@vmware.com>