### PR TITLE
site: improve contrast for code blocks

### DIFF
--- a/site/themes/contour/assets/scss/_components.scss
+++ b/site/themes/contour/assets/scss/_components.scss
@@ -725,7 +725,6 @@
         }
         code {
             border: 2px solid #EFEFEF;
-            color: $grey;
             padding: 2px 8px;
         }
         pre {


### PR DESCRIPTION
Removes setting code block text to grey, to allow
the syntax highlighter to use its default text
color which improves contrast.

Updates #4289.

Signed-off-by: Steve Kriss <krisss@vmware.com>