### PR TITLE
test/e2e: simplify API validation tests

### DIFF
--- a/test/e2e/httpproxy/fqdn_test.go
+++ b/test/e2e/httpproxy/fqdn_test.go
@@ -29,8 +29,6 @@ func testWildcardFQDN(namespace string) {
 	Specify("invalid wildcard fqdn", func() {
 		t := f.T()
 
-		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
-
 		p := &contourv1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -62,6 +62,8 @@ var _ = Describe("HTTPProxy API validation", func() {
 	f.NamespacedTest("httpproxy-required-field-validation", testRequiredFieldValidation)
 
 	f.NamespacedTest("httpproxy-invalid-wildcard-fqdn", testWildcardFQDN)
+
+	f.NamespacedTest("invalid-cookie-rewrite-fields", testInvalidCookieRewriteFields)
 })
 
 var _ = Describe("HTTPProxy", func() {
@@ -340,8 +342,6 @@ descriptors:
 	})
 
 	Context("cookie-rewriting", func() {
-		f.NamespacedTest("invalid-cookie-rewrite-fields", testInvalidCookieRewriteFields)
-
 		f.NamespacedTest("app-cookie-rewrite", testAppCookieRewrite)
 
 		f.NamespacedTest("cookie-rewrite-tls", testCookieRewriteTLS)

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -55,6 +55,15 @@ var _ = AfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
 
+// Contains specs that test that kubebuilder API validations
+// work as expected, and do not require a Contour instance to
+// be running.
+var _ = Describe("HTTPProxy API validation", func() {
+	f.NamespacedTest("httpproxy-required-field-validation", testRequiredFieldValidation)
+
+	f.NamespacedTest("httpproxy-invalid-wildcard-fqdn", testWildcardFQDN)
+})
+
 var _ = Describe("HTTPProxy", func() {
 	var (
 		contourCmd            *gexec.Session
@@ -95,8 +104,6 @@ var _ = Describe("HTTPProxy", func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
 	})
 
-	f.NamespacedTest("httpproxy-required-field-validation", testRequiredFieldValidation)
-
 	f.NamespacedTest("httpproxy-header-condition-match", testHeaderConditionMatch)
 
 	f.NamespacedTest("httpproxy-path-condition-match", testPathConditionMatch)
@@ -117,8 +124,7 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-retry-policy-validation", testRetryPolicyValidation)
 
-	f.NamespacedTest("httpproxy-invalid-wildcard-subdomain-fqdn", testWildcardSubdomainFQDN)
-	f.NamespacedTest("httpproxy-invalid-wildcard-fqdn", testWildcardFQDN)
+	f.NamespacedTest("httpproxy-wildcard-subdomain-fqdn", testWildcardSubdomainFQDN)
 
 	f.NamespacedTest("httpproxy-https-fallback-certificate", func(namespace string) {
 		Context("with fallback certificate", func() {


### PR DESCRIPTION
Moves E2E tests that verify kubebuilder validation
annotations to their own Describe block which
does not run a Contour instance, since it's not
needed for these tests.

Updates #4163.

Signed-off-by: Steve Kriss <krisss@vmware.com>