### PR TITLE
internal/provisioner: support more than one instance per namespace

### DIFF
--- a/changelogs/unreleased/4426-skriss-minor.md
+++ b/changelogs/unreleased/4426-skriss-minor.md
@@ -1,0 +1,6 @@
+## Gateway provisioner: add support for more than one Gateway/Contour instance per namespace
+
+The Gateway provisioner now supports having more than one Gateway/Contour instance per namespace.
+All resource names now include a `-<gateway-name>` suffix to avoid conflicts (cluster-scoped resources also include the namespace as part of the resource name).
+Contour instances are always provisioned in the namespace of the Gateway custom resource itself.
+

--- a/internal/provisioner/model/names.go
+++ b/internal/provisioner/model/names.go
@@ -1,0 +1,117 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigMapName returns the name of the Contour ConfigMap resource.
+func (c *Contour) ConfigMapName() string {
+	return "contour-" + c.Name
+}
+
+// ContourServiceName returns the name of the Contour Service resource.
+func (c *Contour) ContourServiceName() string {
+	return "contour-" + c.Name
+}
+
+// EnvoyServiceName returns the name of the Envoy Service resource.
+func (c *Contour) EnvoyServiceName() string {
+	return "envoy-" + c.Name
+}
+
+// ContourDeploymentName returns the name of the Contour Deployment resource.
+func (c *Contour) ContourDeploymentName() string {
+	return "contour-" + c.Name
+}
+
+// EnvoyDaemonSetName returns the name of the Envoy DaemonSet resource.
+func (c *Contour) EnvoyDaemonSetName() string {
+	return "envoy-" + c.Name
+}
+
+// LeaderElectionLeaseName returns the name of the Contour leader election Lease resource.
+func (c *Contour) LeaderElectionLeaseName() string {
+	return "leader-elect-" + c.Name
+}
+
+// ContourCertsSecretName returns the name of the Contour xDS TLS certs Secret resource.
+func (c *Contour) ContourCertsSecretName() string {
+	return c.Name + "-contourcert"
+}
+
+// EnvoyCertsSecretName returns the name of the Envoy xDS TLS certs Secret resource.
+func (c *Contour) EnvoyCertsSecretName() string {
+	return c.Name + "-envoycert"
+}
+
+// CertgenJobName returns the name of the certgen Job resource.
+func (c *Contour) CertgenJobName(contourImage string) string {
+	return fmt.Sprintf("contour-certgen-%s-%s", tagFromImage(contourImage), c.Name)
+}
+
+// tagFromImage returns the tag from the provided image or an
+// empty string if the image does not contain a tag.
+func tagFromImage(image string) string {
+	if strings.Contains(image, ":") {
+		parsed := strings.Split(image, ":")
+		return parsed[1]
+	}
+	return ""
+}
+
+// ContourRBACNames returns the names of the RBAC resources for
+// the Contour deployment.
+func (c *Contour) ContourRBACNames() RBACNames {
+	return RBACNames{
+		ServiceAccount:     fmt.Sprintf("contour-%s", c.Name),
+		ClusterRole:        fmt.Sprintf("contour-%s-%s", c.Namespace, c.Name),
+		ClusterRoleBinding: fmt.Sprintf("contour-%s-%s", c.Namespace, c.Name),
+		Role:               fmt.Sprintf("contour-%s", c.Name),
+
+		// this one has a different prefix to differentiate from the certgen role binding (see below).
+		RoleBinding: fmt.Sprintf("contour-rolebinding-%s", c.Name),
+	}
+}
+
+// EnvoyRBACNames returns the names of the RBAC resources for
+// the Envoy daemonset.
+func (c *Contour) EnvoyRBACNames() RBACNames {
+	return RBACNames{
+		ServiceAccount: "envoy-" + c.Name,
+	}
+}
+
+// CertgenRBACNames returns the names of the RBAC resources for
+// the Certgen job.
+func (c *Contour) CertgenRBACNames() RBACNames {
+	return RBACNames{
+		ServiceAccount: "contour-certgen-" + c.Name,
+		Role:           "contour-certgen-" + c.Name,
+
+		// this one is name contour-<gateway-name> despite being for certgen for legacy reasons.
+		RoleBinding: "contour-" + c.Name,
+	}
+}
+
+// RBACNames holds a set of names of related RBAC resources.
+type RBACNames struct {
+	ServiceAccount     string
+	ClusterRole        string
+	ClusterRoleBinding string
+	Role               string
+	RoleBinding        string
+}

