### PR TITLE
internal/dag: move ListenerName to Listener struct

### DIFF
--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -125,8 +125,7 @@ func (d *DAG) EnsureSecureVirtualHost(hostname string) *SecureVirtualHost {
 
 	svh := &SecureVirtualHost{
 		VirtualHost: VirtualHost{
-			Name:         hostname,
-			ListenerName: "ingress_https",
+			Name: hostname,
 		},
 	}
 	d.SecureVirtualHosts[hostname] = svh
@@ -147,8 +146,7 @@ func (d *DAG) EnsureVirtualHost(hostname string) *VirtualHost {
 	}
 
 	vhost := &VirtualHost{
-		Name:         hostname,
-		ListenerName: "ingress_http",
+		Name: hostname,
 	}
 	d.VirtualHosts[hostname] = vhost
 	return vhost

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -481,6 +481,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -514,6 +515,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -582,6 +584,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardServiceCustomNs))),
@@ -679,12 +682,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "test.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardServiceCustomNs)),
@@ -717,12 +720,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "test.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -784,12 +787,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "test.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardServiceCustomNs)),
@@ -915,12 +918,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "test.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -1021,6 +1024,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("another.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -1121,6 +1125,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
@@ -1158,6 +1163,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -1191,6 +1197,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -1224,6 +1231,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("*.projectcontour.io",
 						&Route{
@@ -1339,6 +1347,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1376,6 +1385,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1415,6 +1425,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1469,6 +1480,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name:         HTTP_LISTENER_NAME,
 				Port:         80,
 				VirtualHosts: virtualhosts(virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService)))),
 			}),
@@ -1522,6 +1534,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name:         HTTP_LISTENER_NAME,
 				Port:         80,
 				VirtualHosts: virtualhosts(virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService)))),
 			}),
@@ -1574,6 +1587,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1628,6 +1642,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1682,6 +1697,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1737,6 +1753,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			},
 			want: listeners(&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -1769,6 +1786,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
@@ -1819,6 +1837,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
@@ -1860,6 +1879,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
@@ -1904,13 +1924,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
-								Routes:       routes(prefixrouteHTTPRoute("/", service(kuardService))),
+								Name:   "test.projectcontour.io",
+								Routes: routes(prefixrouteHTTPRoute("/", service(kuardService))),
 							},
 							Secret: secret(sec1),
 						},
