### PR TITLE
4109 followups

### DIFF
--- a/changelogs/unreleased/4329-skriss-small.md
+++ b/changelogs/unreleased/4329-skriss-small.md
@@ -1,0 +1,1 @@
+Drops RBAC and caching for the `networking.k8s.io/IngressClass` resource as it's not used by Contour.

--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -65,7 +65,7 @@ func (isw *loadBalancerStatusWriter) Start(ctx context.Context) error {
 			// Configure the StatusAddressUpdater logger.
 			log := isw.log.WithField("context", "StatusAddressUpdater")
 			if len(isw.ingressClassNames) > 0 {
-				return log.WithField("target-ingress-classes", strings.Join(isw.ingressClassNames, ","))
+				return log.WithField("target-ingress-classes", isw.ingressClassNames)
 			}
 
 			return log

--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -51,7 +51,7 @@ type loadBalancerStatusWriter struct {
 	cache                 cache.Cache
 	lbStatus              chan v1.LoadBalancerStatus
 	statusUpdater         k8s.StatusUpdater
-	ingressClassName      string
+	ingressClassNames     []string
 	gatewayControllerName string
 }
 
@@ -64,14 +64,14 @@ func (isw *loadBalancerStatusWriter) Start(ctx context.Context) error {
 		Logger: func() logrus.FieldLogger {
 			// Configure the StatusAddressUpdater logger.
 			log := isw.log.WithField("context", "StatusAddressUpdater")
-			if isw.ingressClassName != "" {
-				return log.WithField("target-ingress-class", isw.ingressClassName)
+			if len(isw.ingressClassNames) > 0 {
+				return log.WithField("target-ingress-classes", strings.Join(isw.ingressClassNames, ","))
 			}
 
 			return log
 		}(),
 		Cache:                 isw.cache,
-		IngressClassName:      isw.ingressClassName,
+		IngressClassNames:     isw.ingressClassNames,
 		GatewayControllerName: isw.gatewayControllerName,
 		StatusUpdater:         isw.statusUpdater,
 	}

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -432,7 +432,6 @@ func (s *Server) doServe() error {
 		"contourconfigurations":     &contour_api_v1alpha1.ContourConfiguration{},
 		"services":                  &corev1.Service{},
 		"ingresses":                 &networking_v1.Ingress{},
-		"ingressclasses":            &networking_v1.IngressClass{},
 	} {
 		if err := informOnResource(r, eventHandler, s.mgr.GetCache()); err != nil {
 			s.log.WithError(err).WithField("resource", name).Fatal("failed to create informer")

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -156,25 +156,33 @@ func TestGetDAGBuilder(t *testing.T) {
 	})
 
 	t.Run("single ingress class specified", func(t *testing.T) {
-		ingressClassNames := "aclass"
+		ingressClassNames := []string{"aclass"}
 
 		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
-		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, ingressClassName: ingressClassNames})
+		got := serve.getDAGBuilder(dagBuilderConfig{
+			rootNamespaces:    []string{},
+			dnsLookupFamily:   contour_api_v1alpha1.AutoClusterDNSFamily,
+			ingressClassNames: ingressClassNames,
+		})
 		commonAssertions(t, got)
-		assert.EqualValues(t, got.Source.IngressClassName, ingressClassNames)
+		assert.EqualValues(t, ingressClassNames, got.Source.IngressClassNames)
 	})
 
 	t.Run("multiple comma-separated ingress classes specified", func(t *testing.T) {
-		ingressClassNames := "aclass,bclass,cclass"
+		ingressClassNames := []string{"aclass", "bclass", "cclass"}
 
 		serve := &Server{
 			log: logrus.StandardLogger(),
 		}
-		got := serve.getDAGBuilder(dagBuilderConfig{rootNamespaces: []string{}, dnsLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily, ingressClassName: ingressClassNames})
+		got := serve.getDAGBuilder(dagBuilderConfig{
+			rootNamespaces:    []string{},
+			dnsLookupFamily:   contour_api_v1alpha1.AutoClusterDNSFamily,
+			ingressClassNames: ingressClassNames,
+		})
 		commonAssertions(t, got)
-		assert.EqualValues(t, got.Source.IngressClassName, ingressClassNames)
+		assert.EqualValues(t, ingressClassNames, got.Source.IngressClassNames)
 	})
 
 	// TODO(3453): test additional properties of the DAG builder (processor fields, cache fields, Gateway tests (requires a client fake))

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -61,14 +61,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -4958,14 +4958,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4961,14 +4961,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4958,14 +4958,6 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
   - ingresses
   verbs:
   - get

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -16,7 +16,6 @@ package dag
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -121,7 +120,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 					WithField("kind", k8s.KindOf(obj)).
 					WithField("ingress-class-annotation", annotation.IngressClass(obj)).
 					WithField("ingress-class-name", pointer.StringPtrDerefOr(obj.Spec.IngressClassName, "")).
-					WithField("target-ingress-classes", strings.Join(kc.IngressClassNames, ",")).
+					WithField("target-ingress-classes", kc.IngressClassNames).
 					Debug("ignoring Ingress with unmatched ingress class")
 				return false
 			}
