### PR TITLE
Gateway API: add request redirect filter support

### DIFF
--- a/changelogs/unreleased/4123-skriss-small.md
+++ b/changelogs/unreleased/4123-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: adds support for the "RequestRedirect" HTTPRoute filter type at the rule level.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2260,6 +2260,63 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
+		"HTTPRoute rule with request redirect filter": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1alpha2.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
+								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+									Scheme:     pointer.String("https"),
+									Hostname:   gatewayapi.ListenerHostname("envoyproxy.io"),
+									Port:       gatewayapi.PortNumPtr(443),
+									StatusCode: pointer.Int(301),
+								},
+							}},
+							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+								{
+									BackendRef: gatewayapi_v1alpha2.BackendRef{
+										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
+										Weight:                 pointer.Int32(1),
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixString("/"),
+							Redirect: &Redirect{
+								Scheme:     "https",
+								Hostname:   "envoyproxy.io",
+								PortNumber: 443,
+								StatusCode: 301,
+							},
+						},
+					)),
+				},
+			),
+		},
 		"different weights for multiple forwardTos": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -193,6 +193,25 @@ type DirectResponse struct {
 	StatusCode uint32
 }
 
+// Redirect allows for a 301/302 redirect to be the response
+// to a route request vs. routing to an envoy cluster.
+type Redirect struct {
+	// Hostname is the host name to redirect to.
+	Hostname string
+
+	// Scheme is the scheme (http or https) to
+	// use in the redirect.
+	Scheme string
+
+	// PortNumber is the port to redirect to,
+	// if any.
+	PortNumber uint32
+
+	// StatusCode is the HTTP response code to
+	// use. Valid options are 301 or 302.
+	StatusCode int
+}
+
 // Route defines the properties of a route to a Cluster.
 type Route struct {
 
@@ -255,6 +274,10 @@ type Route struct {
 	// to be the response to a route request vs routing to
 	// an envoy cluster.
 	DirectResponse *DirectResponse
+
+	// Redirect allows for a 301 Redirect to be the response
+	// to a route request vs. routing to an envoy cluster.
+	Redirect *Redirect
 }
 
 // HasPathPrefix returns whether this route has a PrefixPathCondition.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3423,7 +3423,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionNotImplemented),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ReasonHTTPRouteFilterType),
-					Message: "HTTPRoute.Spec.Rules.Filters: Only RequestHeaderModifier type is supported.",
+					Message: "HTTPRoute.Spec.Rules.Filters: invalid type \"RequestMirror\": only RequestHeaderModifier and RequestRedirect are supported.",
 				},
 				gatewayapi_v1alpha2.ConditionRouteAccepted: {
 					Type:    string(gatewayapi_v1alpha2.ConditionRouteAccepted),

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -122,9 +122,11 @@ func RouteDirectResponse(response *dag.DirectResponse) *envoy_route_v3.Route_Dir
 // client.
 func RouteRedirect(redirect *dag.Redirect) *envoy_route_v3.Route_Redirect {
 	r := &envoy_route_v3.Route_Redirect{
-		Redirect: &envoy_route_v3.RedirectAction{
-			HostRedirect: redirect.Hostname,
-		},
+		Redirect: &envoy_route_v3.RedirectAction{},
+	}
+
+	if len(redirect.Hostname) > 0 {
+		r.Redirect.HostRedirect = redirect.Hostname
 	}
 
 	if len(redirect.Scheme) > 0 {
@@ -137,6 +139,7 @@ func RouteRedirect(redirect *dag.Redirect) *envoy_route_v3.Route_Redirect {
 		r.Redirect.PortRedirect = redirect.PortNumber
 	}
 
+	// Envoy's default is a 301 if not otherwise specified.
 	switch redirect.StatusCode {
 	case 301:
 		r.Redirect.ResponseCode = envoy_route_v3.RedirectAction_MOVED_PERMANENTLY

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -117,6 +117,36 @@ func RouteDirectResponse(response *dag.DirectResponse) *envoy_route_v3.Route_Dir
 	}
 }
 
+// RouteRedirect creates a *envoy_route_v3.Route_Redirect for the
+// redirect specified. This allows a redirect to be returned to the
+// client.
+func RouteRedirect(redirect *dag.Redirect) *envoy_route_v3.Route_Redirect {
+	r := &envoy_route_v3.Route_Redirect{
+		Redirect: &envoy_route_v3.RedirectAction{
+			HostRedirect: redirect.Hostname,
+		},
+	}
+
+	if len(redirect.Scheme) > 0 {
+		r.Redirect.SchemeRewriteSpecifier = &envoy_route_v3.RedirectAction_SchemeRedirect{
+			SchemeRedirect: redirect.Scheme,
+		}
+	}
+
+	if redirect.PortNumber > 0 {
+		r.Redirect.PortRedirect = redirect.PortNumber
+	}
+
+	switch redirect.StatusCode {
+	case 301:
+		r.Redirect.ResponseCode = envoy_route_v3.RedirectAction_MOVED_PERMANENTLY
+	case 302:
+		r.Redirect.ResponseCode = envoy_route_v3.RedirectAction_FOUND
+	}
+
+	return r
+}
+
 // RouteRoute creates a *envoy_route_v3.Route_Route for the services supplied.
 // If len(services) is greater than one, the route's action will be a
 // weighted cluster.

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -173,6 +173,8 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-tcproute-rejected", testWithHTTPGateway(testTCPRouteIsRejected))
 
 		f.NamespacedTest("gateway-udproute-rejected", testWithHTTPGateway(testUDPRouteIsRejected))
+
+		f.NamespacedTest("gateway-request-redirect-rule", testWithHTTPGateway(testRequestRedirectRule))
 	})
 
 	Describe("HTTPRoute: TLS Gateway", func() {

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -1,0 +1,112 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package gateway
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func testRequestRedirectRule(namespace string) {
+	Specify("redirects can be specified on route rule", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+
+		route := &gatewayapi_v1alpha2.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "httproute-redirect",
+			},
+			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1alpha2.Hostname{"requestredirectrule.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1alpha2.ParentRef{
+						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+					},
+				},
+				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+					{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/basic-redirect"),
+						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+							{
+								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+									Hostname: gatewayapi.ListenerHostname("projectcontour.io"),
+								},
+							},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
+					},
+					{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/complex-redirect"),
+						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+							{
+								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+									Hostname:   gatewayapi.ListenerHostname("envoyproxy.io"),
+									StatusCode: pointer.Int(301),
+									Scheme:     pointer.String("https"),
+									Port:       gatewayapi.PortNumPtr(8080),
+								},
+							},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route, httpRouteAccepted)
+
+		// /basic-redirect only specifies a host name to
+		// redirect to.
+		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host: string(route.Spec.Hostnames[0]),
+			Path: "/basic-redirect",
+			ClientOpts: []func(*http.Client){
+				e2e.OptDontFollowRedirects,
+			},
+			Condition: e2e.HasStatusCode(302),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 302 response code, got %d", res.StatusCode)
+		assert.Equal(t, "http://projectcontour.io/basic-redirect", res.Headers.Get("Location"))
+
+		// /complex-redirect specifies a host name,
+		// scheme, port and response code for the
+		// redirect.
+		res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host: string(route.Spec.Hostnames[0]),
+			Path: "/complex-redirect",
+			ClientOpts: []func(*http.Client){
+				e2e.OptDontFollowRedirects,
+			},
+			Condition: e2e.HasStatusCode(301),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 301 response code, got %d", res.StatusCode)
+		assert.Equal(t, "https://envoyproxy.io:8080/complex-redirect", res.Headers.Get("Location"))
+	})
+}


### PR DESCRIPTION
Adds support for the "RequestRedirect" HTTPRoute
filter type at the rule level.

Closes #4087.

Signed-off-by: Steve Kriss <krisss@vmware.com>