### PR TITLE
internal/dag: set Gateway Listener status

### DIFF
--- a/changelogs/unreleased/4160-skriss-minor.md
+++ b/changelogs/unreleased/4160-skriss-minor.md
@@ -1,0 +1,4 @@
+### Gateway API: set Gateway Listener status fields
+
+Contour now sets the `.status.listeners.supportedKinds` and `.status.listeners.attachedRoutes` fields on Gateways for Gateway API.
+The first describes the list of route groups/kinds that the listener supports, and the second captures the total number of routes that are successfully attached to the listener.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -84,14 +84,19 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		return
 	}
 
+	gwAccessor, commit := p.dag.StatusCache.GatewayStatusAccessor(
+		k8s.NamespacedNameOf(p.source.gateway),
+		p.source.gateway.Generation,
+		&p.source.gateway.Status,
+	)
+	defer commit()
+
 	if len(p.source.gateway.Spec.Addresses) > 0 {
 		gatewayErrors = append(gatewayErrors, &field.Error{Type: field.ErrorTypeNotSupported, Field: path.String(), BadValue: p.source.gateway.Spec.Addresses, Detail: "Spec.Addresses is not supported"})
 	}
 
 	for _, listener := range p.source.gateway.Spec.Listeners {
 
-		var matchingHTTPRoutes []*gatewayapi_v1alpha2.HTTPRoute
-		var matchingTLSRoutes []*gatewayapi_v1alpha2.TLSRoute
 		var listenerSecret *Secret
 
 		// Validate the listener protocol is a supported type.
@@ -140,14 +145,12 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			continue
 		}
 
-		// Get a list of the kinds of routes that the listener accepts.
-		routeKinds, err := getListenerRouteKinds(listener)
-		if err != nil {
-			p.Errorf("error getting listener route kinds: %v", err)
-			continue
-		}
+		// Get a list of the route kinds that the listener accepts.
+		listenerRouteKinds := p.getListenerRouteKinds(listener)
+		gwAccessor.SetListenerSupportedKinds(string(listener.Name), listenerRouteKinds)
 
-		for _, routeKind := range routeKinds {
+		attachedRoutes := 0
+		for _, routeKind := range listenerRouteKinds {
 			switch routeKind {
 			case KindHTTPRoute:
 				for _, route := range p.source.httproutes {
@@ -166,16 +169,11 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 						continue
 					}
 
-					matchingHTTPRoutes = append(matchingHTTPRoutes, route)
+					if p.computeHTTPRoute(route, listenerSecret, listener.Hostname, len(gatewayErrors) == 0) {
+						attachedRoutes++
+					}
 				}
 			case KindTLSRoute:
-
-				// Validate the listener protocol is type=TLS.
-				if listener.Protocol != gatewayapi_v1alpha2.TLSProtocolType {
-					p.Errorf("invalid listener protocol %q for Kind: TLSRoute", listener.Protocol)
-					continue
-				}
-
 				for _, route := range p.source.tlsroutes {
 					// Check if the route is in a namespace that the listener allows.
 					nsMatches, err := p.namespaceMatches(listener.AllowedRoutes.Namespaces, route.Namespace)
@@ -192,58 +190,62 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 						continue
 					}
 
-					matchingTLSRoutes = append(matchingTLSRoutes, route)
+					if p.computeTLSRoute(route, listenerSecret, listener.Hostname, len(gatewayErrors) == 0) {
+						attachedRoutes++
+					}
 				}
 			}
 		}
 
-		validGateway := len(gatewayErrors) == 0
-
-		// Process all the HTTPRoutes that match this Gateway.
-		for _, matchingRoute := range matchingHTTPRoutes {
-			p.computeHTTPRoute(matchingRoute, listenerSecret, listener.Hostname, validGateway)
-		}
-
-		// Process all the TLSRoutes that match this Gateway.
-		for _, matchingRoute := range matchingTLSRoutes {
-			p.computeTLSRoute(matchingRoute, validGateway, listenerSecret, listener.Hostname)
-		}
+		gwAccessor.SetListenerAttachedRoutes(string(listener.Name), attachedRoutes)
 	}
 
