### PR TITLE
internal/certgen: Fix error handling when writing to k8s

### DIFF
--- a/changelogs/unreleased/4281-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4281-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Fixes bug in certgen error handling when writing certs to kubernetes.

--- a/internal/certgen/certgen.go
+++ b/internal/certgen/certgen.go
@@ -128,9 +128,13 @@ func WriteSecretsYAML(outputDir string, secrets []*corev1.Secret, force Overwrit
 func WriteSecretsKube(client *kubernetes.Clientset, secrets []*corev1.Secret, force OverwritePolicy) error {
 	for _, s := range secrets {
 		if _, err := client.CoreV1().Secrets(s.Namespace).Create(context.TODO(), s, metav1.CreateOptions{}); err != nil {
-			if k8serrors.IsAlreadyExists(err) && force == NoOverwrite {
+			if !k8serrors.IsAlreadyExists(err) {
+				return err
+			}
+
+			if force == NoOverwrite {
 				fmt.Printf("secret/%s already exists\n", s.Name)
-				return nil
+				continue
 			}
 
 			if _, err := client.CoreV1().Secrets(s.Namespace).Update(context.TODO(), s, metav1.UpdateOptions{}); err != nil {


### PR DESCRIPTION
Previously if creating a secret failed, we fell back to attempting to
update the secret, however if it didn't already exist that would also
fail, shadowing the original error.

Instead we fail fast if the failure to create a secret was not because
it already exists.