### PR TITLE
Add source ip hashing to RequestHash load balancing

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -799,8 +799,14 @@ type RequestHashPolicy struct {
 	// HeaderHashOptions should be set when request header hash based load
 	// balancing is desired. It must be the only hash option field set,
 	// otherwise this request hash policy object will be ignored.
-	// +kubebuilder:validation:Required
+	// +optional
 	HeaderHashOptions *HeaderHashOptions `json:"headerHashOptions,omitempty"`
+
+	// HashSourceIP should be set to true when request source IP hash based
+	// load balancing is desired. It must be the only hash option field set,
+	// otherwise this request hash policy object will be ignored.
+	// +optional
+	HashSourceIP bool `json:"hashSourceIP,omitempty"`
 }
 
 // LoadBalancerPolicy defines the load balancing policy.

--- a/changelogs/unreleased/4141-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4141-sunjayBhatia-minor.md
@@ -1,0 +1,3 @@
+### Source IP hash based load balancing
+
+Contour users can now configure their load balancing policies on `HTTPProxy` resources to hash the source IP of a client to ensure consistent routing to a backend service instance. Using this feature combined with header value hashing can implement advanced request routing and session affinity. See [this page](https://projectcontour.io/docs/v1.20.0/config/request-routing/#load-balancing-strategy) for more details.

--- a/changelogs/unreleased/4141-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4141-sunjayBhatia-minor.md
@@ -1,3 +1,5 @@
 ### Source IP hash based load balancing
 
-Contour users can now configure their load balancing policies on `HTTPProxy` resources to hash the source IP of a client to ensure consistent routing to a backend service instance. Using this feature combined with header value hashing can implement advanced request routing and session affinity. See [this page](https://projectcontour.io/docs/v1.20.0/config/request-routing/#load-balancing-strategy) for more details.
+Contour users can now configure their load balancing policies on `HTTPProxy` resources to hash the source IP of a client to ensure consistent routing to a backend service instance. Using this feature combined with header value hashing can implement advanced request routing and session affinity. Note that if you are using a load balancer to front your Envoy deployment, you will need to ensure it preserves client source IP addresses to ensure this feature is effective.
+
+See [this page](https://projectcontour.io/docs/v1.20.0/config/request-routing/#load-balancing-strategy) for more details on this feature.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1890,6 +1890,12 @@ spec:
                       description: RequestHashPolicy contains configuration for an
                         individual hash policy on a request attribute.
                       properties:
+                        hashSourceIP:
+                          description: HashSourceIP should be set to true when request
+                            source IP hash based load balancing is desired. It must
+                            be the only hash option field set, otherwise this request
+                            hash policy object will be ignored.
+                          type: boolean
                         headerHashOptions:
                           description: HeaderHashOptions should be set when request
                             header hash based load balancing is desired. It must be
@@ -2565,6 +2571,12 @@ spec:
                             description: RequestHashPolicy contains configuration
                               for an individual hash policy on a request attribute.
                             properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
                               headerHashOptions:
                                 description: HeaderHashOptions should be set when
                                   request header hash based load balancing is desired.
@@ -3269,6 +3281,12 @@ spec:
                           description: RequestHashPolicy contains configuration for
                             an individual hash policy on a request attribute.
                           properties:
+                            hashSourceIP:
+                              description: HashSourceIP should be set to true when
+                                request source IP hash based load balancing is desired.
+                                It must be the only hash option field set, otherwise
+                                this request hash policy object will be ignored.
+                              type: boolean
                             headerHashOptions:
                               description: HeaderHashOptions should be set when request
                                 header hash based load balancing is desired. It must

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -2086,6 +2086,12 @@ spec:
                       description: RequestHashPolicy contains configuration for an
                         individual hash policy on a request attribute.
                       properties:
+                        hashSourceIP:
+                          description: HashSourceIP should be set to true when request
+                            source IP hash based load balancing is desired. It must
+                            be the only hash option field set, otherwise this request
+                            hash policy object will be ignored.
+                          type: boolean
                         headerHashOptions:
                           description: HeaderHashOptions should be set when request
                             header hash based load balancing is desired. It must be
@@ -2761,6 +2767,12 @@ spec:
                             description: RequestHashPolicy contains configuration
                               for an individual hash policy on a request attribute.
                             properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
                               headerHashOptions:
                                 description: HeaderHashOptions should be set when
                                   request header hash based load balancing is desired.
@@ -3465,6 +3477,12 @@ spec:
                           description: RequestHashPolicy contains configuration for
                             an individual hash policy on a request attribute.
                           properties:
+                            hashSourceIP:
+                              description: HashSourceIP should be set to true when
+                                request source IP hash based load balancing is desired.
+                                It must be the only hash option field set, otherwise
+                                this request hash policy object will be ignored.
+                              type: boolean
                             headerHashOptions:
                               description: HeaderHashOptions should be set when request
                                 header hash based load balancing is desired. It must

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -2083,6 +2083,12 @@ spec:
                       description: RequestHashPolicy contains configuration for an
                         individual hash policy on a request attribute.
                       properties:
+                        hashSourceIP:
+                          description: HashSourceIP should be set to true when request
+                            source IP hash based load balancing is desired. It must
+                            be the only hash option field set, otherwise this request
+                            hash policy object will be ignored.
+                          type: boolean
                         headerHashOptions:
                           description: HeaderHashOptions should be set when request
                             header hash based load balancing is desired. It must be
@@ -2758,6 +2764,12 @@ spec:
                             description: RequestHashPolicy contains configuration
                               for an individual hash policy on a request attribute.
                             properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
                               headerHashOptions:
                                 description: HeaderHashOptions should be set when
                                   request header hash based load balancing is desired.
@@ -3462,6 +3474,12 @@ spec:
                           description: RequestHashPolicy contains configuration for
                             an individual hash policy on a request attribute.
                           properties:
+                            hashSourceIP:
+                              description: HashSourceIP should be set to true when
+                                request source IP hash based load balancing is desired.
+                                It must be the only hash option field set, otherwise
+                                this request hash policy object will be ignored.
+                              type: boolean
                             headerHashOptions:
                               description: HeaderHashOptions should be set when request
                                 header hash based load balancing is desired. It must

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -370,6 +370,9 @@ type RequestHashPolicy struct {
 
 	// CookieHashOptions is set when a cookie hash is desired.
 	CookieHashOptions *CookieHashOptions
+
+	// HashSourceIP is set to true when source ip hashing is desired.
+	HashSourceIP bool
 }
 
 // GlobalRateLimitPolicy holds global rate limiting parameters.

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -191,6 +191,13 @@ func hashPolicy(requestHashPolicies []dag.RequestHashPolicy) []*envoy_route_v3.R
 				},
 			}
 		}
