### PR TITLE
Added idle connection timeout to HTTPProxy

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -765,6 +765,12 @@ type TimeoutPolicy struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$`
 	Idle string `json:"idle,omitempty"`
+
+	// Timeout for how long connection from the proxy to the upstream service is kept when there are no active requests.
+	// If not supplied, Envoy's default value of 1h applies.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$`
+	IdleConnection string `json:"idleConnection,omitempty"`
 }
 
 // RetryOn is a string type alias with validation to ensure that the value is valid.

--- a/changelogs/unreleased/4356-tsaarni-small.md
+++ b/changelogs/unreleased/4356-tsaarni-small.md
@@ -1,0 +1,1 @@
+New field `HTTPProxy.spec.routes.timeoutPolicy.idleConnection` was added. The field sets timeout for how long the upstream connection will be kept idle between requests before disconnecting it.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -2093,6 +2093,12 @@ spec:
                       manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  idleConnection:
+                    description: Timeout for how long connection from the proxy to
+                      the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
                   response:
                     description: Timeout for receiving a response from the server
                       after processing a request from client. If not supplied, Envoy's
@@ -3350,6 +3356,13 @@ spec:
                             consecutive requests. If not specified, there is no per-route
                             idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: Timeout for how long connection from the proxy
+                            to the upstream service is kept when there are no active
+                            requests. If not supplied, Envoy's default value of 1h
+                            applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -2288,6 +2288,12 @@ spec:
                       manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  idleConnection:
+                    description: Timeout for how long connection from the proxy to
+                      the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
                   response:
                     description: Timeout for receiving a response from the server
                       after processing a request from client. If not supplied, Envoy's
@@ -3545,6 +3551,13 @@ spec:
                             consecutive requests. If not specified, there is no per-route
                             idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: Timeout for how long connection from the proxy
+                            to the upstream service is kept when there are no active
+                            requests. If not supplied, Envoy's default value of 1h
+                            applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -2291,6 +2291,12 @@ spec:
                       manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  idleConnection:
+                    description: Timeout for how long connection from the proxy to
+                      the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
                   response:
                     description: Timeout for receiving a response from the server
                       after processing a request from client. If not supplied, Envoy's
@@ -3548,6 +3554,13 @@ spec:
                             consecutive requests. If not specified, there is no per-route
                             idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: Timeout for how long connection from the proxy
+                            to the upstream service is kept when there are no active
+                            requests. If not supplied, Envoy's default value of 1h
+                            applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -2288,6 +2288,12 @@ spec:
                       manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  idleConnection:
+                    description: Timeout for how long connection from the proxy to
+                      the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
                   response:
                     description: Timeout for receiving a response from the server
                       after processing a request from client. If not supplied, Envoy's
@@ -3545,6 +3551,13 @@ spec:
                             consecutive requests. If not specified, there is no per-route
                             idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: Timeout for how long connection from the proxy
+                            to the upstream service is kept when there are no active
+                            requests. If not supplied, Envoy's default value of 1h
+                            applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -11388,9 +11388,6 @@ func TestDAGInsert(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			if name != "insert httpproxy w/ infinite timeoutpolicy" {
-				return
-			}
 			builder := Builder{
 				Source: KubernetesCache{
 					FieldLogger: fixture.NewTestLogger(t),

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -8274,10 +8274,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
-								ResponseTimeout: timeout.DurationSetting(90 * time.Second),
-							},
+							Clusters:           withTimeout(clustermap(s1), TimeoutPolicy{ResponseTimeout: timeout.DurationSetting(90 * time.Second)}),
+							TimeoutPolicy:      TimeoutPolicy{ResponseTimeout: timeout.DurationSetting(90 * time.Second)},
 						}),
 					),
 				},
@@ -8337,10 +8335,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
-								ResponseTimeout: timeout.DisabledSetting(),
-							},
+							Clusters:           withTimeout(clustermap(s1), TimeoutPolicy{ResponseTimeout: timeout.DisabledSetting()}),
+							TimeoutPolicy:      TimeoutPolicy{ResponseTimeout: timeout.DisabledSetting()},
 						}),
 					),
 				},
@@ -12517,4 +12513,11 @@ func withMirror(r *Route, mirror *Service) *Route {
 		},
 	}
 	return r
+}
+
+func withTimeout(clusters []*Cluster, timeout TimeoutPolicy) []*Cluster {
+	for _, c := range clusters {
+		c.TimeoutPolicy = timeout
+	}
+	return clusters
 }

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -8233,7 +8233,7 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefixString("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
+							TimeoutPolicy: RouteTimeoutPolicy{
 								ResponseTimeout: timeout.DurationSetting(90 * time.Second),
 							},
 						}),
@@ -8254,7 +8254,7 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefixString("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
+							TimeoutPolicy: RouteTimeoutPolicy{
 								ResponseTimeout: timeout.DurationSetting(90 * time.Second),
 							},
 						}),
@@ -8274,8 +8274,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           withTimeout(clustermap(s1), TimeoutPolicy{ResponseTimeout: timeout.DurationSetting(90 * time.Second)}),
-							TimeoutPolicy:      TimeoutPolicy{ResponseTimeout: timeout.DurationSetting(90 * time.Second)},
+							Clusters:           clustermap(s1),
+							TimeoutPolicy:      RouteTimeoutPolicy{ResponseTimeout: timeout.DurationSetting(90 * time.Second)},
 						}),
 					),
 				},
@@ -8294,7 +8294,7 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefixString("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
+							TimeoutPolicy: RouteTimeoutPolicy{
 								ResponseTimeout: timeout.DisabledSetting(),
 							},
 						}),
