### PR TITLE
Gateway API: implement ReferencePolicy

### DIFF
--- a/changelogs/unreleased/4138-skriss-minor.md
+++ b/changelogs/unreleased/4138-skriss-minor.md
@@ -1,0 +1,6 @@
+### Gateway API: support ReferencePolicy
+
+Contour now supports the `ReferencePolicy` CRD in Gateway API v1alpha2.
+`ReferencePolicy` enables certain cross-namespace references to be allowed in Gateway API.
+The primary use case is to enable routes (e.g. `HTTPRoutes`, `TLSRoutes`) to reference backend `Services` in different namespaces.
+When Contour processes a route that references a service in a different namespace, it will check for a `ReferencePolicy` that applies to the route and service, and if one exists, it will allow the reference.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -731,6 +731,11 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 				s.log.WithError(err).Fatal("failed to create udproute-controller")
 			}
 
+			// Inform on ReferencePolicies.
+			if err := informOnResource(s.clients, k8s.ReferencePoliciesResource(), eventHandler, mgr.GetCache()); err != nil {
+				s.log.WithError(err).WithField("resource", k8s.ReferencePoliciesResource()).Fatal("failed to create informer")
+			}
+
 			// Inform on Namespaces.
 			if err := informOnResource(s.clients, k8s.NamespacesResource(), eventHandler, mgr.GetCache()); err != nil {
 				s.log.WithError(err).WithField("resource", k8s.NamespacesResource()).Fatal("failed to create informer")

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -55,6 +55,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencepolicies
   - tcproutes
   - tlsroutes
   - udproutes

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4856,6 +4856,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencepolicies
   - tcproutes
   - tlsroutes
   - udproutes

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4853,6 +4853,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencepolicies
   - tcproutes
   - tlsroutes
   - udproutes

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1383,6 +1383,150 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
+		"HTTPRoute references a backend in a different namespace, no ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1alpha2.BackendRef{
+									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+										Port:      gatewayapi.PortNumPtr(8080),
+									},
+									Weight: pointer.Int32(1),
+								},
+							}},
+						}},
+					},
+				},
+			},
+			want: listeners(&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+				),
+			}),
+		},
+		"HTTPRoute references a backend in a different namespace, with valid ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1alpha2.BackendRef{
+									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+										Port:      gatewayapi.PortNumPtr(8080),
+									},
+									Weight: pointer.Int32(1),
+								},
+							}},
+						}},
+					},
+				},
+				&gatewayapi_v1alpha2.ReferencePolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: kuardService.Namespace,
+					},
+					Spec: gatewayapi_v1alpha2.ReferencePolicySpec{
+						From: []gatewayapi_v1alpha2.ReferencePolicyFrom{{
+							Group:     gatewayapi_v1alpha2.GroupName,
+							Kind:      "HTTPRoute",
+							Namespace: "default",
+						}},
+						To: []gatewayapi_v1alpha2.ReferencePolicyTo{{
+							Kind: "Service",
+						}},
+					},
+				},
+			},
+			want: listeners(&Listener{
+				Port:         80,
+				VirtualHosts: virtualhosts(virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService)))),
+			}),
+		},
+		"HTTPRoute references a backend in a different namespace, with invalid ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1alpha2.BackendRef{
+									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+										Port:      gatewayapi.PortNumPtr(8080),
+									},
+									Weight: pointer.Int32(1),
+								},
+							}},
+						}},
+					},
+				},
+				&gatewayapi_v1alpha2.ReferencePolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: kuardService.Namespace,
+					},
+					Spec: gatewayapi_v1alpha2.ReferencePolicySpec{
+						From: []gatewayapi_v1alpha2.ReferencePolicyFrom{{
+							Group:     gatewayapi_v1alpha2.GroupName,
+							Kind:      "HTTPRoute",
+							Namespace: "some-other-namespace", // would need to be "default" to be valid
+						}},
+						To: []gatewayapi_v1alpha2.ReferencePolicyTo{{
+							Kind: "Service",
+						}},
+					},
+				},
+			},
+			want: listeners(&Listener{
+				Port: 80,
+				VirtualHosts: virtualhosts(
+					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+				),
+			}),
+		},
 		"insert basic single route with exact path match": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
@@ -2568,6 +2712,142 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					),
 				},
 			),
