### PR TITLE
Leader election only uses Lease object

### DIFF
--- a/changelogs/unreleased/4332-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4332-sunjayBhatia-minor.md
@@ -1,0 +1,6 @@
+## Leader election now only uses Lease object
+
+Contour now only uses the Lease object to coordinate leader election.
+RBAC in example manifests has been updated accordingly.
+
+**Note:** Upgrading to this version of Contour will explicitly require you to upgrade to Contour v1.20.0 *first* to ensure proper migration of leader election coordination resources.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -124,8 +124,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("leader-election-lease-duration", "The duration of the leadership lease.").Default("15s").DurationVar(&ctx.Config.LeaderElection.LeaseDuration)
 	serve.Flag("leader-election-renew-deadline", "The duration leader will retry refreshing leadership before giving up.").Default("10s").DurationVar(&ctx.Config.LeaderElection.RenewDeadline)
 	serve.Flag("leader-election-retry-period", "The interval which Contour will attempt to acquire leadership lease.").Default("2s").DurationVar(&ctx.Config.LeaderElection.RetryPeriod)
-	serve.Flag("leader-election-resource-name", "The name of the resource (ConfigMap) leader election will lease.").Default("leader-elect").StringVar(&ctx.Config.LeaderElection.Name)
-	serve.Flag("leader-election-resource-namespace", "The namespace of the resource (ConfigMap) leader election will lease.").Default(ctx.Config.LeaderElection.Namespace).StringVar(&ctx.Config.LeaderElection.Namespace)
+	serve.Flag("leader-election-resource-name", "The name of the resource (Lease) leader election will lease.").Default("leader-elect").StringVar(&ctx.Config.LeaderElection.Name)
+	serve.Flag("leader-election-resource-namespace", "The namespace of the resource (Lease) leader election will lease.").Default(ctx.Config.LeaderElection.Namespace).StringVar(&ctx.Config.LeaderElection.Namespace)
 
 	serve.Flag("xds-address", "xDS gRPC API address.").PlaceHolder("<ipaddr>").StringVar(&ctx.xdsAddr)
 	serve.Flag("xds-port", "xDS gRPC API port.").PlaceHolder("<port>").IntVar(&ctx.xdsPort)