@@ -8315,7 +8315,7 @@ func TestDAGInsert(t *testing.T) {
 						virtualhost("*", &Route{
 							PathMatchCondition: prefixString("/"),
 							Clusters:           clustermap(s1),
-							TimeoutPolicy: TimeoutPolicy{
+							TimeoutPolicy: RouteTimeoutPolicy{
 								ResponseTimeout: timeout.DisabledSetting(),
 							},
 						}),
@@ -8335,8 +8335,8 @@ func TestDAGInsert(t *testing.T) {
 					VirtualHosts: virtualhosts(
 						virtualhost("bar.com", &Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           withTimeout(clustermap(s1), TimeoutPolicy{ResponseTimeout: timeout.DisabledSetting()}),
-							TimeoutPolicy:      TimeoutPolicy{ResponseTimeout: timeout.DisabledSetting()},
+							Clusters:           clustermap(s1),
+							TimeoutPolicy:      RouteTimeoutPolicy{ResponseTimeout: timeout.DisabledSetting()},
 						}),
 					),
 				},
@@ -11388,6 +11388,9 @@ func TestDAGInsert(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			if name != "insert httpproxy w/ infinite timeoutpolicy" {
+				return
+			}
 			builder := Builder{
 				Source: KubernetesCache{
 					FieldLogger: fixture.NewTestLogger(t),
@@ -12513,11 +12516,4 @@ func withMirror(r *Route, mirror *Service) *Route {
 		},
 	}
 	return r
-}
-
-func withTimeout(clusters []*Cluster, timeout TimeoutPolicy) []*Cluster {
-	for _, c := range clusters {
-		c.TimeoutPolicy = timeout
-	}
-	return clusters
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -861,6 +861,7 @@ type ExtensionCluster struct {
 	LoadBalancerPolicy string
 
 	// RouteTimeoutPolicy specifies how to handle timeouts to this extension.
+	// Defines default response timeout unless the
 	RouteTimeoutPolicy RouteTimeoutPolicy
 
 	// TimeoutPolicy specifies how to handle timeouts for this cluster.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -268,7 +268,7 @@ func (r *Route) HasPathRegex() bool {
 	return ok
 }
 
-// TimeoutPolicy defines the timeout policy for a route.
+// TimeoutPolicy defines the timeout policy for a route or a cluster.
 type TimeoutPolicy struct {
 	// ResponseTimeout is the timeout applied to the response
 	// from the backend server.
@@ -280,6 +280,9 @@ type TimeoutPolicy struct {
 
 	// IdleConnectionTimeout is the timeout applied to idle connection.
 	IdleConnectionTimeout timeout.Setting
+
+	// ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
+	ConnectTimeout time.Duration
 }
 
 // RetryPolicy defines the retry / number / timeout options
@@ -690,11 +693,8 @@ type Cluster struct {
 	// private key to be used when establishing TLS connection to upstream cluster.
 	ClientCertificate *Secret
 
-	// ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
-	ConnectTimeout time.Duration
-
-	// IdleConnectionTimeout defines how long the proxy should keep idle connection to upstream service before disconnecting.
-	IdleConnectionTimeout timeout.Setting
+	// TimeoutPolicy specifies how to handle timeouts for this cluster.
+	TimeoutPolicy TimeoutPolicy
 }
 
 // WeightedService represents the load balancing weight of a
@@ -866,12 +866,6 @@ type ExtensionCluster struct {
 	// ClientCertificate is the optional identifier of the TLS secret containing client certificate and
 	// private key to be used when establishing TLS connection to upstream cluster.
 	ClientCertificate *Secret
-
-	// ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
-	ConnectTimeout time.Duration
-
-	// IdleConnectionTimeout defines how long the proxy should keep idle connection to upstream service before disconnecting.
-	IdleConnectionTimeout timeout.Setting
 }
 
 func wildcardDomainHeaderMatch(fqdn string) HeaderMatchCondition {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -274,8 +274,12 @@ type TimeoutPolicy struct {
 	// from the backend server.
 	ResponseTimeout timeout.Setting
 
-	// IdleTimeout is the timeout applied to idle connections.
-	IdleTimeout timeout.Setting
+	// IdleStreamTimeout is the timeout applied to idle connection during single request-response.
+	// Stream is HTTP/2 and HTTP/3 concept, for HTTP/1 it refers to single request-response within connection.
+	IdleStreamTimeout timeout.Setting
+
+	// IdleConnectionTimeout is the timeout applied to idle connection.
+	IdleConnectionTimeout timeout.Setting
 }
 
 // RetryPolicy defines the retry / number / timeout options
@@ -688,6 +692,9 @@ type Cluster struct {
 
 	// ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
 	ConnectTimeout time.Duration
+
+	// IdleConnectionTimeout defines how long the proxy should keep idle connection to upstream service before disconnecting.
+	IdleConnectionTimeout timeout.Setting
 }
 
 // WeightedService represents the load balancing weight of a
@@ -862,6 +869,9 @@ type ExtensionCluster struct {
 
 	// ConnectTimeout defines how long the proxy should wait when establishing connection to upstream service.
 	ConnectTimeout time.Duration
+
+	// IdleConnectionTimeout defines how long the proxy should keep idle connection to upstream service before disconnecting.
+	IdleConnectionTimeout timeout.Setting
 }
 
 func wildcardDomainHeaderMatch(fqdn string) HeaderMatchCondition {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -218,7 +218,7 @@ type Route struct {
 	Websocket bool
 
 	// TimeoutPolicy defines the timeout request/idle
-	TimeoutPolicy TimeoutPolicy
+	TimeoutPolicy RouteTimeoutPolicy
 
 	// RetryPolicy defines the retry / number / timeout options for a route
 	RetryPolicy *RetryPolicy
@@ -268,8 +268,8 @@ func (r *Route) HasPathRegex() bool {
 	return ok
 }
 
-// TimeoutPolicy defines the timeout policy for a route or a cluster.
-type TimeoutPolicy struct {
+// RouteTimeoutPolicy defines the timeout policy for a route.
+type RouteTimeoutPolicy struct {
 	// ResponseTimeout is the timeout applied to the response
 	// from the backend server.
 	ResponseTimeout timeout.Setting
@@ -277,7 +277,10 @@ type TimeoutPolicy struct {
 	// IdleStreamTimeout is the timeout applied to idle connection during single request-response.
 	// Stream is HTTP/2 and HTTP/3 concept, for HTTP/1 it refers to single request-response within connection.
 	IdleStreamTimeout timeout.Setting
+}
 
+// ClusterTimeoutPolicy defines the timeout policy for a cluster.
+type ClusterTimeoutPolicy struct {
 	// IdleConnectionTimeout is the timeout applied to idle connection.
 	IdleConnectionTimeout timeout.Setting
 
@@ -694,7 +697,7 @@ type Cluster struct {
 	ClientCertificate *Secret
 
 	// TimeoutPolicy specifies how to handle timeouts for this cluster.
-	TimeoutPolicy TimeoutPolicy
+	TimeoutPolicy ClusterTimeoutPolicy
 }
 
 // WeightedService represents the load balancing weight of a
@@ -857,8 +860,11 @@ type ExtensionCluster struct {
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-lbpolicy
 	LoadBalancerPolicy string
 
-	// TimeoutPolicy specifies how to handle timeouts to this extension.
-	TimeoutPolicy TimeoutPolicy
+	// RouteTimeoutPolicy specifies how to handle timeouts to this extension.
+	RouteTimeoutPolicy RouteTimeoutPolicy
+
+	// TimeoutPolicy specifies how to handle timeouts for this cluster.
+	ClusterTimeoutPolicy ClusterTimeoutPolicy
 
 	// SNI is used when a route proxies an upstream using TLS.
 	SNI string

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -861,7 +861,6 @@ type ExtensionCluster struct {
 	LoadBalancerPolicy string
 
 	// RouteTimeoutPolicy specifies how to handle timeouts to this extension.
-	// Defines default response timeout unless the
 	RouteTimeoutPolicy RouteTimeoutPolicy
 
 	// TimeoutPolicy specifies how to handle timeouts for this cluster.

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -84,7 +84,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 	ext *contour_api_v1alpha1.ExtensionService,
 	validCondition *contour_api_v1.DetailedCondition,
 ) *ExtensionCluster {
-	tp, err := timeoutPolicy(ext.Spec.TimeoutPolicy, p.ConnectTimeout)
+	tp, _, err := timeoutPolicy(ext.Spec.TimeoutPolicy, p.ConnectTimeout)
 	if err != nil {
 		validCondition.AddErrorf(contour_api_v1.ConditionTypeSpecError, "TimeoutPolicyNotValid",
 			"spec.timeoutPolicy failed to parse: %s", err)
@@ -109,7 +109,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 		},
 		Protocol:           "h2",
 		UpstreamValidation: nil,
-		TimeoutPolicy:      tp,
+		RouteTimeoutPolicy: tp,
 		SNI:                "",
 		ClientCertificate:  clientCertSecret,
 	}

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -84,7 +84,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 	ext *contour_api_v1alpha1.ExtensionService,
 	validCondition *contour_api_v1.DetailedCondition,
 ) *ExtensionCluster {
-	tp, err := timeoutPolicy(ext.Spec.TimeoutPolicy)
+	tp, err := timeoutPolicy(ext.Spec.TimeoutPolicy, p.ConnectTimeout)
 	if err != nil {
 		validCondition.AddErrorf(contour_api_v1.ConditionTypeSpecError, "TimeoutPolicyNotValid",
 			"spec.timeoutPolicy failed to parse: %s", err)
@@ -107,13 +107,11 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 				xds.ClusterLoadAssignmentName(k8s.NamespacedNameOf(ext), ""),
 			),
 		},
-		Protocol:              "h2",
-		UpstreamValidation:    nil,
-		TimeoutPolicy:         tp,
-		SNI:                   "",
-		ClientCertificate:     clientCertSecret,
-		ConnectTimeout:        p.ConnectTimeout,
-		IdleConnectionTimeout: tp.IdleConnectionTimeout,
+		Protocol:           "h2",
+		UpstreamValidation: nil,
+		TimeoutPolicy:      tp,
+		SNI:                "",
+		ClientCertificate:  clientCertSecret,
 	}
 
 	lbPolicy := loadBalancerPolicy(ext.Spec.LoadBalancerPolicy)

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -107,12 +107,13 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 				xds.ClusterLoadAssignmentName(k8s.NamespacedNameOf(ext), ""),
 			),
 		},
-		Protocol:           "h2",
-		UpstreamValidation: nil,
-		TimeoutPolicy:      tp,
-		SNI:                "",
-		ClientCertificate:  clientCertSecret,
-		ConnectTimeout:     p.ConnectTimeout,
+		Protocol:              "h2",
+		UpstreamValidation:    nil,
+		TimeoutPolicy:         tp,
+		SNI:                   "",
+		ClientCertificate:     clientCertSecret,
+		ConnectTimeout:        p.ConnectTimeout,
+		IdleConnectionTimeout: tp.IdleConnectionTimeout,
 	}
 
 	lbPolicy := loadBalancerPolicy(ext.Spec.LoadBalancerPolicy)

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -84,7 +84,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 	ext *contour_api_v1alpha1.ExtensionService,
 	validCondition *contour_api_v1.DetailedCondition,
 ) *ExtensionCluster {
-	tp, _, err := timeoutPolicy(ext.Spec.TimeoutPolicy, p.ConnectTimeout)
+	rtp, ctp, err := timeoutPolicy(ext.Spec.TimeoutPolicy, p.ConnectTimeout)
 	if err != nil {
 		validCondition.AddErrorf(contour_api_v1.ConditionTypeSpecError, "TimeoutPolicyNotValid",
 			"spec.timeoutPolicy failed to parse: %s", err)
@@ -107,11 +107,12 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 				xds.ClusterLoadAssignmentName(k8s.NamespacedNameOf(ext), ""),
 			),
 		},
-		Protocol:           "h2",
-		UpstreamValidation: nil,
-		RouteTimeoutPolicy: tp,
-		SNI:                "",
-		ClientCertificate:  clientCertSecret,
+		Protocol:             "h2",
+		UpstreamValidation:   nil,
+		RouteTimeoutPolicy:   rtp,
+		ClusterTimeoutPolicy: ctp,
+		SNI:                  "",
+		ClientCertificate:    clientCertSecret,
 	}
 
 	lbPolicy := loadBalancerPolicy(ext.Spec.LoadBalancerPolicy)

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -735,7 +735,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 				Upstream:      service,
 				SNI:           service.ExternalName,
 				Weight:        routeWeight,
-				TimeoutPolicy: TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+				TimeoutPolicy: ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 			})
 		}
 
@@ -1085,7 +1085,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			Weight:               routeWeight,
 			Protocol:             service.Protocol,
 			RequestHeadersPolicy: headerPolicy,
-			TimeoutPolicy:        TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+			TimeoutPolicy:        ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		})
 	}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -732,10 +732,10 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 			// https://github.com/projectcontour/contour/issues/3593
 			service.Weighted.Weight = routeWeight
 			proxy.Clusters = append(proxy.Clusters, &Cluster{
-				Upstream:       service,
-				SNI:            service.ExternalName,
-				Weight:         routeWeight,
-				ConnectTimeout: p.ConnectTimeout,
+				Upstream:      service,
+				SNI:           service.ExternalName,
+				Weight:        routeWeight,
+				TimeoutPolicy: TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 			})
 		}
 