--- a/internal/provisioner/objects/configmap/configmap.go
+++ b/internal/provisioner/objects/configmap/configmap.go
@@ -183,7 +183,7 @@ type contourConfig struct {
 func configForContour(contour *model.Contour) *configMapParams {
 	return &configMapParams{
 		Namespace: contour.Namespace,
-		Name:      ContourConfigMapName,
+		Name:      fmt.Sprintf("%s-%s", ContourConfigMapName, contour.Name),
 		Labels:    model.OwnerLabels(contour),
 		Contour: contourConfig{
 			GatewayNamespace:          contour.Namespace,

--- a/internal/provisioner/objects/configmap/configmap.go
+++ b/internal/provisioner/objects/configmap/configmap.go
@@ -31,12 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// ContourConfigMapName is the name of Contour's ConfigMap resource.
-	// [TODO] danehans: Remove and use contour.Name when
-	// https://github.com/projectcontour/contour/issues/2122 is fixed.
-	ContourConfigMapName = "contour"
-)
+// ContourConfigMapName returns the name of Contour's ConfigMap resource.
+func ContourConfigMapName(contour *model.Contour) string {
+	return fmt.Sprintf("%s-%s", "contour", contour.Name)
+}
 
 var contourConfigMapTemplate = template.Must(template.New("contour.yaml").Parse(`#
 # server:
@@ -189,7 +187,7 @@ type contourConfig struct {
 func configForContour(contour *model.Contour) *configMapParams {
 	return &configMapParams{
 		Namespace: contour.Namespace,
-		Name:      fmt.Sprintf("%s-%s", ContourConfigMapName, contour.Name),
+		Name:      ContourConfigMapName(contour),
 		Labels:    model.OwnerLabels(contour),
 		Contour: contourConfig{
 			GatewayNamespace:          contour.Namespace,

--- a/internal/provisioner/objects/configmap/configmap.go
+++ b/internal/provisioner/objects/configmap/configmap.go
@@ -31,11 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ContourConfigMapName returns the name of Contour's ConfigMap resource.
-func ContourConfigMapName(contour *model.Contour) string {
-	return fmt.Sprintf("%s-%s", "contour", contour.Name)
-}
-
 var contourConfigMapTemplate = template.Must(template.New("contour.yaml").Parse(`#
 # server:
 #   determine which XDS Server implementation to utilize in Contour.
@@ -187,13 +182,13 @@ type contourConfig struct {
 func configForContour(contour *model.Contour) *configMapParams {
 	return &configMapParams{
 		Namespace: contour.Namespace,
-		Name:      ContourConfigMapName(contour),
+		Name:      contour.ConfigMapName(),
 		Labels:    model.OwnerLabels(contour),
 		Contour: contourConfig{
 			GatewayNamespace:          contour.Namespace,
 			GatewayName:               contour.Name,
 			EnableExternalNameService: pointer.BoolDeref(contour.Spec.EnableExternalNameService, false),
-			EnvoyServiceName:          fmt.Sprintf("envoy-%s", contour.Name),
+			EnvoyServiceName:          contour.EnvoyServiceName(),
 		},
 	}
 }

--- a/internal/provisioner/objects/configmap/configmap.go
+++ b/internal/provisioner/objects/configmap/configmap.go
@@ -150,6 +150,8 @@ accesslog-format: envoy
 #   Configure the number of additional ingress proxy hops from the
 #   right side of the x-forwarded-for HTTP header to trust.
 #   num-trusted-hops: 0
+# Name of the envoy service to inspect for Ingress status details.
+envoy-service-name: {{ .EnvoyServiceName }}
 `))
 
 // configMapParams contains everything needed to manage a Contour ConfigMap.
@@ -177,6 +179,10 @@ type contourConfig struct {
 	// EnableExternalNameService sets whether ExternalName Services are
 	// allowed.
 	EnableExternalNameService bool
+
+	// EnvoyServiceName is the name of the envoy service to inspect for Ingress
+	// status details.
+	EnvoyServiceName string
 }
 
 // configForContour returns a configMapParams with default fields set for contour.
@@ -189,6 +195,7 @@ func configForContour(contour *model.Contour) *configMapParams {
 			GatewayNamespace:          contour.Namespace,
 			GatewayName:               contour.Name,
 			EnableExternalNameService: pointer.BoolDeref(contour.Spec.EnableExternalNameService, false),
+			EnvoyServiceName:          fmt.Sprintf("envoy-%s", contour.Name),
 		},
 	}
 }

--- a/internal/provisioner/objects/configmap/configmap_test.go
+++ b/internal/provisioner/objects/configmap/configmap_test.go
@@ -132,6 +132,8 @@ accesslog-format: envoy
 #   Configure the number of additional ingress proxy hops from the
 #   right side of the x-forwarded-for HTTP header to trust.
 #   num-trusted-hops: 0
+# Name of the envoy service to inspect for Ingress status details.
+envoy-service-name: envoy-test
 `
 
 	c := &model.Contour{
@@ -257,6 +259,8 @@ accesslog-format: envoy
 #   Configure the number of additional ingress proxy hops from the
 #   right side of the x-forwarded-for HTTP header to trust.
 #   num-trusted-hops: 0
+# Name of the envoy service to inspect for Ingress status details.
+envoy-service-name: envoy-test
 `
 	c := &model.Contour{
 		ObjectMeta: v1.ObjectMeta{
@@ -382,6 +386,8 @@ accesslog-format: envoy
 #   Configure the number of additional ingress proxy hops from the
 #   right side of the x-forwarded-for HTTP header to trust.
 #   num-trusted-hops: 0
+# Name of the envoy service to inspect for Ingress status details.
+envoy-service-name: envoy-test
 `
 
 	c := &model.Contour{

--- a/internal/provisioner/objects/configmap/configmap_test.go
+++ b/internal/provisioner/objects/configmap/configmap_test.go
@@ -142,7 +142,7 @@ accesslog-format: envoy
 	}
 	cm, err := desired(configForContour(c))
 	require.NoError(t, err)
-	require.Equal(t, "contour", cm.Name)
+	require.Equal(t, "contour-test", cm.Name)
 	require.Equal(t, "test-ns", cm.Namespace)
 	require.Contains(t, cm.Data, "contour.yaml")
 	assert.Equal(t, expected, cm.Data["contour.yaml"])
@@ -392,7 +392,7 @@ accesslog-format: envoy
 	}
 	cm, err := desired(configForContour(c))
 	require.NoError(t, err)
-	require.Equal(t, "contour", cm.Name)
+	require.Equal(t, "contour-test", cm.Name)
 	require.Equal(t, "test-ns", cm.Namespace)
 	require.Contains(t, cm.Data, "contour.yaml")
 	assert.Equal(t, expected, cm.Data["contour.yaml"])

--- a/internal/provisioner/objects/daemonset/daemonset.go
+++ b/internal/provisioner/objects/daemonset/daemonset.go
@@ -268,7 +268,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 			Args: []string{
 				"bootstrap",
 				filepath.Join("/", envoyCfgVolMntDir, envoyCfgFileName),
-				"--xds-address=contour",
+				"--xds-address=contour-" + contour.Name,
 				fmt.Sprintf("--xds-port=%d", objcfg.XDSPort),
 				fmt.Sprintf("--xds-resource-version=%s", xdsResourceVersion),
 				fmt.Sprintf("--resources-dir=%s", filepath.Join("/", envoyCfgVolMntDir, "resources")),
@@ -307,13 +307,13 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
-			Name:      envoyDaemonSetName,
+			Name:      fmt.Sprintf("%s-%s", envoyDaemonSetName, contour.Name),
 			Labels:    labels,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			RevisionHistoryLimit: pointer.Int32Ptr(int32(10)),
 			// Ensure the deamonset adopts only its own pods.
-			Selector: EnvoyDaemonSetPodSelector(),
+			Selector: EnvoyDaemonSetPodSelector(contour.Name),
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
@@ -329,7 +329,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 						"prometheus.io/port":   "8002",
 						"prometheus.io/path":   "/stats/prometheus",
 					},
-					Labels: EnvoyDaemonSetPodSelector().MatchLabels,
+					Labels: EnvoyDaemonSetPodSelector(contour.Name).MatchLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers:     containers,
@@ -340,7 +340,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									DefaultMode: pointer.Int32Ptr(int32(420)),
-									SecretName:  envoyCertsSecretName,
+									SecretName:  fmt.Sprintf("%s-%s", contour.Name, envoyCertsSecretName),
 								},
 							},
 						},
@@ -357,7 +357,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 							},
 						},
 					},
