### PR TITLE
release-note/deprecation PR label validated by tooling

### DIFF
--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -9,15 +9,31 @@ env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 jobs:
+  # Ensures correct release-note labels are set:
+  # - At least one label
+  # - At most one of the main category labels
+  # - A deprecation label alone or with something other than "none-required"
+  # Ensures you can have a change that is just a deprecation, or include a
+  # deprecation with another release note.
   check-label:
     name: Check release-note label set
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v1
         with:
-          mode: exactly
+          mode: minimum
           count: 1
-          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/none-required"
+          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/deprecation, release-note, release-note-action-required, release-note/none-required"
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: maximum
+          count: 1
+          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note, release-note-action-required, release-note/none-required"
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: maximum
+          count: 1
+          labels: "release-note/deprecation, release-note/none-required"
   check-changelog:
     name: Check for changelog file
     needs:

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -41,6 +41,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        # * Module download cache
+        # * Build cache (Linux)
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ github.job }}-go-
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.5'
     - run: go run ./hack/actions/check-changefile-exists.go
       env:
         PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -23,12 +23,12 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/deprecation, release-note, release-note-action-required, release-note/none-required"
+          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/deprecation, release-note/none-required"
       - uses: mheap/github-action-required-labels@v1
         with:
           mode: maximum
           count: 1
-          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note, release-note-action-required, release-note/none-required"
+          labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/none-required"
       - uses: mheap/github-action-required-labels@v1
         with:
           mode: maximum

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ the need to cherrypick a commit or rollback arise, it should be clear what a spe
 with a colon as delimiter. For example 'docs:', 'internal/(packagename):', 'design:' or something similar.
 - PRs *must* be labelled with a `release-note/category` label, where category is one of
 `major`, `minor`, `small`, `docs`, or `infra`, unless the change is really small, in which case
-it may have a `release-note/not-required` category.
+it may have a `release-note/not-required` category. PRs may also include a `release-note/deprecation`
+label alone or in addition to the primary label.
 - PRs *must* include a file named `changelogs/unreleased/PR#-githubID-category.md`, which is a Markdown
 file with a description of the change. Please see `changelogs/unreleased/<category>-sample.md` for 
 sample changelogs.

--- a/changelogs/unreleased/deprecation-sample.md
+++ b/changelogs/unreleased/deprecation-sample.md
@@ -1,0 +1,5 @@
+## Sample deprecation or removal change
+
+This change type requires a short explanation, a small paragraph should be sufficient.
+CLI flags, configuration, or API deprecations and removals should be called out here.
+This is also the place to call out any upgrading instructions or considerations that come with a removal.

--- a/hack/actions/check-changefile-exists.go
+++ b/hack/actions/check-changefile-exists.go
@@ -91,7 +91,7 @@ or https://github.com/projectcontour/contour/blob/main/design/changelog.md for b
 	changelogFiles := []string{}
 	for _, label := range prDetails.Labels {
 		name := *label.Name
-		if !strings.HasPrefix(name, "release-note") {
+		if !strings.HasPrefix(name, "release-note/") {
 			continue
 		}
 
@@ -105,8 +105,6 @@ or https://github.com/projectcontour/contour/blob/main/design/changelog.md for b
 			// Exit early if no changelog required.
 			log.Println("No changelog required.")
 			os.Exit(0)
-		case "release-note", "release-note-action-required":
-			category = "major"
 		case "release-note/major", "release-note/minor", "release-note/small", "release-note/docs", "release-note/infra", "release-note/deprecation":
 		default:
 			logFriendlyError(fmt.Sprintf("Invalid release-note label category: %q", category))

--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -250,6 +250,8 @@ func generateReleaseNotes(version, kubeMinVersion, kubeMaxVersion string) error 
 			d.Small = append(d.Small, entry)
 		case "docs":
 			d.Docs = append(d.Docs, entry)
+		case "deprecation":
+			d.Deprecation = append(d.Deprecation, entry)
 		default:
 			fmt.Printf("Unrecognized category %q\n", entry.Category)
 			continue
@@ -345,6 +347,7 @@ type Data struct {
 	Minor                []Entry
 	Small                []Entry
 	Docs                 []Entry
+	Deprecation          []Entry
 	Contributors         []string
 	KubernetesMinVersion string
 	KubernetesMaxVersion string

--- a/hack/release/release-notes-template.md
+++ b/hack/release/release-notes-template.md
@@ -39,7 +39,11 @@ Feedback and bug reports are welcome!
 
 # Deprecation and Removal Notices
 
-TODO
+{{ range .Deprecation }}
+{{ .Content }}
+
+(#{{ .PRNumber }}, {{ .Author }})
+{{ end }}
 
 # Installing and Upgrading
 {{ if .Prerelease}}

--- a/site/data/github-labels.yaml
+++ b/site/data/github-labels.yaml
@@ -21,20 +21,6 @@ default:
       target: issues
       addedBy: anyone
 
-# Release notes.
-    - color: c2e0c6
-      description: Denotes a PR that will be considered when it comes time to generate release notes.
-      name: release-note
-      target: prs
-      addedBy: prow
-      previously:
-        - name: "release note"
-    - color: c2e0c6
-      description: Denotes a PR that introduces potentially breaking changes that require user action. # These actions will be specifically called out when it comes time to generate release notes.
-      name: release-note-action-required
-      target: prs
-      addedBy: prow
-
 # Area.
     - color: 0052cc
       description: Issues or PRs related to dependency changes.


### PR DESCRIPTION
Can be used alone or in conjunction with another label.

Also makes it so release-note and release-note-action-required legacy
labels have to be alone, for simplicity.

Fixes: #4258