@@ -1085,7 +1085,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			Weight:               routeWeight,
 			Protocol:             service.Protocol,
 			RequestHeadersPolicy: headerPolicy,
-			ConnectTimeout:       p.ConnectTimeout,
+			TimeoutPolicy:        TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		})
 	}
 

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -699,6 +699,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				DNSLookupFamily:       string(p.DNSLookupFamily),
 				ClientCertificate:     clientCertSecret,
 				ConnectTimeout:        p.ConnectTimeout,
+				IdleConnectionTimeout: tp.IdleConnectionTimeout,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				validCond.AddError(contour_api_v1.ConditionTypeServiceError, "OnlyOneMirror",

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -512,7 +512,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			return nil
 		}
 
-		tp, err := timeoutPolicy(route.TimeoutPolicy)
+		tp, err := timeoutPolicy(route.TimeoutPolicy, p.ConnectTimeout)
 		if err != nil {
 			validCond.AddErrorf(contour_api_v1.ConditionTypeRouteError, "TimeoutPolicyNotValid",
 				"route.timeoutPolicy failed to parse: %s", err)
@@ -698,8 +698,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				SNI:                   determineSNI(r.RequestHeadersPolicy, reqHP, s),
 				DNSLookupFamily:       string(p.DNSLookupFamily),
 				ClientCertificate:     clientCertSecret,
-				ConnectTimeout:        p.ConnectTimeout,
-				IdleConnectionTimeout: tp.IdleConnectionTimeout,
+				TimeoutPolicy:         tp,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				validCond.AddError(contour_api_v1.ConditionTypeServiceError, "OnlyOneMirror",
@@ -795,7 +794,7 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(validCond *contour_api_v1.
 				LoadBalancerPolicy:   lbPolicy,
 				TCPHealthCheckPolicy: tcpHealthCheckPolicy(tcpproxy.HealthCheckPolicy),
 				SNI:                  s.ExternalName,
-				ConnectTimeout:       p.ConnectTimeout,
+				TimeoutPolicy:        TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 			})
 		}
 		secure := p.dag.EnsureSecureVirtualHost(host)

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -300,7 +300,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				}
 
 				if timeout.UseDefault() {
-					svhost.AuthorizationResponseTimeout = ext.TimeoutPolicy.ResponseTimeout
+					svhost.AuthorizationResponseTimeout = ext.RouteTimeoutPolicy.ResponseTimeout
 				} else {
 					svhost.AuthorizationResponseTimeout = timeout
 				}
