### PR TITLE
[Release 1.18] Cherry-pick: Allow retry policy, num retries to be zero

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -638,9 +638,12 @@ type RetryOn string
 // RetryPolicy defines the attributes associated with retrying policy.
 type RetryPolicy struct {
 	// NumRetries is maximum allowed number of retries.
-	// If not supplied, the number of retries is one.
+	// If set to -1, then retries are disabled.
+	// If set to 0 or not supplied, the value is set
+	// to the Envoy default of 1.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=-1
 	NumRetries int64 `json:"count"`
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if NumRetries is not supplied.

--- a/changelogs/unreleased/4117-stevesloka-minor.md
+++ b/changelogs/unreleased/4117-stevesloka-minor.md
@@ -1,0 +1,8 @@
+### Allow retry policy, num retries to be zero 
+
+The field, NumRetries (e.g. count), in the RetryPolicy allows for a zero to be
+specified, however Contour's internal logic would see that as "undefined"
+and set it back to the Envoy default of 1. This would never allow the value of 
+zero to be set. Users can set the value to be -1 which will represent disabling 
+the retry count. If not specified or set to zero, then the Envoy default value 
+of 1 is used. 

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1041,10 +1041,13 @@ spec:
                       description: The retry policy for this route.
                       properties:
                         count:
+                          default: 1
                           description: NumRetries is maximum allowed number of retries.
-                            If not supplied, the number of retries is one.
+                            If set to -1, then retries are disabled. If set to 0 or
+                            not supplied, the value is set to the Envoy default of
+                            1.
                           format: int64
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         perTryTimeout:
                           description: PerTryTimeout specifies the timeout per retry

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1235,10 +1235,13 @@ spec:
                       description: The retry policy for this route.
                       properties:
                         count:
+                          default: 1
                           description: NumRetries is maximum allowed number of retries.
-                            If not supplied, the number of retries is one.
+                            If set to -1, then retries are disabled. If set to 0 or
+                            not supplied, the value is set to the Envoy default of
+                            1.
                           format: int64
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         perTryTimeout:
                           description: PerTryTimeout specifies the timeout per retry

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -80,10 +80,10 @@ data:
     # SNI defined for a vhost.
       fallback-certificate:
     #   name: fallback-secret-name
-    #   namespace: projectcontour
+      namespace: projectcontour
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
-    #   namespace: projectcontour
+      namespace: projectcontour
     # The following config shows the defaults for the leader election.
     # leaderelection:
     #   configmap-name: leader-elect

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1232,10 +1232,13 @@ spec:
                       description: The retry policy for this route.
                       properties:
                         count:
+                          default: 1
                           description: NumRetries is maximum allowed number of retries.
-                            If not supplied, the number of retries is one.
+                            If set to -1, then retries are disabled. If set to 0 or
+                            not supplied, the value is set to the Envoy default of
+                            1.
                           format: int64
-                          minimum: 0
+                          minimum: -1
                           type: integer
                         perTryTimeout:
                           description: PerTryTimeout specifies the timeout per retry

--- a/internal/annotation/annotations_test.go
+++ b/internal/annotation/annotations_test.go
@@ -35,7 +35,7 @@ func TestParseUint32(t *testing.T) {
 			want: 0,
 		},
 		"negative": {
-			s:    "-6", // for alice
+			s:    "-6",
 			want: 0,
 		},
 		"explicit": {
@@ -55,6 +55,115 @@ func TestParseUint32(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := parseUInt32(tc.s)
+			if got != tc.want {
+				t.Fatalf("expected: %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestParseint32(t *testing.T) {
+	tests := map[string]struct {
+		s    string
+		want int32
+	}{
+		"blank": {
+			s:    "",
+			want: 0,
+		},
+		"negative": {
+			s:    "-1",
+			want: -1,
+		},
+		"explicit": {
+			s:    "0",
+			want: 0,
+		},
+		"positive": {
+			s:    "2",
+			want: 2,
+		},
+		"too large": {
+			s:    "144115188075855872", // larger than int32
+			want: 0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := parseInt32(tc.s)
+			if got != tc.want {
+				t.Fatalf("expected: %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestNumRetries(t *testing.T) {
+	tests := map[string]struct {
+		ingress *networking_v1.Ingress
+		want    uint32
+	}{
+		"blank": {
+			ingress: &networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing",
+					Annotations: map[string]string{
+						"projectcontour.io/num-retries": "",
+					},
+				},
+			},
+			want: 1,
+		},
+		"Set to 1": {
+			ingress: &networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing",
+					Annotations: map[string]string{
+						"projectcontour.io/num-retries": "1",
+					},
+				},
+			},
+			want: 1,
+		},
+		"Set to 0": {
+			ingress: &networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing",
+					Annotations: map[string]string{
+						"projectcontour.io/num-retries": "0",
+					},
+				},
+			},
+			want: 1,
+		},
+		"Set to -1": {
+			ingress: &networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing",
+					Annotations: map[string]string{
+						"projectcontour.io/num-retries": "-1",
+					},
+				},
+			},
+			want: 0,
+		},
+		"Set to 9": {
+			ingress: &networking_v1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ing",
+					Annotations: map[string]string{
+						"projectcontour.io/num-retries": "9",
+					},
+				},
+			},
+			want: 9,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NumRetries(tc.ingress)
 			if got != tc.want {
 				t.Fatalf("expected: %v, got %v", tc.want, got)
 			}

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -84,10 +84,21 @@ func retryPolicy(rp *contour_api_v1.RetryPolicy) *RetryPolicy {
 		perTryTimeout = timeout.DurationSetting(perTryDuration)
 	}
 
+	numRetries := rp.NumRetries
+	// If set to -1, then retries set to 0. If set to 0 or
+	// not supplied, the value is set to the Envoy default of 1.
+	// Otherwise the value supplied is returned.
+	switch rp.NumRetries {
+	case -1:
+		numRetries = 0
+	case 1, 0:
+		numRetries = 1
+	}
+
 	return &RetryPolicy{
 		RetryOn:              retryOn(rp.RetryOn),
 		RetriableStatusCodes: rp.RetriableStatusCodes,
-		NumRetries:           max(1, uint32(rp.NumRetries)),
+		NumRetries:           uint32(numRetries),
 		PerTryTimeout:        perTryTimeout,
 	}
 }
