### PR TITLE
add AuthBeforeRateLimiting field to AuthorizationServer

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -175,6 +175,14 @@ type AuthorizationServer struct {
 	// WithRequestBody specifies configuration for sending the client request's body to authorization server.
 	// +optional
 	WithRequestBody *AuthorizationServerBufferSettings `json:"withRequestBody,omitempty"`
+
+	// AuthBeforeRateLimiting defines whether the authorization server
+	// will be consulted before applying any rate limiting to a
+	// request. The default is false, i.e. to apply rate-limiting first,
+	// in order to protect the authorization server.
+	//
+	// +optional
+	AuthBeforeRateLimiting bool `json:"authBeforeRateLimiting,omitempty"`
 }
 
 // AuthorizationServerBufferSettings enables ExtAuthz filter to buffer client request data and send it as part of authorization request

--- a/changelogs/unreleased/4230-skriss-minor.md
+++ b/changelogs/unreleased/4230-skriss-minor.md
@@ -1,0 +1,5 @@
+### Add authBeforeRateLimiting option to HTTPProxy's authorizationServer
+
+A new field, `authBeforeRateLimiting`, has been added to the `authorizationServer` block in `HTTPProxy`. When set to true, external auth will occur *before* any local or global rate limiting. When left as false (the default), external auth will occur *after* both local and global rate limiting.
+
+Note that, as part of introducing this field, global rate limiting has been moved to occur before external auth by default. Previously, local rate limiting occurred before external auth, but global rate limiting occurred after external auth. Both types of rate limiting are now consistently either before or after external auth, based on the value of this new field.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -3581,6 +3581,12 @@ spec:
                       client certificate is always included in the authentication
                       check request.
                     properties:
+                      authBeforeRateLimiting:
+                        description: AuthBeforeRateLimiting defines whether the authorization
+                          server will be consulted before applying any rate limiting
+                          to a request. The default is false, i.e. to apply rate-limiting
+                          first, in order to protect the authorization server.
+                        type: boolean
                       authPolicy:
                         description: AuthPolicy sets a default authorization policy
                           for client requests. This policy will be used unless overridden

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3777,6 +3777,12 @@ spec:
                       client certificate is always included in the authentication
                       check request.
                     properties:
+                      authBeforeRateLimiting:
+                        description: AuthBeforeRateLimiting defines whether the authorization
+                          server will be consulted before applying any rate limiting
+                          to a request. The default is false, i.e. to apply rate-limiting
+                          first, in order to protect the authorization server.
+                        type: boolean
                       authPolicy:
                         description: AuthPolicy sets a default authorization policy
                           for client requests. This policy will be used unless overridden

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3774,6 +3774,12 @@ spec:
                       client certificate is always included in the authentication
                       check request.
                     properties:
+                      authBeforeRateLimiting:
+                        description: AuthBeforeRateLimiting defines whether the authorization
+                          server will be consulted before applying any rate limiting
+                          to a request. The default is false, i.e. to apply rate-limiting
+                          first, in order to protect the authorization server.
+                        type: boolean
                       authPolicy:
                         description: AuthPolicy sets a default authorization policy
                           for client requests. This policy will be used unless overridden

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -536,6 +536,12 @@ type SecureVirtualHost struct {
 	// AuthorizationServerWithRequestBody specifies configuration
 	// for buffering request data sent to AuthorizationServer
 	AuthorizationServerWithRequestBody *AuthorizationServerBufferSettings
+
+	// AuthBeforeRateLimiting defines whether the authorization server
+	// will be consulted before applying any rate limiting to a
+	// request. The default is false, i.e. to apply rate-limiting first,
+	// in order to protect the authorization server.
+	AuthBeforeRateLimiting bool
 }
 
 // AuthorizationServerBufferSettings enables ExtAuthz filter to buffer client

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -287,6 +287,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 
 				svhost.AuthorizationService = ext
 				svhost.AuthorizationFailOpen = auth.FailOpen
+				svhost.AuthBeforeRateLimiting = auth.AuthBeforeRateLimiting
 
 				timeout, err := timeout.Parse(auth.ResponseTimeout)
 				if err != nil {

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -20,16 +20,23 @@ import (
 
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	ratelimit_config_v3 "github.com/envoyproxy/go-control-plane/envoy/config/ratelimit/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_config_filter_http_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	ratelimit_filter_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
+	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/dag"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/protobuf"
+	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -639,4 +646,242 @@ func TestAuthorization(t *testing.T) {
 			f(t, rh, c)
 		})
 	}
