### PR TITLE
pkg/config: Remove leader election configuration

### DIFF
--- a/changelogs/unreleased/4340-sunjayBhatia-deprecation.md
+++ b/changelogs/unreleased/4340-sunjayBhatia-deprecation.md
@@ -1,0 +1,4 @@
+## Remove leader election configuration from configuration file
+
+Leader election configuration via configuration file was deprecated in Contour v1.20.0.
+Configuration of leader election lease details and resource must now be done via command line flag.

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -85,8 +85,8 @@ type serveContext struct {
 	// PermitInsecureGRPC disables TLS on Contour's gRPC listener.
 	PermitInsecureGRPC bool
 
-	// DisableLeaderElection can only be set by command line flag.
-	DisableLeaderElection bool
+	// Leader election configuration.
+	LeaderElection LeaderElection
 }
 
 type ServerConfig struct {
@@ -96,27 +96,35 @@ type ServerConfig struct {
 	caFile, contourCert, contourKey string
 }
 
+type LeaderElection struct {
+	Disable       bool
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+	Namespace     string
+	Name          string
+}
+
 // newServeContext returns a serveContext initialized to defaults.
 func newServeContext() *serveContext {
 	// Set defaults for parameters which are then overridden via flags, ENV, or ConfigFile
 	return &serveContext{
-		Config:                config.Defaults(),
-		statsAddr:             "0.0.0.0",
-		statsPort:             8002,
-		debugAddr:             "127.0.0.1",
-		debugPort:             6060,
-		healthAddr:            "0.0.0.0",
-		healthPort:            8000,
-		metricsAddr:           "0.0.0.0",
-		metricsPort:           8000,
-		httpAccessLog:         xdscache_v3.DEFAULT_HTTP_ACCESS_LOG,
-		httpsAccessLog:        xdscache_v3.DEFAULT_HTTPS_ACCESS_LOG,
-		httpAddr:              "0.0.0.0",
-		httpsAddr:             "0.0.0.0",
-		httpPort:              8080,
-		httpsPort:             8443,
-		PermitInsecureGRPC:    false,
-		DisableLeaderElection: false,
+		Config:             config.Defaults(),
+		statsAddr:          "0.0.0.0",
+		statsPort:          8002,
+		debugAddr:          "127.0.0.1",
+		debugPort:          6060,
+		healthAddr:         "0.0.0.0",
+		healthPort:         8000,
+		metricsAddr:        "0.0.0.0",
+		metricsPort:        8000,
+		httpAccessLog:      xdscache_v3.DEFAULT_HTTP_ACCESS_LOG,
+		httpsAccessLog:     xdscache_v3.DEFAULT_HTTPS_ACCESS_LOG,
+		httpAddr:           "0.0.0.0",
+		httpsAddr:          "0.0.0.0",
+		httpPort:           8080,
+		httpsPort:          8443,
+		PermitInsecureGRPC: false,
 		ServerConfig: ServerConfig{
 			xdsAddr:     "127.0.0.1",
 			xdsPort:     8001,

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -357,16 +357,6 @@ type GatewayParameters struct {
 	ControllerName string `yaml:"controllerName,omitempty"`
 }
 
-// LeaderElectionParameters holds the config bits for leader election
-// inside the  configuration file.
-type LeaderElectionParameters struct {
-	LeaseDuration time.Duration `yaml:"lease-duration,omitempty"`
-	RenewDeadline time.Duration `yaml:"renew-deadline,omitempty"`
-	RetryPeriod   time.Duration `yaml:"retry-period,omitempty"`
-	Namespace     string        `yaml:"configmap-namespace,omitempty"`
-	Name          string        `yaml:"configmap-name,omitempty"`
-}
-
 // TimeoutParameters holds various configurable proxy timeout values.
 type TimeoutParameters struct {
 	// RequestTimeout sets the client request timeout globally for Contour. Note that
@@ -609,11 +599,6 @@ type Parameters struct {
 	// TODO(youngnick): put a link to the issue and CVE here.
 	EnableExternalNameService bool `yaml:"enableExternalNameService,omitempty"`
 
-	// LeaderElection contains leader election parameters.
-	// Note: This method of configuring leader election is deprecated,
-	// please use command line flags instead.
-	LeaderElection LeaderElectionParameters `yaml:"leaderelection,omitempty"`
-
 	// Timeouts holds various configurable timeouts that can
 	// be set in the config file.
 	Timeouts TimeoutParameters `yaml:"timeouts,omitempty"`
@@ -802,13 +787,6 @@ func Defaults() Parameters {
 		TLS:                       TLSParameters{},
 		DisablePermitInsecure:     false,
 		DisableAllowChunkedLength: false,
-		LeaderElection: LeaderElectionParameters{
-			LeaseDuration: time.Second * 15,
-			RenewDeadline: time.Second * 10,
-			RetryPeriod:   time.Second * 2,
-			Name:          "leader-elect",
-			Namespace:     contourNamespace,
-		},
 		Timeouts: TimeoutParameters{
 			// This is chosen as a rough default to stop idle connections wasting resources,
 			// without stopping slow connections from being terminated too quickly.

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,12 +71,6 @@ json-fields:
 - upstream_service_time
 - user_agent
 - x_forwarded_for
-leaderelection:
-  lease-duration: 15s
-  renew-deadline: 10s
-  retry-period: 2s
-  configmap-namespace: projectcontour
-  configmap-name: leader-elect
 timeouts:
   connection-idle-timeout: 60s
 envoy-service-namespace: projectcontour
@@ -462,12 +455,6 @@ func TestConfigFileDefaultOverrideImport(t *testing.T) {
 incluster: false
 disablePermitInsecure: false
 disableAllowChunkedLength: false
-leaderelection:
-  configmap-name: leader-elect
-  configmap-namespace: projectcontour
-  lease-duration: 15s
-  renew-deadline: 10s
-  retry-period: 2s
 `,
 	)
 
@@ -488,32 +475,6 @@ tls:
   - ECDHE-RSA-AES256-GCM-SHA384
 `)
 
-	check(func(t *testing.T, conf *Parameters) {
-		assert.Equal(t, "foo", conf.LeaderElection.Name)
-		assert.Equal(t, "bar", conf.LeaderElection.Namespace)
-	}, `
-leaderelection:
-  configmap-name: foo
-  configmap-namespace: bar
-`)
-
-	check(func(t *testing.T, conf *Parameters) {
-		assert.Equal(t, conf.LeaderElection,
-			LeaderElectionParameters{
-				Name:          "foo",
-				Namespace:     "bar",
-				LeaseDuration: 600 * time.Second,
-				RenewDeadline: 500 * time.Second,
-				RetryPeriod:   60 * time.Second,
-			})
-	}, `
-leaderelection:
-  configmap-name: foo
-  configmap-namespace: bar
-  lease-duration: 600s
-  renew-deadline: 500s
-  retry-period: 60s
-`)
 	check(func(t *testing.T, conf *Parameters) {
 		assert.ElementsMatch(t,
 			[]HTTPVersionType{HTTPVersion1, HTTPVersion2, HTTPVersion2, HTTPVersion1},


### PR DESCRIPTION
Leader election configuration via configuration file was deprecated in Contour
v1.20.0. Configuration should be done via command line parameters only.