@@ -136,7 +135,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 					WithField("kind", k8s.KindOf(obj)).
 					WithField("ingress-class-annotation", annotation.IngressClass(obj)).
 					WithField("ingress-class-name", obj.Spec.IngressClassName).
-					WithField("target-ingress-classes", strings.Join(kc.IngressClassNames, ",")).
+					WithField("target-ingress-classes", kc.IngressClassNames).
 					Debug("ignoring HTTPProxy with unmatched ingress class")
 				return false
 			}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -171,8 +171,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			kc.WithField("object", obj).Error("insert unknown object")
 			return false
 		}
-
-		return false
 	}
 
 	if maybeInsert(obj) {

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -423,22 +423,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert ingress class correct name": {
-			obj: &networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "contour",
-				},
-			},
-			want: true,
-		},
-		"insert ingress class incorrect name": {
-			obj: &networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "notagoodclass",
-				},
-			},
-			want: false,
-		},
 		"insert ingressv1 empty ingress class": {
 			obj: &networking_v1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
@@ -996,32 +980,6 @@ func TestKubernetesCacheRemove(t *testing.T) {
 				},
 			},
 			want: true,
-		},
-		"remove ingress class correct name": {
-			cache: cache(&networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "contour",
-				},
-			}),
-			obj: &networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "contour",
-				},
-			},
-			want: true,
-		},
-		"remove ingress class wrong name": {
-			cache: cache(&networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "contour",
-				},
-			}),
-			obj: &networking_v1.IngressClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "somethingelse",
-				},
-			},
-			want: false,
 		},
 		"remove ingress": {
 			cache: cache(&networking_v1.Ingress{

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -39,7 +39,7 @@ const (
 
 func TestIngressClassAnnotation_Configured(t *testing.T) {
 	rh, c, done := setup(t, func(b *dag.Builder) {
-		b.Source.IngressClassName = "linkerd"
+		b.Source.IngressClassNames = []string{"linkerd"}
 	})
 	defer done()
 
@@ -504,7 +504,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 func TestIngressClassAnnotationUpdate(t *testing.T) {
 	t.Skip("Test disabled, see issue #2964")
 	rh, c, done := setup(t, func(b *dag.Builder) {
-		b.Source.IngressClassName = "contour"
+		b.Source.IngressClassNames = []string{"contour"}
 	})
 	defer done()
 
@@ -567,7 +567,7 @@ func TestIngressClassAnnotationUpdate(t *testing.T) {
 
 func TestIngressClassResource_Configured(t *testing.T) {
 	rh, c, done := setup(t, func(b *dag.Builder) {
-		b.Source.IngressClassName = "testingressclass"
+		b.Source.IngressClassNames = []string{"testingressclass"}
 	})
 	defer done()
 

--- a/internal/featuretests/v3/route_test.go
+++ b/internal/featuretests/v3/route_test.go
@@ -933,7 +933,7 @@ func TestDefaultBackendIsOverriddenByNoHostIngressRule(t *testing.T) {
 // tested in internal/contour/route_test.go
 func TestRDSIngressClassAnnotation(t *testing.T) {
 	rh, c, done := setup(t, func(b *dag.Builder) {
-		b.Source.IngressClassName = "linkerd"
+		b.Source.IngressClassNames = []string{"linkerd"}
 	})
 	defer done()
 

--- a/internal/ingressclass/ingressclass.go
+++ b/internal/ingressclass/ingressclass.go
@@ -14,8 +14,6 @@
 package ingressclass
 
 import (
-	"strings"
-
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
 	networking_v1 "k8s.io/api/networking/v1"
@@ -30,35 +28,35 @@ const DefaultClassName = "contour"
 // MatchesIngress returns true if the passed in Ingress annotations
 // or Spec.IngressClassName match the passed in ingress class name.
 // Annotations take precedence over spec field if both are set.
-func MatchesIngress(obj *networking_v1.Ingress, ingressClassName string) bool {
+func MatchesIngress(obj *networking_v1.Ingress, ingressClassNames []string) bool {
 	if annotationClass := annotation.IngressClass(obj); annotationClass != "" {
-		return matches(annotationClass, ingressClassName)
+		return matches(annotationClass, ingressClassNames)
 	}
 
-	return matches(pointer.StringPtrDerefOr(obj.Spec.IngressClassName, ""), ingressClassName)
+	return matches(pointer.StringPtrDerefOr(obj.Spec.IngressClassName, ""), ingressClassNames)
 }
 
 // MatchesHTTPProxy returns true if the passed in HTTPProxy annotations
 // or Spec.IngressClassName match the passed in ingress class name.
 // Annotations take precedence over spec field if both are set.
-func MatchesHTTPProxy(obj *contour_v1.HTTPProxy, ingressClassName string) bool {
+func MatchesHTTPProxy(obj *contour_v1.HTTPProxy, ingressClassNames []string) bool {
 	if annotationClass := annotation.IngressClass(obj); annotationClass != "" {
-		return matches(annotationClass, ingressClassName)
+		return matches(annotationClass, ingressClassNames)
 	}
 
-	return matches(obj.Spec.IngressClassName, ingressClassName)
+	return matches(obj.Spec.IngressClassName, ingressClassNames)
 }
 
-func matches(objIngressClass, contourIngressClass string) bool {
-	// If Contour's configured ingress class is empty, the object can either
+func matches(objIngressClass string, contourIngressClasses []string) bool {
+	// If Contour has no configured ingress class, the object can either
 	// not have an ingress class, or can have a "contour" ingress class.
-	if contourIngressClass == "" {
+	if len(contourIngressClasses) == 0 {
 		return objIngressClass == "" || objIngressClass == DefaultClassName
 	}
 
 	// Otherwise, the object's ingress class must match one of Contour's.
-	for _, contourIngressClassEntry := range strings.Split(contourIngressClass, ",") {
-		if objIngressClass == contourIngressClassEntry {
+	for _, contourIngressClass := range contourIngressClasses {
+		if objIngressClass == contourIngressClass {
 			return true
 		}
 	}

--- a/internal/ingressclass/ingressclass_test.go
+++ b/internal/ingressclass/ingressclass_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestMatchesIngress(t *testing.T) {
 	// No annotation, no spec field set, class not configured
-	assert.True(t, MatchesIngress(&networking_v1.Ingress{}, ""))
+	assert.True(t, MatchesIngress(&networking_v1.Ingress{}, nil))
 	// Annotation set to default, no spec field set, class not configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -33,13 +33,13 @@ func TestMatchesIngress(t *testing.T) {
 				"kubernetes.io/ingress.class": "contour",
 			},
 		},
-	}, ""))
+	}, nil))
 	// No annotation set, spec field set to default, class not configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("contour"),
 		},
-	}, ""))
+	}, nil))
 	// Annotation set, no spec field set, class not configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -47,15 +47,15 @@ func TestMatchesIngress(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, ""))
+	}, nil))
 	// No annotation set, spec field set, class not configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("aclass"),
 		},