-					ServiceAccountName:            objutil.EnvoyRbacName,
+					ServiceAccountName:            fmt.Sprintf("%s-%s", objutil.EnvoyRbacName, contour.Name),
 					AutomountServiceAccountToken:  pointer.BoolPtr(false),
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(300)),
 					SecurityContext:               objutil.NewUnprivilegedPodSecurity(),
@@ -385,7 +385,7 @@ func CurrentDaemonSet(ctx context.Context, cli client.Client, contour *model.Con
 	ds := &appsv1.DaemonSet{}
 	key := types.NamespacedName{
 		Namespace: contour.Namespace,
-		Name:      envoyDaemonSetName,
+		Name:      fmt.Sprintf("%s-%s", envoyDaemonSetName, contour.Name),
 	}
 	if err := cli.Get(ctx, key, ds); err != nil {
 		return nil, err
@@ -418,10 +418,10 @@ func updateDaemonSetIfNeeded(ctx context.Context, cli client.Client, contour *mo
 
 // EnvoyDaemonSetPodSelector returns a label selector using "app: envoy" as the
 // key/value pair.
-func EnvoyDaemonSetPodSelector() *metav1.LabelSelector {
+func EnvoyDaemonSetPodSelector(contourName string) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"app": "envoy",
+			"app": "envoy-" + contourName,
 		},
 	}
 }

--- a/internal/provisioner/objects/job/job.go
+++ b/internal/provisioner/objects/job/job.go
@@ -127,7 +127,7 @@ func DesiredJob(contour *model.Contour, image string) *batchv1.Job {
 	}
 	spec := corev1.PodSpec{
 		Containers:                    []corev1.Container{container},
-		ServiceAccountName:            fmt.Sprintf("%s-%s", objutil.CertGenRbacName, contour.Name),
+		ServiceAccountName:            objutil.GetCertgenRBACNames(contour).ServiceAccount,
 		SecurityContext:               objutil.NewUnprivilegedPodSecurity(),
 		RestartPolicy:                 corev1.RestartPolicyNever,
 		DNSPolicy:                     corev1.DNSClusterFirst,

--- a/internal/provisioner/objects/object.go
+++ b/internal/provisioner/objects/object.go
@@ -14,8 +14,6 @@
 package objects
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -30,14 +28,4 @@ func NewUnprivilegedPodSecurity() *corev1.PodSecurityContext {
 		RunAsGroup:   &group,
 		RunAsNonRoot: &nonRoot,
 	}
-}
-
-// TagFromImage returns the tag from the provided image or an
-// empty string if the image does not contain a tag.
-func TagFromImage(image string) string {
-	if strings.Contains(image, ":") {
-		parsed := strings.Split(image, ":")
-		return parsed[1]
-	}
-	return ""
 }

--- a/internal/provisioner/objects/service/service.go
+++ b/internal/provisioner/objects/service/service.go
@@ -196,7 +196,7 @@ func DesiredContourService(contour *model.Contour) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
-			Name:      contourSvcName,
+			Name:      fmt.Sprintf("%s-%s", contourSvcName, contour.Name),
 			Labels:    model.OwnerLabels(contour),
 		},
 		Spec: corev1.ServiceSpec{
@@ -208,7 +208,7 @@ func DesiredContourService(contour *model.Contour) *corev1.Service {
 					TargetPort: intstr.IntOrString{IntVal: xdsPort},
 				},
 			},
