### PR TITLE
cmd/contour: pass ApplyToIngress flag to DAG processor

### DIFF
--- a/changelogs/unreleased/4287-skriss-small.md
+++ b/changelogs/unreleased/4287-skriss-small.md
@@ -1,0 +1,1 @@
+Fixes a bug where the global headers policy `ApplyToIngress` field was being ignored, causing Ingresses never to have the global headers policy applied.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -389,6 +389,11 @@ func (s *Server) doServe() error {
 		return err
 	}
 
+	var applyHeaderPolicyToIngress bool
+	if contourConfiguration.Policy != nil {
+		applyHeaderPolicyToIngress = contourConfiguration.Policy.ApplyToIngress
+	}
+
 	builder := s.getDAGBuilder(dagBuilderConfig{
 		ingressClassName:           ingressClassName,
 		rootNamespaces:             contourConfiguration.HTTPProxy.RootNamespaces,
@@ -397,7 +402,7 @@ func (s *Server) doServe() error {
 		enableExternalNameService:  contourConfiguration.EnableExternalNameService,
 		dnsLookupFamily:            contourConfiguration.Envoy.Cluster.DNSLookupFamily,
 		headersPolicy:              contourConfiguration.Policy,
-		applyHeaderPolicyToIngress: contourConfiguration.Policy.ApplyToIngress,
+		applyHeaderPolicyToIngress: applyHeaderPolicyToIngress,
 		clientCert:                 clientCert,
 		fallbackCert:               fallbackCert,
 	})

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -390,15 +390,16 @@ func (s *Server) doServe() error {
 	}
 
 	builder := s.getDAGBuilder(dagBuilderConfig{
-		ingressClassName:          ingressClassName,
-		rootNamespaces:            contourConfiguration.HTTPProxy.RootNamespaces,
-		gatewayAPIConfigured:      contourConfiguration.Gateway != nil,
-		disablePermitInsecure:     contourConfiguration.HTTPProxy.DisablePermitInsecure,
-		enableExternalNameService: contourConfiguration.EnableExternalNameService,
-		dnsLookupFamily:           contourConfiguration.Envoy.Cluster.DNSLookupFamily,
-		headersPolicy:             contourConfiguration.Policy,
-		clientCert:                clientCert,
-		fallbackCert:              fallbackCert,
+		ingressClassName:           ingressClassName,
+		rootNamespaces:             contourConfiguration.HTTPProxy.RootNamespaces,
+		gatewayAPIConfigured:       contourConfiguration.Gateway != nil,
+		disablePermitInsecure:      contourConfiguration.HTTPProxy.DisablePermitInsecure,
+		enableExternalNameService:  contourConfiguration.EnableExternalNameService,
+		dnsLookupFamily:            contourConfiguration.Envoy.Cluster.DNSLookupFamily,
+		headersPolicy:              contourConfiguration.Policy,
+		applyHeaderPolicyToIngress: contourConfiguration.Policy.ApplyToIngress,
+		clientCert:                 clientCert,
+		fallbackCert:               fallbackCert,
 	})
 
 	// Build the core Kubernetes event handler.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -389,22 +389,16 @@ func (s *Server) doServe() error {
 		return err
 	}
 
-	var applyHeaderPolicyToIngress bool
-	if contourConfiguration.Policy != nil {
-		applyHeaderPolicyToIngress = contourConfiguration.Policy.ApplyToIngress
-	}
-
 	builder := s.getDAGBuilder(dagBuilderConfig{
-		ingressClassName:           ingressClassName,
-		rootNamespaces:             contourConfiguration.HTTPProxy.RootNamespaces,
-		gatewayAPIConfigured:       contourConfiguration.Gateway != nil,
-		disablePermitInsecure:      contourConfiguration.HTTPProxy.DisablePermitInsecure,
-		enableExternalNameService:  contourConfiguration.EnableExternalNameService,
-		dnsLookupFamily:            contourConfiguration.Envoy.Cluster.DNSLookupFamily,
-		headersPolicy:              contourConfiguration.Policy,
-		applyHeaderPolicyToIngress: applyHeaderPolicyToIngress,
-		clientCert:                 clientCert,
-		fallbackCert:               fallbackCert,
+		ingressClassName:          ingressClassName,
+		rootNamespaces:            contourConfiguration.HTTPProxy.RootNamespaces,
+		gatewayAPIConfigured:      contourConfiguration.Gateway != nil,
+		disablePermitInsecure:     contourConfiguration.HTTPProxy.DisablePermitInsecure,
+		enableExternalNameService: contourConfiguration.EnableExternalNameService,
+		dnsLookupFamily:           contourConfiguration.Envoy.Cluster.DNSLookupFamily,
+		headersPolicy:             contourConfiguration.Policy,
+		clientCert:                clientCert,
+		fallbackCert:              fallbackCert,
 	})
 
 	// Build the core Kubernetes event handler.
