### PR TITLE
Gateway API: set TCPRoute and UDPRoute status

### DIFF
--- a/changelogs/unreleased/4143-skriss-small.md
+++ b/changelogs/unreleased/4143-skriss-small.md
@@ -1,0 +1,1 @@
+Set an "Accepted: false" condition on TCPRoutes and UDPRoutes that reference a Contour-controller Gateway since Contour does not support these Gateway API route types.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -701,14 +701,34 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 				s.log.WithError(err).Fatal("failed to create gateway-controller")
 			}
 
-			// Create and register the NewHTTPRouteController controller with the manager.
+			// Create and register the HTTPRoute controller with the manager.
 			if _, err := controller.NewHTTPRouteController(mgr, eventHandler, s.log.WithField("context", "httproute-controller")); err != nil {
 				s.log.WithError(err).Fatal("failed to create httproute-controller")
 			}
 
-			// Create and register the NewTLSRouteController controller with the manager.
+			// Create and register the TLSRoute controller with the manager.
 			if _, err := controller.NewTLSRouteController(mgr, eventHandler, s.log.WithField("context", "tlsroute-controller")); err != nil {
 				s.log.WithError(err).Fatal("failed to create tlsroute-controller")
+			}
+
+			// Create and register the TCPRoute controller with the manager.
+			if _, err := controller.NewTCPRouteController(
+				mgr,
+				sh.Writer(),
+				gatewayClassControllerName,
+				s.log.WithField("context", "tcproute-controller"),
+			); err != nil {
+				s.log.WithError(err).Fatal("failed to create tcproute-controller")
+			}
+
+			// Create and register the UDPRoute controller with the manager.
+			if _, err := controller.NewUDPRouteController(
+				mgr,
+				sh.Writer(),
+				gatewayClassControllerName,
+				s.log.WithField("context", "udproute-controller"),
+			); err != nil {
+				s.log.WithError(err).Fatal("failed to create udproute-controller")
 			}
 
 			// Inform on Namespaces.

--- a/internal/controller/gateway.go
+++ b/internal/controller/gateway.go
@@ -155,37 +155,7 @@ func (r *gatewayReconciler) hasMatchingController(obj client.Object) bool {
 		"name":      obj.GetName(),
 	})
 
