### PR TITLE
test/e2e: minor fixes and improvements

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -348,7 +348,7 @@ func (f *Framework) CreateNamespace(name string) {
 		// Got an existing namespace and it's terminating: give it a chance to go
 		// away.
 		require.Eventually(f.t, func() bool {
-			return api_errors.IsNotFound(f.Client.Get(context.TODO(), key, ns))
+			return api_errors.IsNotFound(f.Client.Get(context.TODO(), key, existing))
 		}, 3*time.Minute, time.Second)
 	}
 

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -63,7 +63,7 @@ type HTTPRequestOpts struct {
 	OverrideURL string
 	RequestOpts []func(*http.Request)
 	ClientOpts  []func(*http.Client)
-	Condition   func(*http.Response) bool
+	Condition   func(*HTTPResponse) bool
 }
 
 func (o *HTTPRequestOpts) requestURLBase(defaultURL string) string {
@@ -157,7 +157,7 @@ type HTTPSRequestOpts struct {
 	OverrideURL   string
 	RequestOpts   []func(*http.Request)
 	TLSConfigOpts []func(*tls.Config)
-	Condition     func(*http.Response) bool
+	Condition     func(*HTTPResponse) bool
 }
 
 func (o *HTTPSRequestOpts) requestURLBase(defaultURL string) string {
@@ -252,7 +252,7 @@ func (h *HTTP) SecureRequest(opts *HTTPSRequestOpts) (*HTTPResponse, error) {
 	}, nil
 }
 
-func (h *HTTP) requestUntil(makeRequest func() (*http.Response, error), condition func(*http.Response) bool) (*HTTPResponse, bool) {
+func (h *HTTP) requestUntil(makeRequest func() (*http.Response, error), condition func(*HTTPResponse) bool) (*HTTPResponse, bool) {
 	var res *HTTPResponse
 
 	if err := wait.PollImmediate(h.RetryInterval, h.RetryTimeout, func() (bool, error) {
@@ -275,7 +275,7 @@ func (h *HTTP) requestUntil(makeRequest func() (*http.Response, error), conditio
 		}
 
 		if condition != nil {
-			return condition(r), nil
+			return condition(res), nil
 		}
 		return false, nil
 	}); err != nil {
@@ -294,8 +294,8 @@ type HTTPResponse struct {
 // HasStatusCode returns a function that returns true
 // if the response has the specified status code, or
 // false otherwise.
-func HasStatusCode(code int) func(*http.Response) bool {
-	return func(res *http.Response) bool {
+func HasStatusCode(code int) func(*HTTPResponse) bool {
+	return func(res *HTTPResponse) bool {
 		return res != nil && res.StatusCode == code
 	}
 }


### PR DESCRIPTION
- Fixes a bug in the code that waits for an existing
terminating namespace to be gone before creating a
new one for E2E tests which caused the create to
fail.
- Changes the type of the condition func used
by HTTP.RequestUntil to allow checking for
properties of the response body.