### PR TITLE
internal/dag: removed duplicated function for secret validation

### DIFF
--- a/changelogs/unreleased/4316-alessandroargentieri-small.md
+++ b/changelogs/unreleased/4316-alessandroargentieri-small.md
@@ -1,0 +1,1 @@
+Removed code duplication for the secret validation in the dag package.

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -295,20 +295,3 @@ func (d *DAG) GetSecureVirtualHostRoutes() map[*SecureVirtualHost][]*Route {
 
 	return res
 }
-
-// validSecret returns true if the Secret contains certificate and private key material.
-func validSecret(s *v1.Secret) error {
-	if s.Type != v1.SecretTypeTLS {
-		return fmt.Errorf("Secret type is not %q", v1.SecretTypeTLS)
-	}
-
-	if len(s.Data[v1.TLSCertKey]) == 0 {
-		return fmt.Errorf("empty %q key", v1.TLSCertKey)
-	}
-
-	if len(s.Data[v1.TLSPrivateKeyKey]) == 0 {
-		return fmt.Errorf("empty %q key", v1.TLSPrivateKeyKey)
-	}
-
-	return nil
-}

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -88,7 +88,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 
 	var clientCertSecret *Secret
 	if p.ClientCertificate != nil {
-		clientCertSecret, err = cache.LookupSecret(*p.ClientCertificate, validSecret)
+		clientCertSecret, err = cache.LookupSecret(*p.ClientCertificate, validTLSSecret)
 		if err != nil {
 			validCondition.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 				"tls.envoy-client-certificate Secret %q is invalid: %s", p.ClientCertificate, err)

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -387,7 +387,7 @@ func (p *GatewayAPIProcessor) validGatewayTLS(listenerTLS gatewayapi_v1alpha2.Ga
 		meta = types.NamespacedName{Name: string(certificateRef.Name), Namespace: p.source.gateway.Namespace}
 	}
 
-	listenerSecret, err := p.source.LookupSecret(meta, validSecret)
+	listenerSecret, err := p.source.LookupSecret(meta, validTLSSecret)
 	if err != nil {
 		gwAccessor.AddListenerCondition(
 			listenerName,

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -180,7 +180,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 		// Attach secrets to TLS enabled vhosts.
 		if !tls.Passthrough {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(proxy.Namespace))
-			sec, err := p.source.LookupSecret(secretName, validSecret)
+			sec, err := p.source.LookupSecret(secretName, validTLSSecret)
 			if err != nil {
 				validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 					"Spec.VirtualHost.TLS Secret %q is invalid: %s", tls.SecretName, err)
@@ -224,7 +224,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 					return
 				}
 
-				sec, err = p.source.LookupSecret(*p.FallbackCertificate, validSecret)
+				sec, err = p.source.LookupSecret(*p.FallbackCertificate, validTLSSecret)
 				if err != nil {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotValid",
 						"Spec.Virtualhost.TLS Secret %q fallback certificate is invalid: %s", p.FallbackCertificate, err)
@@ -673,7 +673,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 
 			var clientCertSecret *Secret
 			if p.ClientCertificate != nil {
-				clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validSecret)
+				clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validTLSSecret)
 				if err != nil {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 						"tls.envoy-client-certificate Secret %q is invalid: %s", p.ClientCertificate, err)

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -76,7 +76,7 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 	for _, ing := range p.source.ingresses {
 		for _, tls := range ing.Spec.TLS {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ing), k8s.DefaultNamespace(ing.GetNamespace()))
-			sec, err := p.source.LookupSecret(secretName, validSecret)
+			sec, err := p.source.LookupSecret(secretName, validTLSSecret)
 			if err != nil {
 				p.WithError(err).
 					WithField("name", ing.GetName()).
@@ -131,7 +131,7 @@ func (p *IngressProcessor) computeIngressRule(ing *networking_v1.Ingress, rule n
 	var clientCertSecret *Secret
 	var err error
 	if p.ClientCertificate != nil {
-		clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validSecret)
+		clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validTLSSecret)
 		if err != nil {
 			p.WithError(err).
 				WithField("name", ing.GetName()).

--- a/internal/dag/secret.go
+++ b/internal/dag/secret.go
@@ -27,6 +27,15 @@ import (
 // CACertificateKey is the key name for accessing TLS CA certificate bundles in Kubernetes Secrets.
 const CACertificateKey = "ca.crt"
 
+// validTLSSecret returns an error if the Secret is not of type TLS or if it doesn't contain certificate and private key material.
+func validTLSSecret(s *v1.Secret) error {
+	if s.Type != v1.SecretTypeTLS {
+		return fmt.Errorf("secret type is not %q", v1.SecretTypeTLS)
+	}
+	_, err := isValidSecret(s)
+	return err
+}
+
 // isValidSecret returns true if the secret is interesting and well
 // formed. TLS certificate/key pairs must be secrets of type
 // "kubernetes.io/tls". Certificate bundles may be "kubernetes.io/tls"


### PR DESCRIPTION
internal/dag: Removed duplicated function for secret validation in dag layer

Removed validSecret function from accessors.go in the dag package.
This function checked if a secret is a valid TLS secret and returned an error.
Substituted with the validTLSSecret in secret.go in the dag package,
function that wraps the isValidSecret function by adding some logic on it.
This way the duplication of code is avoided and the feature of the deleted function is maintained.

Fixes #3503

Signed-off-by: alessandroargentieri <alexmawashi87@gmail.com>