### PR TITLE
Cherrypicks for Contour 1.20.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.21.0
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.21.1
 GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4350-tsaarni-small.md
+++ b/changelogs/unreleased/4350-tsaarni-small.md
@@ -1,0 +1,1 @@
+Fixed a bug where upstream TLS SNI (`HTTProxy.spec.routes.requestHeadersPolicy` `Host` key) and protocol fields might not take effect when e.g. two `HTTPProxies` were otherwise equal but differed only on those fields.

--- a/changelogs/unreleased/4361-tsaarni-small.md
+++ b/changelogs/unreleased/4361-tsaarni-small.md
@@ -1,0 +1,1 @@
+Update github.com/prometheus/client_golang to v1.11.1 to address CVE-2022-21698.

--- a/changelogs/unreleased/4365-skriss-small.md
+++ b/changelogs/unreleased/4365-skriss-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.21.1. See the [Envoy changelog](https://www.envoyproxy.io/docs/envoy/v1.21.1/version_history/current) for details.

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.0
+        image: docker.io/envoyproxy/envoy:v1.21.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.21.0
+          image: docker.io/envoyproxy/envoy:v1.21.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5217,7 +5217,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.21.0
+          image: docker.io/envoyproxy/envoy:v1.21.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5207,7 +5207,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.0
+        image: docker.io/envoyproxy/envoy:v1.21.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5204,7 +5204,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.0
+        image: docker.io/envoyproxy/envoy:v1.21.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jetstack/cert-manager v1.5.1
 	github.com/onsi/ginkgo/v2 v2.0.0
 	github.com/onsi/gomega v1.17.0
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.28.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,9 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -24,6 +24,10 @@ import (
 )
 
 // Clustername returns the name of the CDS cluster for this service.
+//
+// Note: Cluster name is used to deduplicate clusters.
+// When for example two HTTPProxies result in Clusters with equal name, only single cluster will be configured to Envoy.
+// Therefore the generated name must contain all relevant fields that make the cluster unique.
 func Clustername(cluster *dag.Cluster) string {
 	service := cluster.Upstream
 	buf := cluster.LoadBalancerPolicy
@@ -46,6 +50,7 @@ func Clustername(cluster *dag.Cluster) string {
 		buf += uv.CACertificate.Object.ObjectMeta.Name
 		buf += uv.SubjectName
 	}
+	buf += cluster.Protocol + cluster.SNI
 
 	// This isn't a crypto hash, we just want a unique name.
 	hash := sha1.Sum([]byte(buf)) // nolint:gosec

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -132,7 +132,7 @@ func TestCluster(t *testing.T) {
 				Protocol: "h2c",
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/da39a3ee5e",
+				Name:                 "default/kuard/443/f4f94965ec",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -157,7 +157,7 @@ func TestCluster(t *testing.T) {
 				Protocol: "h2",
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/da39a3ee5e",
+				Name:                 "default/kuard/443/bf1c365741",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -248,7 +248,7 @@ func TestCluster(t *testing.T) {
 				Protocol: "tls",
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/da39a3ee5e",
+				Name:                 "default/kuard/443/4929fca9d4",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -267,7 +267,7 @@ func TestCluster(t *testing.T) {
 				SNI:      "projectcontour.local",
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/da39a3ee5e",
+				Name:                 "default/kuard/443/a996a742af",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				LoadAssignment:       StaticClusterLoadAssignment(service(svcExternal, "tls")),
@@ -286,7 +286,7 @@ func TestCluster(t *testing.T) {
 				},
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/3ac4e90987",
+				Name:                 "default/kuard/443/62d1f9ad02",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -496,7 +496,7 @@ func TestCluster(t *testing.T) {
 				ClientCertificate: clientSecret,
 			},
 			want: &envoy_cluster_v3.Cluster{
-				Name:                 "default/kuard/443/da39a3ee5e",
+				Name:                 "default/kuard/443/4929fca9d4",
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
@@ -529,113 +529,133 @@ func TestClusterLoadAssignmentName(t *testing.T) {
 }
 
 func TestClustername(t *testing.T) {
-	tests := map[string]struct {
+	type testcase struct {
 		cluster *dag.Cluster
 		want    string
-	}{
-		"simple": {
-			cluster: &dag.Cluster{
-				Upstream: &dag.Service{
-					Weighted: dag.WeightedService{
-						Weight:           1,
-						ServiceName:      "backend",
-						ServiceNamespace: "default",
-						ServicePort: v1.ServicePort{
-							Name:       "http",
-							Protocol:   "TCP",
-							Port:       80,
-							TargetPort: intstr.FromInt(6502),
-						},
-					},
-				},
-			},
-			want: "default/backend/80/da39a3ee5e",
-		},
-		"far too long": {
-			cluster: &dag.Cluster{
-				Upstream: &dag.Service{
-					Weighted: dag.WeightedService{
-						Weight:           1,
-						ServiceName:      "must-be-in-want-of-a-wife",
-						ServiceNamespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
-						ServicePort: v1.ServicePort{
-							Name:       "http",
-							Protocol:   "TCP",
-							Port:       9999,
-							TargetPort: intstr.FromString("http-alt"),
-						},
-					},
-				},
-			},
-			want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
-		},
-		"various healthcheck params": {
-			cluster: &dag.Cluster{
-				Upstream: &dag.Service{
-					Weighted: dag.WeightedService{
-						Weight:           1,
-						ServiceName:      "backend",
-						ServiceNamespace: "default",
-						ServicePort: v1.ServicePort{
-							Name:       "http",
-							Protocol:   "TCP",
-							Port:       80,
-							TargetPort: intstr.FromInt(6502),
-						},
-					},
-				},
-				LoadBalancerPolicy: "Random",
-				HTTPHealthCheckPolicy: &dag.HTTPHealthCheckPolicy{
-					Path:               "/healthz",
-					Interval:           5 * time.Second,
-					Timeout:            30 * time.Second,
-					UnhealthyThreshold: 3,
-					HealthyThreshold:   1,
-				},
-			},
-			want: "default/backend/80/5c26077e1d",
-		},
-		"upstream tls validation with subject alt name": {
-			cluster: &dag.Cluster{
-				Upstream: &dag.Service{
-					Weighted: dag.WeightedService{
-						Weight:           1,
-						ServiceName:      "backend",
-						ServiceNamespace: "default",
-						ServicePort: v1.ServicePort{
-							Name:       "http",
-							Protocol:   "TCP",
-							Port:       80,
-							TargetPort: intstr.FromInt(6502),
-						},
-					},
-				},
-				LoadBalancerPolicy: "Random",
-				UpstreamValidation: &dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: &v1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "secret",
-								Namespace: "default",
-							},
-							Data: map[string][]byte{
-								dag.CACertificateKey: []byte("somethingsecret"),
-							},
-						},
-					},
-					SubjectName: "foo.com",
-				},
-			},
-			want: "default/backend/80/6bf46b7b3a",
-		},
 	}
 
-	for name, tc := range tests {
+	run := func(t *testing.T, name string, tc testcase) {
+		t.Helper()
 		t.Run(name, func(t *testing.T) {
+			t.Helper()
 			got := envoy.Clustername(tc.cluster)
 			assert.Equal(t, tc.want, got)
 		})
 	}
+
+	run(t, "simple", testcase{
+		cluster: &dag.Cluster{
+			Upstream: &dag.Service{
+				Weighted: dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "backend",
+					ServiceNamespace: "default",
+					ServicePort: v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
+				},
+			},
+		},
+		want: "default/backend/80/da39a3ee5e",
+	})
+
+	run(t, "far too long", testcase{
+		cluster: &dag.Cluster{
+			Upstream: &dag.Service{
+				Weighted: dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "must-be-in-want-of-a-wife",
+					ServiceNamespace: "it-is-a-truth-universally-acknowledged-that-a-single-man-in-possession-of-a-good-fortune",
+					ServicePort: v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       9999,
+						TargetPort: intstr.FromString("http-alt"),
+					},
+				},
+			},
+		},
+		want: "it-is-a--dea8b0/must-be--dea8b0/9999/da39a3ee5e",
+	})
+
+	run(t, "various healthcheck params", testcase{
+		cluster: &dag.Cluster{
+			Upstream: &dag.Service{
+				Weighted: dag.WeightedService{
+					Weight:           1,
+					ServiceName:      "backend",
+					ServiceNamespace: "default",
+					ServicePort: v1.ServicePort{
+						Name:       "http",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.FromInt(6502),
+					},
+				},
+			},
+			LoadBalancerPolicy: "Random",
+			HTTPHealthCheckPolicy: &dag.HTTPHealthCheckPolicy{
+				Path:               "/healthz",
+				Interval:           5 * time.Second,
+				Timeout:            30 * time.Second,
+				UnhealthyThreshold: 3,
+				HealthyThreshold:   1,
+			},
+		},
+		want: "default/backend/80/5c26077e1d",
+	})
+
+	cluster1 := &dag.Cluster{
+		Upstream: &dag.Service{
+			Weighted: dag.WeightedService{
+				Weight:           1,
+				ServiceName:      "backend",
+				ServiceNamespace: "default",
+				ServicePort: v1.ServicePort{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(6502),
+				},
+			},
+		},
+		LoadBalancerPolicy: "Random",
+		UpstreamValidation: &dag.PeerValidationContext{
+			CACertificate: &dag.Secret{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: []byte("somethingsecret"),
+					},
+				},
+			},
+			SubjectName: "foo.com",
+		},
+	}
+
+	run(t, "upstream tls validation with subject alt name", testcase{
+		cluster: cluster1,
+		want:    "default/backend/80/6bf46b7b3a",
+	})
+
+	cluster1.SNI = "foo.bar"
+	run(t, "upstream tls validation with subject alt name with SNI", testcase{
+		cluster: cluster1,
+		want:    "default/backend/80/b8a2ccb774",
+	})
+
+	cluster1.Protocol = "h2"
+	run(t, "upstream tls validation with subject alt name with Protocol", testcase{
+		cluster: cluster1,
+		want:    "default/backend/80/50abc1400c",
+	})
+
 }
 
 func TestLBPolicy(t *testing.T) {

--- a/internal/featuretests/v3/backendcavalidation_test.go
+++ b/internal/featuretests/v3/backendcavalidation_test.go
@@ -78,7 +78,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that there is a regular, non validation enabled cluster in CDS.
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
+			tlsCluster(cluster("default/kuard/443/4929fca9d4", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
 		),
 		TypeUrl: clusterType,
 	})