@@ -512,7 +512,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			return nil
 		}
 
-		tp, err := timeoutPolicy(route.TimeoutPolicy, p.ConnectTimeout)
+		rtp, ctp, err := timeoutPolicy(route.TimeoutPolicy, p.ConnectTimeout)
 		if err != nil {
 			validCond.AddErrorf(contour_api_v1.ConditionTypeRouteError, "TimeoutPolicyNotValid",
 				"route.timeoutPolicy failed to parse: %s", err)
@@ -540,7 +540,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			HeaderMatchConditions: mergeHeaderMatchConditions(routeConditions),
 			Websocket:             route.EnableWebsockets,
 			HTTPSUpgrade:          routeEnforceTLS(enforceTLS, route.PermitInsecure && !p.DisablePermitInsecure),
-			TimeoutPolicy:         tp,
+			TimeoutPolicy:         rtp,
 			RetryPolicy:           retryPolicy(route.RetryPolicy),
 			RequestHeadersPolicy:  reqHP,
 			ResponseHeadersPolicy: respHP,
@@ -698,7 +698,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				SNI:                   determineSNI(r.RequestHeadersPolicy, reqHP, s),
 				DNSLookupFamily:       string(p.DNSLookupFamily),
 				ClientCertificate:     clientCertSecret,
-				TimeoutPolicy:         tp,
+				TimeoutPolicy:         ctp,
 			}
 			if service.Mirror && r.MirrorPolicy != nil {
 				validCond.AddError(contour_api_v1.ConditionTypeServiceError, "OnlyOneMirror",
@@ -794,7 +794,7 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(validCond *contour_api_v1.
 				LoadBalancerPolicy:   lbPolicy,
 				TCPHealthCheckPolicy: tcpHealthCheckPolicy(tcpproxy.HealthCheckPolicy),
 				SNI:                  s.ExternalName,
-				TimeoutPolicy:        TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+				TimeoutPolicy:        ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 			})
 		}
 		secure := p.dag.EnsureSecureVirtualHost(host)

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -233,7 +233,7 @@ func (p *IngressProcessor) route(ingress *networking_v1.Ingress, host string, pa
 			ClientCertificate:     clientCertSecret,
 			RequestHeadersPolicy:  reqHP,
 			ResponseHeadersPolicy: respHP,
-			ConnectTimeout:        p.ConnectTimeout,
+			TimeoutPolicy:         TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		}},
 	}
 

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -233,7 +233,7 @@ func (p *IngressProcessor) route(ingress *networking_v1.Ingress, host string, pa
 			ClientCertificate:     clientCertSecret,
 			RequestHeadersPolicy:  reqHP,
 			ResponseHeadersPolicy: respHP,
-			TimeoutPolicy:         TimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+			TimeoutPolicy:         ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		}},
 	}
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -415,7 +415,7 @@ func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger
 	// construct and use the HTTPProxy timeout policy logic.
 	tp, err := timeoutPolicy(&contour_api_v1.TimeoutPolicy{
 		Response: response,
-	})
+	}, 0)
 	if err != nil {
 		log.WithError(err).Error("Error parsing response-timeout annotation, using the default value")
 		return TimeoutPolicy{}
@@ -424,7 +424,7 @@ func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger
 	return tp
 }
 
-func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy) (TimeoutPolicy, error) {
+func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy, connectTimeout time.Duration) (TimeoutPolicy, error) {
 	if tp == nil {
 		return TimeoutPolicy{
 			ResponseTimeout:       timeout.DefaultSetting(),
@@ -452,6 +452,7 @@ func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy) (TimeoutPolicy, error) {
 		ResponseTimeout:       responseTimeout,
 		IdleStreamTimeout:     idleStreamTimeout,
 		IdleConnectionTimeout: idleConnectionTimeout,
+		ConnectTimeout:        connectTimeout,
 	}, nil
 }
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -405,8 +405,8 @@ func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger
 		response = annotation.ContourAnnotation(ingress, "request-timeout")
 		if len(response) == 0 {
 			return TimeoutPolicy{
-				ResponseTimeout: timeout.DefaultSetting(),
-				IdleTimeout:     timeout.DefaultSetting(),
+				ResponseTimeout:   timeout.DefaultSetting(),
+				IdleStreamTimeout: timeout.DefaultSetting(),
 			}
 		}
 	}