+		},
+		"TLSRoute references a backend in a different namespace, no ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayTLSPassthroughAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
+						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
+							BackendRefs: gatewayapi.TLSRouteBackendRef("kuard", 8080, nil),
+						}},
+					},
+				},
+			},
+			want: listeners(),
+		},
+		"TLSRoute references a backend in a different namespace, with valid ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayTLSPassthroughAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
+						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
+							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+										Port:      gatewayapi.PortNumPtr(8080),
+									},
+									Weight: pointer.Int32(1),
+								},
+							},
+						}},
+					},
+				},
+				&gatewayapi_v1alpha2.ReferencePolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: kuardService.Namespace,
+					},
+					Spec: gatewayapi_v1alpha2.ReferencePolicySpec{
+						From: []gatewayapi_v1alpha2.ReferencePolicyFrom{{
+							Group:     gatewayapi_v1alpha2.GroupName,
+							Kind:      "TLSRoute",
+							Namespace: "default",
+						}},
+						To: []gatewayapi_v1alpha2.ReferencePolicyTo{{
+							Kind: "Service",
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					VirtualHosts: virtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name:         "tcp.projectcontour.io",
+								ListenerName: "ingress_https",
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clustersWeight(service(kuardService)),
+							},
+						},
+					),
+				},
+			),
+		},
+		"TLSRoute references a backend in a different namespace, with invalid ReferencePolicy": {
+			gatewayclass: validClass,
+			gateway:      gatewayTLSPassthroughAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1alpha2.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentRef{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
+						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
+							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+										Port:      gatewayapi.PortNumPtr(8080),
+									},
+									Weight: pointer.Int32(1),
+								},
+							},
+						}},
+					},
+				},
+				&gatewayapi_v1alpha2.ReferencePolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: kuardService.Namespace,
+					},
+					Spec: gatewayapi_v1alpha2.ReferencePolicySpec{
+						From: []gatewayapi_v1alpha2.ReferencePolicyFrom{{
+							Group:     gatewayapi_v1alpha2.GroupName,
+							Kind:      "HTTPRoute", // would need to be TLSRoute to be valid
+							Namespace: "default",
+						}},
+						To: []gatewayapi_v1alpha2.ReferencePolicyTo{{
+							Kind: "Service",
+						}},
+					},
+				},
+			},
+			want: listeners(),
 		},
 		"TLSRoute with multiple SNIs": {
 			gatewayclass: validClass,
@@ -11173,49 +11453,6 @@ func directResponseRouteService(prefix string, statusCode uint32, first *Service
 		Clusters:           clustersWeight(services...),
 	}
 }