@@ -1954,19 +1974,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
-								Routes:       routes(prefixrouteHTTPRoute("/", service(kuardService))),
+								Name:   "test.projectcontour.io",
+								Routes: routes(prefixrouteHTTPRoute("/", service(kuardService))),
 							},
 							Secret: secret(sec1),
 						},
 					),
 				},
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -2190,19 +2211,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "test.projectcontour.io",
-								ListenerName: "ingress_https",
-								Routes:       routes(prefixrouteHTTPRoute("/", service(blogService))),
+								Name:   "test.projectcontour.io",
+								Routes: routes(prefixrouteHTTPRoute("/", service(blogService))),
 							},
 							Secret: secret(sec1),
 						},
 					),
 				},
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io", prefixrouteHTTPRoute("/", service(kuardService))),
@@ -2242,6 +2264,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2295,6 +2318,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2340,6 +2364,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2385,6 +2410,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2436,6 +2462,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2500,6 +2527,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2549,6 +2577,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2610,6 +2639,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2654,6 +2684,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2706,6 +2737,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
@@ -2759,6 +2791,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixrouteHTTPRoute("/",
@@ -2820,6 +2853,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixrouteHTTPRoute("/",
@@ -2877,6 +2911,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", directResponseRouteService("/", http.StatusServiceUnavailable, &Service{
@@ -2914,12 +2949,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3001,12 +3036,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3066,12 +3101,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3305,12 +3340,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "another.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "another.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3318,8 +3353,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3327,8 +3361,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "thing.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "thing.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3365,12 +3398,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3378,8 +3411,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "thing.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "thing.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3438,12 +3470,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "*",
-								ListenerName: "ingress_https",
+								Name: "*",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clustersWeight(service(kuardService)),
@@ -3504,12 +3536,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 
@@ -3553,12 +3585,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 
@@ -3602,12 +3634,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "tcp.projectcontour.io",
-								ListenerName: "ingress_https",
+								Name: "tcp.projectcontour.io",
 							},
 							TCPProxy: &TCPProxy{
 
@@ -3645,6 +3677,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("gateway.projectcontour.io",
@@ -3679,6 +3712,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("http.projectcontour.io",
@@ -7181,6 +7215,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7201,6 +7236,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7227,6 +7263,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
@@ -7262,6 +7299,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7276,6 +7314,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7290,6 +7329,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7304,6 +7344,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7332,6 +7373,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7354,12 +7396,14 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("kuard.example.com", sec1, prefixroute("/", service(s1))),
@@ -7375,12 +7419,14 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("kuard.example.com", sec3, prefixroute("/", service(s1))),
@@ -7403,6 +7449,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -7425,6 +7472,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com", prefixroute("/", service(s1))),
@@ -7445,6 +7493,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("a.example.com", prefixroute("/", service(s1))),
@@ -7460,6 +7509,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("a.example.com", prefixroute("/", service(s1))),
@@ -7476,12 +7526,14 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("a.example.com", prefixroute("/", service(s1))),
 						virtualhost("b.example.com", prefixroute("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
@@ -7497,12 +7549,14 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("a.example.com", prefixroute("/", service(s1))),
 						virtualhost("b.example.com", prefixroute("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
@@ -7517,6 +7571,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com",
@@ -7534,6 +7589,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com",
@@ -7550,6 +7606,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com",
@@ -7574,6 +7631,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1,
@@ -7608,6 +7666,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1, prefixroute("/", service(s1))),
@@ -7621,11 +7680,13 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
@@ -7640,11 +7701,13 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("b.example.com", sec1, routeUpgrade("/", service(s1))),
@@ -7658,17 +7721,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("foo.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "foo.com",
-								ListenerName: "ingress_https",
+								Name: "foo.com",
 								Routes: routes(
 									routeUpgrade("/", service(s1)),
 								),
@@ -7686,17 +7750,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("foo.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "foo.com",
-								ListenerName: "ingress_https",
+								Name: "foo.com",
 								Routes: routes(
 									routeUpgrade("/", service(s1)),
 								),
@@ -7714,11 +7779,13 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("foo.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
@@ -7732,6 +7799,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s2))),
@@ -7745,6 +7813,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*.projectcontour.io",
@@ -7765,6 +7834,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s1), service(s2))),
@@ -7780,17 +7850,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("b.example.com", prefixroute("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "b.example.com",
-								ListenerName: "ingress_https",
+								Name: "b.example.com",
 								Routes: routes(
 									prefixroute("/", service(s1)),
 								),
@@ -7809,6 +7880,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -7826,6 +7898,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7843,6 +7916,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7867,6 +7941,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7887,6 +7962,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7907,6 +7983,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
@@ -7927,6 +8004,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7947,6 +8025,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -7967,6 +8046,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
@@ -7993,6 +8073,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
@@ -8015,6 +8096,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
@@ -8037,6 +8119,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
@@ -8059,6 +8142,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -8081,6 +8165,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", &Route{
@@ -8105,6 +8190,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -8149,6 +8235,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*", prefixroute("/", service(s1))),
@@ -8173,6 +8260,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8181,6 +8269,7 @@ func TestDAGInsert(t *testing.T) {
 						),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("example.com", sec13,
@@ -8197,6 +8286,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -8220,6 +8310,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -8243,6 +8334,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -8267,6 +8359,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("*",
@@ -8293,6 +8386,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8329,6 +8423,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8366,6 +8461,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s1))),
@@ -8379,6 +8475,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s1))),
@@ -8409,6 +8506,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -8427,6 +8525,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -8450,6 +8549,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -8475,6 +8575,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -8500,6 +8601,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -8523,6 +8625,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8543,6 +8646,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8564,6 +8668,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8580,6 +8685,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8597,6 +8703,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8612,11 +8719,13 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("foo.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						securevirtualhost("foo.com", sec1, routeUpgrade("/", service(s1))),
@@ -8630,6 +8739,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8662,6 +8772,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8699,6 +8810,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8733,6 +8845,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -8765,17 +8878,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 								Routes: routes(
 									routeUpgrade("/", service(s1))),
 							},
@@ -8795,12 +8909,12 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -8823,17 +8937,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 								Routes: routes(
 									routeUpgrade("/", service(s1))),
 							},
@@ -8853,17 +8968,18 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s1))),
 					),
 				}, &Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 								Routes: routes(
 									routeUpgrade("/", service(s1))),
 							},
