### PR TITLE
certgen: add optional --name-prefix flag

### DIFF
--- a/changelogs/unreleased/4394-skriss-small.md
+++ b/changelogs/unreleased/4394-skriss-small.md
@@ -1,0 +1,1 @@
+Adds an optional `--name-prefix` flag to the `contour certgen` command which, if specified, will be added as a prefix to the names of the generated Kubernetes secrets (e.g. `myprefix-contourcert` and `myprefix-envoycert`).


### PR DESCRIPTION
Adds an optional --name-prefix flag to the
certgen command that, if specified, adds a
prefix to the outputted Kubernetes secret
names, e.g. prefix-contourcert.

Signed-off-by: Steve Kriss <krisss@vmware.com>