### PR TITLE
internal/k8s: StatusUpdateWriter only writes to update channel when leader

### DIFF
--- a/internal/k8s/status.go
+++ b/internal/k8s/status.go
@@ -151,7 +151,7 @@ type StatusUpdateWriter struct {
 
 // Send sends the given StatusUpdate off to the update channel for writing by the StatusUpdateHandler.
 func (suw *StatusUpdateWriter) Send(update StatusUpdate) {
-	// Non-blocking recieve to see if we should pass along update.
+	// Non-blocking receive to see if we should pass along update.
 	select {
 	case <-suw.enabled:
 		suw.updateChannel <- update

--- a/test/e2e/incluster/smoke_test.go
+++ b/test/e2e/incluster/smoke_test.go
@@ -17,6 +17,8 @@
 package incluster
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
@@ -26,36 +28,43 @@ import (
 
 func testSimpleSmoke(namespace string) {
 	Specify("simple smoke test", func() {
-		f.Fixtures.Echo.Deploy(namespace, "echo")
+		// Make multiple instances to ensure many events/updates are
+		// processed correctly.
+		// This test may become flaky and should be investigated if there
+		// are changes that cause differences between the leader and
+		// non-leader contour instances.
+		for i := 0; i < 20; i++ {
+			f.Fixtures.Echo.Deploy(namespace, fmt.Sprintf("echo-%d", i))
 
-		p := &contourv1.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "smoke-test",
-			},
-			Spec: contourv1.HTTPProxySpec{
-				VirtualHost: &contourv1.VirtualHost{
-					Fqdn: "smoke-test.projectcontour.io",
+			p := &contourv1.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      fmt.Sprintf("smoke-test-%d", i),
 				},
-				Routes: []contourv1.Route{
-					{
-						Services: []contourv1.Service{
-							{
-								Name: "echo",
-								Port: 80,
+				Spec: contourv1.HTTPProxySpec{
+					VirtualHost: &contourv1.VirtualHost{
+						Fqdn: fmt.Sprintf("smoke-test-%d.projectcontour.io", i),
+					},
+					Routes: []contourv1.Route{
+						{
+							Services: []contourv1.Service{
+								{
+									Name: fmt.Sprintf("echo-%d", i),
+									Port: 80,
+								},
 							},
 						},
 					},
 				},
-			},
-		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			}
+			f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
 
-		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-			Host:      p.Spec.VirtualHost.Fqdn,
-			Condition: e2e.HasStatusCode(200),
-		})
-		require.NotNil(f.T(), res, "request never succeeded")
-		require.Truef(f.T(), ok, "expected 200 response code, got %d", res.StatusCode)
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host:      p.Spec.VirtualHost.Fqdn,
+				Condition: e2e.HasStatusCode(200),
+			})
+			require.NotNil(f.T(), res, "request never succeeded")
+			require.Truef(f.T(), ok, "expected 200 response code, got %d for echo-%d", res.StatusCode, i)
+		}
 	})
 }


### PR DESCRIPTION
Otherwise, when not leader, update buffered channel can be filled up,
since StatusUpdateHandler does not run. This deadlocks the EventHandler.

Shows up in e2e tests in intermittent in-cluster smoke-test failures.
More prevalent with more instances so modified smoke test to test more
apps. The failure occurs when the contour instance Envoy connects to is
not the leader.