### PR TITLE
test/e2e: install Contour CRDs during cluster setup

### DIFF
--- a/test/scripts/make-kind-cluster.sh
+++ b/test/scripts/make-kind-cluster.sh
@@ -117,3 +117,6 @@ ${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=webhook deploymen
 
 # Install Gateway API CRDs.
 ${KUBECTL} apply -f "${REPO}/examples/gateway/00-crds.yaml"
+
+# Install Contour CRDs.
+${KUBECTL} apply -f "${REPO}/examples/contour/01-crds.yaml"


### PR DESCRIPTION
Moves Contour CRD installation to cluster setup
since they don't change across test suites, which
simplifies the code.

Signed-off-by: Steve Kriss <krisss@vmware.com>