### PR TITLE
test/e2e: Fix possible cause of flakes in cookie rewrite test

### DIFF
--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -443,11 +443,11 @@ func testHeaderGlobalRewriteCookieRewrite(namespace string) {
 		p := &contourv1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      "header-rewrite-cookie-rewrite",
+				Name:      "global-header-rewrite-cookie-rewrite",
 			},
 			Spec: contourv1.HTTPProxySpec{
 				VirtualHost: &contourv1.VirtualHost{
-					Fqdn: "header-rewrite-cookie-rewrite.projectcontour.io",
+					Fqdn: "global-header-rewrite-cookie-rewrite.projectcontour.io",
 				},
 				Routes: []contourv1.Route{
 					{


### PR DESCRIPTION
Names of resources and FQDN in HTTPProxies were the same across tests,
possible causing some test flakes in CI where globally set cookies were
not rewritten.