-
-// func gatewayapi.HTTPRouteMatch(pathType gatewayapi_v1alpha2.PathMatchType, value string) []gatewayapi_v1alpha2.HTTPRouteMatch {
-// 	return []gatewayapi_v1alpha2.HTTPRouteMatch{{
-// 		Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-// 			Type:  gatewayapi.PathMatchTypePtr(pathType),
-// 			Value: pointer.StringPtr(value),
-// 		},
-// 	}}
-// }
-
-// func httpRouteForwards(forwards ...[]gatewayapi_v1alpha2.HTTPRouteForwardTo) []gatewayapi_v1alpha2.HTTPRouteForwardTo {
-// 	var fwds []gatewayapi_v1alpha2.HTTPRouteForwardTo
-
-// 	for _, f := range forwards {
-// 		fwds = append(fwds, f...)
-// 	}
-// 	return fwds
-// }
-
-// func gatewayapi.HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1alpha2.HTTPRouteForwardTo {
-// 	return []gatewayapi_v1alpha2.HTTPRouteForwardTo{{
-// 		ServiceName: pointer.StringPtr(serviceName),
-// 		Port:        gatewayPort(port),
-// 		Weight:      pointer.Int32Ptr(weight),
-// 	}}
-// }
-
-// func gatewayapi.TCPRouteBackendRefs(forwards ...[]gatewayapi_v1alpha2.RouteForwardTo) []gatewayapi_v1alpha2.RouteForwardTo {
-// 	var fwds []gatewayapi_v1alpha2.RouteForwardTo
-
-// 	for _, f := range forwards {
-// 		fwds = append(fwds, f...)
-// 	}
-// 	return fwds
-// }
-
-// func gatewayapi.TCPRouteBackendRef(serviceName string, port int, weight *int32) []gatewayapi_v1alpha2.RouteForwardTo {
-// 	return []gatewayapi_v1alpha2.RouteForwardTo{{
-// 		ServiceName: pointer.StringPtr(serviceName),
-// 		Port:        gatewayPort(port),
-// 		Weight:      weight,
-// 	}}
-// }
 
 func prefixroute(prefix string, first *Service, rest ...*Service) *Route {
 	services := append([]*Service{first}, rest...)

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -60,6 +60,7 @@ type KubernetesCache struct {
 	gateway                   *gatewayapi_v1alpha2.Gateway
 	httproutes                map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute
 	tlsroutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute
+	referencepolicies         map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy
 	extensions                map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
@@ -76,6 +77,7 @@ func (kc *KubernetesCache) init() {
 	kc.services = make(map[types.NamespacedName]*v1.Service)
 	kc.namespaces = make(map[string]*v1.Namespace)
 	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute)
+	kc.referencepolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
@@ -196,6 +198,9 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *gatewayapi_v1alpha2.TLSRoute:
 		kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
+	case *gatewayapi_v1alpha2.ReferencePolicy:
+		kc.referencepolicies[k8s.NamespacedNameOf(obj)] = obj
+		return true
 	case *contour_api_v1alpha1.ExtensionService:
 		kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 		return true
@@ -275,6 +280,11 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.tlsroutes[m]
 		delete(kc.tlsroutes, m)
+		return ok
+	case *gatewayapi_v1alpha2.ReferencePolicy:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.referencepolicies[m]
+		delete(kc.referencepolicies, m)
 		return ok
 	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -874,6 +874,15 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert gateway-api ReferencePolicy": {
+			obj: &gatewayapi_v1alpha2.ReferencePolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "referencepolicy-1",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
 		"insert extension service": {
 			obj: &contour_api_v1alpha1.ExtensionService{
 				ObjectMeta: fixture.ObjectMeta("default/extension"),
@@ -1142,6 +1151,21 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &gatewayapi_v1alpha2.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tlsroute",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove gateway-api ReferencePolicy": {
+			cache: cache(&gatewayapi_v1alpha2.ReferencePolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "referencepolicy",
+					Namespace: "default",
+				},
+			}),
+			obj: &gatewayapi_v1alpha2.ReferencePolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "referencepolicy",
 					Namespace: "default",
 				},
 			},

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/projectcontour/contour/internal/errors"
-	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/status"
 
@@ -750,7 +749,7 @@ func (p *GatewayAPIProcessor) validateBackendRef(backendRef gatewayapi_v1alpha2.
 			// is being referenced.
 			var toAllowed bool
 			for _, to := range referencePolicy.Spec.To {
-				if (to.Group == "" || to.Group == "core") && to.Kind == "Service" && (to.Name == nil || to.Name == gatewayapi.ObjectNamePtr("") || to.Name == &backendRef.Name) {
+				if (to.Group == "" || to.Group == "core") && to.Kind == "Service" && (to.Name == nil || *to.Name == "" || *to.Name == backendRef.Name) {
 					toAllowed = true
 					break
 				}

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/projectcontour/contour/internal/errors"
+	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/status"
 
@@ -501,7 +502,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 
 		for _, backendRef := range rule.BackendRefs {
 
-			service, err := p.validateBackendRef(backendRef, route.Namespace)
+			service, err := p.validateBackendRef(backendRef, KindTLSRoute, route.Namespace)
 			if err != nil {
 				routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
 				continue
@@ -704,7 +705,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 
 // validateBackendRef verifies that the specified BackendRef is valid.
 // Returns an error if not or the service found in the cache.
-func (p *GatewayAPIProcessor) validateBackendRef(backendRef gatewayapi_v1alpha2.BackendRef, routeNamespace string) (*Service, error) {
+func (p *GatewayAPIProcessor) validateBackendRef(backendRef gatewayapi_v1alpha2.BackendRef, routeKind, routeNamespace string) (*Service, error) {
 	if !(backendRef.Group == nil || *backendRef.Group == "" || *backendRef.Group == "core") {
 		return nil, fmt.Errorf("Spec.Rules.BackendRef.Group must be empty or 'core'")
 	}
@@ -721,13 +722,58 @@ func (p *GatewayAPIProcessor) validateBackendRef(backendRef gatewayapi_v1alpha2.
 		return nil, fmt.Errorf("Spec.Rules.BackendRef.Port must be specified")
 	}
 
+	// If the backend is in a different namespace than the route, then we need to
+	// check for a ReferencePolicy that allows the reference.
 	if backendRef.Namespace != nil && string(*backendRef.Namespace) != routeNamespace {
-		// we haven't implemented ReferencePolicy yet, so disallow any
-		// cross-namespace reference.
-		return nil, fmt.Errorf("Spec.Rules.BackendRef.Namespace must match the route's namespace")
+		var allowed bool
+		for _, referencePolicy := range p.source.referencepolicies {
+			// The ReferencePolicy must be defined in the namespace of
+			// the "referent" (i.e. the Service).
+			if referencePolicy.Namespace != string(*backendRef.Namespace) {
+				continue
+			}
+
+			// "From" must contain an entry matching the route that is
+			// referencing the service.
+			var fromAllowed bool
+			for _, from := range referencePolicy.Spec.From {
+				if from.Namespace == gatewayapi_v1alpha2.Namespace(routeNamespace) && from.Group == gatewayapi_v1alpha2.GroupName && from.Kind == gatewayapi_v1alpha2.Kind(routeKind) {
+					fromAllowed = true
+					break
+				}
+			}
+			if !fromAllowed {
+				continue
+			}
+
+			// "To" must contain an entry matching the Service that
+			// is being referenced.
+			var toAllowed bool
+			for _, to := range referencePolicy.Spec.To {
+				if (to.Group == "" || to.Group == "core") && to.Kind == "Service" && (to.Name == nil || to.Name == gatewayapi.ObjectNamePtr("") || to.Name == &backendRef.Name) {
+					toAllowed = true
+					break
+				}
+			}
+			if !toAllowed {
+				continue
+			}
+
+			allowed = true
+			break
+		}
+
+		if !allowed {
+			return nil, fmt.Errorf("Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy")
+		}
 	}
 
-	meta := types.NamespacedName{Name: string(backendRef.Name), Namespace: routeNamespace}
+	var meta types.NamespacedName
+	if backendRef.Namespace != nil {
+		meta = types.NamespacedName{Name: string(backendRef.Name), Namespace: string(*backendRef.Namespace)}
+	} else {
+		meta = types.NamespacedName{Name: string(backendRef.Name), Namespace: routeNamespace}
+	}
 
 	// TODO: Refactor EnsureService to take an int32 so conversion to intstr is not needed.
 	service, err := p.dag.EnsureService(meta, intstr.FromInt(int(*backendRef.Port)), p.source, p.EnableExternalNameService)
@@ -797,7 +843,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 	// Validate the backend refs.
 	totalWeight := uint32(0)
 	for _, backendRef := range backendRefs {
-		service, err := p.validateBackendRef(backendRef.BackendRef, routeNamespace)
+		service, err := p.validateBackendRef(backendRef.BackendRef, KindHTTPRoute, routeNamespace)
 		if err != nil {
 			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
 			continue

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3247,7 +3247,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
-					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace",
+					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy",
 				},
 				gatewayapi_v1alpha2.ConditionRouteAccepted: {
 					Type:    string(gatewayapi_v1alpha2.ConditionRouteAccepted),

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -106,6 +106,11 @@ func NamespacePtr(namespace string) *gatewayapi_v1alpha2.Namespace {
 	return &gwNamespace
 }
 
+func ObjectNamePtr(name string) *gatewayapi_v1alpha2.ObjectName {
+	objectName := gatewayapi_v1alpha2.ObjectName(name)
+	return &objectName
+}
+
 func ServiceBackendObjectRef(name string, port int) gatewayapi_v1alpha2.BackendObjectReference {
 	return gatewayapi_v1alpha2.BackendObjectReference{
 		Group: GroupPtr(""),

--- a/internal/k8s/informers.go
+++ b/internal/k8s/informers.go
@@ -47,7 +47,7 @@ func DefaultResources() []schema.GroupVersionResource {
 	}
 }
 
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;tcproutes;udproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;tcproutes;udproutes;referencepolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;tcproutes/status;udproutes/status,verbs=update
 
 // GatewayAPIResources returns a list of Gateway API group/version resources.
@@ -77,6 +77,14 @@ func GatewayAPIResources() []schema.GroupVersionResource {
 		Version:  gatewayapi_v1alpha2.GroupVersion.Version,
 		Resource: "udproutes",
 	}}
+}
+
+func ReferencePoliciesResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    gatewayapi_v1alpha2.GroupVersion.Group,
+		Version:  gatewayapi_v1alpha2.GroupVersion.Version,
+		Resource: "referencepolicies",
+	}
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch


### PR DESCRIPTION
Implements ReferencePolicy, which enables certain
cross-namespace references to be allowed. This
currently applies only to Route->Service refs.

Closes #4118.

Signed-off-by: Steve Kriss <krisss@vmware.com>