-	}, ""))
+	}, nil))
 	// No annotation, no spec field set, class configured
-	assert.False(t, MatchesIngress(&networking_v1.Ingress{}, "something"))
+	assert.False(t, MatchesIngress(&networking_v1.Ingress{}, []string{"something"}))
 	// Annotation set, no spec field set, class configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,13 +63,13 @@ func TestMatchesIngress(t *testing.T) {
 				"kubernetes.io/ingress.class": "something",
 			},
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// No annotation set, spec field set, class configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("something"),
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, no spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -77,13 +77,13 @@ func TestMatchesIngress(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// No annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("aclass"),
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +94,7 @@ func TestMatchesIngress(t *testing.T) {
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("aclass"),
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -105,7 +105,7 @@ func TestMatchesIngress(t *testing.T) {
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("something"),
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Multiple classes: Annotation set, no spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -113,13 +113,13 @@ func TestMatchesIngress(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 	// Multiple classes: No annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("aclass"),
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 	// Multiple classes: Annotation set, spec field set, class configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -130,7 +130,7 @@ func TestMatchesIngress(t *testing.T) {
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("aclass"),
 		},
-	}, "somethingelse,something"))
+	}, []string{"somethingelse", "something"}))
 	// Multiple classes: Annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -141,12 +141,12 @@ func TestMatchesIngress(t *testing.T) {
 		Spec: networking_v1.IngressSpec{
 			IngressClassName: pointer.StringPtr("something"),
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 }
 
 func TestMatchesHTTPProxy(t *testing.T) {
 	// No annotation, no spec field set, class not configured
-	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{}, ""))
+	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{}, nil))
 	// Annotation set to default, no spec field set, class not configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -154,13 +154,13 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "contour",
 			},
 		},
