### PR TITLE
Add question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,23 @@
+---
+name: Question
+about: Ask a question about configuration, recommendations, general guidance, etc.
+title: ''
+labels: kind/question, lifecycle/needs-triage
+assignees: ''
+
+---
+
+**What question do you have?:**
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- Contour version:
+- Kubernetes version: (use `kubectl version`):
+- Kubernetes installer & version:
+- Cloud provider or hardware configuration:
+- OS (e.g. from `/etc/os-release`):


### PR DESCRIPTION
We get a lot of issues tagged as bugs that are just questions. Since
reporters have no blank template to use, it appears the bug template is
the easiest to repurpose. This change adds a question template so that
contributor questions can be categorized appropriately.