### PR TITLE
internal/dag: support HTTP method matching for Gateway API

### DIFF
--- a/changelogs/unreleased/4120-skriss-small.md
+++ b/changelogs/unreleased/4120-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: adds support for HTTP method matching in `HTTPRoute` rules. See the [Gateway API documentation](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRouteMatch) for more information.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -591,6 +591,17 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHeaderMatchType, "HTTPRoute.Spec.Rules.HeaderMatch: Only Exact match type is supported.")
 				continue
 			}
+
+			// Envoy uses the HTTP/2 ":method" header internally
+			// for both HTTP/1 and HTTP/2 method matching.
+			if match.Method != nil {
+				headerMatches = append(headerMatches, HeaderMatchCondition{
+					Name:      ":method",
+					Value:     string(*match.Method),
+					MatchType: HeaderMatchTypeExact,
+				})
+			}
+
 			matchconditions = append(matchconditions, &matchConditions{
 				path:    pathMatch,
 				headers: headerMatches,

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -44,6 +44,10 @@ func TLSModeTypePtr(mode gatewayapi_v1alpha2.TLSModeType) *gatewayapi_v1alpha2.T
 	return &mode
 }
 
+func HTTPMethodPtr(method gatewayapi_v1alpha2.HTTPMethod) *gatewayapi_v1alpha2.HTTPMethod {
+	return &method
+}
+
 func ListenerHostname(host string) *gatewayapi_v1alpha2.Hostname {
 	h := gatewayapi_v1alpha2.Hostname(host)
 	return &h


### PR DESCRIPTION
Closes #4088.

Signed-off-by: Steve Kriss <krisss@vmware.com>