+}
+
+func TestAuthzBeforeRateLimiting(t *testing.T) {
+	rh, c, done := setup(
+		t,
+		func(cfg *xdscache_v3.ListenerConfig) {
+			cfg.RateLimitConfig = &xdscache_v3.RateLimitConfig{
+				ExtensionService: k8s.NamespacedNameFrom("projectcontour/ratelimit"),
+				Domain:           "contour",
+			}
+		},
+	)
+	defer done()
+
+	// Add ext auth service
+	rh.OnAdd(fixture.NewService("auth/oidc-server").
+		WithPorts(corev1.ServicePort{Port: 8081}))
+
+	rh.OnAdd(&v1alpha1.ExtensionService{
+		ObjectMeta: fixture.ObjectMeta("auth/extension"),
+		Spec: v1alpha1.ExtensionServiceSpec{
+			Services: []v1alpha1.ExtensionServiceTarget{
+				{Name: "oidc-server", Port: 8081},
+			},
+			TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
+				Response: defaultResponseTimeout.String(),
+			},
+		},
+	})
+
+	// Add rate limit service
+	rh.OnAdd(fixture.NewService("projectcontour/ratelimit").
+		WithPorts(corev1.ServicePort{Port: 8081}))
+
+	rh.OnAdd(&v1alpha1.ExtensionService{
+		ObjectMeta: fixture.ObjectMeta("projectcontour/ratelimit"),
+		Spec: v1alpha1.ExtensionServiceSpec{
+			Services: []v1alpha1.ExtensionServiceTarget{
+				{Name: "ratelimit", Port: 8081},
+			},
+		},
+	})
+
+	// Add app service
+	rh.OnAdd(fixture.NewService("app-server").
+		WithPorts(corev1.ServicePort{Port: 80}))
+
+	rh.OnAdd(&corev1.Secret{
+		ObjectMeta: fixture.ObjectMeta("certificate"),
+		Type:       "kubernetes.io/tls",
+		Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+	})
+
+	const fqdn = "authbefore.ratelimiting.projectcontour.io"
+
+	// HTTPProxy.Spec.AuthorizationService.AuthBeforeRateLimiting == false
+	p := fixture.NewProxy("proxy").
+		WithFQDN(fqdn).
+		WithCertificate("certificate").
+		WithAuthServer(contour_api_v1.AuthorizationServer{
+			ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
+				Namespace: "auth",
+				Name:      "extension",
+			},
+			AuthBeforeRateLimiting: false,
+		}).
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{Name: "app-server", Port: 80}},
+			}},
+		})
+
+	rh.OnAdd(p)
+
+	// Get an expected HTTP listener that replaces the default filter chains
+	// with an HCM that includes the global rate limit filter.
+	httpListener := defaultHTTPListener()
+	hcm := envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPRateLimit,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&ratelimit_filter_v3.RateLimit{
+					Domain:          "contour",
+					FailureModeDeny: true,
+					RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
+						GrpcService: &envoy_core_v3.GrpcService{
+							TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+								EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+									ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+								},
+							},
+						},
+						TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+					},
+				}),
+			},
+		}).
+		Get()
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				FilterChains: []*envoy_listener_v3.FilterChain{
+					filterchaintls(fqdn,
+						&corev1.Secret{
+							ObjectMeta: fixture.ObjectMeta("certificate"),
+							Type:       "kubernetes.io/tls",
+							Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+						},
+						envoy_v3.HTTPConnectionManagerBuilder().
+							AddFilter(envoy_v3.FilterMisdirectedRequests(fqdn)).
+							DefaultFilters().
+							AddFilter(&http.HttpFilter{
+								Name: "envoy.filters.http.ratelimit",
+								ConfigType: &http.HttpFilter_TypedConfig{
+									TypedConfig: protobuf.MustMarshalAny(&ratelimit_filter_v3.RateLimit{
+										Domain:          "contour",
+										FailureModeDeny: true,
+										RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
+											GrpcService: &envoy_core_v3.GrpcService{
+												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+														ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													},
+												},
+											},
+											TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+										},
+									}),
+								},
+							}).
+							// Auth filter is expected to come *after* global rate limit filter.
+							AddFilter(&http.HttpFilter{
+								Name: "envoy.filters.http.ext_authz",
+								ConfigType: &http.HttpFilter_TypedConfig{
+									TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+										Services:               grpcCluster("extension/auth/extension"),
+										ClearRouteCache:        true,
+										IncludePeerCertificate: true,
+										StatusOnError: &envoy_type.HttpStatus{
+											Code: envoy_type.StatusCode_Forbidden,
+										},
+										TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+									}),
+								},
+							}).
+							RouteConfigName(path.Join("https", fqdn)).
+							MetricsPrefix(xdscache_v3.ENVOY_HTTPS_LISTENER).
+							AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil)).
+							Get(),
+						nil, "h2", "http/1.1"),
+				},
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+			statsListener()),
+	}).Status(p).IsValid()
+
+	// HTTPProxy.Spec.AuthorizationService.AuthBeforeRateLimiting == true
+	rh.OnDelete(p)
+	p.Spec.VirtualHost.Authorization.AuthBeforeRateLimiting = true
+	rh.OnAdd(p)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				FilterChains: []*envoy_listener_v3.FilterChain{
+					filterchaintls(fqdn,
+						&corev1.Secret{
+							ObjectMeta: fixture.ObjectMeta("certificate"),
+							Type:       "kubernetes.io/tls",
+							Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+						},
+						envoy_v3.HTTPConnectionManagerBuilder().
+							AddFilter(envoy_v3.FilterMisdirectedRequests(fqdn)).
+							DefaultFilters().
+							// Auth filter is expected to come *before* global rate limit filter.
+							AddFilter(&http.HttpFilter{
+								Name: "envoy.filters.http.ext_authz",
+								ConfigType: &http.HttpFilter_TypedConfig{
+									TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+										Services:               grpcCluster("extension/auth/extension"),
+										ClearRouteCache:        true,
+										IncludePeerCertificate: true,
+										StatusOnError: &envoy_type.HttpStatus{
+											Code: envoy_type.StatusCode_Forbidden,
+										},
+										TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+									}),
+								},
+							}).
+							AddFilter(&http.HttpFilter{
+								Name: "envoy.filters.http.ratelimit",
+								ConfigType: &http.HttpFilter_TypedConfig{
+									TypedConfig: protobuf.MustMarshalAny(&ratelimit_filter_v3.RateLimit{
+										Domain:          "contour",
+										FailureModeDeny: true,
+										RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
+											GrpcService: &envoy_core_v3.GrpcService{
+												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+														ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													},
+												},
+											},
+											TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+										},
+									}),
+								},
+							}).
+							RouteConfigName(path.Join("https", fqdn)).
+							MetricsPrefix(xdscache_v3.ENVOY_HTTPS_LISTENER).
+							AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil)).
+							Get(),
+						nil, "h2", "http/1.1"),
+				},
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+			statsListener()),
+	}).Status(p).IsValid()
 }

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -840,8 +840,8 @@ func TestAuthzBeforeRateLimiting(t *testing.T) {
 						envoy_v3.HTTPConnectionManagerBuilder().
 							AddFilter(envoy_v3.FilterMisdirectedRequests(fqdn)).
 							DefaultFilters().
-							// Auth filter is expected to come *before* global rate limit filter.
-							AddFilter(&http.HttpFilter{
+							// Auth filter is expected to come *before* local/global rate limit filters.
+							AddFilterBefore(&http.HttpFilter{
 								Name: "envoy.filters.http.ext_authz",
 								ConfigType: &http.HttpFilter_TypedConfig{
 									TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
@@ -854,7 +854,7 @@ func TestAuthzBeforeRateLimiting(t *testing.T) {
 										TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 									}),
 								},
-							}).
+							}, "local_ratelimit").
 							AddFilter(&http.HttpFilter{
 								Name: "envoy.filters.http.ratelimit",
 								ConfigType: &http.HttpFilter_TypedConfig{

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -427,8 +427,8 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 				if vh.AuthorizationService != nil && vh.AuthBeforeRateLimiting {
 					hcmBuilder.
 						AddFilter(envoy_v3.FilterMisdirectedRequests(vh.VirtualHost.Name)).
-						DefaultFilters(). // TODO this includes the local rate limit filter, which should go after the auth filter in this case
-						AddFilter(authFilter).
+						DefaultFilters().
+						AddFilterBefore(authFilter, "local_ratelimit").
 						AddFilter(envoy_v3.OriginalIPDetectionFilter(cfg.XffNumTrustedHops)).
 						AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig)))
 				} else {

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -424,6 +424,22 @@ AuthorizationServerBufferSettings
 <p>WithRequestBody specifies configuration for sending the client request&rsquo;s body to authorization server.</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>authBeforeRateLimiting</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuthBeforeRateLimiting defines whether the authorization server
+will be consulted before applying any rate limiting to a
+request. The default is false, i.e. to apply rate-limiting first,
+in order to protect the authorization server.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1.AuthorizationServerBufferSettings">AuthorizationServerBufferSettings


### PR DESCRIPTION
Adds an AuthBeforeRateLimiting field, which allows
the user to control whether auth happens first, or
rate limiting happens first.

This also flips the default behavior to rate limit
before auth.

Closes #3726.

Signed-off-by: Steve Kriss <krisss@vmware.com>