-	p.computeGatewayConditions(p.source.gateway, gatewayErrors)
+	p.computeGatewayConditions(gwAccessor, gatewayErrors)
 }
 
-// getListenerRouteKinds gets a list of the kinds of routes that
+// getListenerRouteKinds gets a list of the valid route kinds that
 // the listener accepts.
-func getListenerRouteKinds(listener gatewayapi_v1alpha2.Listener) ([]string, error) {
+func (p *GatewayAPIProcessor) getListenerRouteKinds(listener gatewayapi_v1alpha2.Listener) []gatewayapi_v1alpha2.Kind {
+	// None specified on the listener: return the default based on
+	// the listener's protocol.
 	if len(listener.AllowedRoutes.Kinds) == 0 {
 		switch listener.Protocol {
 		case gatewayapi_v1alpha2.HTTPProtocolType:
-			return []string{KindHTTPRoute}, nil
+			return []gatewayapi_v1alpha2.Kind{KindHTTPRoute}
 		case gatewayapi_v1alpha2.HTTPSProtocolType:
-			return []string{KindHTTPRoute}, nil
+			return []gatewayapi_v1alpha2.Kind{KindHTTPRoute}
 		case gatewayapi_v1alpha2.TLSProtocolType:
-			return []string{KindTLSRoute}, nil
+			return []gatewayapi_v1alpha2.Kind{KindTLSRoute}
 		}
 	}
 
-	var routeKinds []string
+	var routeKinds []gatewayapi_v1alpha2.Kind
+
+	// TODO if a kind is invalid, set "ResolvedRefs: false" condition
+	// on the listener with "InvalidRouteKinds" reason.
 
 	for _, routeKind := range listener.AllowedRoutes.Kinds {
 		if routeKind.Group == nil {
-			return nil, fmt.Errorf("Listener.AllowedRoutes.Group not specified")
+			p.Errorf("Listener.AllowedRoutes.Group not specified")
+			continue
 		}
 		if *routeKind.Group != gatewayapi_v1alpha2.GroupName {
-			return nil, fmt.Errorf("Listener.AllowedRoutes.Group %q not supported", *routeKind.Group)
+			p.Errorf("Listener.AllowedRoutes.Group %q not supported", *routeKind.Group)
+			continue
 		}
 		if routeKind.Kind != gatewayapi_v1alpha2.Kind(KindHTTPRoute) && routeKind.Kind != gatewayapi_v1alpha2.Kind(KindTLSRoute) {
-			return nil, fmt.Errorf("Listener.AllowedRoutes.Kind %q not supported", routeKind.Kind)
+			p.Errorf("Listener.AllowedRoutes.Kind %q not supported", routeKind.Kind)
+			continue
+		}
+		if routeKind.Kind == gatewayapi_v1alpha2.Kind(KindTLSRoute) && listener.Protocol != gatewayapi_v1alpha2.TLSProtocolType {
+			p.Errorf("invalid listener protocol %q for Kind: TLSRoute", listener.Protocol)
+			continue
 		}
 
-		routeKinds = append(routeKinds, string(routeKind.Kind))
+		routeKinds = append(routeKinds, routeKind.Kind)
 	}
 
-	return routeKinds, nil
+	return routeKinds
 }
 
 func (p *GatewayAPIProcessor) validGatewayTLS(listener gatewayapi_v1alpha2.Listener) *Secret {
@@ -453,11 +455,7 @@ func routeSelectsGatewayListener(gateway *gatewayapi_v1alpha2.Gateway, listener 
 	return false
 }
 
-func (p *GatewayAPIProcessor) computeGatewayConditions(gateway *gatewayapi_v1alpha2.Gateway, fieldErrs field.ErrorList) {
-
-	gwAccessor, commit := p.dag.StatusCache.GatewayStatusAccessor(k8s.NamespacedNameOf(gateway), gateway.Generation, &gateway.Status)
-	defer commit()
-
+func (p *GatewayAPIProcessor) computeGatewayConditions(gwAccessor *status.GatewayStatusUpdate, fieldErrs field.ErrorList) {
 	// Determine the gateway status based on fieldErrs.
 	switch len(fieldErrs) {
 	case 0:
@@ -467,7 +465,7 @@ func (p *GatewayAPIProcessor) computeGatewayConditions(gateway *gatewayapi_v1alp
 	}
 }
 
-func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRoute, validGateway bool, listenerSecret *Secret, listenerHostname *gatewayapi_v1alpha2.Hostname) {
+func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRoute, listenerSecret *Secret, listenerHostname *gatewayapi_v1alpha2.Hostname, validGateway bool) bool {
 
 	routeAccessor, commit := p.dag.StatusCache.RouteConditionsAccessor(k8s.NamespacedNameOf(route), route.Generation, &gatewayapi_v1alpha2.TLSRoute{}, route.Status.Parents)
 	defer commit()
@@ -475,7 +473,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 	// If the Gateway is invalid, set status on the route.
 	if !validGateway {
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonInvalidGateway, "Invalid Gateway")
-		return
+		return false
 	}
 
 	hosts, errs := p.computeHosts(route.Spec.Hostnames, listenerHostname)
@@ -486,9 +484,10 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 	// Check if all the hostnames are invalid.
 	if len(hosts) == 0 {
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
-		return
+		return false
 	}
 
+	var programmed bool
 	for _, rule := range route.Spec.Rules {
 		if len(rule.BackendRefs) == 0 {
 			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
@@ -546,6 +545,8 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 			}
 
 			secure.TCPProxy = &proxy
+
+			programmed = true
 		}
 	}
 
@@ -557,16 +558,18 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 	default:
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
 	}
+
+	return programmed
 }
 
