### PR TITLE
Add base RTDS implementation

### DIFF
--- a/changelogs/unreleased/4380-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4380-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Add base implementation for RTDS (Runtime Discovery Service). This will be used to enable dynamic configuration of Envoy Runtime settings.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -355,6 +355,7 @@ func (s *Server) doServe() error {
 		&xdscache_v3.RouteCache{},
 		&xdscache_v3.ClusterCache{},
 		endpointHandler,
+		&xdscache_v3.RuntimeCache{},
 	}
 
 	// snapshotHandler is used to produce new snapshots when the internal state changes for any xDS resource.

--- a/internal/xds/v3/contour.go
+++ b/internal/xds/v3/contour.go
@@ -23,6 +23,7 @@ import (
 	envoy_service_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	envoy_service_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	envoy_service_route_v3 "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	envoy_service_runtime_v3 "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
 	envoy_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
@@ -63,6 +64,7 @@ type contourServer struct {
 	envoy_service_endpoint_v3.UnimplementedEndpointDiscoveryServiceServer
 	envoy_service_cluster_v3.UnimplementedClusterDiscoveryServiceServer
 	envoy_service_listener_v3.UnimplementedListenerDiscoveryServiceServer
+	envoy_service_runtime_v3.UnimplementedRuntimeDiscoveryServiceServer
 
 	logrus.FieldLogger
 	resources   map[string]xds.Resource
@@ -175,5 +177,9 @@ func (s *contourServer) StreamRoutes(srv envoy_service_route_v3.RouteDiscoverySe
 }
 
 func (s *contourServer) StreamSecrets(srv envoy_service_secret_v3.SecretDiscoveryService_StreamSecretsServer) error {
+	return s.stream(srv)
+}
+
+func (s *contourServer) StreamRuntime(srv envoy_service_runtime_v3.RuntimeDiscoveryService_StreamRuntimeServer) error {
 	return s.stream(srv)
 }

--- a/internal/xds/v3/server.go
+++ b/internal/xds/v3/server.go
@@ -19,6 +19,7 @@ import (
 	envoy_service_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	envoy_service_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	envoy_service_route_v3 "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	envoy_service_runtime_v3 "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
 	envoy_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	"google.golang.org/grpc"
 )
@@ -31,6 +32,7 @@ type Server interface {
 	envoy_service_route_v3.RouteDiscoveryServiceServer
 	envoy_service_discovery_v3.AggregatedDiscoveryServiceServer
 	envoy_service_secret_v3.SecretDiscoveryServiceServer
+	envoy_service_runtime_v3.RuntimeDiscoveryServiceServer
 }
 
 // RegisterServer registers the given xDS protocol Server with the gRPC
@@ -43,4 +45,5 @@ func RegisterServer(srv Server, g *grpc.Server) {
 	envoy_service_endpoint_v3.RegisterEndpointDiscoveryServiceServer(g, srv)
 	envoy_service_listener_v3.RegisterListenerDiscoveryServiceServer(g, srv)
 	envoy_service_route_v3.RegisterRouteDiscoveryServiceServer(g, srv)
+	envoy_service_runtime_v3.RegisterRuntimeDiscoveryServiceServer(g, srv)
 }

--- a/internal/xdscache/snapshot.go
+++ b/internal/xdscache/snapshot.go
@@ -84,6 +84,7 @@ func (s *SnapshotHandler) generateNewSnapshot() {
 		envoy_resource_v3.RouteType:    asResources(s.resources[envoy_resource_v3.RouteType].Contents()),
 		envoy_resource_v3.ListenerType: asResources(s.resources[envoy_resource_v3.ListenerType].Contents()),
 		envoy_resource_v3.SecretType:   asResources(s.resources[envoy_resource_v3.SecretType].Contents()),
+		envoy_resource_v3.RuntimeType:  asResources(s.resources[envoy_resource_v3.RuntimeType].Contents()),
 	}
 
 	s.snapLock.Lock()

--- a/internal/xdscache/v3/runtime.go
+++ b/internal/xdscache/v3/runtime.go
@@ -1,0 +1,42 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/projectcontour/contour/internal/contour"
+	"github.com/projectcontour/contour/internal/dag"
+)
+
+// RuntimeCache manages the contents of the gRPC RTDS cache.
+type RuntimeCache struct {
+	contour.Cond
+}
+
+// Contents returns an empty set of layers for now.
+func (c *RuntimeCache) Contents() []proto.Message {
+	return []proto.Message{}
+}
+
+// Query returns an empty set of layers for now.
+func (c *RuntimeCache) Query(names []string) []proto.Message {
+	return []proto.Message{}
+}
+
+func (*RuntimeCache) TypeURL() string { return resource.RuntimeType }
+
+func (c *RuntimeCache) OnChange(root *dag.DAG) {
+	// DAG changes do not affect runtime layers at the moment.
+}


### PR DESCRIPTION
Part of gradual implementation of RTDS, first step to allow configurable
runtime values. Returns an empty set of Runtime layers (instead of just
returning unimplemented to avoid issues in future upgrades). Next step
will be to add ability to dynamically fetch Runtime layer in bootstrap.

Updates: #3452