@@ -426,8 +426,9 @@ func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger
 func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy) (TimeoutPolicy, error) {
 	if tp == nil {
 		return TimeoutPolicy{
-			ResponseTimeout: timeout.DefaultSetting(),
-			IdleTimeout:     timeout.DefaultSetting(),
+			ResponseTimeout:       timeout.DefaultSetting(),
+			IdleStreamTimeout:     timeout.DefaultSetting(),
+			IdleConnectionTimeout: timeout.DefaultSetting(),
 		}, nil
 	}
 
@@ -436,14 +437,20 @@ func timeoutPolicy(tp *contour_api_v1.TimeoutPolicy) (TimeoutPolicy, error) {
 		return TimeoutPolicy{}, fmt.Errorf("error parsing response timeout: %w", err)
 	}
 
-	idleTimeout, err := timeout.Parse(tp.Idle)
+	idleStreamTimeout, err := timeout.Parse(tp.Idle)
 	if err != nil {
 		return TimeoutPolicy{}, fmt.Errorf("error parsing idle timeout: %w", err)
 	}
 
+	idleConnectionTimeout, err := timeout.Parse(tp.IdleConnection)
+	if err != nil {
+		return TimeoutPolicy{}, fmt.Errorf("error parsing idle connection timeout: %w", err)
+	}
+
 	return TimeoutPolicy{
-		ResponseTimeout: responseTimeout,
-		IdleTimeout:     idleTimeout,
+		ResponseTimeout:       responseTimeout,
+		IdleStreamTimeout:     idleStreamTimeout,
+		IdleConnectionTimeout: idleConnectionTimeout,
 	}, nil
 }
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -405,8 +405,9 @@ func ingressTimeoutPolicy(ingress *networking_v1.Ingress, log logrus.FieldLogger
 		response = annotation.ContourAnnotation(ingress, "request-timeout")
 		if len(response) == 0 {
 			return TimeoutPolicy{
-				ResponseTimeout:   timeout.DefaultSetting(),
-				IdleStreamTimeout: timeout.DefaultSetting(),
+				ResponseTimeout:       timeout.DefaultSetting(),
+				IdleStreamTimeout:     timeout.DefaultSetting(),
+				IdleConnectionTimeout: timeout.DefaultSetting(),
 			}
 		}
 	}

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -261,7 +261,7 @@ func TestTimeoutPolicy(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := timeoutPolicy(tc.tp)
+			got, gotErr := timeoutPolicy(tc.tp, 0)
 			if tc.wantErr {
 				assert.Error(t, gotErr)
 			} else {

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -193,23 +193,24 @@ func TestRetryPolicy(t *testing.T) {
 
 func TestTimeoutPolicy(t *testing.T) {
 	tests := map[string]struct {
-		tp      *contour_api_v1.TimeoutPolicy
-		want    TimeoutPolicy
-		wantErr bool
+		tp                       *contour_api_v1.TimeoutPolicy
+		wantRouteTimeoutPolicy   RouteTimeoutPolicy
+		wantClusterTimeoutPolicy ClusterTimeoutPolicy
+		wantErr                  bool
 	}{
 		"nil timeout policy": {
-			tp:   nil,
-			want: TimeoutPolicy{},
+			tp:                     nil,
+			wantRouteTimeoutPolicy: RouteTimeoutPolicy{},
 		},
 		"empty timeout policy": {
-			tp:   &contour_api_v1.TimeoutPolicy{},
-			want: TimeoutPolicy{},
+			tp:                     &contour_api_v1.TimeoutPolicy{},
+			wantRouteTimeoutPolicy: RouteTimeoutPolicy{},
 		},
 		"valid response timeout": {
 			tp: &contour_api_v1.TimeoutPolicy{
 				Response: "1m30s",
 			},
-			want: TimeoutPolicy{
+			wantRouteTimeoutPolicy: RouteTimeoutPolicy{
 				ResponseTimeout: timeout.DurationSetting(90 * time.Second),
 			},
 		},
@@ -223,7 +224,7 @@ func TestTimeoutPolicy(t *testing.T) {
 			tp: &contour_api_v1.TimeoutPolicy{
 				Response: "infinite",
 			},
-			want: TimeoutPolicy{
+			wantRouteTimeoutPolicy: RouteTimeoutPolicy{
 				ResponseTimeout: timeout.DisabledSetting(),
 			},
 		},
@@ -231,7 +232,7 @@ func TestTimeoutPolicy(t *testing.T) {
 			tp: &contour_api_v1.TimeoutPolicy{
 				Idle: "900s",
 			},
-			want: TimeoutPolicy{
+			wantRouteTimeoutPolicy: RouteTimeoutPolicy{
 				IdleStreamTimeout: timeout.DurationSetting(900 * time.Second),
 			},
 		},
@@ -239,7 +240,7 @@ func TestTimeoutPolicy(t *testing.T) {
 			tp: &contour_api_v1.TimeoutPolicy{
 				IdleConnection: "900s",
 			},
-			want: TimeoutPolicy{
+			wantClusterTimeoutPolicy: ClusterTimeoutPolicy{
 				IdleConnectionTimeout: timeout.DurationSetting(900 * time.Second),
 			},
 		},
@@ -247,7 +248,7 @@ func TestTimeoutPolicy(t *testing.T) {
 			tp: &contour_api_v1.TimeoutPolicy{
 				IdleConnection: "infinite",
 			},
-			want: TimeoutPolicy{
+			wantClusterTimeoutPolicy: ClusterTimeoutPolicy{
 				IdleConnectionTimeout: timeout.DisabledSetting(),
 			},
 		},
@@ -261,11 +262,12 @@ func TestTimeoutPolicy(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := timeoutPolicy(tc.tp, 0)
+			gotRouteTimeoutPolicy, gotClusterTimeoutPolicy, gotErr := timeoutPolicy(tc.tp, 0)
 			if tc.wantErr {
 				assert.Error(t, gotErr)
 			} else {
-				assert.Equal(t, tc.want, got)
+				assert.Equal(t, tc.wantRouteTimeoutPolicy, gotRouteTimeoutPolicy)
+				assert.Equal(t, tc.wantClusterTimeoutPolicy, gotClusterTimeoutPolicy)
 				assert.NoError(t, gotErr)
 			}
 

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -232,7 +232,7 @@ func TestTimeoutPolicy(t *testing.T) {
 				Idle: "900s",
 			},
 			want: TimeoutPolicy{
-				IdleTimeout: timeout.DurationSetting(900 * time.Second),
+				IdleStreamTimeout: timeout.DurationSetting(900 * time.Second),
 			},
 		},
 	}

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -227,13 +227,35 @@ func TestTimeoutPolicy(t *testing.T) {
 				ResponseTimeout: timeout.DisabledSetting(),
 			},
 		},
-		"idle timeout": {
+		"idle stream timeout": {
 			tp: &contour_api_v1.TimeoutPolicy{
 				Idle: "900s",
 			},
 			want: TimeoutPolicy{
 				IdleStreamTimeout: timeout.DurationSetting(900 * time.Second),
 			},
+		},
+		"idle connection timeout": {
+			tp: &contour_api_v1.TimeoutPolicy{
+				IdleConnection: "900s",
+			},
+			want: TimeoutPolicy{
+				IdleConnectionTimeout: timeout.DurationSetting(900 * time.Second),
+			},
+		},
+		"infinite idle connection timeout": {
+			tp: &contour_api_v1.TimeoutPolicy{
+				IdleConnection: "infinite",
+			},
+			want: TimeoutPolicy{
+				IdleConnectionTimeout: timeout.DisabledSetting(),
+			},
+		},
+		"invalid idle connection timeout": {
+			tp: &contour_api_v1.TimeoutPolicy{
+				IdleConnection: "invalid value",
+			},
+			wantErr: true,
 		},
 	}
 

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -51,6 +51,9 @@ func Clustername(cluster *dag.Cluster) string {
 		buf += uv.SubjectName
 	}
 	buf += cluster.Protocol + cluster.SNI
+	if !cluster.IdleConnectionTimeout.UseDefault() {
+		buf += cluster.IdleConnectionTimeout.Duration().String()
+	}
 
 	// This isn't a crypto hash, we just want a unique name.
 	hash := sha1.Sum([]byte(buf)) // nolint:gosec

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -51,8 +51,8 @@ func Clustername(cluster *dag.Cluster) string {
 		buf += uv.SubjectName
 	}
 	buf += cluster.Protocol + cluster.SNI
-	if !cluster.IdleConnectionTimeout.UseDefault() {
-		buf += cluster.IdleConnectionTimeout.Duration().String()
+	if !cluster.TimeoutPolicy.IdleConnectionTimeout.UseDefault() {
+		buf += cluster.TimeoutPolicy.IdleConnectionTimeout.Duration().String()
 	}
 
 	// This isn't a crypto hash, we just want a unique name.

--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -16,9 +16,7 @@ package v3
 import (
 	envoy_api_v3_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_v3_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -121,17 +119,4 @@ func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_
 	}
 
 	return context
-}
-
-func http2ProtocolOptions() map[string]*any.Any {
-	return map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
-			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
-				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
-					},
-				},
-			}),
-	}
 }

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -38,6 +38,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/timeout"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -213,7 +214,7 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 						KeepaliveInterval: protobuf.UInt32(5),
 					},
 				},
-				TypedExtensionProtocolOptions: http2ProtocolOptions(),
+				TypedExtensionProtocolOptions: protocolOptions(HTTPVersion2, timeout.DefaultSetting()),
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
 					Thresholds: []*envoy_cluster_v3.CircuitBreakers_Thresholds{{
 						Priority:           envoy_core_v3.RoutingPriority_HIGH,

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -102,11 +102,11 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 		httpVersion = HTTPVersion2
 	}
 
-	if c.ConnectTimeout > time.Duration(0) {
-		cluster.ConnectTimeout = protobuf.Duration(c.ConnectTimeout)
+	if c.TimeoutPolicy.ConnectTimeout > time.Duration(0) {
+		cluster.ConnectTimeout = protobuf.Duration(c.TimeoutPolicy.ConnectTimeout)
 	}
 
-	cluster.TypedExtensionProtocolOptions = protocolOptions(httpVersion, c.IdleConnectionTimeout)
+	cluster.TypedExtensionProtocolOptions = protocolOptions(httpVersion, c.TimeoutPolicy.IdleConnectionTimeout)
 
 	return cluster
 }
@@ -154,10 +154,10 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 		http2Version = HTTPVersion2
 	}
 
-	if ext.ConnectTimeout > time.Duration(0) {
-		cluster.ConnectTimeout = protobuf.Duration(ext.ConnectTimeout)
+	if ext.TimeoutPolicy.ConnectTimeout > time.Duration(0) {
+		cluster.ConnectTimeout = protobuf.Duration(ext.TimeoutPolicy.ConnectTimeout)
 	}
-	cluster.TypedExtensionProtocolOptions = protocolOptions(http2Version, ext.IdleConnectionTimeout)
+	cluster.TypedExtensionProtocolOptions = protocolOptions(http2Version, ext.TimeoutPolicy.IdleConnectionTimeout)
 
 	return cluster
 }

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -154,10 +154,10 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 		http2Version = HTTPVersion2
 	}
 
