### PR TITLE
Ratelimit example: Update image

### DIFF
--- a/examples/ratelimit/02-ratelimit.yaml
+++ b/examples/ratelimit/02-ratelimit.yaml
@@ -44,7 +44,7 @@ spec:
             - name: REDIS_URL
               value: redis:6379
         - name: ratelimit
-          image: docker.io/envoyproxy/ratelimit:6f5de117  # latest a/o Jan 22 2021
+          image: docker.io/envoyproxy/ratelimit:8d6488ea  # latest a/o Mar 24 2022
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Update ratelimit image so users of the example can use newer features
like https://github.com/envoyproxy/ratelimit#custom-headers

This came up in a recent query in Slack, investigating it I noticed this feature
was added in a more recent version of ratelimit than our examples used.