### PR TITLE
stop pushing images to Docker Hub

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -16,18 +16,6 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to Docker Hub
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        REGISTRY: docker.io/projectcontour
-        VERSION: main
-        TAG_LATEST: "false"
-        PUSH_IMAGE: "true"
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        make multiarch-build
-        docker logout
     - name: Log in to GHCR
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -23,16 +23,6 @@ jobs:
       uses: docker/setup-buildx-action@v1
       with:
         version: latest
-    - name: Build and Push to Docker Hub
-      env:
-        REGISTRY: docker.io/projectcontour
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        TAG_LATEST: "false"
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        ./hack/actions/build-and-push-release-images.sh
-        docker logout
     - name: Log in to GHCR
       uses: docker/login-action@v1
       with:

--- a/changelogs/unreleased/4314-skriss-major.md
+++ b/changelogs/unreleased/4314-skriss-major.md
@@ -1,0 +1,3 @@
+## Container Images Now Exclusively Published on GitHub Container Registry (GHCR) 
+
+Contour's container images are now exclusively published [on GHCR](https://github.com/projectcontour/contour/pkgs/container/contour). They are no longer being pushed to Docker Hub (past images have been left on Docker Hub for posterity.)


### PR DESCRIPTION
Removes the Docker Hub image push since
images are now published on GHCR.

Closes #3998.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Last chance for anyone to weigh in if they think this is a bad idea and we should keep pushing images to Docker Hub in the background!