### PR TITLE
don't set issues to stale or close them

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,13 +14,12 @@ jobs:
     - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Leave the issue message empty so that issues are not marked stale.
-        stale-issue-message:
         stale-pr-message: >
           Marking this PR stale since there has been no activity for 14
           days. It will be closed if there is no activity for another
           30 days.
-        stale-issue-label: 'lifecycle/stale'
         stale-pr-label: 'lifecycle/stale'
         days-before-stale: 14
         days-before-close: 30
+        days-before-issue-stale: -1 # disable marking issues as stale
+        days-before-issue-close: -1 # disable closing stale issues


### PR DESCRIPTION
Follow-up to #4250, updates the workflow config
for a breaking change in how to disable marking
issues as stale or closing them.

Signed-off-by: Steve Kriss <krisss@vmware.com>