### PR TITLE
test/e2e: enable retrying flaky tests

### DIFF
--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -29,7 +29,8 @@ import (
 )
 
 func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
-	Specify("global rate limit policy set on non-TLS virtualhost is applied", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4246
+	Specify("global rate limit policy set on non-TLS virtualhost is applied", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
@@ -112,7 +113,8 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 }
 
 func testGlobalRateLimitingRouteNonTLS(namespace string) {
-	Specify("global rate limit policy set on non-TLS route is applied", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4246
+	Specify("global rate limit policy set on non-TLS route is applied", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
@@ -219,7 +221,8 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 }
 
 func testGlobalRateLimitingVirtualHostTLS(namespace string) {
-	Specify("global rate limit policy set on TLS virtualhost is applied", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4246
+	Specify("global rate limit policy set on TLS virtualhost is applied", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
@@ -306,7 +309,8 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 }
 
 func testGlobalRateLimitingRouteTLS(namespace string) {
-	Specify("global rate limit policy set on TLS route is applied", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4246
+	Specify("global rate limit policy set on TLS route is applied", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")

--- a/test/e2e/infra/metrics_test.go
+++ b/test/e2e/infra/metrics_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func testMetrics() {
-	Specify("requests to default metrics listener are served", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4229
+	Specify("requests to default metrics listener are served", FlakeAttempts(3), func() {
 		t := f.T()
 
 		res, ok := f.HTTP.MetricsRequestUntil(&e2e.HTTPRequestOpts{


### PR DESCRIPTION
Enables up to 3 attempts for E2E tests that
are known to be flaky and have a tracking
GitHub issue.

Signed-off-by: Steve Kriss <krisss@vmware.com>

This is my proposed pattern for dealing with recurring flakes: file an issue, label it as `kind/flake`, and add the `FlakeAttempts(3)` option to the test spec (see https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs) along with a comment linking to the issue. This is more efficient than re-running the entire CI suite for known flakes, and is explicitly opt-in on a per-test basis (vs. enabling flake re-runs for *all* tests, which could hide actual bugs or new flakes). We should also spend time each release cycle trying to fix flakes so this doesn't become unmanageable.

Log output in case of a flake occurrence looks like:

```
[1642705776] Ingress tests - 3/3 specs ••• SUCCESS! 29.649280082s PASS
[1642705776] Gateway API tests - 15/15 specs ••••••••••••••• SUCCESS! 1m51.665450375s PASS
[1642705776] In-cluster tests - 4/4 specs •••• SUCCESS! 2m25.073192087s PASS
[1642705776] HTTPProxy tests - 38/38 specs •••••••••••••••••••S•••••••••••••••••• SUCCESS! 3m9.305112419s PASS
[1642705776] Infra tests - 4/4 specs •••
------------------------------
↺ [FLAKEY TEST - TOOK 2 ATTEMPTS TO PASS] [73.429 seconds]
Infra requests to default metrics listener are served
/home/runner/work/contour/contour/test/e2e/infra/metrics_test.go:31
------------------------------
 SUCCESS! 1m34.735436331s PASS

Ginkgo ran 5 suites in 10m4.535281267s
Test Suite Passed
./test/scripts/cleanup.sh
Deleting cluster "contour-e2e" ...
```