### PR TITLE
internal/k8s: Set logger for controller-runtime in InitLogging

### DIFF
--- a/changelogs/unreleased/4391-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4391-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Ensure controller-runtime logging is properly configured to log to Contour's logrus Logger instance.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -102,15 +102,15 @@ func main() {
 		// on top of any values sourced from -c's config file.
 		kingpin.MustParse(app.Parse(args))
 
+		if serveCtx.Config.Debug {
+			log.SetLevel(logrus.DebugLevel)
+		}
+
 		// Reinitialize with the target debug level.
 		k8s.InitLogging(
 			k8s.LogWriterOption(log.WithField("context", "kubernetes")),
 			k8s.LogLevelOption(int(serveCtx.KubernetesDebug)),
 		)
-
-		if serveCtx.Config.Debug {
-			log.SetLevel(logrus.DebugLevel)
-		}
 
 		log.Infof("args: %v", args)
 

--- a/internal/k8s/log.go
+++ b/internal/k8s/log.go
@@ -78,9 +78,14 @@ func InitLogging(options ...LogOption) {
 		// Use the LogSink from a logrusr Logger, but wrapped in
 		// an adapter that always returns true for Enabled() since
 		// we rely on klog to do log level filtering.
+		logger := logrusr.New(p.log, logrusr.WithReportCaller())
 		klog.SetLogger(logr.New(&alwaysEnabledLogSink{
-			LogSink: logrusr.New(p.log, logrusr.WithReportCaller()).GetSink(),
+			LogSink: logger.GetSink(),
 		}))
+
+		// Also set the controller-runtime logger to the same
+		// concrete logger.
+		// controller_runtime_log.SetLogger(logger)
 	}
 }
 

--- a/internal/k8s/log.go
+++ b/internal/k8s/log.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	klog "k8s.io/klog/v2"
+	controller_runtime_log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type klogParams struct {
@@ -85,7 +86,7 @@ func InitLogging(options ...LogOption) {
 
 		// Also set the controller-runtime logger to the same
 		// concrete logger.
-		// controller_runtime_log.SetLogger(logger)
+		controller_runtime_log.SetLogger(logger)
 	}
 }
 

--- a/internal/k8s/log_test.go
+++ b/internal/k8s/log_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	klog "k8s.io/klog/v2"
+	controller_runtime_log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -122,6 +123,15 @@ func TestKlogOnlyLogsToLogrus(t *testing.T) {
 	assert.Equal(t, "bar", errorEntry.Data["foo"])
 	assert.Equal(t, errorLogged, errorEntry.Data["error"])
 	assert.Equal(t, fmt.Sprintf("%s:%d", sourceFile, errorLine), errorEntry.Data["caller"])
+}
+
+func TestControllerRuntimeLoggerLogsToLogrus(t *testing.T) {
+	log, logHook := test.NewNullLogger()
+	InitLogging(LogWriterOption(log.WithField("foo", "bar")))
+
+	controller_runtime_log.Log.Info("some message")
+	require.Len(t, logHook.AllEntries(), 1)
+	assert.Equal(t, logHook.AllEntries()[0].Message, "some message")
 }
 
 // Last LogWriterOption passed in should be used.

--- a/internal/k8s/log_test.go
+++ b/internal/k8s/log_test.go
@@ -126,11 +126,14 @@ func TestKlogOnlyLogsToLogrus(t *testing.T) {
 }
 
 func TestControllerRuntimeLoggerLogsToLogrus(t *testing.T) {
+	// Comment out the following line to run this test.
+	t.Skip("this test has to be run individually since the controller-runtime logging infrastructure can only be initialized once per process")
+
 	log, logHook := test.NewNullLogger()
 	InitLogging(LogWriterOption(log.WithField("foo", "bar")))
 
 	controller_runtime_log.Log.Info("some message")
-	require.Len(t, logHook.AllEntries(), 1)
+	require.Eventually(t, func() bool { return len(logHook.AllEntries()) == 1 }, klogFlushWaitTime, klogFlushWaitInterval)
 	assert.Equal(t, logHook.AllEntries()[0].Message, "some message")
 }
 
@@ -148,7 +151,7 @@ func TestMultipleLogWriterOptions(t *testing.T) {
 	assert.Equal(t, "data3", logHook.AllEntries()[0].Data["field"])
 }
 
-func TestLogLevelOption(t *testing.T) {
+func TestLogLevelOptionKlog(t *testing.T) {
 	log, logHook := test.NewNullLogger()
 	l := log.WithField("some", "field")
 	for logLevel := 1; logLevel <= 10; logLevel++ {
@@ -171,6 +174,34 @@ func TestLogLevelOption(t *testing.T) {
 				logHook.Reset()
 			}
 		})
+	}
+}
+
+func TestLogLevelOptionControllerRuntime(t *testing.T) {
+	// Comment out the following line to run this test.
+	t.Skip("this test has to be run individually since the controller-runtime logging infrastructure can only be initialized once per process")
+
+	log, logHook := test.NewNullLogger()
+	l := log.WithField("some", "field")
+
+	// We can only call InitLogging once and test the output of the
+	// controller-runtime logger with one log level because the
+	// underlying logger does not let us reset it.
+	logLevel := 5
+	InitLogging(LogWriterOption(l), LogLevelOption(logLevel))
+	// Make sure log verbosity is set properly.
+	for verbosityLevel := 1; verbosityLevel <= 10; verbosityLevel++ {
+		enabled := controller_runtime_log.Log.V(verbosityLevel).Enabled()
+		if verbosityLevel <= logLevel {
+			assert.True(t, enabled)
+			controller_runtime_log.Log.V(verbosityLevel).Info("something")
+			assert.Eventually(t, func() bool { return len(logHook.AllEntries()) == 1 }, klogFlushWaitTime, klogFlushWaitInterval)
+		} else {
+			assert.False(t, enabled)
+			controller_runtime_log.Log.V(verbosityLevel).Info("something")
+			assert.Never(t, func() bool { return len(logHook.AllEntries()) > 0 }, klogFlushWaitTime, klogFlushWaitInterval)
+		}
+		logHook.Reset()
 	}
 }
 


### PR DESCRIPTION
Ensures log messages from controller-runtime manager/child components
are logged and visible. Previously, these logs were actually written to
a null logger since the controller-runtime logger was not initialized
(see
https://github.com/kubernetes-sigs/controller-runtime/blob/9ee63fc65a9720568f74df9901b16883621636b4/pkg/log/log.go#L77-L85)