### PR TITLE
Remove the hack in scripts for certgen job

### DIFF
--- a/changelogs/unreleased/4402-rajatvig-small.md
+++ b/changelogs/unreleased/4402-rajatvig-small.md
@@ -1,0 +1,1 @@
+Removed the hack for ImagePullPolicy for certgen

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -4908,7 +4908,7 @@ spec:
       containers:
       - name: contour
         image: ghcr.io/projectcontour/contour:main
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - contour
         - certgen

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4911,7 +4911,7 @@ spec:
       containers:
       - name: contour
         image: ghcr.io/projectcontour/contour:main
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - contour
         - certgen

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4908,7 +4908,7 @@ spec:
       containers:
       - name: contour
         image: ghcr.io/projectcontour/contour:main
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - contour
         - certgen

--- a/hack/generate-deployment.sh
+++ b/hack/generate-deployment.sh
@@ -53,14 +53,9 @@ done
 
 echo
 
-# certgen uses the ':latest' image tag, so it always needs to be pulled. Everything
-# else correctly uses versioned image tags so we should use IfNotPresent.
 for y in $FILES ; do
     echo # Ensure we have at least one newline between joined fragments.
     case $y in
-    */02-job-certgen.yaml)
-        cat "$y"
-        ;;
     $SKIP_FILE)
        # skip this file
         ;;

--- a/hack/generate-gateway-deployment.sh
+++ b/hack/generate-gateway-deployment.sh
@@ -31,9 +31,6 @@ done
 
 echo
 
-# certgen uses the ':latest' image tag, so it always needs to be pulled. Everything
-# else correctly uses versioned image tags so we should use IfNotPresent and updates
-# the Contour config for Gateway API.
 for y in "${REPO}/examples/contour/"*.yaml ; do
     echo # Ensure we have at least one newline between joined fragments.
     case $y in
@@ -42,9 +39,6 @@ for y in "${REPO}/examples/contour/"*.yaml ; do
         ;;
     */01-contour-config.yaml)
         sed 's|# gateway:|gateway:|g ; s|#   controllerName: projectcontour.io/projectcontour/contour|  controllerName: projectcontour.io/projectcontour/contour|g' < "$y"
-        ;;
-    */02-job-certgen.yaml)
-        cat "$y"
         ;;
     *)
         sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' < "$y"


### PR DESCRIPTION
examples/render: Set the `imagePullPolicy` for certen job to `IfNotPresent`

Set the `imagePullPolicy` for certen job to `IfNotPresent`

Fixes #4318 

Signed-off-by: Rajat Vig <rvig@etsy.com>