@@ -205,9 +205,7 @@ func NewServer(log logrus.FieldLogger, ctx *serveContext) (*Server, error) {
 		options.LeaderElection = false
 	} else {
 		options.LeaderElection = true
-		// This represents a multilock on configmaps and leases.
-		// TODO: switch to solely "leases" once a release cycle has passed.
-		options.LeaderElectionResourceLock = "configmapsleases"
+		options.LeaderElectionResourceLock = "leases"
 		options.LeaderElectionNamespace = ctx.Config.LeaderElection.Namespace
 		options.LeaderElectionID = ctx.Config.LeaderElection.Name
 		options.LeaseDuration = &ctx.Config.LeaderElection.LeaseDuration

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -45,10 +45,6 @@ data:
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
     #   namespace: projectcontour
-    # The following config shows the defaults for the leader election.
-    # leaderelection:
-    #   configmap-name: leader-elect
-    #   configmap-namespace: projectcontour
     ####
     # ExternalName Services are disabled by default due to CVE-2021-XXXXX
     # You can re-enable them by setting this setting to `true`.

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -12,15 +12,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - events
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   - namespaces
   - secrets
@@ -29,6 +20,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -78,10 +78,6 @@ data:
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
     #   namespace: projectcontour
-    # The following config shows the defaults for the leader election.
-    # leaderelection:
-    #   configmap-name: leader-elect
-    #   configmap-namespace: projectcontour
     ####
     # ExternalName Services are disabled by default due to CVE-2021-XXXXX
     # You can re-enable them by setting this setting to `true`.
@@ -4909,15 +4905,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - events
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   - namespaces
   - secrets
@@ -4926,6 +4913,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -81,10 +81,6 @@ data:
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
     #   namespace: projectcontour
-    # The following config shows the defaults for the leader election.
-    # leaderelection:
-    #   configmap-name: leader-elect
-    #   configmap-namespace: projectcontour
     ####
     # ExternalName Services are disabled by default due to CVE-2021-XXXXX
     # You can re-enable them by setting this setting to `true`.
@@ -4912,15 +4908,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - events
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   - namespaces
   - secrets
@@ -4929,6 +4916,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -78,10 +78,6 @@ data:
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
     #   namespace: projectcontour
-    # The following config shows the defaults for the leader election.
-    # leaderelection:
-    #   configmap-name: leader-elect
-    #   configmap-namespace: projectcontour
     ####
     # ExternalName Services are disabled by default due to CVE-2021-XXXXX
     # You can re-enable them by setting this setting to `true`.
@@ -4909,15 +4905,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  - events
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   - namespaces
   - secrets
@@ -4926,6 +4913,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -25,5 +25,5 @@ package k8s
 // +kubebuilder:rbac:groups="",resources=secrets;endpoints;services;namespaces,verbs=get;list;watch
 
 // Add RBAC policy to support leader election.
-// +kubebuilder:rbac:groups="",resources=configmaps;events,verbs=create;get;update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;get;update
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -53,8 +53,8 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | `--leader-election-lease-duration`                       | The duration of the leadership lease.                                  |
 | `--leader-election-renew-deadline`                       | The duration leader will retry refreshing leadership before giving up. |
 | `--leader-election-retry-period`                         | The interval which Contour will attempt to acquire leadership lease.   |
-| `--leader-election-resource-name`                        | The name of the resource (ConfigMap) leader election will lease.       |
-| `--leader-election-resource-namespace`                   | The namespace of the resource (ConfigMap) leader election will lease.  |
+| `--leader-election-resource-name`                        | The name of the resource (Lease) leader election will lease.           |
+| `--leader-election-resource-namespace`                   | The namespace of the resource (Lease) leader election will lease.      |
 | `-d, --debug`                                            | Enable debug logging                                                   |
 | `--kubernetes-debug=<log level>`                         | Enable Kubernetes client debug logging                                 |
 
@@ -294,10 +294,6 @@ data:
       envoy-client-certificate:
     #   name: envoy-client-cert-secret-name
     #   namespace: projectcontour
-    # The following config shows the defaults for the leader election.
-    # leaderelection:
-    #   configmap-name: leader-elect
-    #   configmap-namespace: projectcontour
     ### Logging options
     # Default setting
     accesslog-format: envoy
@@ -407,7 +403,7 @@ If present, the value of the `CONTOUR_NAMESPACE` environment variable is used as
 1. The value for the `contour bootstrap --namespace` flag unless otherwise specified.
 1. The value for the `contour certgen --namespace` flag unless otherwise specified.
 1. The value for the `contour serve --envoy-service-namespace` flag unless otherwise specified.
-1. The value for the `leaderelection.configmap-namespace` config file setting for `contour serve` unless otherwise specified.
+1. The value for the `contour serve --leader-election-resource-namespace` flag unless otherwise specified.
 
 The `CONTOUR_NAMESPACE` environment variable is set via the [Downward API][6] in the Contour [example manifests][7].
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -864,12 +864,6 @@ func (d *Deployment) EnsureResourcesForInclusterContour(startContourDeployment b
 func (d *Deployment) DeleteResourcesForInclusterContour() error {
 	// Also need to delete leader election resources to ensure
 	// multiple test runs can be run cleanly.
-	leaderElectionConfigMap := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "leader-elect",
-			Namespace: d.Namespace.Name,
-		},
-	}
 	leaderElectionLease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "leader-elect",
@@ -888,7 +882,6 @@ func (d *Deployment) DeleteResourcesForInclusterContour() error {
 		envoy,
 		d.ContourDeployment,
 		leaderElectionLease,
-		leaderElectionConfigMap,
 		d.EnvoyService,
 		d.ContourService,
 		d.ContourClusterRole,

--- a/test/e2e/incluster/leaderelection_test.go
+++ b/test/e2e/incluster/leaderelection_test.go
@@ -18,8 +18,6 @@ package incluster
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -42,20 +40,6 @@ func testLeaderElection(namespace string) {
 	// has set status on an object.
 	Specify("leader election resources are created as expected", func() {
 		getLeaderID := func() (string, error) {
-			type leaderInfo struct {
-				HolderIdentity string
-			}
-
-			leaderElectionConfigMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "leader-elect",
-					Namespace: f.Deployment.Namespace.Name,
-				},
-			}
-			if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(leaderElectionConfigMap), leaderElectionConfigMap); err != nil {
-				return "", err
-			}
-
 			leaderElectionLease := &coordinationv1.Lease{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "leader-elect",
@@ -66,26 +50,11 @@ func testLeaderElection(namespace string) {
 				return "", err
 			}
 
-			var (
-				infoRaw string
-				found   bool
-				li      leaderInfo
-			)
-
-			if infoRaw, found = leaderElectionConfigMap.Annotations["control-plane.alpha.kubernetes.io/leader"]; !found {
-				return "", errors.New("leaderelection configmap did not have leader annotation: control-plane.alpha.kubernetes.io/leader")
-			}
-			if err := json.Unmarshal([]byte(infoRaw), &li); err != nil {
-				return "", err
-			}
 			leaseHolder := pointer.StringDeref(leaderElectionLease.Spec.HolderIdentity, "")
-			if leaseHolder != li.HolderIdentity {
-				return "", fmt.Errorf("lease leader %q and configmap leader %q do not match", leaseHolder, li.HolderIdentity)
+			if !strings.HasPrefix(leaseHolder, "contour-") {
+				return "", fmt.Errorf("invalid leader name: %q", leaseHolder)
 			}
-			if !strings.HasPrefix(li.HolderIdentity, "contour-") {
-				return "", fmt.Errorf("invalid leader name: %q", li.HolderIdentity)
-			}
-			return li.HolderIdentity, nil
+			return leaseHolder, nil
 		}
 
 		podNameFromLeaderID := func(id string) string {
@@ -109,15 +78,12 @@ func testLeaderElection(namespace string) {
 				if err := f.Client.List(context.TODO(), events, listOptions); err != nil {
 					return false
 				}
-				foundEvents := map[string]struct{}{}
 				for _, e := range events.Items {
-					if e.Reason == "LeaderElection" && e.Source.Component == leader {
-						foundEvents[e.InvolvedObject.Kind] = struct{}{}
+					if e.Reason == "LeaderElection" && e.Source.Component == leader && e.InvolvedObject.Kind == "Lease" {
+						return true
 					}
 				}
-				_, foundLease := foundEvents["Lease"]
-				_, foundConfigMap := foundEvents["ConfigMap"]
-				return foundLease && foundConfigMap
+				return false
 			}
 		}
 


### PR DESCRIPTION
- Removes RBAC for ConfigMaps
- Also removes mentions of leader election ConfigMaps from examples
- Updates e2e tests

Fixes: #1393