### PR TITLE
internal/dag: apply TCPProxy service weights

### DIFF
--- a/changelogs/unreleased/4169-skriss-minor.md
+++ b/changelogs/unreleased/4169-skriss-minor.md
@@ -1,0 +1,5 @@
+### HTTPProxy TCPProxy service weights are now applied
+
+Previously, Contour did not apply any service weights defined in an HTTPProxy's TCPProxy, and all services were equally weighted.
+Now, if those weights are defined, they are applied so traffic is weighted appropriately across the services.
+Note that if no TCPProxy service weights are defined, traffic continues to be equally spread across all services.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -10587,7 +10587,140 @@ func TestDAGInsert(t *testing.T) {
 				},
 			),
 		},
-		"multiple services with weight and missing service reference": {},
+		"httpproxy with tcpproxy with multiple services, no explicit weights": {
+			objs: []interface{}{
+				s1, s2, s9,
+				&contour_api_v1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "weighted-tcpproxy",
+						Namespace: "default",
+					},
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							Fqdn: "example.com",
+							TLS: &contour_api_v1.TLS{
+								Passthrough: true,
+							},
+						},
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{
+								{Name: s1.Name, Port: int(s1.Spec.Ports[0].Port)},
+								{Name: s2.Name, Port: int(s2.Spec.Ports[0].Port)},
+								{Name: s9.Name, Port: int(s9.Spec.Ports[0].Port)},
+							},
+						},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					SecureVirtualHosts: securevirtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: clusters(service(s1), service(s2), service(s9)),
+							},
+						},
+					),
+				},
+			),
+		},
+		"httpproxy with tcpproxy with multiple weighted services": {
+			objs: []interface{}{
+				s1, s2, s9,
+				&contour_api_v1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "weighted-tcpproxy",
+						Namespace: "default",
+					},
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							Fqdn: "example.com",
+							TLS: &contour_api_v1.TLS{
+								Passthrough: true,
+							},
+						},
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{
+								{Name: s1.Name, Port: int(s1.Spec.Ports[0].Port), Weight: 1},
+								{Name: s2.Name, Port: int(s2.Spec.Ports[0].Port), Weight: 2},
+								{Name: s9.Name, Port: int(s9.Spec.Ports[0].Port), Weight: 3},
+							},
+						},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					SecureVirtualHosts: securevirtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: []*Cluster{
+									{Upstream: service(s1), Weight: 1},
+									{Upstream: service(s2), Weight: 2},
+									{Upstream: service(s9), Weight: 3},
+								},
+							},
+						},
+					),
+				},
+			),
+		},
+		"httpproxy with tcpproxy with multiple services, some weighted, some not": {
+			objs: []interface{}{
+				s1, s2, s9,
+				&contour_api_v1.HTTPProxy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "weighted-tcpproxy",
+						Namespace: "default",
+					},
+					Spec: contour_api_v1.HTTPProxySpec{
+						VirtualHost: &contour_api_v1.VirtualHost{
+							Fqdn: "example.com",
+							TLS: &contour_api_v1.TLS{
+								Passthrough: true,
+							},
+						},
+						TCPProxy: &contour_api_v1.TCPProxy{
+							Services: []contour_api_v1.Service{
+								{Name: s1.Name, Port: int(s1.Spec.Ports[0].Port), Weight: 1},
+								{Name: s2.Name, Port: int(s2.Spec.Ports[0].Port), Weight: 0},
+								{Name: s9.Name, Port: int(s9.Spec.Ports[0].Port), Weight: 3},
+							},
+						},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Port: 443,
+					SecureVirtualHosts: securevirtualhosts(
+						&SecureVirtualHost{
+							VirtualHost: VirtualHost{
+								Name:         "example.com",
+								ListenerName: "ingress_https",
+							},
+							TCPProxy: &TCPProxy{
+								Clusters: []*Cluster{
+									{Upstream: service(s1), Weight: 1},
+									{Upstream: service(s2), Weight: 0},
+									{Upstream: service(s9), Weight: 3},
+								},
+							},
+						},
+					),
+				},
+			),
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -760,6 +760,7 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(validCond *contour_api_v1.
 
 			proxy.Clusters = append(proxy.Clusters, &Cluster{
 				Upstream:             s,
+				Weight:               uint32(service.Weight),
 				Protocol:             protocol,
 				LoadBalancerPolicy:   lbPolicy,
 				TCPHealthCheckPolicy: tcpHealthCheckPolicy(tcpproxy.HealthCheckPolicy),

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -434,6 +434,35 @@ func tcpproxy(statPrefix, cluster string) *envoy_listener_v3.Filter {
 	}
 }
 
+type clusterWeight struct {
+	name   string
+	weight uint32
+}
+
+func tcpproxyWeighted(statPrefix string, clusters ...clusterWeight) *envoy_listener_v3.Filter {
+	weightedClusters := &envoy_tcp_proxy_v3.TcpProxy_WeightedCluster{}
+	for _, clusterWeight := range clusters {
+		weightedClusters.Clusters = append(weightedClusters.Clusters, &envoy_tcp_proxy_v3.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   clusterWeight.name,
+			Weight: clusterWeight.weight,
+		})
+	}
+
+	return &envoy_listener_v3.Filter{
+		Name: wellknown.TCPProxy,
+		ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+			TypedConfig: protobuf.MustMarshalAny(&envoy_tcp_proxy_v3.TcpProxy{
+				StatPrefix: statPrefix,
+				ClusterSpecifier: &envoy_tcp_proxy_v3.TcpProxy_WeightedClusters{
+					WeightedClusters: weightedClusters,
+				},
+				AccessLog:   envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil),
+				IdleTimeout: protobuf.Duration(9001 * time.Second),
+			}),
+		},
+	}
+}
+
 func statsListener() *envoy_listener_v3.Listener {
 	return envoy_v3.StatsListener("0.0.0.0", 8002)
 }


### PR DESCRIPTION
Fixes a bug where HTTPProxy TCPProxy service
weights were not being applied.

Closes #4158.

Signed-off-by: Steve Kriss <krisss@vmware.com>