-	if ext.TimeoutPolicy.ConnectTimeout > time.Duration(0) {
-		cluster.ConnectTimeout = protobuf.Duration(ext.TimeoutPolicy.ConnectTimeout)
+	if ext.ClusterTimeoutPolicy.ConnectTimeout > time.Duration(0) {
+		cluster.ConnectTimeout = protobuf.Duration(ext.ClusterTimeoutPolicy.ConnectTimeout)
 	}
-	cluster.TypedExtensionProtocolOptions = protocolOptions(http2Version, ext.TimeoutPolicy.IdleConnectionTimeout)
+	cluster.TypedExtensionProtocolOptions = protocolOptions(http2Version, ext.ClusterTimeoutPolicy.IdleConnectionTimeout)
 
 	return cluster
 }

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -21,10 +21,13 @@ import (
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/projectcontour/contour/internal/xds"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -75,6 +78,7 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 		}
 	}
 
+	httpVersion := HTTPVersionAuto
 	switch c.Protocol {
 	case "tls":
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
@@ -85,7 +89,7 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		httpVersion = HTTPVersion2
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				c.UpstreamValidation,
@@ -95,12 +99,14 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		httpVersion = HTTPVersion2
 	}
 
 	if c.ConnectTimeout > time.Duration(0) {
 		cluster.ConnectTimeout = protobuf.Duration(c.ConnectTimeout)
 	}
+
+	cluster.TypedExtensionProtocolOptions = protocolOptions(httpVersion, c.IdleConnectionTimeout)
 
 	return cluster
 }
@@ -132,9 +138,10 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 
 	// TODO(jpeach): Externalname service support in https://github.com/projectcontour/contour/issues/2875
 
+	http2Version := HTTPVersionAuto
 	switch ext.Protocol {
 	case "h2":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		http2Version = HTTPVersion2
 		cluster.TransportSocket = UpstreamTLSTransportSocket(
 			UpstreamTLSContext(
 				ext.UpstreamValidation,
@@ -144,12 +151,13 @@ func ExtensionCluster(ext *dag.ExtensionCluster) *envoy_cluster_v3.Cluster {
 			),
 		)
 	case "h2c":
-		cluster.TypedExtensionProtocolOptions = http2ProtocolOptions()
+		http2Version = HTTPVersion2
 	}
 
 	if ext.ConnectTimeout > time.Duration(0) {
 		cluster.ConnectTimeout = protobuf.Duration(ext.ConnectTimeout)
 	}
+	cluster.TypedExtensionProtocolOptions = protocolOptions(http2Version, ext.IdleConnectionTimeout)
 
 	return cluster
 }
@@ -260,4 +268,43 @@ func parseDNSLookupFamily(value string) envoy_cluster_v3.Cluster_DnsLookupFamily
 		return envoy_cluster_v3.Cluster_V6_ONLY
 	}
 	return envoy_cluster_v3.Cluster_AUTO