@@ -119,7 +119,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the cluster now has a certificate and subject name.
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
+			tlsCluster(cluster("default/kuard/443/c6ccd34de5", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
 		),
 		TypeUrl: clusterType,
 	})
@@ -169,7 +169,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	// assert that the cluster now has a certificate and subject name.
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/98c0f31c72", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
+			tlsCluster(cluster("default/kuard/443/c6ccd34de5", "default/kuard/securebackend", "default_kuard_443"), []byte(featuretests.CERTIFICATE), "subjname", "", nil),
 		),
 		TypeUrl: clusterType,
 	})

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -116,7 +116,7 @@ func TestBackendClientAuthenticationWithHTTPProxy(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/backend/443/d411a4160f", "default/backend/http", "default_backend_443"), []byte(featuretests.CERTIFICATE), "subjname", "", sec1),
+			tlsCluster(cluster("default/backend/443/950c17581f", "default/backend/http", "default_backend_443"), []byte(featuretests.CERTIFICATE), "subjname", "", sec1),
 		),
 		TypeUrl: clusterType,
 	})
@@ -154,7 +154,7 @@ func TestBackendClientAuthenticationWithIngress(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsClusterWithoutValidation(cluster("default/backend/443/da39a3ee5e", "default/backend/http", "default_backend_443"), "", sec1),
+			tlsClusterWithoutValidation(cluster("default/backend/443/4929fca9d4", "default/backend/http", "default_backend_443"), "", sec1),
 		),
 		TypeUrl: clusterType,
 	})

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -105,7 +105,7 @@ func TestExternalNameService(t *testing.T) {
 				envoy_v3.VirtualHost("kuard.projectcontour.io",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeCluster("default/kuard/80/da39a3ee5e"),
+						Action: routeCluster("default/kuard/80/a28d1ec01b"),
 					},
 				),
 			),
