### PR TITLE
test/scripts: ignore pre-release tags when getting upgrade version

### DIFF
--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -6,12 +6,12 @@ set -o pipefail
 
 if CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
   # We are on a tag, so find previous tag to this one.
-  git tag -l --sort=-v:refname | grep -A1 $CURRENT_TAG| tail -1
+  git tag -l --sort=-v:refname | grep -A10 $CURRENT_TAG | grep -v 'alpha\|beta\|rc' | head -1
 elif git branch --show-current | grep -q release; then
   # We are on a release branch, so find tag.
   git describe --tags --abbrev=0
 else
   # We are likely on main or some other checkout, just use latest tag.
   # If needed, user can override this version with environment variables.
-  git describe --tags $(git rev-list --tags --max-count=1)
+  git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | head -1
 fi


### PR DESCRIPTION
Excludes tags with "alpha", "beta" or "rc" when
getting the tag to upgrade from for upgrade tests.

Signed-off-by: Steve Kriss <krisss@vmware.com>