+}
+
+func protocolOptions(explicitHTTPVersion HTTPVersionType, idleConnectionTimeout timeout.Setting) map[string]*any.Any {
+	// Keep Envoy defaults by not setting protocol options at all if not necessary.
+	if explicitHTTPVersion == HTTPVersionAuto && idleConnectionTimeout.UseDefault() {
+		return nil
+	}
+
+	options := envoy_extensions_upstream_http_v3.HttpProtocolOptions{}
+
+	switch explicitHTTPVersion {
+	// Default protocol version in Envoy is HTTP1.1.
+	case HTTPVersion1, HTTPVersionAuto:
+		options.UpstreamProtocolOptions = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+			},
+		}
+	case HTTPVersion2:
+		options.UpstreamProtocolOptions = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+			},
+		}
+	case HTTPVersion3:
+		options.UpstreamProtocolOptions = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+			ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+				ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http3ProtocolOptions{},
+			},
+		}
+	}
+
+	if !idleConnectionTimeout.UseDefault() {
+		options.CommonHttpProtocolOptions = &envoy_core_v3.HttpProtocolOptions{IdleTimeout: protobuf.Duration(idleConnectionTimeout.Duration())}
+	}
+
+	return map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(&options),
+	}
 }

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -511,8 +511,8 @@ func TestCluster(t *testing.T) {
 		},
 		"cluster with connect timeout set": {
 			cluster: &dag.Cluster{
-				Upstream:       service(s1),
-				ConnectTimeout: 10 * time.Second,
+				Upstream:      service(s1),
+				TimeoutPolicy: dag.TimeoutPolicy{ConnectTimeout: 10 * time.Second},
 			},
 			want: &envoy_cluster_v3.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -527,8 +527,8 @@ func TestCluster(t *testing.T) {
 		},
 		"cluster with idle connection timeout set": {
 			cluster: &dag.Cluster{
-				Upstream:              service(s1),
-				IdleConnectionTimeout: timeout.DurationSetting(10 * time.Second),
+				Upstream:      service(s1),
+				TimeoutPolicy: dag.TimeoutPolicy{IdleConnectionTimeout: timeout.DurationSetting(10 * time.Second)},
 			},
 			want: &envoy_cluster_v3.Cluster{
 				Name:                 "default/kuard/443/357c84df09",

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -512,7 +512,7 @@ func TestCluster(t *testing.T) {
 		"cluster with connect timeout set": {
 			cluster: &dag.Cluster{
 				Upstream:      service(s1),
-				TimeoutPolicy: dag.TimeoutPolicy{ConnectTimeout: 10 * time.Second},
+				TimeoutPolicy: dag.ClusterTimeoutPolicy{ConnectTimeout: 10 * time.Second},
 			},
 			want: &envoy_cluster_v3.Cluster{
 				Name:                 "default/kuard/443/da39a3ee5e",
@@ -528,7 +528,7 @@ func TestCluster(t *testing.T) {
 		"cluster with idle connection timeout set": {
 			cluster: &dag.Cluster{
 				Upstream:      service(s1),
-				TimeoutPolicy: dag.TimeoutPolicy{IdleConnectionTimeout: timeout.DurationSetting(10 * time.Second)},
+				TimeoutPolicy: dag.ClusterTimeoutPolicy{IdleConnectionTimeout: timeout.DurationSetting(10 * time.Second)},
 			},
 			want: &envoy_cluster_v3.Cluster{
 				Name:                 "default/kuard/443/357c84df09",

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/projectcontour/contour/internal/xds"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -522,6 +523,35 @@ func TestCluster(t *testing.T) {
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: protobuf.Duration(10 * time.Second),
+			},
+		},
+		"cluster with idle connection timeout set": {
+			cluster: &dag.Cluster{
+				Upstream:              service(s1),
+				IdleConnectionTimeout: timeout.DurationSetting(10 * time.Second),
+			},
+			want: &envoy_cluster_v3.Cluster{
+				Name:                 "default/kuard/443/357c84df09",
+				AltStatName:          "default_kuard_443",
+				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
+				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
+					EdsConfig:   ConfigSource("contour"),
+					ServiceName: "default/kuard/http",
+				},
+				TypedExtensionProtocolOptions: map[string]*any.Any{
+					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+						&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+							CommonHttpProtocolOptions: &envoy_core_v3.HttpProtocolOptions{
+								IdleTimeout: protobuf.Duration(10 * time.Second),
+							},
+							UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+								ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+									ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+								},
+							},
+						},
+					),
+				},
 			},
 		},
 	}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -263,7 +263,7 @@ func routeRoute(r *dag.Route) *envoy_route_v3.Route_Route {
 	ra := envoy_route_v3.RouteAction{
 		RetryPolicy:           retryPolicy(r),
 		Timeout:               envoy.Timeout(r.TimeoutPolicy.ResponseTimeout),
-		IdleTimeout:           envoy.Timeout(r.TimeoutPolicy.IdleTimeout),
+		IdleTimeout:           envoy.Timeout(r.TimeoutPolicy.IdleStreamTimeout),
 		PrefixRewrite:         r.PrefixRewrite,
 		HashPolicy:            hashPolicy(r.RequestHashPolicies),
 		RequestMirrorPolicies: mirrorPolicy(r),

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -322,7 +322,7 @@ func TestRouteRoute(t *testing.T) {
 		},
 		"timeout 90s": {
 			route: &dag.Route{
-				TimeoutPolicy: dag.TimeoutPolicy{
+				TimeoutPolicy: dag.RouteTimeoutPolicy{
 					ResponseTimeout: timeout.DurationSetting(90 * time.Second),
 				},
 				Clusters: []*dag.Cluster{c1},
@@ -338,7 +338,7 @@ func TestRouteRoute(t *testing.T) {
 		},
 		"timeout infinity": {
 			route: &dag.Route{
-				TimeoutPolicy: dag.TimeoutPolicy{
+				TimeoutPolicy: dag.RouteTimeoutPolicy{
 					ResponseTimeout: timeout.DisabledSetting(),
 				},
 				Clusters: []*dag.Cluster{c1},
@@ -354,7 +354,7 @@ func TestRouteRoute(t *testing.T) {
 		},
 		"idle timeout 10m": {
 			route: &dag.Route{
-				TimeoutPolicy: dag.TimeoutPolicy{
+				TimeoutPolicy: dag.RouteTimeoutPolicy{
 					IdleStreamTimeout: timeout.DurationSetting(10 * time.Minute),
 				},
 				Clusters: []*dag.Cluster{c1},
@@ -370,7 +370,7 @@ func TestRouteRoute(t *testing.T) {
 		},
 		"idle timeout infinity": {
 			route: &dag.Route{
-				TimeoutPolicy: dag.TimeoutPolicy{
+				TimeoutPolicy: dag.RouteTimeoutPolicy{
 					IdleStreamTimeout: timeout.DisabledSetting(),
 				},
 				Clusters: []*dag.Cluster{c1},

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -355,7 +355,7 @@ func TestRouteRoute(t *testing.T) {
 		"idle timeout 10m": {
 			route: &dag.Route{
 				TimeoutPolicy: dag.TimeoutPolicy{
-					IdleTimeout: timeout.DurationSetting(10 * time.Minute),
+					IdleStreamTimeout: timeout.DurationSetting(10 * time.Minute),
 				},
 				Clusters: []*dag.Cluster{c1},
 			},
@@ -371,7 +371,7 @@ func TestRouteRoute(t *testing.T) {
 		"idle timeout infinity": {
 			route: &dag.Route{
 				TimeoutPolicy: dag.TimeoutPolicy{
-					IdleTimeout: timeout.DisabledSetting(),
+					IdleStreamTimeout: timeout.DisabledSetting(),
 				},
 				Clusters: []*dag.Cluster{c1},
 			},

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -216,7 +216,26 @@ func h2cCluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
 	return c
 }
 
-func withConnectionTimeout(c *envoy_cluster_v3.Cluster, timeout time.Duration) *envoy_cluster_v3.Cluster {
+func withConnectionTimeout(c *envoy_cluster_v3.Cluster, timeout time.Duration, httpVersion envoy_v3.HTTPVersionType) *envoy_cluster_v3.Cluster {
+	var config *envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig
+
+	switch httpVersion {
+	// Default protocol version in Envoy is HTTP1.1.
+	case envoy_v3.HTTPVersion1, envoy_v3.HTTPVersionAuto:
+		config = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+			ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+		}
+	case envoy_v3.HTTPVersion2:
+		config = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+			ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+		}
+
+	case envoy_v3.HTTPVersion3:
+		config = &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+			ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http3ProtocolOptions{},
+		}
+	}
+
 	c.TypedExtensionProtocolOptions = map[string]*any.Any{
 		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
 			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
@@ -224,9 +243,7 @@ func withConnectionTimeout(c *envoy_cluster_v3.Cluster, timeout time.Duration) *
 					IdleTimeout: protobuf.Duration(timeout),
 				},
 				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
-					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
-						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
-					},
+					ExplicitHttpConfig: config,
 				},
 			}),
 	}

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -216,6 +216,23 @@ func h2cCluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
 	return c
 }
 
+func withConnectionTimeout(c *envoy_cluster_v3.Cluster, timeout time.Duration) *envoy_cluster_v3.Cluster {
+	c.TypedExtensionProtocolOptions = map[string]*any.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
+			&envoy_extensions_upstream_http_v3.HttpProtocolOptions{
+				CommonHttpProtocolOptions: &envoy_core_v3.HttpProtocolOptions{
+					IdleTimeout: protobuf.Duration(timeout),
+				},
+				UpstreamProtocolOptions: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
+					ExplicitHttpConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
+						ProtocolConfig: &envoy_extensions_upstream_http_v3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{},
+					},
+				},
+			}),
+	}
+	return c
+}
+
 func withResponseTimeout(route *envoy_route_v3.Route_Route, timeout time.Duration) *envoy_route_v3.Route_Route {
 	route.Route.Timeout = protobuf.Duration(timeout)
 	return route

--- a/internal/featuretests/v3/timeoutpolicy_test.go
+++ b/internal/featuretests/v3/timeoutpolicy_test.go
@@ -275,7 +275,7 @@ func TestTimeoutPolicyIdleConnectionTimeout(t *testing.T) {
 
 	// Check that cluster has connection timeout set.
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/b7427dbbf9", "default/kuard", "default_kuard_8080"), 3*time.Minute)),
+		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/b7427dbbf9", "default/kuard", "default_kuard_8080"), 3*time.Minute, envoy_v3.HTTPVersion1)),
 		TypeUrl:   clusterType,
 	})
 
@@ -284,7 +284,7 @@ func TestTimeoutPolicyIdleConnectionTimeout(t *testing.T) {
 
 	// Check that cluster has connection timeout set to zero (infinite).
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/97705cb30a", "default/kuard", "default_kuard_8080"), 0)),
+		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/97705cb30a", "default/kuard", "default_kuard_8080"), 0, envoy_v3.HTTPVersion1)),
 		TypeUrl:   clusterType,
 	})
 }

--- a/internal/featuretests/v3/timeoutpolicy_test.go
+++ b/internal/featuretests/v3/timeoutpolicy_test.go
@@ -150,25 +150,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 	rh.OnDelete(i4)
 
-	p1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Response: "600", // not 600s
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p1 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Response: "600"}) // not 600s
 	rh.OnAdd(p1)
 
 	// check timeout policy with malformed response timeout is not propagated
@@ -179,22 +161,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: p1.ObjectMeta,
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Response: "3m",
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p2 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Response: "3m"})
 	rh.OnUpdate(p1, p2)
 
 	// check timeout policy with response timeout is propagated correctly
@@ -212,22 +179,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p3 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: p2.ObjectMeta,
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Response: "infinity",
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p3 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Response: "infinity"})
 	rh.OnUpdate(p2, p3)
 
 	// check timeout policy with explicit infine response timeout is propagated as infinity