-func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRoute, listenerSecret *Secret, listenerHostname *gatewayapi_v1alpha2.Hostname, validGateway bool) {
+func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRoute, listenerSecret *Secret, listenerHostname *gatewayapi_v1alpha2.Hostname, validGateway bool) bool {
 	routeAccessor, commit := p.dag.StatusCache.RouteConditionsAccessor(k8s.NamespacedNameOf(route), route.Generation, &gatewayapi_v1alpha2.HTTPRoute{}, route.Status.Parents)
 	defer commit()
 
 	// If the Gateway is invalid, set status on the route.
 	if !validGateway {
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonInvalidGateway, "Invalid Gateway")
-		return
+		return false
 	}
 
 	hosts, errs := p.computeHosts(route.Spec.Hostnames, listenerHostname)
@@ -577,9 +580,10 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 	// Check if all the hostnames are invalid.
 	if len(hosts) == 0 {
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
-		return
+		return false
 	}
 
+	var programmed bool
 	for _, rule := range route.Spec.Rules {
 		// Get match conditions for the rule.
 		var matchconditions []*matchConditions
@@ -680,6 +684,8 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 					vhost := p.dag.EnsureVirtualHost(host)
 					vhost.addRoute(route)
 				}
+
+				programmed = true
 			}
 		}
 	}
@@ -692,6 +698,8 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 	default:
 		routeAccessor.AddCondition(gatewayapi_v1alpha2.ConditionRouteAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
 	}
+
+	return programmed
 }
 
 // validateBackendRef verifies that the specified BackendRef is valid.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -455,7 +455,7 @@ func routeSelectsGatewayListener(gateway *gatewayapi_v1alpha2.Gateway, listener 
 
 func (p *GatewayAPIProcessor) computeGatewayConditions(gateway *gatewayapi_v1alpha2.Gateway, fieldErrs field.ErrorList) {
 
-	gwAccessor, commit := p.dag.StatusCache.GatewayConditionsAccessor(k8s.NamespacedNameOf(gateway), gateway.Generation, &gateway.Status)
+	gwAccessor, commit := p.dag.StatusCache.GatewayStatusAccessor(k8s.NamespacedNameOf(gateway), gateway.Generation, &gateway.Status)
 	defer commit()
 
 	// Determine the gateway status based on fieldErrs.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2625,7 +2625,7 @@ func TestDAGStatus(t *testing.T) {
 	})
 }
 
