### PR TITLE
internal/envoy: increase default upstream connect timeout

### DIFF
--- a/changelogs/unreleased/4151-tsaarni-small.md
+++ b/changelogs/unreleased/4151-tsaarni-small.md
@@ -1,0 +1,1 @@
+Timeout for upstream network connection timeout increased from 250 msec to 2 seconds.

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -31,7 +31,7 @@ import (
 
 func clusterDefaults() *envoy_cluster_v3.Cluster {
 	return &envoy_cluster_v3.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
+		ConnectTimeout: protobuf.Duration(2 * time.Second),
 		CommonLbConfig: ClusterCommonLBConfig(),
 		LbPolicy:       lbPolicy(dag.LoadBalancerPolicyRoundRobin),
 	}

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -48,7 +48,7 @@ import (
 func DefaultCluster(clusters ...*envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &envoy_cluster_v3.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
+		ConnectTimeout: protobuf.Duration(2 * time.Second),
 		LbPolicy:       envoy_cluster_v3.Cluster_ROUND_ROBIN,
 		CommonLbConfig: envoy_v3.ClusterCommonLBConfig(),
 	}

--- a/internal/xdscache/v3/cluster_test.go
+++ b/internal/xdscache/v3/cluster_test.go
@@ -845,7 +845,7 @@ func serviceWithAnnotations(ns, name string, annotations map[string]string, port
 func cluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &envoy_cluster_v3.Cluster{
-		ConnectTimeout: protobuf.Duration(250 * time.Millisecond),
+		ConnectTimeout: protobuf.Duration(2 * time.Second),
 		CommonLbConfig: envoy_v3.ClusterCommonLBConfig(),
 		LbPolicy:       envoy_cluster_v3.Cluster_ROUND_ROBIN,
 	}


### PR DESCRIPTION
This change sets the new default connect timeout to 2 seconds. The default connect timeout was 250 msec which can be too short and may cause failed requests with slow upstream services.

Updates #2264

Signed-off-by: Tero Saarni <tero.saarni@est.tech>