### PR TITLE
Gateway API: drop 'core' as allowed core API group name

### DIFF
--- a/changelogs/unreleased/4219-skriss-small.md
+++ b/changelogs/unreleased/4219-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: "core" is no longer allowed as a magic string to reference the core Kubernetes API group. Instead, the empty string should be used to align with the Gateway API spec.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -360,7 +360,7 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 }
 
 func isRefToService(ref gatewayapi_v1alpha2.BackendObjectReference, service *v1.Service, routeNamespace string) bool {
-	return ref.Group != nil && (*ref.Group == "" || *ref.Group == "core") &&
+	return ref.Group != nil && *ref.Group == "" &&
 		ref.Kind != nil && *ref.Kind == "Service" &&
 		((ref.Namespace != nil && *ref.Namespace == gatewayapi_v1alpha2.Namespace(service.Namespace)) || (ref.Namespace == nil && routeNamespace == service.Namespace)) &&
 		string(ref.Name) == service.Name
@@ -467,7 +467,7 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 }
 
 func isRefToSecret(ref gatewayapi_v1alpha2.SecretObjectReference, secret *v1.Secret, gatewayNamespace string) bool {
-	return ref.Group != nil && (*ref.Group == "" || *ref.Group == "core") &&
+	return ref.Group != nil && *ref.Group == "" &&
 		ref.Kind != nil && *ref.Kind == "Secret" &&
 		((ref.Namespace != nil && *ref.Namespace == gatewayapi_v1alpha2.Namespace(secret.Namespace)) || (ref.Namespace == nil && gatewayNamespace == secret.Namespace)) &&
 		string(ref.Name) == secret.Name

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -456,7 +456,7 @@ func (p *GatewayAPIProcessor) validCrossNamespaceRef(from crossNamespaceFrom, to
 }
 
 func isSecretRef(certificateRef gatewayapi_v1alpha2.SecretObjectReference) bool {
-	return certificateRef.Group != nil && (*certificateRef.Group == "" || *certificateRef.Group == "core") &&
+	return certificateRef.Group != nil && *certificateRef.Group == "" &&
 		certificateRef.Kind != nil && *certificateRef.Kind == "Secret"
 }
 
@@ -907,8 +907,8 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1alpha2.HTTPRo
 // validateBackendRef verifies that the specified BackendRef is valid.
 // Returns an error if not or the service found in the cache.
 func (p *GatewayAPIProcessor) validateBackendRef(backendRef gatewayapi_v1alpha2.BackendRef, routeKind, routeNamespace string) (*Service, error) {
-	if !(backendRef.Group == nil || *backendRef.Group == "" || *backendRef.Group == "core") {
-		return nil, fmt.Errorf("Spec.Rules.BackendRef.Group must be empty or 'core'")
+	if !(backendRef.Group == nil || *backendRef.Group == "") {
+		return nil, fmt.Errorf("Spec.Rules.BackendRef.Group must be \"\"")
 	}
 
 	if !(backendRef.Kind != nil && *backendRef.Kind == "Service") {

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -55,7 +55,7 @@ func ListenerHostname(host string) *gatewayapi_v1alpha2.Hostname {
 
 func CertificateRef(name, namespace string) *gatewayapi_v1alpha2.SecretObjectReference {
 	ref := &gatewayapi_v1alpha2.SecretObjectReference{
-		Group: GroupPtr("core"),
+		Group: GroupPtr(""),
 		Kind:  KindPtr("Secret"),
 		Name:  gatewayapi_v1alpha2.ObjectName(name),
 	}


### PR DESCRIPTION
Previously Contour accepted either the empty string
or "core" as the group name for the core API group,
i.e. the one containing Services, Secrets, etc. However,
the "core" string is not part of the Gateway API spec
and adds complexity to all logic that interacts with
groups. This PR drops support for it, and expects
that any references to the core API group will have
an empty group string.

Signed-off-by: Steve Kriss <krisss@vmware.com>