### PR TITLE
site: add a Gateway API v1alpha2 guide

### DIFF
--- a/changelogs/unreleased/4122-skriss-docs.md
+++ b/changelogs/unreleased/4122-skriss-docs.md
@@ -1,0 +1,1 @@
+Adds a Gateway API v1alpha2 guide.


### PR DESCRIPTION
Adds a second copy of the Gateway API
guide, for v1alpha2. Once Contour 1.20
is released, the v1alpha1 guide will
be dropped and the v1alpha2 guide will
be updated with the proper links.

Updates #4091.

Signed-off-by: Steve Kriss <krisss@vmware.com>