-			Selector:        objdeploy.ContourDeploymentPodSelector().MatchLabels,
+			Selector:        objdeploy.ContourDeploymentPodSelector(contour.Name).MatchLabels,
 			Type:            corev1.ServiceTypeClusterIP,
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
@@ -264,13 +264,13 @@ func DesiredEnvoyService(contour *model.Contour) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   contour.Namespace,
-			Name:        envoySvcName,
+			Name:        fmt.Sprintf("%s-%s", envoySvcName, contour.Name),
 			Annotations: map[string]string{},
 			Labels:      model.OwnerLabels(contour),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:           ports,
-			Selector:        objds.EnvoyDaemonSetPodSelector().MatchLabels,
+			Selector:        objds.EnvoyDaemonSetPodSelector(contour.Name).MatchLabels,
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
@@ -356,7 +356,7 @@ func currentContourService(ctx context.Context, cli client.Client, contour *mode
 	current := &corev1.Service{}
 	key := types.NamespacedName{
 		Namespace: contour.Namespace,
-		Name:      contourSvcName,
+		Name:      fmt.Sprintf("%s-%s", contourSvcName, contour.Name),
 	}
 	err := cli.Get(ctx, key, current)
 	if err != nil {
@@ -370,7 +370,7 @@ func currentEnvoyService(ctx context.Context, cli client.Client, contour *model.
 	current := &corev1.Service{}
 	key := types.NamespacedName{
 		Namespace: contour.Namespace,
-		Name:      envoySvcName,
+		Name:      fmt.Sprintf("%s-%s", envoySvcName, contour.Name),
 	}
 	err := cli.Get(ctx, key, current)
 	if err != nil {

--- a/internal/provisioner/validation/validation.go
+++ b/internal/provisioner/validation/validation.go
@@ -25,9 +25,6 @@ import (
 
 // Contour returns true if contour is valid.
 func Contour(ctx context.Context, cli client.Client, contour *model.Contour) error {
-	// TODO(sk) this used to check for existence of another Contour in the namespace,
-	// we likely want to do the same for Gateways somehow.
-
 	if err := ContainerPorts(contour); err != nil {
 		return err
 	}

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -95,6 +95,60 @@ var _ = Describe("Gateway provisioner", func() {
 			require.True(f.T(), ok)
 		})
 	})
+
+	f.NamespacedTest("multiple-gateways-per-namespace", func(namespace string) {
+		Specify("Multiple basic one-listener HTTP gateways can be provisioned in a single namespace", func() {
+			gateway := &gatewayapi_v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "http-1",
+					Namespace: namespace,
+				},
+				Spec: gatewayapi_v1alpha2.GatewaySpec{
+					GatewayClassName: gatewayapi_v1alpha2.ObjectName("contour"),
+					Listeners: []gatewayapi_v1alpha2.Listener{
+						{
+							Name:     "http",
+							Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+							Port:     gatewayapi_v1alpha2.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1alpha2.AllowedRoutes{
+								Namespaces: &gatewayapi_v1alpha2.RouteNamespaces{
+									From: gatewayapi.FromNamespacesPtr(gatewayapi_v1alpha2.NamespacesFromSame),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, ok := f.CreateGatewayAndWaitFor(gateway, gatewayReady)
+			require.True(f.T(), ok)
+
+			gateway = &gatewayapi_v1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "http-2",
+					Namespace: namespace,
+				},
+				Spec: gatewayapi_v1alpha2.GatewaySpec{
+					GatewayClassName: gatewayapi_v1alpha2.ObjectName("contour"),
+					Listeners: []gatewayapi_v1alpha2.Listener{
+						{
+							Name:     "http",
+							Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+							Port:     gatewayapi_v1alpha2.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1alpha2.AllowedRoutes{
+								Namespaces: &gatewayapi_v1alpha2.RouteNamespaces{
+									From: gatewayapi.FromNamespacesPtr(gatewayapi_v1alpha2.NamespacesFromSame),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, ok = f.CreateGatewayAndWaitFor(gateway, gatewayReady)
+			require.True(f.T(), ok)
+		})
+	})
 })
 
 // gatewayClassAccepted returns true if the gateway has a .status.conditions


### PR DESCRIPTION
Adds support for provisioning more than one Contour+Envoy instance per namespace.

Closes #4418.