@@ -115,7 +115,7 @@ func TestExternalNameService(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
+			externalNameCluster("default/kuard/80/a28d1ec01b", "default/kuard", "default_kuard_80", "foo.io", 80),
 		),
 		TypeUrl: clusterType,
 	})
@@ -148,7 +148,7 @@ func TestExternalNameService(t *testing.T) {
 				envoy_v3.VirtualHost("kuard.projectcontour.io",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
+						Action: routeHostRewrite("default/kuard/80/95e871afaf", "external.address"),
 					},
 				),
 			),
@@ -158,7 +158,7 @@ func TestExternalNameService(t *testing.T) {
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: clusterType,
 		Resources: resources(t,
-			externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
+			externalNameCluster("default/kuard/80/95e871afaf", "default/kuard", "default_kuard_80", "foo.io", 80),
 		),
 	})
 
@@ -193,7 +193,7 @@ func TestExternalNameService(t *testing.T) {
 				envoy_v3.VirtualHost("kuard.projectcontour.io",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
+						Action: routeHostRewrite("default/kuard/80/cdbf075ad8", "external.address"),
 					},
 				),
 			),
@@ -204,7 +204,7 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			DefaultCluster(
-				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
+				externalNameCluster("default/kuard/80/cdbf075ad8", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
 					TypedExtensionProtocolOptions: map[string]*any.Any{
 						"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
@@ -257,7 +257,7 @@ func TestExternalNameService(t *testing.T) {
 				envoy_v3.VirtualHost("kuard.projectcontour.io",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeHostRewrite("default/kuard/80/da39a3ee5e", "external.address"),
+						Action: routeHostRewrite("default/kuard/80/f9439c1de8", "external.address"),
 					},
 				),
 			),
@@ -268,7 +268,7 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			DefaultCluster(
-				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
+				externalNameCluster("default/kuard/80/f9439c1de8", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(
 						envoy_v3.UpstreamTLSContext(nil, "external.address", nil),
@@ -309,7 +309,7 @@ func TestExternalNameService(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			DefaultCluster(
-				externalNameCluster("default/kuard/80/da39a3ee5e", "default/kuard", "default_kuard_80", "foo.io", 80),
+				externalNameCluster("default/kuard/80/7d449598f5", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(
 						envoy_v3.UpstreamTLSContext(nil, "foo.io", nil),

--- a/internal/featuretests/v3/headerpolicy_test.go
+++ b/internal/featuretests/v3/headerpolicy_test.go
@@ -64,7 +64,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 				envoy_v3.VirtualHost("hello.world",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeHostRewrite("default/svc1/80/da39a3ee5e", "goodbye.planet"),
+						Action: routeHostRewrite("default/svc1/80/3eb3d00648", "goodbye.planet"),
 					},
 				),
 			),
@@ -208,7 +208,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 				envoy_v3.VirtualHost("hello.world",
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: routeHostRewrite("default/externalname/443/da39a3ee5e", "goodbye.planet"),
+						Action: routeHostRewrite("default/externalname/443/9ebffe8f28", "goodbye.planet"),
 					},
 				)),
 		),
@@ -217,7 +217,7 @@ func TestHeaderPolicy_ReplaceHeader_HTTProxy(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(externalNameCluster("default/externalname/443/da39a3ee5e", "default/externalname/https", "default_externalname_443", "goodbye.planet", 443), nil, "goodbye.planet", "goodbye.planet", nil),
+			tlsCluster(externalNameCluster("default/externalname/443/9ebffe8f28", "default/externalname/https", "default_externalname_443", "goodbye.planet", 443), nil, "goodbye.planet", "goodbye.planet", nil),
 		),
 		TypeUrl: clusterType,
 	})

--- a/internal/featuretests/v3/tcpproxy_test.go
+++ b/internal/featuretests/v3/tcpproxy_test.go
@@ -357,7 +357,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
 				FilterChains: appendFilterChains(
 					filterchaintls("k8s.run.ubisoft.org", s1,
-						tcpproxy("ingress_https", svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e"), nil),
+						tcpproxy("ingress_https", svc.Namespace+"/"+svc.Name+"/443/4929fca9d4"), nil),
 				),
 				ListenerFilters: envoy_v3.ListenerFilters(
 					envoy_v3.TLSInspector(),
@@ -371,7 +371,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
 			tlsCluster(cluster(
-				svc.Namespace+"/"+svc.Name+"/443/da39a3ee5e",
+				svc.Namespace+"/"+svc.Name+"/443/4929fca9d4",
 				svc.Namespace+"/"+svc.Name+"/https",
 				svc.Namespace+"_"+svc.Name+"_443",
 			), nil, "", "", nil),

--- a/internal/featuretests/v3/upstreamprotocol_test.go
+++ b/internal/featuretests/v3/upstreamprotocol_test.go
@@ -49,7 +49,7 @@ func TestUpstreamProtocolTLS(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
+			tlsCluster(cluster("default/kuard/443/4929fca9d4", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
 		),
 		TypeUrl: clusterType,
 	})
@@ -61,7 +61,7 @@ func TestUpstreamProtocolTLS(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			tlsCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
+			tlsCluster(cluster("default/kuard/443/4929fca9d4", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil),
 		),
 		TypeUrl: clusterType,
 	})
@@ -91,7 +91,7 @@ func TestUpstreamProtocolH2C(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			h2cCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443")),
+			h2cCluster(cluster("default/kuard/443/f4f94965ec", "default/kuard/securebackend", "default_kuard_443")),
 		),
 		TypeUrl: clusterType,
 	})
@@ -103,7 +103,7 @@ func TestUpstreamProtocolH2C(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			h2cCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443")),
+			h2cCluster(cluster("default/kuard/443/f4f94965ec", "default/kuard/securebackend", "default_kuard_443")),
 		),
 		TypeUrl: clusterType,
 	})
