### PR TITLE
internal/envoy: Fix disableMergeSlashes config option propagation

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -448,6 +448,7 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 			Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
 				UseProxyProto:             &ctx.useProxyProto,
 				DisableAllowChunkedLength: &ctx.Config.DisableAllowChunkedLength,
+				DisableMergeSlashes:       &ctx.Config.DisableMergeSlashes,
 				ConnectionBalancer:        ctx.Config.Listener.ConnectionBalancer,
 				TLS: &contour_api_v1alpha1.EnvoyTLS{
 					MinimumProtocolVersion: ctx.Config.TLS.MinimumProtocolVersion,


### PR DESCRIPTION
In 335e816ec14de417abebcb3c387c462c0470143d we made Envoy's
merge_slashes option configurable via the ContourConfiguration CRD and
the main configuration file, but the value from the configuration isn't
actually propagated to listeners. I did not notice this in our original
testing pass as that was performed before the polarity of the config
option was inverted.

As a fix, ensure we correctly pass the disableMergeSlashes config option
value to Envoy listener configs and add E2E test cases to verify the
default behavior as well as the config option.
