### PR TITLE
Fix typo

### DIFF
--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -39,7 +39,7 @@ This quickstart guide installs Contour on a kubernetes cluster with a web applic
 
 
 ## 1. Set up a kubernetes environment
-This procedure uses Docker and kind to deploy a kubernetes cluster. If you already have a cluster available, skip to step 3  – Install a Contour service.  
+This procedure uses Docker and kind to deploy a kubernetes cluster. If you already have a cluster available, skip to step 2  – Install a Contour service.  
 
 
 ### Install kind:


### PR DESCRIPTION
The quickstart has three steps:

1. Set up a kubernetes environment
2. Install a Contour service
3. Install a kuard workload

On step 1,  there is the option to skip to "Install a Contour service", which is the step 2, but is referred to as 3.