### PR TITLE
hack/release: Remove ttlSecondsAfterFinished from certgen job

### DIFF
--- a/changelogs/unreleased/4200-lrewega-small.md
+++ b/changelogs/unreleased/4200-lrewega-small.md
@@ -1,0 +1,1 @@
+Removes spec.ttlSecondsAfterFinished from certgen job in versioned releases, as immediately deleting it upon completion will not be useful for most consumers.

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -52,6 +52,14 @@ for example in examples/contour/02-job-certgen.yaml ; do
         "$example"
 done
 
+# Remove spec.ttlSecondsAfterFinished from the certgen job, as it is versioned
+# for releases and doesn't need to be cleaned up.
+for example in examples/contour/02-job-certgen.yaml ; do
+    run::sed \
+        '-e/^[[:blank:]]*ttlSecondsAfterFinished:/d' \
+        "$example"
+done
+
 make generate
 
 # If pushing the tag failed, then we might have already committed the


### PR DESCRIPTION
The certgen job is versioned in releases, so deleting it should not be
necessary for most consumers. Deleting the job can cause problems when
applying the quickstart config via continous deployment (e.g. Argo CD)
as the job disappears before an external observer can acknowledge it
completed successfully, or even confirm that it ever existed.

Signed-off-by: Luke Rewega <lrewega@buf.build>