### PR TITLE
hack/release: allow GitHub usernames with '-'

### DIFF
--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -231,6 +231,7 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 		entry, err := parseChangelogFilename(dirEntry.Name())
 		if err != nil {
 			fmt.Printf("Skipping changelog file: %v\n", err)
+			continue
 		}
 
 		contents, err := ioutil.ReadFile(filepath.Join("changelogs", "unreleased", dirEntry.Name()))

--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -228,11 +228,9 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 			continue
 		}
 
-		nameParts := strings.Split(strings.TrimSuffix(dirEntry.Name(), ".md"), "-")
-
-		if len(nameParts) != 3 {
-			fmt.Printf("Skipping changelog file with invalid name format %q\n", dirEntry.Name())
-			continue
+		entry, err := parseChangelogFilename(dirEntry.Name())
+		if err != nil {
+			fmt.Printf("Skipping changelog file: %v\n", err)
 		}
 
 		contents, err := ioutil.ReadFile(filepath.Join("changelogs", "unreleased", dirEntry.Name()))
@@ -240,13 +238,9 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 			return fmt.Errorf("error reading file %s: %v", filepath.Join("changelogs", "unreleased", dirEntry.Name()), err)
 		}
 
-		entry := Entry{
-			PRNumber: nameParts[0],
-			Author:   "@" + nameParts[1],
-			Content:  strings.TrimSpace(string(contents)),
-		}
+		entry.Content = strings.TrimSpace(string(contents))
 
-		switch strings.ToLower(nameParts[2]) {
+		switch strings.ToLower(entry.Category) {
 		case "major":
 			d.Major = append(d.Major, entry)
 		case "minor":
@@ -256,7 +250,7 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 		case "docs":
 			d.Docs = append(d.Docs, entry)
 		default:
-			fmt.Printf("Unrecognized category %s\n", nameParts[2])
+			fmt.Printf("Unrecognized category %q\n", entry.Category)
 			continue
 		}
 
@@ -296,6 +290,22 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 	return nil
 }
 
+func parseChangelogFilename(filename string) (Entry, error) {
+	parts := strings.Split(strings.TrimSuffix(filename, ".md"), "-")
+
+	// We may have more than 3 parts if the GitHub username itself
+	// contains a '-'.
+	if len(parts) < 3 {
+		return Entry{}, fmt.Errorf("invalid name format %q\n", filename)
+	}
+
+	return Entry{
+		PRNumber: parts[0],
+		Author:   "@" + strings.Join(parts[1:len(parts)-1], "-"),
+		Category: parts[len(parts)-1],
+	}, nil
+}
+
 // recordContributor adds contributor to contributors if they
 // are not a maintainer and not already present.
 func recordContributor(contributors []string, contributor string) []string {
@@ -324,6 +334,7 @@ type Entry struct {
 	PRNumber string
 	Author   string
 	Content  string
+	Category string
 }
 
 type Data struct {


### PR DESCRIPTION
Fixes a bug where GitHub usernames containing
a '-' would break the changelog generator.

Closes #4280.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Tested manually, we now have a changelog file with a hyphenated username, all looks good.