### PR TITLE
test/e2e: add test for Gateway with multiple HTTPS listeners

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -18,6 +18,8 @@ package e2e
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -521,4 +523,17 @@ func DetailedConditionInvalid(conditions []contourv1.DetailedCondition) bool {
 		}
 	}
 	return false
+}
+
+// VerifyTLSServerCert returns a TLS config functional
+// option that enables verifying the TLS server cert using
+// the provided CA cert.
+func VerifyTLSServerCert(caCert []byte) func(*tls.Config) {
+	return func(c *tls.Config) {
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM(caCert)
+
+		c.RootCAs = certPool
+		c.InsecureSkipVerify = false
+	}
 }

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -70,7 +70,6 @@ var _ = Describe("Gateway API", func() {
 	// body. Modifies contour config to point to gateway.
 	testWithGateway := func(gateway *gatewayapi_v1alpha2.Gateway, gatewayClass *gatewayapi_v1alpha2.GatewayClass, body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
 		return func(namespace string) {
-
 			Context(fmt.Sprintf("with gateway %s/%s, controllerName: %s", namespace, gateway.Name, gatewayClass.Spec.ControllerName), func() {
 				BeforeEach(func() {
 					// Ensure gateway created in this test's namespace.
@@ -132,7 +131,7 @@ var _ = Describe("Gateway API", func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
 	})
 
-	Describe("HTTPRoute: Insecure (Non-TLS) Gateway", func() {
+	Describe("Gateway with one HTTP listener", func() {
 		testWithHTTPGateway := func(body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
 			gw := &gatewayapi_v1alpha2.Gateway{
@@ -176,7 +175,7 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-request-redirect-rule", testWithHTTPGateway(testRequestRedirectRule))
 	})
 
-	Describe("HTTPRoute: TLS Gateway", func() {
+	Describe("Gateway with one HTTP listener and one HTTPS listener", func() {
 		testWithHTTPSGateway := func(hostname string, body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
 
@@ -237,7 +236,7 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-httproute-tls-wildcard-host", testWithHTTPSGateway("*.wildcardhost.gateway.projectcontour.io", testTLSWildcardHost))
 	})
 
-	Describe("TLSRoute Gateway: Mode: Passthrough", func() {
+	Describe("Gateway with one TLS listener with Mode=Passthrough", func() {
 		gatewayClass := getGatewayClass()
 		gw := &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
@@ -265,8 +264,7 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-tlsroute-mode-passthrough", testWithGateway(gw, gatewayClass, testTLSRoutePassthrough))
 	})
 
-	Describe("TLSRoute Gateway: Mode: Terminate", func() {
-
+	Describe("Gateway with one TLS listener with Mode=Terminate", func() {
 		testWithTLSGateway := func(hostname string, body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
 			gw := &gatewayapi_v1alpha2.Gateway{

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -19,7 +19,6 @@ package gateway
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -75,13 +74,7 @@ func testMultipleHTTPSListeners(namespace string) {
 				TLSConfigOpts: []func(*tls.Config){
 					// Verify the server cert to ensure we're getting
 					// the right one.
-					func(c *tls.Config) {
-						certPool := x509.NewCertPool()
-						certPool.AppendCertsFromPEM(certSecret.Data["ca.crt"])
-
-						c.RootCAs = certPool
-						c.InsecureSkipVerify = false
-					},
+					e2e.VerifyTLSServerCert(certSecret.Data["ca.crt"]),
 				},
 				Condition: e2e.HasStatusCode(200),
 			})

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -1,0 +1,93 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func testMultipleHTTPSListeners(namespace string) {
+	Specify("Multiple HTTPS listeners work", func() {
+		t := f.T()
+
+		// Set up a backend and HTTPRoute for each listener.
+		for _, tc := range []string{"1", "2", "3"} {
+			f.Fixtures.Echo.Deploy(namespace, "echo-"+tc)
+
+			route := &gatewayapi_v1alpha2.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "httproute-" + tc,
+				},
+				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1alpha2.ParentRef{
+							gatewayapi.GatewayListenerParentRef("", "multiple-https-listeners", "https-"+tc),
+						},
+					},
+					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+						{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							BackendRefs: gatewayapi.HTTPBackendRef("echo-"+tc, 80, 1),
+						},
+					},
+				},
+			}
+			_, ok := f.CreateHTTPRouteAndWaitFor(route, httpRouteAccepted)
+			require.True(t, ok, "expected HTTPRoute to be accepted")
+		}
+
+		// Make requests to each listener hostname and validate the response
+		// and upstream service.
+		for _, tc := range []string{"1", "2", "3"} {
+			certSecret := &corev1.Secret{}
+			key := client.ObjectKey{Namespace: namespace, Name: "tlscert-" + tc}
+			require.NoError(t, f.Client.Get(context.Background(), key, certSecret))
+
+			res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+				Host: fmt.Sprintf("https-%s.gateway.projectcontour.io", tc),
+				TLSConfigOpts: []func(*tls.Config){
+					// Verify the server cert to ensure we're getting
+					// the right one.
+					func(c *tls.Config) {
+						certPool := x509.NewCertPool()
+						certPool.AppendCertsFromPEM(certSecret.Data["ca.crt"])
+
+						c.RootCAs = certPool
+						c.InsecureSkipVerify = false
+					},
+				},
+				Condition: e2e.HasStatusCode(200),
+			})
+			require.NotNil(t, res, "request never succeeded")
+			require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+			require.Equal(t, "echo-"+tc, f.GetEchoResponseBody(res.Body).Service)
+		}
+	})
+}

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -19,7 +19,6 @@ package httpproxy
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 
 	. "github.com/onsi/ginkgo/v2"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -68,13 +67,7 @@ func testTCPRouteHTTPSTermination(namespace string) {
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host: p.Spec.VirtualHost.Fqdn,
 			TLSConfigOpts: []func(*tls.Config){
-				func(c *tls.Config) {
-					certPool := x509.NewCertPool()
-					certPool.AppendCertsFromPEM(certSecret.Data["ca.crt"])
-
-					c.RootCAs = certPool
-					c.InsecureSkipVerify = false
-				},
+				e2e.VerifyTLSServerCert(certSecret.Data["ca.crt"]),
 			},
 			Condition: e2e.HasStatusCode(200),
 		})


### PR DESCRIPTION
Adds a test that demonstrates a Gateway
with multiple HTTPS Listeners, each with
a different hostname and TLS cert.

Also updated some of the Describe text for clarity.

Signed-off-by: Steve Kriss <krisss@vmware.com>