@@ -313,9 +324,7 @@ func ingressRetryPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger) 
 
 	// if there is a non empty retry-on annotation, build a RetryPolicy manually.
 	rp := &RetryPolicy{
-		RetryOn: retryOn,
-		// TODO(dfc) k8s.NumRetries may parse as 0, which is inconsistent with
-		// retryPolicy()'s default value of 1.
+		RetryOn:    retryOn,
 		NumRetries: annotation.NumRetries(ingress),
 	}
 
@@ -419,13 +428,6 @@ func loadBalancerPolicy(lbp *contour_api_v1.LoadBalancerPolicy) string {
 	default:
 		return ""
 	}
-}
-
-func max(a, b uint32) uint32 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func prefixReplacementsAreValid(replacements []contour_api_v1.ReplacePrefix) (string, error) {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -44,15 +44,16 @@ func TestRetryPolicyIngress(t *testing.T) {
 				},
 			},
 			want: &RetryPolicy{
-				RetryOn: "5xx",
+				RetryOn:    "5xx",
+				NumRetries: 1,
 			},
 		},
-		"explicitly zero retries": {
+		"explicitly disabled retries": {
 			i: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"projectcontour.io/retry-on":    "5xx",
-						"projectcontour.io/num-retries": "0",
+						"projectcontour.io/num-retries": "-1",
 					},
 				},
 			},
@@ -86,7 +87,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 			want: &RetryPolicy{
 				RetryOn:       "5xx",
-				NumRetries:    0,
+				NumRetries:    1,
 				PerTryTimeout: timeout.DurationSetting(10 * time.Second),
 			},
 		},
@@ -101,7 +102,7 @@ func TestRetryPolicyIngress(t *testing.T) {
 			},
 			want: &RetryPolicy{
 				RetryOn:       "5xx",
-				NumRetries:    0,
+				NumRetries:    1,
 				PerTryTimeout: timeout.DefaultSetting(),
 			},
 		},

--- a/site/content/docs/main/config/annotations.md
+++ b/site/content/docs/main/config/annotations.md
@@ -43,7 +43,7 @@ The `ingress.kubernetes.io/force-ssl-redirect` annotation takes precedence over 
 ## Contour specific Ingress annotations
 
  - `projectcontour.io/ingress.class`: The Ingress class that should interpret and serve the Ingress. See the [main Ingress class annotation section](#ingress-class) for more details.
- - `projectcontour.io/num-retries`: [The maximum number of retries][1] Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified.
+ - `projectcontour.io/num-retries`: [The maximum number of retries][1] Envoy should make before abandoning and returning an error to the client. Applies only if `projectcontour.io/retry-on` is specified. Set to -1 to disable retries.
  - `projectcontour.io/per-try-timeout`: [The timeout per retry attempt][2], if there should be one. Applies only if `projectcontour.io/retry-on` is specified.
  - `projectcontour.io/response-timeout`: [The Envoy HTTP route timeout][3], specified as a [golang duration][4]. By default, Envoy has a 15 second timeout for a backend service to respond. Set this to `infinity` to specify that Envoy should never timeout the connection to the backend. Note that the value `0s` / zero has special semantics for Envoy.
  - `projectcontour.io/retry-on`: [The conditions for Envoy to retry a request][5]. See also [possible values and their meanings for `retry-on`][6].

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2120,7 +2120,9 @@ int64
 <td>
 <em>(Optional)</em>
 <p>NumRetries is maximum allowed number of retries.
-If not supplied, the number of retries is one.</p>
+If set to -1, then retries are disabled.
+If set to 0 or not supplied, the value is set
+to the Envoy default of 1.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -216,7 +216,7 @@ The string 'infinity' is also a valid input and specifies no timeout.
 
 - `retryPolicy`: A retry will be attempted if the server returns an error code in the 5xx range, or if the server takes more than `retryPolicy.perTryTimeout` to process a request.
 
-- `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1.
+- `retryPolicy.count` specifies the maximum number of retries allowed. This parameter is optional and defaults to 1. Set to -1 to disable. If set to 0, the Envoy default of 1 is used.
 
 - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional.
   If left unspecified, `timeoutPolicy.request` will be used.


### PR DESCRIPTION
Cherry-pick PR #4117 to release-1.18, in preparation for a 1.18.3 release.

Updates #4168

Original commit message below.

---
Since the current field for NumRetries is not a pointer, Contour
doesn't have a good way to understand if the field is unspecified,
or set to zero.

To keep the v1 API contract, Contour will allow this field to be set
to -1 which means the numRetries should be zero. If unspecified or set
to zero, then the Envoy default of 1 is used.

Signed-off-by: Steve Sloka <slokas@vmware.com>