-var validGatewayConditionsUpdate = []*status.GatewayConditionsUpdate{{
+var validGatewayStatusUpdate = []*status.GatewayStatusUpdate{{
 	FullName: types.NamespacedName{Namespace: "projectcontour", Name: "contour"},
 	Conditions: map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition{
 		gatewayapi_v1alpha2.GatewayConditionReady: {
@@ -2640,10 +2640,10 @@ var validGatewayConditionsUpdate = []*status.GatewayConditionsUpdate{{
 func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	type testcase struct {
-		objs                  []interface{}
-		gateway               *gatewayapi_v1alpha2.Gateway
-		wantRouteConditions   []*status.RouteConditionsUpdate
-		wantGatewayConditions []*status.GatewayConditionsUpdate
+		objs                    []interface{}
+		gateway                 *gatewayapi_v1alpha2.Gateway
+		wantRouteConditions     []*status.RouteConditionsUpdate
+		wantGatewayStatusUpdate []*status.GatewayStatusUpdate
 	}
 
 	run := func(t *testing.T, desc string, tc testcase) {
@@ -2720,9 +2720,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Generation"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "TransitionTime"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Resource"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "ExistingConditions"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "Generation"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "TransitionTime"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "ExistingConditions"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "Generation"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "TransitionTime"),
 				cmpopts.SortSlices(func(i, j metav1.Condition) bool {
 					return i.Message < j.Message
 				}),
@@ -2739,8 +2739,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				t.Fatalf("expected route status: %v, got %v", tc.wantRouteConditions, diff)
 			}
 
-			if diff := cmp.Diff(tc.wantGatewayConditions, gotGatewayUpdates, ops...); diff != "" {
-				t.Fatalf("expected gateway status: %v, got %v", tc.wantGatewayConditions, diff)
+			if diff := cmp.Diff(tc.wantGatewayStatusUpdate, gotGatewayUpdates, ops...); diff != "" {
+				t.Fatalf("expected gateway status: %v, got %v", tc.wantGatewayStatusUpdate, diff)
 			}
 
 		})
@@ -2796,7 +2796,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "simple httproute with backendref namespace matching route's explicitly specified", testcase{
@@ -2846,7 +2846,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "invalid prefix match for httproute", testcase{
@@ -2895,7 +2895,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "regular expression match not yet supported for httproute", testcase{
@@ -2939,7 +2939,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "RegularExpression header match not yet supported for httproute", testcase{
@@ -2995,7 +2995,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.backendRef.name not specified", testcase{
@@ -3048,7 +3048,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.backendRef.serviceName invalid on two matches", testcase{
@@ -3104,7 +3104,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.backendRef.port not specified", testcase{
@@ -3157,7 +3157,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.backendRefs not specified", testcase{
@@ -3200,7 +3200,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.backendRef.namespace does not match route", testcase{
@@ -3255,7 +3255,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.hostname: invalid wildcard", testcase{
@@ -3298,7 +3298,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.hostname: invalid hostname", testcase{
@@ -3341,7 +3341,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "spec.rules.hostname: invalid hostname, ip address", testcase{
@@ -3384,7 +3384,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "HTTPRouteFilterRequestMirror not yet supported for httproute rule", testcase{
@@ -3431,7 +3431,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "HTTPRouteFilterRequestMirror not yet supported for httproute backendref", testcase{
@@ -3485,7 +3485,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "Invalid RequestHeaderModifier due to duplicated headers", testcase{
@@ -3538,7 +3538,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "Invalid RequestHeaderModifier after forward due to invalid headers", testcase{
@@ -3596,7 +3596,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		wantGatewayConditions: validGatewayConditionsUpdate,
+		wantGatewayStatusUpdate: validGatewayStatusUpdate,
 	})
 
 	run(t, "gateway.spec.addresses results in invalid gateway", testcase{
@@ -3621,7 +3621,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				}},
 			},
 		},
-		wantGatewayConditions: []*status.GatewayConditionsUpdate{{
+		wantGatewayStatusUpdate: []*status.GatewayStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "projectcontour", Name: "contour"},
 			Conditions: map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition{
 				gatewayapi_v1alpha2.GatewayConditionReady: {
@@ -3641,7 +3641,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		objs                  []interface{}
 		gateway               *gatewayapi_v1alpha2.Gateway
 		wantRouteConditions   []*status.RouteConditionsUpdate
-		wantGatewayConditions []*status.GatewayConditionsUpdate
+		wantGatewayConditions []*status.GatewayStatusUpdate
 	}
 
 	run := func(t *testing.T, desc string, tc testcase) {
@@ -3700,9 +3700,9 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Generation"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "TransitionTime"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Resource"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "ExistingConditions"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "Generation"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "TransitionTime"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "ExistingConditions"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "Generation"),
+				cmpopts.IgnoreFields(status.GatewayStatusUpdate{}, "TransitionTime"),
 				cmpopts.SortSlices(func(i, j metav1.Condition) bool {
 					return i.Message < j.Message
 				}),
@@ -3859,7 +3859,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.backendRef.name invalid on two matches", testcase{
@@ -3903,7 +3903,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.backendRef.port not specified", testcase{
@@ -3954,7 +3954,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.backendRefs not specified", testcase{
@@ -3998,7 +3998,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.hostname: invalid wildcard", testcase{
@@ -4042,7 +4042,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.hostname: invalid hostname", testcase{
@@ -4086,7 +4086,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.hostname: invalid hostname, ip address", testcase{
@@ -4130,7 +4130,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 
 		run(t, "TLSRoute: spec.rules.backendRefs has 0 weight", testcase{
@@ -4171,7 +4171,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 				},
 			}},
-			wantGatewayConditions: validGatewayConditionsUpdate,
+			wantGatewayConditions: validGatewayStatusUpdate,
 		})
 	}
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2721,7 +2721,6 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "TransitionTime"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Resource"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "ExistingConditions"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "GatewayRef"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "Generation"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "TransitionTime"),
 				cmpopts.SortSlices(func(i, j metav1.Condition) bool {
@@ -3702,7 +3701,6 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "TransitionTime"),
 				cmpopts.IgnoreFields(status.RouteConditionsUpdate{}, "Resource"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "ExistingConditions"),
-				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "GatewayRef"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "Generation"),
 				cmpopts.IgnoreFields(status.GatewayConditionsUpdate{}, "TransitionTime"),
 				cmpopts.SortSlices(func(i, j metav1.Condition) bool {

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -174,7 +174,6 @@ func (c *Cache) GatewayConditionsAccessor(nsName types.NamespacedName, generatio
 		FullName:           nsName,
 		Conditions:         make(map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition),
 		ExistingConditions: getGatewayConditions(gs),
-		GatewayRef:         c.gatewayRef,
 		Generation:         generation,
 		TransitionTime:     metav1.NewTime(clock.Now()),
 	}

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -179,7 +179,7 @@ func (c *Cache) GatewayStatusAccessor(nsName types.NamespacedName, generation in
 	}
 
 	return gu, func() {
-		if len(gu.Conditions) == 0 {
+		if len(gu.Conditions) == 0 && len(gu.ListenerStatus) == 0 {
 			return
 		}
 		c.gatewayUpdates[gu.FullName] = gu

--- a/internal/status/gatewayconditions.go
+++ b/internal/status/gatewayconditions.go
@@ -33,7 +33,6 @@ type GatewayConditionsUpdate struct {
 	FullName           types.NamespacedName
 	Conditions         map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition
 	ExistingConditions map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition
-	GatewayRef         types.NamespacedName
 	Generation         int64
 	TransitionTime     metav1.Time
 }

--- a/internal/status/gatewayconditions.go
+++ b/internal/status/gatewayconditions.go
@@ -57,32 +57,6 @@ func (gatewayUpdate *GatewayConditionsUpdate) AddCondition(cond gatewayapi_v1alp
 	return newCond
 }
 
-// GatewayConditionsAccessor returns a GatewayConditionsUpdate that allows a client to build up a list of
-// metav1.Conditions as well as a function to commit the change back to the cache when everything
-// is done. The commit function pattern is used so that the GatewayConditionsUpdate does not need
-// to know anything the cache internals.
-func (c *Cache) GatewayConditionsAccessor(nsName types.NamespacedName, generation int64, gs *gatewayapi_v1alpha2.GatewayStatus) (*GatewayConditionsUpdate, func()) {
-	gu := &GatewayConditionsUpdate{
-		FullName:           nsName,
-		Conditions:         make(map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition),
-		ExistingConditions: getGatewayConditions(gs),
-		GatewayRef:         c.gatewayRef,
-		Generation:         generation,
-		TransitionTime:     metav1.NewTime(clock.Now()),
-	}
-
-	return gu, func() {
-		c.commitGateway(gu)
-	}
-}
-
-func (c *Cache) commitGateway(gu *GatewayConditionsUpdate) {
-	if len(gu.Conditions) == 0 {
-		return
-	}
-	c.gatewayUpdates[gu.FullName] = gu
-}
-
 func getGatewayConditions(gs *gatewayapi_v1alpha2.GatewayStatus) map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition {
 	conditions := make(map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition)
 	for _, cond := range gs.Conditions {

--- a/internal/status/gatewayconditions_test.go
+++ b/internal/status/gatewayconditions_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
@@ -40,7 +39,6 @@ func TestGatewayAddCondition(t *testing.T) {
 		FullName:           k8s.NamespacedNameFrom("test/test"),
 		Conditions:         make(map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition),
 		ExistingConditions: nil,
-		GatewayRef:         types.NamespacedName{},
 		Generation:         testGeneration,
 		TransitionTime:     metav1.Time{},
 	}

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -29,7 +29,9 @@ const ReasonInvalidGateway = "Invalid"
 
 const MessageValidGateway = "Valid Gateway"
 
-type GatewayConditionsUpdate struct {
+// GatewayStatusUpdate represents an atomic update to a
+// Gateway's status.
+type GatewayStatusUpdate struct {
 	FullName           types.NamespacedName
 	Conditions         map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition
 	ExistingConditions map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition
@@ -38,7 +40,12 @@ type GatewayConditionsUpdate struct {
 }
 
 // AddCondition returns a metav1.Condition for a given GatewayConditionType.
-func (gatewayUpdate *GatewayConditionsUpdate) AddCondition(cond gatewayapi_v1alpha2.GatewayConditionType, status metav1.ConditionStatus, reason GatewayReasonType, message string) metav1.Condition {
+func (gatewayUpdate *GatewayStatusUpdate) AddCondition(
+	cond gatewayapi_v1alpha2.GatewayConditionType,
+	status metav1.ConditionStatus,
+	reason GatewayReasonType,
+	message string,
+) metav1.Condition {
 
 	if c, ok := gatewayUpdate.Conditions[cond]; ok {
 		message = fmt.Sprintf("%s, %s", c.Message, message)
@@ -66,7 +73,7 @@ func getGatewayConditions(gs *gatewayapi_v1alpha2.GatewayStatus) map[gatewayapi_
 	return conditions
 }
 
-func (gatewayUpdate *GatewayConditionsUpdate) Mutate(obj client.Object) client.Object {
+func (gatewayUpdate *GatewayStatusUpdate) Mutate(obj client.Object) client.Object {
 
 	var conditionsToWrite []metav1.Condition
 
@@ -110,7 +117,7 @@ func (gatewayUpdate *GatewayConditionsUpdate) Mutate(obj client.Object) client.O
 		}
 		return gw
 	default:
-		panic(fmt.Sprintf("Unsupported %T object %s/%s in GatewayConditionsUpdate status mutator",
+		panic(fmt.Sprintf("Unsupported %T object %s/%s in GatewayStatusUpdate status mutator",
 			obj, gatewayUpdate.FullName.Namespace, gatewayUpdate.FullName.Name,
 		))
 	}

--- a/internal/status/gatewaystatus_test.go
+++ b/internal/status/gatewaystatus_test.go
@@ -16,15 +16,16 @@ package status
 import (
 	"testing"
 
+	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestGatewayAddCondition(t *testing.T) {
-
 	var testGeneration int64 = 7
 
 	simpleValidCondition := metav1.Condition{
@@ -51,4 +52,108 @@ func TestGatewayAddCondition(t *testing.T) {
 	assert.Equal(t, simpleValidCondition.Type, got.Type)
 	assert.Equal(t, simpleValidCondition.Status, got.Status)
 	assert.Equal(t, simpleValidCondition.ObservedGeneration, got.ObservedGeneration)
+}
+
+func TestGatewaySetListenerSupportedKinds(t *testing.T) {
+	var gsu GatewayStatusUpdate
+
+	gsu.SetListenerSupportedKinds("http", []gatewayapi_v1alpha2.Kind{"HTTPRoute"})
+	gsu.SetListenerSupportedKinds("https", []gatewayapi_v1alpha2.Kind{"HTTPRoute", "TLSRoute"})
+
+	assert.Len(t, gsu.ListenerStatus, 2)
+
+	require.NotNil(t, gsu.ListenerStatus["http"])
+	require.NotNil(t, gsu.ListenerStatus["https"])
+
+	assert.ElementsMatch(t,
+		[]gatewayapi_v1alpha2.RouteGroupKind{
+			{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "HTTPRoute"},
+		},
+		gsu.ListenerStatus["http"].SupportedKinds,
+	)
+
+	assert.ElementsMatch(t,
+		[]gatewayapi_v1alpha2.RouteGroupKind{
+			{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "HTTPRoute"},
+			{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+		},
+		gsu.ListenerStatus["https"].SupportedKinds,
+	)
+}
+
+func TestGatewaySetListenerAttachedRoutes(t *testing.T) {
+	var gsu GatewayStatusUpdate
+
+	gsu.SetListenerAttachedRoutes("http", 7)
+	gsu.SetListenerAttachedRoutes("https", 77)
+
+	assert.Len(t, gsu.ListenerStatus, 2)
+
+	require.NotNil(t, gsu.ListenerStatus["http"])
+	require.NotNil(t, gsu.ListenerStatus["https"])
+
+	assert.Equal(t, int32(7), gsu.ListenerStatus["http"].AttachedRoutes)
+	assert.Equal(t, int32(77), gsu.ListenerStatus["https"].AttachedRoutes)
+}
+
+func TestGatewayMutate(t *testing.T) {
+	var gsu GatewayStatusUpdate
+
+	gsu.ListenerStatus = map[string]*gatewayapi_v1alpha2.ListenerStatus{
+		"http": {
+			Name:           "http",
+			AttachedRoutes: 7,
+			SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+				{
+					Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName),
+					Kind:  gatewayapi_v1alpha2.Kind("FooRoute"),
+				},
+				{
+					Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName),
+					Kind:  gatewayapi_v1alpha2.Kind("BarRoute"),
+				},
+			},
+			Conditions: []metav1.Condition{},
+		},
+		"https": {
+			Name:           "https",
+			AttachedRoutes: 77,
+			SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+				{
+					Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName),
+					Kind:  gatewayapi_v1alpha2.Kind("TLSRoute"),
+				},
+			},
+			Conditions: []metav1.Condition{},
+		},
+	}
+
+	gw := &gatewayapi_v1alpha2.Gateway{
+		Status: gatewayapi_v1alpha2.GatewayStatus{
+			Listeners: []gatewayapi_v1alpha2.ListenerStatus{
+				{
+					Name:           "http",
+					AttachedRoutes: 3,
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{
+							Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName),
+							Kind:  gatewayapi_v1alpha2.Kind("HTTPRoute"),
+						},
+					},
+					Conditions: []metav1.Condition{},
+				},
+			},
+		},
+	}
+
+	got, ok := gsu.Mutate(gw).(*gatewayapi_v1alpha2.Gateway)
+	require.True(t, ok)
+
+	assert.Len(t, got.Status.Listeners, 2)
+
+	var want []gatewayapi_v1alpha2.ListenerStatus
+	for _, v := range gsu.ListenerStatus {
+		want = append(want, *v)
+	}
+	assert.ElementsMatch(t, want, got.Status.Listeners)
 }

--- a/internal/status/gatewaystatus_test.go
+++ b/internal/status/gatewaystatus_test.go
@@ -35,7 +35,7 @@ func TestGatewayAddCondition(t *testing.T) {
 		ObservedGeneration: testGeneration,
 	}
 
-	gatewayUpdate := GatewayConditionsUpdate{
+	gatewayUpdate := GatewayStatusUpdate{
 		FullName:           k8s.NamespacedNameFrom("test/test"),
 		Conditions:         make(map[gatewayapi_v1alpha2.GatewayConditionType]metav1.Condition),
 		ExistingConditions: nil,

--- a/internal/status/proxystatus.go
+++ b/internal/status/proxystatus.go
@@ -15,12 +15,8 @@ package status
 
 import (
 	"fmt"
-	"time"
 
-	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	projectcontour "github.com/projectcontour/contour/apis/projectcontour/v1"
-	"github.com/projectcontour/contour/internal/k8s"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,45 +41,6 @@ type ProxyUpdate struct {
 	// keyed by the Type (since that's what the apiserver will end up
 	// doing.)
 	Conditions map[ConditionType]*projectcontour.DetailedCondition
-}
-
-// ProxyAccessor returns a ProxyUpdate that allows a client to build up a list of
-// errors and warnings to go onto the proxy as conditions, and a function to commit the change
-// back to the cache when everything is done.
-// The commit function pattern is used so that the ProxyUpdate does not need to know anything
-// the cache internals.
-func (c *Cache) ProxyAccessor(proxy *contour_api_v1.HTTPProxy) (*ProxyUpdate, func()) {
-	pu := &ProxyUpdate{
-		Fullname:       k8s.NamespacedNameOf(proxy),
-		Generation:     proxy.Generation,
-		TransitionTime: metav1.NewTime(time.Now()),
-		Conditions:     make(map[ConditionType]*contour_api_v1.DetailedCondition),
-	}
-
-	return pu, func() {
-		c.commitProxy(pu)
-	}
-}
-
-func (c *Cache) commitProxy(pu *ProxyUpdate) {
-	if len(pu.Conditions) == 0 {
-		return
-	}
-
-	_, ok := c.proxyUpdates[pu.Fullname]
-	if ok {
-		// When we're committing, if we already have a Valid Condition with an error, and we're trying to
-		// set the object back to Valid, skip the commit, as we've visited too far down.
-		// If this is removed, the status reporting for when a parent delegates to a child that delegates to itself
-		// will not work. Yes, I know, problems everywhere. I'm sorry.
-		// TODO(youngnick)#2968: This issue has more details.
-		if c.proxyUpdates[pu.Fullname].Conditions[ValidCondition].Status == contour_api_v1.ConditionFalse {
-			if pu.Conditions[ValidCondition].Status == contour_api_v1.ConditionTrue {
-				return
-			}
-		}
-	}
-	c.proxyUpdates[pu.Fullname] = pu
 }
 
 // ConditionFor returns a DetailedCondition for a given ConditionType.

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -72,33 +72,6 @@ func (routeUpdate *RouteConditionsUpdate) AddCondition(cond gatewayapi_v1alpha2.
 	return newDc
 }
 
-// RouteConditionsAccessor returns a RouteConditionsUpdate that allows a client to build up a list of
-// metav1.Conditions as well as a function to commit the change back to the cache when everything
-// is done. The commit function pattern is used so that the RouteConditionsUpdate does not need
-// to know anything the cache internals.
-func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation int64, resource client.Object, gateways []gatewayapi_v1alpha2.RouteParentStatus) (*RouteConditionsUpdate, func()) {
-	pu := &RouteConditionsUpdate{
-		FullName:           nsName,
-		Conditions:         make(map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition),
-		ExistingConditions: c.getRouteGatewayConditions(gateways),
-		GatewayRef:         c.gatewayRef,
-		GatewayController:  c.gatewayController,
-		Generation:         generation,
-		TransitionTime:     metav1.NewTime(clock.Now()),
-		Resource:           resource,
-	}
-
-	return pu, func() {
-		c.commitRoute(pu)
-	}
-}
-
-func (c *Cache) commitRoute(pu *RouteConditionsUpdate) {
-	if len(pu.Conditions) == 0 {
-		return
-	}
-	c.routeUpdates[pu.FullName] = pu
-}
 func (routeUpdate *RouteConditionsUpdate) Mutate(obj client.Object) client.Object {
 
 	var gatewayStatuses []gatewayapi_v1alpha2.RouteParentStatus


### PR DESCRIPTION
Sets status for Gateway Listeners, specifically
the "attachedRoutes" and "supportedKinds" fields.

Updates #4124.

Signed-off-by: Steve Kriss <krisss@vmware.com>