-	}, ""))
+	}, nil))
 	// No annotation set, spec field set to default, class not configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "contour",
 		},
-	}, ""))
+	}, nil))
 	// Annotation set, no spec field set, class not configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -168,15 +168,15 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, ""))
+	}, nil))
 	// No annotation set, spec field set, class not configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "aclass",
 		},
-	}, ""))
+	}, nil))
 	// No annotation, no spec field set, class configured
-	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{}, "something"))
+	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{}, []string{"something"}))
 	// Annotation set, no spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -184,13 +184,13 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "something",
 			},
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// No annotation set, spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "something",
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, no spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -198,13 +198,13 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// No annotation set, spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "aclass",
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -215,7 +215,7 @@ func TestMatchesHTTPProxy(t *testing.T) {
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "aclass",
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -226,7 +226,7 @@ func TestMatchesHTTPProxy(t *testing.T) {
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "something",
 		},
-	}, "something"))
+	}, []string{"something"}))
 	// Multiple classes: Annotation set, no spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -234,13 +234,13 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "something",
 			},
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 	// Multiple classes: No annotation set, spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "something",
 		},
-	}, "athing,something,somethingelse"))
+	}, []string{"athing", "something", "somethingelse"}))
 	// Multiple classes: Annotation set, no spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,13 +248,13 @@ func TestMatchesHTTPProxy(t *testing.T) {
 				"kubernetes.io/ingress.class": "foo",
 			},
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 	// Multiple classes: No annotation set, spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "aclass",
 		},
