### PR TITLE
Add generated example yaml file back to fix the test

### DIFF
--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -2104,6 +2104,12 @@ spec:
                       manager-wide stream_idle_timeout default of 5m still applies.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  idleConnection:
+                    description: Timeout for how long connection from the proxy to
+                      the upstream service is kept when there are no active requests.
+                      If not supplied, Envoy's default value of 1h applies.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
                   response:
                     description: Timeout for receiving a response from the server
                       after processing a request from client. If not supplied, Envoy's
@@ -3361,6 +3367,13 @@ spec:
                             consecutive requests. If not specified, there is no per-route
                             idle timeout, though a connection manager-wide stream_idle_timeout
                             default of 5m still applies.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        idleConnection:
+                          description: Timeout for how long connection from the proxy
+                            to the upstream service is kept when there are no active
+                            requests. If not supplied, Envoy's default value of 1h
+                            applies.
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                         response:


### PR DESCRIPTION
Changes to generated file `contour-gateway-provisioner.yaml` did not get picked up while doing merge of #4356.
Automatic squash&merge missed it and tests failed first time when running against main.

This change adds the changes back to the generated file to fix the CI/CD failure.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>