### PR TITLE
internal/dag: Avoid error log for all Opaque secrets that do not contain ca.crt

### DIFF
--- a/internal/dag/secret.go
+++ b/internal/dag/secret.go
@@ -74,9 +74,16 @@ func isValidSecret(secret *v1.Secret) (bool, error) {
 			return false, nil
 		}
 
+		data, ok := secret.Data[CACertificateKey]
+
+		// Secret is not a CA
+		if !ok {
+			return false, nil
+		}
+
 		// If there's an Opaque Secret with a `ca.crt` key, and it's zero
 		// length, Contour can't use it, so return an error.
-		if data := secret.Data[CACertificateKey]; len(data) == 0 {
+		if len(data) == 0 {
 			return false, errors.New("can't use zero-length ca.crt value")
 		}
 


### PR DESCRIPTION
When validating secrets contour would print an error log for every Opaque cluster secret that doesn't contain a ca.crt key.
This MR make sure that an error is printed only when a ca.crt key is present AND it's value is not a valid PEM certificate list.

Signed-off-by: Jerome Quere <jerome.quere@bodyguard.ai>