@@ -776,22 +770,24 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 }
 
 type dagBuilderConfig struct {
-	ingressClassName           string
-	rootNamespaces             []string
-	gatewayAPIConfigured       bool
-	disablePermitInsecure      bool
-	enableExternalNameService  bool
-	dnsLookupFamily            contour_api_v1alpha1.ClusterDNSFamilyType
-	headersPolicy              *contour_api_v1alpha1.PolicyConfig
-	applyHeaderPolicyToIngress bool
-	clientCert                 *types.NamespacedName
-	fallbackCert               *types.NamespacedName
+	ingressClassName          string
+	rootNamespaces            []string
+	gatewayAPIConfigured      bool
+	disablePermitInsecure     bool
+	enableExternalNameService bool
+	dnsLookupFamily           contour_api_v1alpha1.ClusterDNSFamilyType
+	headersPolicy             *contour_api_v1alpha1.PolicyConfig
+	clientCert                *types.NamespacedName
+	fallbackCert              *types.NamespacedName
 }
 
 func (s *Server) getDAGBuilder(dbc dagBuilderConfig) *dag.Builder {
 
-	var requestHeadersPolicy dag.HeadersPolicy
-	var responseHeadersPolicy dag.HeadersPolicy
+	var (
+		requestHeadersPolicy       dag.HeadersPolicy
+		responseHeadersPolicy      dag.HeadersPolicy
+		applyHeaderPolicyToIngress bool
+	)
 
 	if dbc.headersPolicy != nil {
 		if dbc.headersPolicy.RequestHeadersPolicy != nil {
@@ -819,11 +815,14 @@ func (s *Server) getDAGBuilder(dbc dagBuilderConfig) *dag.Builder {
 				responseHeadersPolicy.Remove = append(responseHeadersPolicy.Remove, dbc.headersPolicy.ResponseHeadersPolicy.Remove...)
 			}
 		}
+
+		applyHeaderPolicyToIngress = dbc.headersPolicy.ApplyToIngress
 	}
 
 	var requestHeadersPolicyIngress dag.HeadersPolicy
 	var responseHeadersPolicyIngress dag.HeadersPolicy
-	if dbc.applyHeaderPolicyToIngress {
+
+	if applyHeaderPolicyToIngress {
 		requestHeadersPolicyIngress = requestHeadersPolicy
 		responseHeadersPolicyIngress = responseHeadersPolicy
 	}

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -135,14 +135,17 @@ func TestGetDAGBuilder(t *testing.T) {
 				},
 				Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 			},
-			ApplyToIngress: false,
+			ApplyToIngress: true,
 		}
 
 		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
-		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
-			headersPolicy: policy, applyHeaderPolicyToIngress: true})
+		got := serve.getDAGBuilder(dagBuilderConfig{
+			rootNamespaces:  []string{},
+			dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
+			headersPolicy:   policy,
+		})
 		commonAssertions(t, got)
 
 		ingressProcessor := mustGetIngressProcessor(t, got)

