### PR TITLE
remove dependency from daily build

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -13,7 +13,6 @@ env:
 jobs:
   e2e-envoy-xds:
     runs-on: ubuntu-latest
-    needs: [build-image]
     strategy:
       matrix:
         # use stable kubernetes_version values since they're included


### PR DESCRIPTION
Fixes error seen with daily build:
```
The workflow is not valid. .github/workflows/build_daily.yaml (Line: 14, Col: 3): The workflow must contain at least one job with no dependencies.
```

We can just run against the last built main image.

Signed-off-by: Steve Kriss <krisss@vmware.com>