### PR TITLE
test/e2e/httpproxy: Loosen cookie matching to a contains match

### DIFF
--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -397,11 +397,10 @@ func testAppCookieRewrite(namespace string) {
 					continue
 				}
 				for _, v := range values {
-					switch v {
-					case "service=baz; Path=/svc-new":
-						services["echo"] = struct{}{}
-					case "service=baz; Path=/svc-new-other":
+					if strings.Contains(v, "Path=/svc-new-other") {
 						services["echo-other"] = struct{}{}
+					} else if strings.Contains(v, "Path=/svc-new") {
+						services["echo"] = struct{}{}
 					}
 				}
 			}


### PR DESCRIPTION
In case cookie attributes are in different order

Re:
https://github.com/projectcontour/contour/runs/4435347950?check_suite_focus=true