+		if rhp.HashSourceIP {
+			newHP.PolicySpecifier = &envoy_route_v3.RouteAction_HashPolicy_ConnectionProperties_{
+				ConnectionProperties: &envoy_route_v3.RouteAction_HashPolicy_ConnectionProperties{
+					SourceIp: true,
+				},
+			}
+		}
 		hashPolicies = append(hashPolicies, newHP)
 	}
 	return hashPolicies

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -491,6 +491,44 @@ func TestRouteRoute(t *testing.T) {
 				},
 			},
 		},
+		"single service w/ request source ip hashing": {
+			route: &dag.Route{
+				Clusters: []*dag.Cluster{c3},
+				RequestHashPolicies: []dag.RequestHashPolicy{
+					{
+						HashSourceIP: true,
+					},
+					{
+						HeaderHashOptions: &dag.HeaderHashOptions{
+							HeaderName: "User-Agent",
+						},
+					},
+				},
+			},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/1a2ffc1fef",
+					},
+					HashPolicy: []*envoy_route_v3.RouteAction_HashPolicy{
+						{
+							PolicySpecifier: &envoy_route_v3.RouteAction_HashPolicy_ConnectionProperties_{
+								ConnectionProperties: &envoy_route_v3.RouteAction_HashPolicy_ConnectionProperties{
+									SourceIp: true,
+								},
+							},
+						},
+						{
+							PolicySpecifier: &envoy_route_v3.RouteAction_HashPolicy_Header_{
+								Header: &envoy_route_v3.RouteAction_HashPolicy_Header{
+									HeaderName: "User-Agent",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"host header rewrite": {
 			route: &dag.Route{
 				RequestHeadersPolicy: &dag.HeadersPolicy{

--- a/internal/featuretests/v3/loadbalancerpolicy_test.go
+++ b/internal/featuretests/v3/loadbalancerpolicy_test.go
@@ -212,10 +212,80 @@ func TestLoadBalancerPolicyRequestHashHeader(t *testing.T) {
 				envoy_v3.VirtualHost("www.example.com",
 					&envoy_route_v3.Route{
 						Match: routePrefix("/cart"),
-						Action: withRequestHashPolicyHeader(
+						Action: withRequestHashPolicySpecifiers(
 							routeCluster("default/app/80/1a2ffc1fef"),
-							headerTerminalPair{"X-Some-Header", true},
-							headerTerminalPair{"X-Some-Other-Header", false},
+							hashPolicySpecifier{headerName: "X-Some-Header", terminal: true},
+							hashPolicySpecifier{headerName: "X-Some-Other-Header"},
+						),
+					},
+				),
+			),
+		),
+		TypeUrl: routeType,
+	})
+}
+
+func TestLoadBalancerPolicyRequestHashSourceIP(t *testing.T) {
+	rh, c, done := setup(t)
+	defer done()
+
+	s1 := fixture.NewService("app").WithPorts(
+		v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
+		v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
+	rh.OnAdd(s1)
+
+	proxy1 := fixture.NewProxy("simple").
+		WithFQDN("www.example.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Conditions: matchconditions(prefixMatchCondition("/cart")),
+				LoadBalancerPolicy: &contour_api_v1.LoadBalancerPolicy{
+					Strategy: "RequestHash",
+					RequestHashPolicies: []contour_api_v1.RequestHashPolicy{
+						{
+							HeaderHashOptions: &contour_api_v1.HeaderHashOptions{
+								HeaderName: "X-Some-Header",
+							},
+						},
+						{
+							HashSourceIP: true,
+						},
+					},
+				},
+				Services: []contour_api_v1.Service{{
+					Name: s1.Name,
+					Port: 80,
+				}},
+			}},
+		})
+	rh.OnAdd(proxy1)
+
+	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			DefaultCluster(&envoy_cluster_v3.Cluster{
+				Name:                 s1.Namespace + "/" + s1.Name + "/80/1a2ffc1fef",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					ServiceName: s1.Namespace + "/" + s1.Name,
+				},
+				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
+			}),
+		),
+		TypeUrl: clusterType,
+	})
+
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost("www.example.com",
+					&envoy_route_v3.Route{
+						Match: routePrefix("/cart"),
+						Action: withRequestHashPolicySpecifiers(
+							routeCluster("default/app/80/1a2ffc1fef"),
+							hashPolicySpecifier{headerName: "X-Some-Header"},
+							hashPolicySpecifier{hashSourceIP: true},
 						),
 					},
 				),

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2123,8 +2123,24 @@ HeaderHashOptions
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>HeaderHashOptions should be set when request header hash based load
 balancing is desired. It must be the only hash option field set,