--- a/test/e2e/ingress/headers_policy_test.go
+++ b/test/e2e/ingress/headers_policy_test.go
@@ -1,0 +1,93 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package ingress
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testGlobalHeadersPolicy(applyToIngress bool) e2e.NamespacedTestBody {
+	return func(namespace string) {
+		var text string
+		if applyToIngress {
+			text = "global headers policy is applied to ingress objects"
+		} else {
+			text = "global headers policy is not applied to ingress objects"
+		}
+
+		Specify(text, func() {
+			t := f.T()
+
+			f.Fixtures.Echo.Deploy(namespace, "echo")
+
+			i := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "global-headers-policy",
+				},
+				Spec: networkingv1.IngressSpec{
+					Rules: []networkingv1.IngressRule{
+						{
+							Host: "global-headers-policy.ingress.projectcontour.io",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{
+										{
+											PathType: e2e.IngressPathTypePtr(networkingv1.PathTypePrefix),
+											Path:     "/",
+											Backend: networkingv1.IngressBackend{
+												Service: &networkingv1.IngressServiceBackend{
+													Name: "echo",
+													Port: networkingv1.ServiceBackendPort{
+														Number: 80,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			require.NoError(f.T(), f.Client.Create(context.Background(), i))
+
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host:      i.Spec.Rules[0].Host,
+				Condition: e2e.HasStatusCode(200),
+			})
+			require.NotNil(t, res, "request never succeeded")
+			require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+			if applyToIngress {
+				assert.Equal(t, "foo", f.GetEchoResponseBody(res.Body).RequestHeaders.Get("X-Contour-GlobalRequestHeader"))
+				assert.Equal(t, "bar", res.Headers.Get("X-Contour-GlobalResponseHeader"))
+			} else {
+				assert.Equal(t, "", f.GetEchoResponseBody(res.Body).RequestHeaders.Get("X-Contour-GlobalRequestHeader"))
+				assert.Equal(t, "", res.Headers.Get("X-Contour-GlobalResponseHeader"))
+			}
+		})
+	}
+}

--- a/test/e2e/ingress/headers_policy_test.go
+++ b/test/e2e/ingress/headers_policy_test.go
@@ -41,6 +41,13 @@ func testGlobalHeadersPolicy(applyToIngress bool) e2e.NamespacedTestBody {
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
+			var host string
+			if applyToIngress {
+				host = "global-headers-policy-apply-to-ingress-false.ingress.projectcontour.io"
+			} else {
+				host = "global-headers-policy-apply-to-ingress-true.ingress.projectcontour.io"
+			}
+
 			i := &networkingv1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -49,7 +56,7 @@ func testGlobalHeadersPolicy(applyToIngress bool) e2e.NamespacedTestBody {
 				Spec: networkingv1.IngressSpec{
 					Rules: []networkingv1.IngressRule{
 						{
-							Host: "global-headers-policy.ingress.projectcontour.io",
+							Host: host,
 							IngressRuleValue: networkingv1.IngressRuleValue{
 								HTTP: &networkingv1.HTTPIngressRuleValue{
 									Paths: []networkingv1.HTTPIngressPath{

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -182,4 +182,47 @@ var _ = Describe("Ingress", func() {
 	})
 
 	f.NamespacedTest("long-path-match", testLongPathMatch)
+
+	Context("with global headers policy defined", func() {
+		BeforeEach(func() {
+			contourConfig.Policy.RequestHeadersPolicy.Set = map[string]string{
+				"X-Contour-GlobalRequestHeader": "foo",
+			}
+			contourConfig.Policy.ResponseHeadersPolicy.Set = map[string]string{
+				"X-Contour-GlobalResponseHeader": "bar",
+			}
+
+			contourConfiguration.Spec.Policy = &contour_api_v1alpha1.PolicyConfig{
+				RequestHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+					Set: map[string]string{
+						"X-Contour-GlobalRequestHeader": "foo",
+					},
+				},
+				ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
+					Set: map[string]string{
+						"X-Contour-GlobalResponseHeader": "bar",
+					},
+				},
+			}
+		})
+
+		Context("when ApplyToIngress is false", func() {
+			BeforeEach(func() {
+				contourConfig.Policy.ApplyToIngress = false
+				contourConfiguration.Spec.Policy.ApplyToIngress = false
+			})
+
+			f.NamespacedTest("global-headers-policy-apply-to-ingress-false", testGlobalHeadersPolicy(false))
+		})
+
+		Context("when ApplyToIngress is true", func() {
+			BeforeEach(func() {
+				contourConfig.Policy.ApplyToIngress = true
+				contourConfiguration.Spec.Policy.ApplyToIngress = true
+			})
+
+			f.NamespacedTest("global-headers-policy-apply-to-ingress-true", testGlobalHeadersPolicy(true))
+		})
+
+	})
 })


### PR DESCRIPTION
Fixes a bug where the ApplyToIngress flag
from the global headers policy was not being
passed to the ingress DAG processor, so the
headers policy was never being applied to
Ingress objects.

Closes #4285.

Signed-off-by: Steve Kriss <krisss@vmware.com>