### PR TITLE
test/e2e/upgrade: Add app polling during upgrade

### DIFF
--- a/test/e2e/poller.go
+++ b/test/e2e/poller.go
@@ -1,0 +1,86 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type appPoller struct {
+	cancel             context.CancelFunc
+	wg                 *sync.WaitGroup
+	totalRequests      uint
+	successfulRequests uint
+}
+
+func StartAppPoller(address string, hostName string, expectedStatus int) (*appPoller, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	poller := &appPoller{
+		wg:     new(sync.WaitGroup),
+		cancel: cancel,
+	}
+
+	client := &http.Client{
+		Timeout: 100 * time.Millisecond,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Host = hostName
+
+	poller.wg.Add(1)
+	go func() {
+		defer poller.wg.Done()
+		wait.PollImmediateInfiniteWithContext(ctx, 200*time.Millisecond, func(ctx context.Context) (bool, error) {
+			// Stop polling if we are being shut down so we don't
+			// get extra failures.
+			select {
+			case <-ctx.Done():
+				return true, nil
+			default:
+			}
+
+			poller.totalRequests++
+			res, err := client.Do(req)
+			if err != nil {
+				return false, nil
+			}
+			if res.StatusCode == expectedStatus {
+				poller.successfulRequests++
+			}
+			return false, nil
+		})
+	}()
+
+	return poller, nil
+}
+
+func (p *appPoller) Stop() {
+	p.cancel()
+	p.wg.Wait()
+}
+
+func (p *appPoller) Results() (uint, uint) {
+	return p.totalRequests, p.successfulRequests
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -18,6 +18,8 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
@@ -97,6 +99,9 @@ var _ = Describe("upgrading Contour", func() {
 			By("ensuring it is routable")
 			checkRoutability(appHost)
 
+			poller, err := e2e.StartAppPoller(f.HTTP.HTTPURLBase, appHost, http.StatusOK)
+			require.NoError(f.T(), err)
+
 			updateContourDeploymentResources()
 
 			By("waiting for contour deployment to be updated")
@@ -107,6 +112,13 @@ var _ = Describe("upgrading Contour", func() {
 
 			By("ensuring app is still routable")
 			checkRoutability(appHost)
+
+			poller.Stop()
+			totalRequests, successfulRequests := poller.Results()
+			fmt.Fprintf(GinkgoWriter, "Total requests: %d, successful requests: %d\n", totalRequests, successfulRequests)
+			require.Greater(f.T(), totalRequests, uint(0))
+			successPercentage := 100 * float64(successfulRequests) / float64(totalRequests)
+			require.Greaterf(f.T(), successPercentage, float64(90.0), "success rate of %.2f%% less than 90%", successPercentage)
 		})
 	})
 })


### PR DESCRIPTION
- adds poller that can be used to asynchronously send requests to an app
and get total/successful request counts
- in upgrade test, started after app is deemed routable
- assertion is that > 90% of requests must succeed, arbitrary
measurement for now

Updates: https://github.com/projectcontour/contour/issues/3679