### PR TITLE
cmd/contour: Disable unused listeners

### DIFF
--- a/changelogs/unreleased/4312-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4312-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Explicitly disable controller-runtime manager metrics and health listeners.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -196,7 +196,9 @@ func NewServer(log logrus.FieldLogger, ctx *serveContext) (*Server, error) {
 
 	// Instantiate a controller-runtime manager.
 	options := manager.Options{
-		Scheme: scheme,
+		Scheme:                 scheme,
+		MetricsBindAddress:     "0",
+		HealthProbeBindAddress: "0",
 	}
 	if ctx.DisableLeaderElection {
 		log.Info("Leader election disabled")


### PR DESCRIPTION
controller-runtime manager provided listeners for metrics and health
(both are implemented via our own mechanisms, health was already
disabled but this explicitly does so)

Helps with e2e tests especially, ensure Contour can start up and doesn't
conflict on binding to the same port (e.g. default metrics port 8080)
if a Contour instance does not exit properly.