@@ -246,33 +198,14 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 }
 
-func TestTimeoutPolicyIdleTimeout(t *testing.T) {
+func TestTimeoutPolicyIdleStreamTimeout(t *testing.T) {
 	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
 	defer done()
 
 	svc := fixture.NewService("kuard").
 		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
 	rh.OnAdd(svc)
-
-	p1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Idle: "600", // not 600s
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p1 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Idle: "600"}) // not 600s
 	rh.OnAdd(p1)
 
 	// check timeout policy with malformed response timeout is not propagated
@@ -283,22 +216,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: p1.ObjectMeta,
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Idle: "3m",
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p2 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Idle: "3m"})
 	rh.OnUpdate(p1, p2)
 
 	// check timeout policy with response timeout is propagated correctly
@@ -316,22 +234,7 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
-	p3 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: p2.ObjectMeta,
-		Spec: contour_api_v1.HTTPProxySpec{
-			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
-			Routes: []contour_api_v1.Route{{
-				Conditions: matchconditions(prefixMatchCondition("/")),
-				TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
-					Idle: "infinity",
-				},
-				Services: []contour_api_v1.Service{{
-					Name: svc.Name,
-					Port: 8080,
-				}},
-			}},
-		},
-	}
+	p3 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Idle: "infinity"})
 	rh.OnUpdate(p2, p3)
 
 	// check timeout policy with explicit infine response timeout is propagated as infinity
@@ -349,4 +252,59 @@ func TestTimeoutPolicyIdleTimeout(t *testing.T) {
 		TypeUrl: routeType,
 	})
 
+}
+
+func TestTimeoutPolicyIdleConnectionTimeout(t *testing.T) {
+	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
+	defer done()
+
+	svc := fixture.NewService("kuard").WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
+	rh.OnAdd(svc)
+
+	p1 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{IdleConnection: "invalid"})
+	rh.OnAdd(p1)
+
+	// Check that cluster was not created with invalid input.
+	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: nil,
+		TypeUrl:   clusterType,
+	})
+
+	p2 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{IdleConnection: "3m"})
+	rh.OnUpdate(p1, p2)
+
+	// Check that cluster has connection timeout set.
+	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/b7427dbbf9", "default/kuard", "default_kuard_8080"), 3*time.Minute)),
+		TypeUrl:   clusterType,
+	})
+
+	p3 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{IdleConnection: "infinite"})
+	rh.OnUpdate(p2, p3)
+
+	// Check that cluster has connection timeout set to zero (infinite).
+	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t, withConnectionTimeout(cluster("default/kuard/8080/97705cb30a", "default/kuard", "default_kuard_8080"), 0)),
+		TypeUrl:   clusterType,
+	})
+}
+
+func httpProxyWithTimoutPolicy(svc *v1.Service, tp *contour_api_v1.TimeoutPolicy) *contour_api_v1.HTTPProxy {
+	return &contour_api_v1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: svc.Namespace,
+		},
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions:    matchconditions(prefixMatchCondition("/")),
+				TimeoutPolicy: tp,
+				Services: []contour_api_v1.Service{{
+					Name: svc.Name,
+					Port: 8080,
+				}},
+			}},
+		},
+	}
 }

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3465,6 +3465,20 @@ If not specified, there is no per-route idle timeout, though a connection manage
 stream_idle_timeout default of 5m still applies.</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>idleConnection</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout for how long connection from the proxy to the upstream service is kept when there are no active requests.
+If not supplied, Envoy&rsquo;s default value of 1h applies.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1.UpstreamValidation">UpstreamValidation


### PR DESCRIPTION
This change adds field `HTTPProxy.spec.routes.timeoutPolicy.idleConnection`. The field sets timeout for how long the upstream connection will be kept idle between requests before disconnecting it. This [connection timeout](https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#connection-timeouts) is different than previously existing field `timeoutPolicy.idle`, which controls the [stream timeout](https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#stream-timeouts): a timeout for single request-response. Altough connection timeout might be what user wanted in the first place, the existing field and functionality is kept for backwards compatibility and new field was introduced for the connection timeout.

When `timeoutPolicy.idleConnection` is not set then Envoy defaults to [1 hour](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#config-core-v3-httpprotocoloptions). User can also set `infinite` to disable the timeout

Timeout is set in Envoy `Cluster` by using [`HttpProtocolOptions`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/upstreams/http/v3/http_protocol_options.proto.html). If two `HTTPProxies` refer to single upstream service and are otherwise equal except for the `timeoutpolicy.idleConnection` value, then separate `Clusters` will be created for both to allow different timeouts.

Fixes #3313
    
Signed-off-by: Tero Saarni <tero.saarni@est.tech>
