### PR TITLE
hack/actions: fix release image tag fetching

### DIFF
--- a/hack/actions/build-and-push-release-images.sh
+++ b/hack/actions/build-and-push-release-images.sh
@@ -28,7 +28,7 @@ fi
 
 # Fetch all tags so we can check if the current tag
 # is the highest semver.
-git fetch --tags
+git fetch --tags --force
 
 HIGHEST_SEMVER_TAG=""
 


### PR DESCRIPTION
Adds `--force` to `git fetch --tags` to
work with the v2 checkout action.

Closes #4309.

Signed-off-by: Steve Kriss <krisss@vmware.com>

I was able to repro the error locally by running through the relevant git commands, and to confirm that with this change, the error no longer occurs. Won't be able to exercise the full workflow without pushing a dummy tag, though.