-	}, "somethingelse,something"))
+	}, []string{"somethingelse", "something"}))
 	// Multiple classes: Annotation set, spec field set, class configured
 	assert.True(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -265,7 +265,7 @@ func TestMatchesHTTPProxy(t *testing.T) {
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "aclass",
 		},
-	}, "somethingelse,something"))
+	}, []string{"somethingelse", "something"}))
 	// Multiple classes: Annotation set, spec field set, class configured
 	assert.False(t, MatchesHTTPProxy(&contour_v1.HTTPProxy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -276,5 +276,5 @@ func TestMatchesHTTPProxy(t *testing.T) {
 		Spec: contour_v1.HTTPProxySpec{
 			IngressClassName: "something",
 		},
-	}, "something,somethingelse"))
+	}, []string{"something", "somethingelse"}))
 }

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -14,7 +14,6 @@
 package k8s
 
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=get;list;watch
-// +kubebuilder:rbac:groups="networking.k8s.io",resources=ingressclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses/status,verbs=create;get;update
 
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies;tlscertificatedelegations;extensionservices;contourconfigurations,verbs=get;list;watch

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -16,7 +16,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -78,7 +77,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 			WithField("namespace", obj.GetNamespace()).
 			WithField("ingress-class-annotation", annotation.IngressClass(obj)).
 			WithField("kind", KindOf(obj)).
-			WithField("target-ingress-classes", strings.Join(s.IngressClassNames, ",")).
+			WithField("target-ingress-classes", s.IngressClassNames).
 			Debug("unmatched ingress class, skipping status address update")
 	}
 

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -314,10 +314,12 @@ func TestStatusAddressUpdater(t *testing.T) {
 			assert.True(t, suc.Add(objName, objName, tc.preop), "unable to add object to cache")
 
 			isu := StatusAddressUpdater{
-				Logger:           log,
-				LBStatus:         tc.status,
-				IngressClassName: tc.ingressClassName,
-				StatusUpdater:    &suc,
+				Logger:        log,
+				LBStatus:      tc.status,
+				StatusUpdater: &suc,
+			}
+			if len(tc.ingressClassName) > 0 {
+				isu.IngressClassNames = []string{tc.ingressClassName}
 			}
 
 			isu.OnAdd(tc.preop)
@@ -331,10 +333,12 @@ func TestStatusAddressUpdater(t *testing.T) {
 			assert.True(t, suc.Add(objName, objName, tc.preop), "unable to add object to cache")
 
 			isu := StatusAddressUpdater{
-				Logger:           log,
-				LBStatus:         tc.status,
-				IngressClassName: tc.ingressClassName,
-				StatusUpdater:    &suc,
+				Logger:        log,
+				LBStatus:      tc.status,
+				StatusUpdater: &suc,
+			}
+			if len(tc.ingressClassName) > 0 {
+				isu.IngressClassNames = []string{tc.ingressClassName}
 			}
 
 			isu.OnUpdate(tc.preop, tc.preop)

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/projectcontour/contour/test/e2e"
@@ -456,20 +455,3 @@ descriptors:
 		})
 	})
 })
-
-// httpProxyValid returns true if the proxy has a .status.currentStatus
-// of "valid".
-func httpProxyValid(proxy *contourv1.HTTPProxy) bool {
-
-	if proxy == nil {
-		return false
-	}
-
-	if len(proxy.Status.Conditions) == 0 {
-		return false
-	}
-
-	cond := proxy.Status.GetConditionFor("Valid")
-	return cond.Status == "True"
-
-}

--- a/test/e2e/httpproxy/multiple_ingress_classes_test.go
+++ b/test/e2e/httpproxy/multiple_ingress_classes_test.go
@@ -56,7 +56,7 @@ func testMultipleIngressClassesField(namespace string) {
 				p.Spec.IngressClassName = class
 			}
 
-			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
 			if !valid {
 				t.Fatalf("The HTTPProxy did not become valid: %+v", proxy)
 			}
@@ -105,7 +105,7 @@ func testMultipleIngressClassesAnnotation(namespace string) {
 				}
 			}
 
-			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, httpProxyValid)
+			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
 			if !valid {
 				t.Fatalf("The HTTPProxy did not become valid - %+v", proxy)
 			}


### PR DESCRIPTION
- removes duplicate `httpProxyValid` func from E2E's
- drops `IngressClass` caching from the DAG as the `IngressClass` resource itself is not used anywhere
- switch to using a string slice internally to represent ingress classes for clarity; convert comma-separated string to slice upfront in `serve.go`