@@ -133,7 +133,7 @@ func TestUpstreamProtocolH2(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			h2cCluster(tlsCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil, "h2")),
+			h2cCluster(tlsCluster(cluster("default/kuard/443/bf1c365741", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil, "h2")),
 		),
 		TypeUrl: clusterType,
 	})
@@ -145,7 +145,7 @@ func TestUpstreamProtocolH2(t *testing.T) {
 
 	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		Resources: resources(t,
-			h2cCluster(tlsCluster(cluster("default/kuard/443/da39a3ee5e", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil, "h2")),
+			h2cCluster(tlsCluster(cluster("default/kuard/443/bf1c365741", "default/kuard/securebackend", "default_kuard_443"), nil, "", "", nil, "h2")),
 		),
 		TypeUrl: clusterType,
 	})

--- a/internal/xdscache/v3/cluster_test.go
+++ b/internal/xdscache/v3/cluster_test.go
@@ -262,7 +262,7 @@ func TestClusterVisit(t *testing.T) {
 			},
 			want: clustermap(
 				&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/80/da39a3ee5e",
+					Name:                 "default/kuard/80/f4f94965ec",
 					AltStatName:          "default_kuard_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.21.0][14]         | 1.23, 1.22, 1.21    | [main][50]       | v1alpha2            |
+| main            | [1.21.1][15]         | 1.23, 1.22, 1.21    | [main][50]       | v1alpha2            |
 | 1.20.0          | [1.21.0][14]         | 1.23, 1.22, 1.21    | [1.20.0][67]     | v1alpha2            |
 | 1.19.1          | [1.19.1][13]         | 1.22, 1.21, 1.20    | [1.19.1][65]     | v1alpha1            |
 | 1.19.0          | [1.19.1][13]         | 1.22, 1.21, 1.20    | [1.19.0][64]     | v1alpha1            |
@@ -109,6 +109,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [12]: https://www.envoyproxy.io/docs/envoy/v1.18.4/version_history/current
 [13]: https://www.envoyproxy.io/docs/envoy/v1.19.1/version_history/current
 [14]: https://www.envoyproxy.io/docs/envoy/v1.21.0/version_history/current
+[15]: https://www.envoyproxy.io/docs/envoy/v1.21.1/version_history/current
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.21.0"
+      envoy: "1.21.1"
       kubernetes:
         - "1.23"
         - "1.22"


### PR DESCRIPTION
- update Envoy to v1.21.1 (#4365)
- internal/envoy: fix cluster deduplication (#4350)
- Bump github.com/prometheus/client_golang (#4361)