-	gw, ok := obj.(*gatewayapi_v1alpha2.Gateway)
-	if !ok {
-		log.Debugf("unexpected object type %T, bypassing reconciliation.", obj)
-		return false
-	}
-
-	matches, err := r.hasContourOwnedClass(gw)
-	if err != nil {
-		log.Error(err)
-		return false
-	}
-	if matches {
-		log.Debug("enqueueing gateway")
-		return true
-	}
-
-	log.Debugf("gateway's class controller is not %s; bypassing reconciliation", r.gatewayClassControllerName)
-	return false
-}
-
-// hasContourOwnedClass returns true if the class referenced by gateway exists
-// and matches the configured controllerName.
-func (r *gatewayReconciler) hasContourOwnedClass(gw *gatewayapi_v1alpha2.Gateway) (bool, error) {
-	gc := &gatewayapi_v1alpha2.GatewayClass{}
-	if err := r.client.Get(r.ctx, types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}, gc); err != nil {
-		return false, fmt.Errorf("failed to get gatewayclass %s: %w", gw.Spec.GatewayClassName, err)
-	}
-	if gc.Spec.ControllerName != r.gatewayClassControllerName {
-		return false, nil
-	}
-	return true, nil
+	return gatewayHasMatchingController(obj, r.gatewayClassControllerName, r.client, log)
 }
 
 func (r *gatewayReconciler) gatewayClassHasMatchingController(obj client.Object) bool {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -1,0 +1,154 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// setRouteCondition sets a condition on a Gateway API route
+// for a given gateway & controller. It performs an upsert,
+// updating the existing condition (if there has been a change),
+// otherwise adding a new condition.
+func setRouteCondition(
+	routeParentStatuses []gatewayapi_v1alpha2.RouteParentStatus,
+	condition metav1.Condition,
+	gateway *gatewayapi_v1alpha2.Gateway,
+	controllerName gatewayapi_v1alpha2.GatewayController,
+) []gatewayapi_v1alpha2.RouteParentStatus {
+	// Look for a RouteParentStatus for the relevant Gateway.
+	for _, parentStatus := range routeParentStatuses {
+		if !isRefToGateway(parentStatus.ParentRef, k8s.NamespacedNameOf(gateway)) {
+			continue
+		}
+
+		for i := range parentStatus.Conditions {
+			cond := &parentStatus.Conditions[i]
+
+			if cond.Type != condition.Type {
+				continue
+			}
+
+			// Update only if something has changed.
+			if cond.Status != condition.Status || cond.Reason != condition.Reason || cond.Message != condition.Message {
+				cond.Status = condition.Status
+				cond.Reason = condition.Reason
+				cond.Message = condition.Message
+				cond.LastTransitionTime = condition.LastTransitionTime
+				cond.ObservedGeneration = condition.ObservedGeneration
+			}
+
+			return routeParentStatuses
+		}
+
+		// condition of type "Accepted" does not already exist for the parent:
+		// append it.
+		parentStatus.Conditions = append(parentStatus.Conditions, condition)
+		return routeParentStatuses
+	}
+
+	// RouteParentStatus for the Gateway does not already exist: add it.
+	routeParentStatuses = append(routeParentStatuses, gatewayapi_v1alpha2.RouteParentStatus{
+		ParentRef:      gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+		ControllerName: controllerName,
+		Conditions:     []metav1.Condition{condition},
+	})
+
+	return routeParentStatuses
+}
+
+// isRefToGateway returns whether the given ref refers to a Gateway with the
+// specified name and namespace.
+func isRefToGateway(ref gatewayapi_v1alpha2.ParentRef, gateway types.NamespacedName) bool {
+	return ref.Group != nil && *ref.Group == gatewayapi_v1alpha2.GroupName &&
+		ref.Kind != nil && *ref.Kind == "Gateway" &&
+		ref.Namespace != nil && *ref.Namespace == gatewayapi_v1alpha2.Namespace(gateway.Namespace) &&
+		string(ref.Name) == gateway.Name
+}
+
+// referencesContourGateway returns whether a given list of
+// ParentRefs references a Gateway controlled by this Contour.
+func referencesContourGateway(
+	parentRefs []gatewayapi_v1alpha2.ParentRef,
+	routeNamespace string,
+	controllerName gatewayapi_v1alpha2.GatewayController,
+	kubeClient client.Client,
+	log logrus.FieldLogger,
+) (bool, *gatewayapi_v1alpha2.Gateway) {
+	for _, parentRef := range parentRefs {
+		if !(parentRef.Group == nil || string(*parentRef.Group) == "" || string(*parentRef.Group) == gatewayapi_v1alpha2.GroupName) {
+			continue
+		}
+		if !(parentRef.Kind == nil || string(*parentRef.Kind) == "" || string(*parentRef.Kind) == "Gateway") {
+			continue
+		}
+
+		key := client.ObjectKey{
+			Namespace: routeNamespace,
+			Name:      string(parentRef.Name),
+		}
+		if parentRef.Namespace != nil {
+			key.Namespace = string(*parentRef.Namespace)
+		}
+
+		gateway := &gatewayapi_v1alpha2.Gateway{}
+		if err := kubeClient.Get(context.Background(), key, gateway); err != nil {
+			log.WithError(err).Error("error getting gateway")
+			continue
+		}
+
+		gatewayClass := &gatewayapi_v1alpha2.GatewayClass{}
+		if err := kubeClient.Get(context.Background(), client.ObjectKey{Name: string(gateway.Spec.GatewayClassName)}, gatewayClass); err != nil {
+			log.WithError(err).Error("error getting gatewayclass")
+			continue
+		}
+
+		if gatewayClass.Spec.ControllerName == controllerName {
+			return true, gateway
+		}
+	}
+
+	return false, nil
+}
+
+// gatewayHasMatchingController returns true if the provided Gateway
+// uses a GatewayClass with a Spec.Controller string matching this Contour's
+// controller string, or false otherwise.
+func gatewayHasMatchingController(obj client.Object, controllerName gatewayapi_v1alpha2.GatewayController, kubeClient client.Client, log logrus.FieldLogger) bool {
+	gw, ok := obj.(*gatewayapi_v1alpha2.Gateway)
+	if !ok {
+		log.Debugf("unexpected object type %T, bypassing reconciliation.", obj)
+		return false
+	}
+
+	gc := &gatewayapi_v1alpha2.GatewayClass{}
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}, gc); err != nil {
+		log.WithError(err).Errorf("failed to get gatewayclass %s", gw.Spec.GatewayClassName)
+		return false
+	}
+	if gc.Spec.ControllerName != controllerName {
+		log.Debugf("gateway's class controller is not %s; bypassing reconciliation", controllerName)
+		return false
+	}
+
+	return true
+}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -85,15 +85,16 @@ func isRefToGateway(ref gatewayapi_v1alpha2.ParentRef, gateway types.NamespacedN
 		string(ref.Name) == gateway.Name
 }
 
