### PR TITLE
test/e2e: Verbose only on failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ e2e: | setup-kind-cluster run-e2e cleanup-kind ## Run E2E tests against a real k
 .PHONY: run-e2e
 run-e2e:
 	CONTOUR_E2E_LOCAL_HOST=$(CONTOUR_E2E_LOCAL_HOST) \
-		ginkgo -tags=e2e -mod=readonly -skip-package=upgrade -keep-going -randomize-suites -randomize-all -slow-spec-threshold=15s -r -v ./test/e2e
+		ginkgo -tags=e2e -mod=readonly -skip-package=upgrade -keep-going -randomize-suites -randomize-all -slow-spec-threshold=120s -r ./test/e2e
 
 .PHONY: cleanup-kind
 cleanup-kind:

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -373,7 +373,8 @@ descriptors:
 
 			BeforeEach(func() {
 				if !e2e.UsingContourConfigCRD() {
-					Skip("test only applies to contour config CRD")
+					// Test only applies to contour config CRD.
+					Skip("")
 				}
 				for _, ns := range rootNamespaces {
 					f.CreateNamespace(ns)
@@ -398,7 +399,8 @@ descriptors:
 
 			BeforeEach(func() {
 				if e2e.UsingContourConfigCRD() {
-					Skip("test only applies to contour configmap")
+					// Test only applies to contour configmap.
+					Skip("")
 				}
 				for _, ns := range rootNamespaces {
 					f.CreateNamespace(ns)


### PR DESCRIPTION
Run ginkgo without -v to reduce the number of redundant logs on successful runs. This makes it easier to find the failures in the logs.

Test runner will still capture the stdout and stderr of tests, and replay the output when test fails.  

Fixes #4161

Signed-off-by: Tero Saarni <tero.saarni@est.tech>