### PR TITLE
internal/envoy/v3: Reenable larger max regex program size

### DIFF
--- a/changelogs/unreleased/4379-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4379-sunjayBhatia-minor.md
@@ -1,0 +1,12 @@
+## Re-increase maximum allowed regex program size
+
+Regex patterns Contour configures in Envoy (for path matching etc.) currently have a limited "program size" (approximate cost) of 100.
+This was inadvertently set back to the Envoy default, from the intended 1048576 (2^20) when moving away from using deprecated API fields.
+Note: regex program size is a feature of the regex library Envoy uses, [Google RE2](https://github.com/google/re2).
+
+This limit has now been reset to the intended value and an additional program size warning threshold of 1000 has been configured.
+
+Operators concerned with performance implications of allowing large regex programs can monitor Envoy memory usage and regex statistics.
+Envoy offers two statistics for monitoring regex program size, `re2.program_size` and `re2.exceeded_warn_level`.
+See [this documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/matcher/v3/regex.proto.html?highlight=warn_level#type-matcher-v3-regexmatcher-googlere2) for more detail.
+Future versions of Contour may allow configuration of regex program size thresholds via RTDS (Runtime Discovery Service).

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -175,6 +175,11 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 						},
 					},
 				},
+				// Admin layer needs to be included here to maintain ability to
+				// modify runtime settings via admin console. We have it as the
+				// last layer so changes made via admin console override any
+				// settings from previous layers.
+				// See https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#admin-console
 				{
 					Name: "admin",
 					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_AdminLayer_{

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -38,6 +38,12 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/projectcontour/contour/internal/envoy"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	maxRegexProgramSizeError = 1 << 20
+	maxRegexProgramSizeWarn  = 1000
 )
 
 // WriteBootstrap writes bootstrap configuration to files.
@@ -156,6 +162,27 @@ func bootstrap(c *envoy.BootstrapConfig) ([]bootstrapf, error) {
 
 func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 	return &envoy_bootstrap_v3.Bootstrap{
+		LayeredRuntime: &envoy_bootstrap_v3.LayeredRuntime{
+			Layers: []*envoy_bootstrap_v3.RuntimeLayer{
+				{
+					Name: "base",
+					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_StaticLayer{
+						StaticLayer: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"re2.max_program_size.error_level": {Kind: &structpb.Value_NumberValue{NumberValue: maxRegexProgramSizeError}},
+								"re2.max_program_size.warn_level":  {Kind: &structpb.Value_NumberValue{NumberValue: maxRegexProgramSizeWarn}},
+							},
+						},
+					},
+				},
+				{
+					Name: "admin",
+					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_AdminLayer_{
+						AdminLayer: &envoy_bootstrap_v3.RuntimeLayer_AdminLayer{},
+					},
+				},
+			},
+		},
 		DynamicResources: &envoy_bootstrap_v3.Bootstrap_DynamicResources{
 			LdsConfig: ConfigSource("contour"),
 			CdsConfig: ConfigSource("contour"),

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -171,6 +171,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -313,6 +328,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -455,6 +485,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -598,6 +643,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -741,6 +801,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -884,6 +959,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -1029,6 +1119,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -1208,6 +1313,21 @@ func TestBootstrap(t *testing.T) {
         "mode": "420"
       }
     }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "base",
+        "static_layer": {
+          "re2.max_program_size.error_level": 1048576,
+          "re2.max_program_size.warn_level": 1000
+        }
+      },
+      {
+        "name": "admin",
+        "admin_layer": {}
+      }
+    ]
   }
 }`,
 		},
@@ -1376,11 +1496,26 @@ func TestBootstrap(t *testing.T) {
             }
           ],
           "address": {
-           "pipe": {
-		    "path": "/admin/admin.sock",
-			   "mode": "420"
-			}
+            "pipe": {
+              "path": "/admin/admin.sock",
+              "mode": "420"
+            }
           }
+        },
+        "layered_runtime": {
+          "layers": [
+            {
+              "name": "base",
+              "static_layer": {
+                "re2.max_program_size.error_level": 1048576,
+                "re2.max_program_size.warn_level": 1000
+              }
+            },
+            {
+              "name": "admin",
+              "admin_layer": {}
+            }
+          ]
         }
     }`,
 			wantedTLSCertificateConfig: `{


### PR DESCRIPTION
Was inadvertently reverted previously to Envoy's default of 100. This
change sets the error limit of a regex program size back to 1048576
(2^20).

Also adds warning threshold that Envoy will log and collect stats about.

Updates: #4241
Updates: #3452