### PR TITLE
internal/envoy: Enable gzip compression for grpc-web content types.

### DIFF
--- a/changelogs/unreleased/4403-bourquep-small.md
+++ b/changelogs/unreleased/4403-bourquep-small.md
@@ -1,0 +1,1 @@
+internal/envoy: Enable gzip compression for grpc-web content types.

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -246,6 +246,15 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 							TypeUrl: HTTPFilterGzip,
 						},
 					},
+					ContentType: []string{
+						// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+						"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+						"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+						"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+						"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+						// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+						"application/grpc-web-text", "application/grpc-web+proto",
+					},
 				}),
 			},
 		},

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -252,8 +252,9 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 						"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 						"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 						"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-						// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-						"application/grpc-web-text", "application/grpc-web+proto",
+						// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+						"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+						"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 					},
 				}),
 			},

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -430,6 +430,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
+									},
 								}),
 							},
 						}, {
@@ -527,6 +536,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 										TypedConfig: &any.Any{
 											TypeUrl: HTTPFilterGzip,
 										},
+									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
 									},
 								}),
 							},
@@ -626,6 +644,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 										TypedConfig: &any.Any{
 											TypeUrl: HTTPFilterGzip,
 										},
+									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
 									},
 								}),
 							},
@@ -727,6 +754,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
+									},
 								}),
 							},
 						}, {
@@ -825,6 +861,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 										TypedConfig: &any.Any{
 											TypeUrl: HTTPFilterGzip,
 										},
+									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
 									},
 								}),
 							},
@@ -926,6 +971,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
+									},
 								}),
 							},
 						}, {
@@ -1023,6 +1077,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 										TypedConfig: &any.Any{
 											TypeUrl: HTTPFilterGzip,
 										},
+									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
 									},
 								}),
 							},
@@ -1123,6 +1186,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
+									},
 								}),
 							},
 						}, {
@@ -1222,6 +1294,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 										TypedConfig: &any.Any{
 											TypeUrl: HTTPFilterGzip,
 										},
+									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
 									},
 								}),
 							},
@@ -1772,6 +1853,15 @@ func TestAddFilter(t *testing.T) {
 									TypeUrl: HTTPFilterGzip,
 								},
 							},
+							ContentType: []string{
+								// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+								"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+								"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+								"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+								"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+								// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+								"application/grpc-web-text", "application/grpc-web+proto",
+							},
 						}),
 					},
 				},
@@ -1838,6 +1928,15 @@ func TestAddFilter(t *testing.T) {
 								TypedConfig: &any.Any{
 									TypeUrl: HTTPFilterGzip,
 								},
+							},
+							ContentType: []string{
+								// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+								"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+								"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+								"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+								"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+								// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+								"application/grpc-web-text", "application/grpc-web+proto",
 							},
 						}),
 					},

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -1404,6 +1404,15 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
+									ContentType: []string{
+										// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+										"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
+										"application/grpc-web-text", "application/grpc-web+proto",
+									},
 								}),
 							},
 						}, {

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -436,8 +436,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -543,8 +544,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -651,8 +653,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -760,8 +763,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -868,8 +872,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -977,8 +982,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -1084,8 +1090,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -1192,8 +1199,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -1301,8 +1309,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -1410,8 +1419,9 @@ func TestHTTPConnectionManager(t *testing.T) {
 										"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 										"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 										"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-										// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-										"application/grpc-web-text", "application/grpc-web+proto",
+										// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+										"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+										"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 									},
 								}),
 							},
@@ -1868,8 +1878,9 @@ func TestAddFilter(t *testing.T) {
 								"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 								"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 								"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-								// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-								"application/grpc-web-text", "application/grpc-web+proto",
+								// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+								"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+								"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 							},
 						}),
 					},
@@ -1944,8 +1955,9 @@ func TestAddFilter(t *testing.T) {
 								"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
 								"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
 								"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-								// Additional content-types for grpc-web https://github.com/grpc/grpc-web#wire-format-mode
-								"application/grpc-web-text", "application/grpc-web+proto",
+								// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+								"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+								"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
 							},
 						}),
 					},


### PR DESCRIPTION
When Envoy serves as a `grpc-web` gateway, HTTP requests/responses use one of the [documented content-type](https://github.com/grpc/grpc-web#wire-format-mode), for which gzip compression is _not_ enabled by [default in Envoy](https://www.envoyproxy.io/docs/envoy/v1.17.4/api-v2/config/filter/http/compressor/v2/compressor.proto#envoy-api-msg-config-filter-http-compressor-v2-compressor).

This MR adds the `grpc-web` content types to Envoy's default ones, so they are gzip-compressed by default.

Fixes #4345

Signed-off-by: Pascal Bourque <pascal@studyo.co>