@@ -8900,12 +9016,12 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{proxy38, proxy39, s1},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "www.example.com", // this is proxy39, not proxy38
-								ListenerName: "ingress_https",
+								Name: "www.example.com", // this is proxy39, not proxy38
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -8921,12 +9037,12 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{proxy39broot, proxy39bchild, s1},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "www.example.com",
-								ListenerName: "ingress_https",
+								Name: "www.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -8943,12 +9059,12 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{proxy39brootplural, proxy39bchild, s1},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "www.example.com",
-								ListenerName: "ingress_https",
+								Name: "www.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -8964,12 +9080,12 @@ func TestDAGInsert(t *testing.T) {
 			objs: []interface{}{proxy38, proxy40, s1},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "passthrough.example.com",
-								ListenerName: "ingress_https",
+								Name: "passthrough.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -8991,6 +9107,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9029,6 +9146,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9069,6 +9187,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9133,6 +9252,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9171,6 +9291,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9209,6 +9330,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9247,6 +9369,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9285,6 +9408,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9329,6 +9453,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						// route on root proxy is served, includes is ignored since condition is invalid
@@ -9349,12 +9474,12 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "kuard.example.com",
-								ListenerName: "ingress_https",
+								Name: "kuard.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -9373,6 +9498,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com",
@@ -9381,12 +9507,12 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "kuard.example.com",
-								ListenerName: "ingress_https",
+								Name: "kuard.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -9404,6 +9530,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("kuard.example.com",
@@ -9423,12 +9550,12 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "kuard.example.com",
-								ListenerName: "ingress_https",
+								Name: "kuard.example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: clusters(
@@ -9447,6 +9574,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
@@ -9505,18 +9633,19 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 							},
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
@@ -9563,6 +9692,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						// not upgraded because the route is permitInsecure: true
@@ -9570,12 +9700,12 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 							},
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
@@ -9621,6 +9751,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						// not upgraded because the route is permitInsecure: true
@@ -9628,12 +9759,12 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 							},
 							MinTLSVersion: "",
 							TCPProxy: &TCPProxy{
@@ -9653,6 +9784,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", prefixroute("/", service(s2a))),
@@ -9668,6 +9800,7 @@ func TestDAGInsert(t *testing.T) {
 			enableExternalNameSvc: true,
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9704,6 +9837,7 @@ func TestDAGInsert(t *testing.T) {
 			enableExternalNameSvc: true,
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9734,12 +9868,12 @@ func TestDAGInsert(t *testing.T) {
 			enableExternalNameSvc: true,
 			want: listeners(
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
+								Name: "example.com",
 							},
 							TCPProxy: &TCPProxy{
 								Clusters: []*Cluster{{
@@ -9770,6 +9904,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9794,6 +9929,7 @@ func TestDAGInsert(t *testing.T) {
 			enableExternalNameSvc: true,
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9854,6 +9990,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9881,6 +10018,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9903,6 +10041,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9925,6 +10064,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -9956,6 +10096,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -10018,6 +10159,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -10046,6 +10188,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -10076,6 +10219,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -10108,6 +10252,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", &Route{
@@ -10151,19 +10296,20 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10247,19 +10393,20 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10312,19 +10459,20 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10449,6 +10597,7 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
@@ -10456,13 +10605,13 @@ func TestDAGInsert(t *testing.T) {
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10470,9 +10619,8 @@ func TestDAGInsert(t *testing.T) {
 						},
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "projectcontour.io",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "projectcontour.io",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10512,19 +10660,20 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -10565,19 +10714,20 @@ func TestDAGInsert(t *testing.T) {
 			},
 			want: listeners(
 				&Listener{
+					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com", routeUpgrade("/", service(s9))),
 					),
 				},
 				&Listener{
+					Name: HTTPS_LISTENER_NAME,
 					Port: 443,
 					SecureVirtualHosts: securevirtualhosts(
 						&SecureVirtualHost{
 							VirtualHost: VirtualHost{
-								Name:         "example.com",
-								ListenerName: "ingress_https",
-								Routes:       routes(routeUpgrade("/", service(s9))),
+								Name:   "example.com",
+								Routes: routes(routeUpgrade("/", service(s9))),
 							},
 							MinTLSVersion:       "1.2",
 							Secret:              secret(sec1),
@@ -11334,6 +11484,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com", directResponseRoute("/", http.StatusServiceUnavailable)),
@@ -11394,6 +11545,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com", directResponseRoute("/", http.StatusBadGateway)),
@@ -11435,6 +11587,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com",
@@ -11483,6 +11636,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com",
@@ -11549,6 +11703,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com",
@@ -11599,6 +11754,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 			}},
 		wantListeners: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com", directResponseRoute("/missing", http.StatusServiceUnavailable)),
@@ -11666,6 +11822,7 @@ func TestHTTPProxyConficts(t *testing.T) {
 		},
 		wantListeners: []*Listener{
 			{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: []*VirtualHost{
 					virtualhost("example.com",
@@ -11771,6 +11928,7 @@ func TestDefaultHeadersPolicies(t *testing.T) {
 		},
 		want: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("*", &Route{
@@ -11808,6 +11966,7 @@ func TestDefaultHeadersPolicies(t *testing.T) {
 		},
 		want: listeners(
 			&Listener{
+				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
 					virtualhost("example.com", &Route{
@@ -12085,18 +12244,16 @@ func securevirtualhosts(vx ...*SecureVirtualHost) []*SecureVirtualHost {
 
 func virtualhost(name string, first *Route, rest ...*Route) *VirtualHost {
 	return &VirtualHost{
-		Name:         name,
-		ListenerName: "ingress_http",
-		Routes:       routes(append([]*Route{first}, rest...)...),
+		Name:   name,
+		Routes: routes(append([]*Route{first}, rest...)...),
 	}
 }
 
 func securevirtualhost(name string, sec *v1.Secret, first *Route, rest ...*Route) *SecureVirtualHost {
 	return &SecureVirtualHost{
 		VirtualHost: VirtualHost{
-			Name:         name,
-			ListenerName: "ingress_https",
-			Routes:       routes(append([]*Route{first}, rest...)...),
+			Name:   name,
+			Routes: routes(append([]*Route{first}, rest...)...),
 		},
 		MinTLSVersion: "1.2",
 		Secret:        secret(sec),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -469,8 +469,6 @@ type VirtualHost struct {
 	// as defined by RFC 3986.
 	Name string
 
-	ListenerName string
-
 	// CORSPolicy is the cross-origin policy to apply to the VirtualHost.
 	CORSPolicy *CORSPolicy
 
@@ -543,14 +541,10 @@ func (s *SecureVirtualHost) Valid() bool {
 	return (s.Secret != nil && len(s.Routes) > 0) || s.TCPProxy != nil
 }
 
-type ListenerName struct {
-	Name         string
-	ListenerName string
-}
-
 // A Listener represents a TCP socket that accepts
 // incoming connections.
 type Listener struct {
+	// Name is the unique name of the listener.
 	Name string
 
 	// Address is the TCP address to listen on.

--- a/internal/dag/listener_processor.go
+++ b/internal/dag/listener_processor.go
@@ -15,6 +15,12 @@ package dag
 
 import "sort"
 
+// nolint:revive
+const (
+	HTTP_LISTENER_NAME  = "ingress_http"
+	HTTPS_LISTENER_NAME = "ingress_https"
+)
+
 // ListenerProcessor adds an HTTP and an HTTPS listener to
 // the DAG if there are virtual hosts and secure virtual
 // hosts already defined as roots in the DAG.
@@ -47,6 +53,7 @@ func (p *ListenerProcessor) buildHTTPListener(dag *DAG) {
 	})
 
 	http := &Listener{
+		Name:         HTTP_LISTENER_NAME,
 		Port:         80,
 		VirtualHosts: vhosts,
 	}
@@ -73,6 +80,7 @@ func (p *ListenerProcessor) buildHTTPSListener(dag *DAG) {
 	})
 
 	https := &Listener{
+		Name:               HTTPS_LISTENER_NAME,
 		Port:               443,
 		SecureVirtualHosts: vhosts,
 	}


### PR DESCRIPTION
Moves the ListenerName field from VirtualHost
to Listener, to better reflect the data model.
This field is now populated by the listener
processor.

Signed-off-by: Steve Kriss <krisss@vmware.com>