-// referencesContourGateway returns whether a given list of
-// ParentRefs references a Gateway controlled by this Contour.
+// referencesContourGateway returns the first Gateway from the
+// given list of ParentRefs that matches this Contour's GatewayClass
+// controller, if one exists.
 func referencesContourGateway(
 	parentRefs []gatewayapi_v1alpha2.ParentRef,
 	routeNamespace string,
 	controllerName gatewayapi_v1alpha2.GatewayController,
 	kubeClient client.Client,
 	log logrus.FieldLogger,
-) (bool, *gatewayapi_v1alpha2.Gateway) {
+) (*gatewayapi_v1alpha2.Gateway, bool) {
 	for _, parentRef := range parentRefs {
 		if !(parentRef.Group == nil || string(*parentRef.Group) == "" || string(*parentRef.Group) == gatewayapi_v1alpha2.GroupName) {
 			continue
@@ -123,11 +124,11 @@ func referencesContourGateway(
 		}
 
 		if gatewayClass.Spec.ControllerName == controllerName {
-			return true, gateway
+			return gateway, true
 		}
 	}
 
-	return false, nil
+	return nil, false
 }
 
 // gatewayHasMatchingController returns true if the provided Gateway

--- a/internal/controller/tcproute.go
+++ b/internal/controller/tcproute.go
@@ -1,0 +1,215 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var tcpRouteGVR = schema.GroupVersionResource{
+	Group:    gatewayapi_v1alpha2.GroupVersion.Group,
+	Version:  gatewayapi_v1alpha2.GroupVersion.Version,
+	Resource: "tcproutes",
+}
+
+type tcpRouteReconciler struct {
+	client                     client.Client
+	statusUpdater              k8s.StatusUpdater
+	gatewayClassControllerName gatewayapi_v1alpha2.GatewayController
+	log                        logrus.FieldLogger
+}
+
+// NewTCPRouteController creates the tcproute controller from mgr. The controller will be pre-configured
+// to watch for TCPRoute objects across all namespaces.
+func NewTCPRouteController(
+	mgr manager.Manager,
+	statusUpdater k8s.StatusUpdater,
+	gatewayClassControllerName string,
+	log logrus.FieldLogger) (controller.Controller, error) {
+	r := &tcpRouteReconciler{
+		client:                     mgr.GetClient(),
+		statusUpdater:              statusUpdater,
+		gatewayClassControllerName: gatewayapi_v1alpha2.GatewayController(gatewayClassControllerName),
+		log:                        log,
+	}
+	c, err := controller.New("tcproute-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch TCPRoutes to update their status whenever they
+	// change.
+	if err := c.Watch(
+		&source.Kind{Type: &gatewayapi_v1alpha2.TCPRoute{}},
+		&handler.EnqueueRequestForObject{},
+	); err != nil {
+		return nil, err
+	}
+
+	// Watch Gateways to update associated TCPRoutes' status
+	// when Contour-controlled Gateways change. This allows
+	// TCPRoutes' status to be updated properly if their
+	// Gateway is created *after* the TCPRoute itself.
+	if err := c.Watch(
+		&source.Kind{Type: &gatewayapi_v1alpha2.Gateway{}},
+		handler.EnqueueRequestsFromMapFunc(r.mapGatewayToTCPRoutes),
+		predicate.NewPredicateFuncs(r.gatewayHasMatchingController),
+	); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// mapGatewayToTCPRoutes returns a list of reconcile requests for all TCPRoutes
+// that have a parentRef to the provided Gateway.
+func (r *tcpRouteReconciler) mapGatewayToTCPRoutes(gateway client.Object) []reconcile.Request {
+	var tcpRoutes gatewayapi_v1alpha2.TCPRouteList
+	if err := r.client.List(context.Background(), &tcpRoutes); err != nil {
+		r.log.WithError(err).Error("error listing TCPRoutes")
+		return nil
+	}
+
+	var reconciles []reconcile.Request
+	for _, tcpRoute := range tcpRoutes.Items {
+		for _, parentRef := range tcpRoute.Spec.ParentRefs {
+			if isRefToGateway(parentRef, k8s.NamespacedNameOf(gateway)) {
+				reconciles = append(reconciles, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: tcpRoute.Namespace,
+						Name:      tcpRoute.Name,
+					},
+				})
+			}
+		}
+	}
+
+	return reconciles
+}
+
+// hasMatchingController returns true if the provided object is a Gateway
+// using a GatewayClass with a Spec.Controller string matching this Contour's
+// controller string, or false otherwise.
+func (r *tcpRouteReconciler) gatewayHasMatchingController(obj client.Object) bool {
+	log := r.log.WithFields(logrus.Fields{
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	return gatewayHasMatchingController(obj, r.gatewayClassControllerName, r.client, log)
+}
+
+// referencesContourGateway returns whether a given TCPRoute has a parentRef
+// to a Gateway with a GatewayClass controlled by this Contour.
+func (r *tcpRouteReconciler) referencesContourGateway(obj client.Object) (bool, *gatewayapi_v1alpha2.Gateway) {
+	log := r.log.WithFields(logrus.Fields{
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	route, ok := obj.(*gatewayapi_v1alpha2.TCPRoute)
+	if !ok {
+		log.Debugf("unexpected object type %T, bypassing reconciliation.", obj)
+		return false, nil
+	}
+
+	return referencesContourGateway(
+		route.Spec.ParentRefs,
+		route.Namespace,
+		r.gatewayClassControllerName,
+		r.client,
+		log,
+	)
+}
+
+// Reconcile sets "Accepted: false" on any TCPRoutes that have a Gateway
+// controlled by this Contour.
+func (r *tcpRouteReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithField("namespace", request.Namespace).WithField("name", request.Name)
+
+	tcpRoute := &gatewayapi_v1alpha2.TCPRoute{}
+	if err := r.client.Get(ctx, request.NamespacedName, tcpRoute); err != nil {
+		// not-found errors mean the TCPRoute has been deleted, OK
+		// to ignore.
+		if !errors.IsNotFound(err) {
+			log.WithError(err).Error("error getting TCPRoute")
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// Check if the TCPRoute is referencing a Gateway
+	// controlled by this Contour.
+	ok, gw := r.referencesContourGateway(tcpRoute)
+	if !ok {
+		return reconcile.Result{}, nil
+	}
+	log.Info("reconciling TCPRoute")
+
+	// If so, set the TCPRoute's status to indicate it's
+	// an unsupported route type.
+	r.statusUpdater.Send(k8s.StatusUpdate{
+		NamespacedName: k8s.NamespacedNameOf(tcpRoute),
+		Resource:       tcpRouteGVR,
+		Mutator: k8s.StatusMutatorFunc(func(obj interface{}) interface{} {
+			route, ok := obj.(*gatewayapi_v1alpha2.TCPRoute)
+			if !ok {
+				panic(fmt.Sprintf("unsupported object type %T", obj))
+			}
+
+			// Note that the statusUpdater will filter out no-op status updates,
+			// so we don't have to worry here about sending updates that don't
+			// actually change anything and triggering cascading reconciliations.
+			return setTCPRouteNotAccepted(route.DeepCopy(), gw, r.gatewayClassControllerName)
+		}),
+	})
+
+	return reconcile.Result{}, nil
+}
+
+func setTCPRouteNotAccepted(tcpRoute *gatewayapi_v1alpha2.TCPRoute, gateway *gatewayapi_v1alpha2.Gateway, controllerName gatewayapi_v1alpha2.GatewayController) *gatewayapi_v1alpha2.TCPRoute {
+	notAcceptedCondition := metav1.Condition{
+		Type:               string(gatewayapi_v1alpha2.ConditionRouteAccepted),
+		Status:             metav1.ConditionFalse,
+		Reason:             "UnsupportedRouteType",
+		Message:            "TCPRoutes are not supported by this Gateway",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		ObservedGeneration: tcpRoute.Generation,
+	}
+
+	tcpRoute.Status.Parents = setRouteCondition(
+		tcpRoute.Status.Parents,
+		notAcceptedCondition,
+		gateway,
+		controllerName,
+	)
+
+	return tcpRoute
+}

--- a/internal/controller/tcproute.go
+++ b/internal/controller/tcproute.go
@@ -127,9 +127,9 @@ func (r *tcpRouteReconciler) gatewayHasMatchingController(obj client.Object) boo
 	return gatewayHasMatchingController(obj, r.gatewayClassControllerName, r.client, log)
 }
 
-// referencesContourGateway returns whether a given TCPRoute has a parentRef
-// to a Gateway with a GatewayClass controlled by this Contour.
-func (r *tcpRouteReconciler) referencesContourGateway(obj client.Object) (bool, *gatewayapi_v1alpha2.Gateway) {
+// referencesContourGateway returns the first Gateway from the TCPRoute's
+// ParentRefs with a GatewayClass controlled by this Contour, if one exists.
+func (r *tcpRouteReconciler) referencesContourGateway(obj client.Object) (*gatewayapi_v1alpha2.Gateway, bool) {
 	log := r.log.WithFields(logrus.Fields{
 		"namespace": obj.GetNamespace(),
 		"name":      obj.GetName(),
@@ -138,7 +138,7 @@ func (r *tcpRouteReconciler) referencesContourGateway(obj client.Object) (bool, 
 	route, ok := obj.(*gatewayapi_v1alpha2.TCPRoute)
 	if !ok {
 		log.Debugf("unexpected object type %T, bypassing reconciliation.", obj)
-		return false, nil
+		return nil, false
 	}
 
 	return referencesContourGateway(
@@ -167,7 +167,7 @@ func (r *tcpRouteReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 	// Check if the TCPRoute is referencing a Gateway
 	// controlled by this Contour.
-	ok, gw := r.referencesContourGateway(tcpRoute)
+	gw, ok := r.referencesContourGateway(tcpRoute)
 	if !ok {
 		return reconcile.Result{}, nil
 	}

--- a/internal/controller/udproute.go
+++ b/internal/controller/udproute.go
@@ -1,0 +1,215 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+var udpRouteGVR = schema.GroupVersionResource{
+	Group:    gatewayapi_v1alpha2.GroupVersion.Group,
+	Version:  gatewayapi_v1alpha2.GroupVersion.Version,
+	Resource: "udproutes",
+}
+
+type udpRouteReconciler struct {
+	client                     client.Client
+	statusUpdater              k8s.StatusUpdater
+	gatewayClassControllerName gatewayapi_v1alpha2.GatewayController
+	log                        logrus.FieldLogger
+}
+
+// NewUDPRouteController creates the udproute controller from mgr. The controller will be pre-configured
+// to watch for UDPRoute objects across all namespaces.
+func NewUDPRouteController(
+	mgr manager.Manager,
+	statusUpdater k8s.StatusUpdater,
+	gatewayClassControllerName string,
+	log logrus.FieldLogger) (controller.Controller, error) {
+	r := &udpRouteReconciler{
+		client:                     mgr.GetClient(),
+		statusUpdater:              statusUpdater,
+		gatewayClassControllerName: gatewayapi_v1alpha2.GatewayController(gatewayClassControllerName),
+		log:                        log,
+	}
+	c, err := controller.New("udproute-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch UDPRoutes to update their status whenever they
+	// change.
+	if err := c.Watch(
+		&source.Kind{Type: &gatewayapi_v1alpha2.UDPRoute{}},
+		&handler.EnqueueRequestForObject{},
+	); err != nil {
+		return nil, err
+	}
+
+	// Watch Gateways to update associated UDPRoutes' status
+	// when Contour-controlled Gateways change. This allows
+	// UDPRoutes' status to be updated properly if their
+	// Gateway is created *after* the UDPRoute itself.
+	if err := c.Watch(
+		&source.Kind{Type: &gatewayapi_v1alpha2.Gateway{}},
+		handler.EnqueueRequestsFromMapFunc(r.mapGatewayToUDPRoutes),
+		predicate.NewPredicateFuncs(r.gatewayHasMatchingController),
+	); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// mapGatewayToUDPRoutes returns a list of reconcile requests for all UDPRoutes
+// that have a parentRef to the provided Gateway.
+func (r *udpRouteReconciler) mapGatewayToUDPRoutes(gateway client.Object) []reconcile.Request {
+	var udpRoutes gatewayapi_v1alpha2.UDPRouteList
+	if err := r.client.List(context.Background(), &udpRoutes); err != nil {
+		r.log.WithError(err).Error("error listing UDPRoutes")
+		return nil
+	}
+
+	var reconciles []reconcile.Request
+	for _, udpRoute := range udpRoutes.Items {
+		for _, parentRef := range udpRoute.Spec.ParentRefs {
+			if isRefToGateway(parentRef, k8s.NamespacedNameOf(gateway)) {
+				reconciles = append(reconciles, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: udpRoute.Namespace,
+						Name:      udpRoute.Name,
+					},
+				})
+			}
+		}
+	}
+
+	return reconciles
+}
+
+// hasMatchingController returns true if the provided object is a Gateway
+// using a GatewayClass with a Spec.Controller string matching this Contour's
+// controller string, or false otherwise.
+func (r *udpRouteReconciler) gatewayHasMatchingController(obj client.Object) bool {
+	log := r.log.WithFields(logrus.Fields{
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	return gatewayHasMatchingController(obj, r.gatewayClassControllerName, r.client, log)
+}
+
+// referencesContourGateway returns whether a given UDPRoute has a parentRef
+// to a Gateway with a GatewayClass controlled by this Contour.
+func (r *udpRouteReconciler) referencesContourGateway(obj client.Object) (bool, *gatewayapi_v1alpha2.Gateway) {
+	log := r.log.WithFields(logrus.Fields{
+		"namespace": obj.GetNamespace(),
+		"name":      obj.GetName(),
+	})
+
+	route, ok := obj.(*gatewayapi_v1alpha2.UDPRoute)
+	if !ok {
+		log.Debugf("unexpected object type %T, bypassing reconciliation.", obj)
+		return false, nil
+	}
+
+	return referencesContourGateway(
+		route.Spec.ParentRefs,
+		route.Namespace,
+		r.gatewayClassControllerName,
+		r.client,
+		log,
+	)
+}
+
+// Reconcile sets "Accepted: false" on any UDPRoutes that have a Gateway
+// controlled by this Contour.
+func (r *udpRouteReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithField("namespace", request.Namespace).WithField("name", request.Name)
+
+	udpRoute := &gatewayapi_v1alpha2.UDPRoute{}
+	if err := r.client.Get(ctx, request.NamespacedName, udpRoute); err != nil {
+		// not-found errors mean the UDPRoute has been deleted, OK
+		// to ignore.
+		if !errors.IsNotFound(err) {
+			log.WithError(err).Error("error getting TCPRoute")
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// Check if the UDPRoute is referencing a Gateway
+	// controlled by this Contour.
+	ok, gw := r.referencesContourGateway(udpRoute)
+	if !ok {
+		return reconcile.Result{}, nil
+	}
+	log.Info("reconciling UDPRoute")
+
+	// If so, set the UDPRoute's status to indicate it's
+	// an unsupported route type.
+	r.statusUpdater.Send(k8s.StatusUpdate{
+		NamespacedName: k8s.NamespacedNameOf(udpRoute),
+		Resource:       udpRouteGVR,
+		Mutator: k8s.StatusMutatorFunc(func(obj interface{}) interface{} {
+			route, ok := obj.(*gatewayapi_v1alpha2.UDPRoute)
+			if !ok {
+				panic(fmt.Sprintf("unsupported object type %T", obj))
+			}
+
+			// Note that the statusUpdater will filter out no-op status updates,
+			// so we don't have to worry here about sending updates that don't
+			// actually change anything and triggering cascading reconciliations.
+			return setUDPRouteNotAccepted(route.DeepCopy(), gw, r.gatewayClassControllerName)
+		}),
+	})
+
+	return reconcile.Result{}, nil
+}
+
+func setUDPRouteNotAccepted(udpRoute *gatewayapi_v1alpha2.UDPRoute, gateway *gatewayapi_v1alpha2.Gateway, controllerName gatewayapi_v1alpha2.GatewayController) *gatewayapi_v1alpha2.UDPRoute {
+	notAcceptedCondition := metav1.Condition{
+		Type:               string(gatewayapi_v1alpha2.ConditionRouteAccepted),
+		Status:             metav1.ConditionFalse,
+		Reason:             "UnsupportedRouteType",
+		Message:            "UDPRoutes are not supported by this Gateway",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		ObservedGeneration: udpRoute.Generation,
+	}
+
+	udpRoute.Status.Parents = setRouteCondition(
+		udpRoute.Status.Parents,
+		notAcceptedCondition,
+		gateway,
+		controllerName,
+	)
+
+	return udpRoute
+}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -60,8 +60,6 @@ type KubernetesCache struct {
 	gateway                   *gatewayapi_v1alpha2.Gateway
 	httproutes                map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute
 	tlsroutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute
-	tcproutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.TCPRoute
-	udproutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.UDPRoute
 	extensions                map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	initialize sync.Once
@@ -78,8 +76,6 @@ func (kc *KubernetesCache) init() {
 	kc.services = make(map[types.NamespacedName]*v1.Service)
 	kc.namespaces = make(map[string]*v1.Namespace)
 	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute)
-	kc.tcproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.TCPRoute)
-	kc.udproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.UDPRoute)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
@@ -197,12 +193,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 	case *gatewayapi_v1alpha2.HTTPRoute:
 		kc.httproutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
-	case *gatewayapi_v1alpha2.TCPRoute:
-		kc.tcproutes[k8s.NamespacedNameOf(obj)] = obj
-		return true
-	case *gatewayapi_v1alpha2.UDPRoute:
-		kc.udproutes[k8s.NamespacedNameOf(obj)] = obj
-		return true
 	case *gatewayapi_v1alpha2.TLSRoute:
 		kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
 		return true
@@ -280,16 +270,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.httproutes[m]
 		delete(kc.httproutes, m)
-		return ok
-	case *gatewayapi_v1alpha2.TCPRoute:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.tcproutes[m]
-		delete(kc.tcproutes, m)
-		return ok
-	case *gatewayapi_v1alpha2.UDPRoute:
-		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.udproutes[m]
-		delete(kc.udproutes, m)
 		return ok
 	case *gatewayapi_v1alpha2.TLSRoute:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -865,24 +865,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert gateway-api TCPRoute": {
-			obj: &gatewayapi_v1alpha2.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"insert gateway-api UDPRoute": {
-			obj: &gatewayapi_v1alpha2.UDPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "udproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
 		"insert gateway-api TLSRoute": {
 			obj: &gatewayapi_v1alpha2.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1145,36 +1127,6 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &gatewayapi_v1alpha2.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"remove gateway-api TCPRoute": {
-			cache: cache(&gatewayapi_v1alpha2.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
-					Namespace: "default",
-				},
-			}),
-			obj: &gatewayapi_v1alpha2.TCPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tcproute",
-					Namespace: "default",
-				},
-			},
-			want: true,
-		},
-		"remove gateway-api UDPRoute": {
-			cache: cache(&gatewayapi_v1alpha2.UDPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "udproute",
-					Namespace: "default",
-				},
-			}),
-			obj: &gatewayapi_v1alpha2.UDPRoute{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "udproute",
 					Namespace: "default",
 				},
 			},

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -315,6 +315,54 @@ func (f *Framework) CreateTLSRouteAndWaitFor(route *gatewayapi_v1alpha2.TLSRoute
 	return res, true
 }
 
+// CreateTCPRouteAndWaitFor creates the provided TCPRoute in the Kubernetes API
+// and then waits for the specified condition to be true.
+func (f *Framework) CreateTCPPRouteAndWaitFor(route *gatewayapi_v1alpha2.TCPRoute, condition func(*gatewayapi_v1alpha2.TCPRoute) bool) (*gatewayapi_v1alpha2.TCPRoute, bool) {
+	require.NoError(f.t, f.Client.Create(context.TODO(), route))
+
+	res := &gatewayapi_v1alpha2.TCPRoute{}
+
+	if err := wait.PollImmediate(f.RetryInterval, f.RetryTimeout, func() (bool, error) {
+		if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(route), res); err != nil {
+			// if there was an error, we want to keep
+			// retrying, so just return false, not an
+			// error.
+			return false, nil
+		}
+
+		return condition(res), nil
+	}); err != nil {
+		// return the last response for logging/debugging purposes
+		return res, false
+	}
+
+	return res, true
+}
+
+// CreateUDPRouteAndWaitFor creates the provided UDPRoute in the Kubernetes API
+// and then waits for the specified condition to be true.
+func (f *Framework) CreateUDPPRouteAndWaitFor(route *gatewayapi_v1alpha2.UDPRoute, condition func(*gatewayapi_v1alpha2.UDPRoute) bool) (*gatewayapi_v1alpha2.UDPRoute, bool) {
+	require.NoError(f.t, f.Client.Create(context.TODO(), route))
+
+	res := &gatewayapi_v1alpha2.UDPRoute{}
+
+	if err := wait.PollImmediate(f.RetryInterval, f.RetryTimeout, func() (bool, error) {
+		if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(route), res); err != nil {
+			// if there was an error, we want to keep
+			// retrying, so just return false, not an
+			// error.
+			return false, nil
+		}
+
+		return condition(res), nil
+	}); err != nil {
+		// return the last response for logging/debugging purposes
+		return res, false
+	}
+
+	return res, true
+}
+
 // CreateNamespace creates a namespace with the given name in the
 // Kubernetes API or fails the test if it encounters an error.
 func (f *Framework) CreateNamespace(name string) {

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -169,6 +169,10 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-host-rewrite", testWithHTTPGateway(testHostRewrite))
 
 		f.NamespacedTest("gateway-route-parent-refs", testWithHTTPGateway(testRouteParentRefs))
+
+		f.NamespacedTest("gateway-tcproute-rejected", testWithHTTPGateway(testTCPRouteIsRejected))
+
+		f.NamespacedTest("gateway-udproute-rejected", testWithHTTPGateway(testUDPRouteIsRejected))
 	})
 
 	Describe("HTTPRoute: TLS Gateway", func() {
@@ -333,6 +337,42 @@ func tlsRouteAccepted(route *gatewayapi_v1alpha2.TLSRoute) bool {
 	for _, gw := range route.Status.Parents {
 		for _, cond := range gw.Conditions {
 			if cond.Type == string(gatewayapi_v1alpha2.ConditionRouteAccepted) && cond.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// tcpRouteRejected returns true if the route has a .status.conditions
+// entry of "Accepted: false".
+func tcpRouteRejected(route *gatewayapi_v1alpha2.TCPRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		for _, cond := range gw.Conditions {
+			if cond.Type == string(gatewayapi_v1alpha2.ConditionRouteAccepted) && cond.Status == metav1.ConditionFalse {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// udpRouteRejected returns true if the route has a .status.conditions
+// entry of "Accepted: false".
+func udpRouteRejected(route *gatewayapi_v1alpha2.UDPRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		for _, cond := range gw.Conditions {
+			if cond.Type == string(gatewayapi_v1alpha2.ConditionRouteAccepted) && cond.Status == metav1.ConditionFalse {
 				return true
 			}
 		}

--- a/test/e2e/gateway/unsupported_route_types_test.go
+++ b/test/e2e/gateway/unsupported_route_types_test.go
@@ -1,0 +1,80 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func testTCPRouteIsRejected(namespace string) {
+	Specify("TCPRoutes are rejected", func() {
+		route := &gatewayapi_v1alpha2.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "tcproute-1",
+			},
+			Spec: gatewayapi_v1alpha2.TCPRouteSpec{
+				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1alpha2.ParentRef{
+						gatewayapi.GatewayParentRef("", "http"),
+					},
+				},
+				Rules: []gatewayapi_v1alpha2.TCPRouteRule{
+					{
+						BackendRefs: []gatewayapi_v1alpha2.BackendRef{
+							{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("foo", 80),
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateTCPPRouteAndWaitFor(route, tcpRouteRejected)
+	})
+}
+
+func testUDPRouteIsRejected(namespace string) {
+	Specify("UDPRoutes are rejected", func() {
+		route := &gatewayapi_v1alpha2.UDPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "udproute-1",
+			},
+			Spec: gatewayapi_v1alpha2.UDPRouteSpec{
+				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1alpha2.ParentRef{
+						gatewayapi.GatewayParentRef("", "http"),
+					},
+				},
+				Rules: []gatewayapi_v1alpha2.UDPRouteRule{
+					{
+						BackendRefs: []gatewayapi_v1alpha2.BackendRef{
+							{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("foo", 80),
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateUDPPRouteAndWaitFor(route, udpRouteRejected)
+	})
+}


### PR DESCRIPTION
Contour does not support Gateway API's
TCPRoute or UDPRoute. This PR sets a
condition of "Accepted: false" on all
TCPRoutes & UDPRoutes referencing a
Contour Gateway.

Closes #3441.
Closes #3442.

Signed-off-by: Steve Kriss <krisss@vmware.com>