+otherwise this request hash policy object will be ignored.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>hashSourceIP</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HashSourceIP should be set to true when request source IP hash based
+load balancing is desired. It must be the only hash option field set,
 otherwise this request hash policy object will be ignored.</p>
 </td>
 </tr>

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -228,7 +228,7 @@ The following list are the options available to choose from:
 - `RoundRobin`: Each healthy upstream Endpoint is selected in round robin order (Default strategy if none selected).
 - `WeightedLeastRequest`:  The least request load balancer uses different algorithms depending on whether hosts have the same or different weights in an attempt to route traffic based upon the number of active requests or the load at the time of selection. 
 - `Random`: The random strategy selects a random healthy Endpoints.
-- `RequestHash`: The request hashing strategy allows for load balancing based on request attributes. An upstream Endpoint is selected based on the hash of an element of a request. Requests that contain a consistent value in a HTTP request header for example will be routed to the same upstream Endpoint. Currently only hashing of HTTP request headers is supported.
+- `RequestHash`: The request hashing strategy allows for load balancing based on request attributes. An upstream Endpoint is selected based on the hash of an element of a request. For example, requests that contain a consistent value in a HTTP request header will be routed to the same upstream Endpoint. Currently only hashing of HTTP request headers and the source IP of a request is supported.
 - `Cookie`: The cookie load balancing strategy is similar to the request hash strategy and is a convenience feature to implement session affinity, as described below.
 
 More information on the load balancing strategy can be found in [Envoy's documentation][7].
@@ -257,7 +257,7 @@ spec:
         strategy: WeightedLeastRequest
 ```
 
-The below example demonstrates how header hash load balancing policies can be configured:
+The below example demonstrates how request hash load balancing policies can be configured:
 
 ```yaml
 # httpproxy-lb-request-hash.yaml
@@ -283,9 +283,10 @@ spec:
         terminal: true
       - headerHashOptions:
           headerName: User-Agent
+      - hashSourceIP: true
 ```
 
-In this example, if a client request contains the `X-Some-Header` header, the value of the header will be hashed and used to route to an upstream Endpoint. This could be used to implement a similar workflow to cookie-based session affinity by passing a consistent value for this header. If it is present, because it is set as a `terminal` hash option, Envoy will not continue on to process to `User-Agent` header to calculate a hash. If `X-Some-Header` is not present, Envoy will use the `User-Agent` header value to make a routing decision.
+In this example, if a client request contains the `X-Some-Header` header, the value of the header will be hashed and used to route to an upstream Endpoint. This could be used to implement a similar workflow to cookie-based session affinity by passing a consistent value for this header. If it is present, because it is set as a `terminal` hash option, Envoy will not continue on to process to `User-Agent` header or source IP to calculate a hash. If `X-Some-Header` is not present, Envoy will use the `User-Agent` header value to make a routing decision along with the source IP of the client making the request. These policies can be used alone or as shown for an advanced routing decision.
 
 ## Session Affinity
 


### PR DESCRIPTION
- must specify exactly one of header hashing policy or source ip hashing
in a list element (otherwise ignored and warning generated)
- cant specify to hash source ip multiple times (otherwise ignored and
warning generated)

Fixes: #3703