### PR TITLE
clean up provisioner RBAC and reuse Contour RBAC for it

### DIFF
--- a/examples/gateway-provisioner/01-roles.yaml
+++ b/examples/gateway-provisioner/01-roles.yaml
@@ -13,6 +13,9 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
+  - serviceaccounts
+  - services
   verbs:
   - create
   - delete
@@ -24,6 +27,9 @@ rules:
   - ""
   resources:
   - endpoints
+  - namespaces
+  - secrets
+  - services
   verbs:
   - get
   - list
@@ -37,33 +43,9 @@ rules:
   - get
   - update
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - daemonsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
   verbs:
   - create
@@ -79,8 +61,15 @@ rules:
   verbs:
   - create
   - get
-  - list
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - gateway.networking.k8s.io
@@ -93,8 +82,14 @@ rules:
   verbs:
   - get
   - list
-  - update
   - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  verbs:
+  - update
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -103,8 +98,6 @@ rules:
   - httproutes/status
   - tlsroutes/status
   verbs:
-  - create
-  - get
   - update
 - apiGroups:
   - networking.k8s.io

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -8448,6 +8448,9 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
+  - serviceaccounts
+  - services
   verbs:
   - create
   - delete
@@ -8459,6 +8462,9 @@ rules:
   - ""
   resources:
   - endpoints
+  - namespaces
+  - secrets
+  - services
   verbs:
   - get
   - list
@@ -8472,33 +8478,9 @@ rules:
   - get
   - update
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - daemonsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
   verbs:
   - create
@@ -8514,8 +8496,15 @@ rules:
   verbs:
   - create
   - get
-  - list
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - gateway.networking.k8s.io
@@ -8528,8 +8517,14 @@ rules:
   verbs:
   - get
   - list
-  - update
   - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  verbs:
+  - update
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -8538,8 +8533,6 @@ rules:
   - httproutes/status
   - tlsroutes/status
   verbs:
-  - create
-  - get
   - update
 - apiGroups:
   - networking.k8s.io

--- a/hack/generate-rbac.sh
+++ b/hack/generate-rbac.sh
@@ -34,5 +34,5 @@ EOF
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
     rbac:roleName=contour-gateway-provisioner \
     output:stdout \
-    paths="./internal/provisioner/rbac" \
+    paths="./internal/provisioner/rbac;./internal/k8s" \
 >> "${REPO}/examples/gateway-provisioner/01-roles.yaml"

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
@@ -62,6 +62,7 @@ func desiredClusterRole(name string, contour *model.Contour) *rbacv1.ClusterRole
 	var (
 		createGetUpdate = []string{"create", "get", "update"}
 		getListWatch    = []string{"get", "list", "watch"}
+		update          = []string{"update"}
 	)
 
 	policyRuleFor := func(apiGroup string, verbs []string, resources ...string) rbacv1.PolicyRule {
@@ -87,7 +88,7 @@ func desiredClusterRole(name string, contour *model.Contour) *rbacv1.ClusterRole
 			// Gateway API resources.
 			// Note, ReferencePolicy does not currently have a .status field so it's omitted from the status rule.
 			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencepolicies"),
-			policyRuleFor(gatewayv1alpha2.GroupName, createGetUpdate, "gatewayclasses/status", "gateways/status", "httproutes/status", "tlsroutes/status"),
+			policyRuleFor(gatewayv1alpha2.GroupName, update, "gatewayclasses/status", "gateways/status", "httproutes/status", "tlsroutes/status"),
 
 			// Ingress resources.
 			policyRuleFor(networkingv1.GroupName, getListWatch, "ingresses"),

--- a/internal/provisioner/rbac/rbac.go
+++ b/internal/provisioner/rbac/rbac.go
@@ -13,22 +13,29 @@
 
 package rbac
 
-// +kubebuilder:rbac:groups="",resources=namespaces;secrets;serviceaccounts;services,verbs=get;list;watch;delete;create;update
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;delete;create;update
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;create;update
-// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
-// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways;httproutes;tlsroutes;referencepolicies,verbs=get;list;watch;update
-// Note, ReferencePolicy does not currently have a .status field so it's omitted from the below.
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status,verbs=create;get;update
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/status,verbs=create;get;update
-// +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies;tlscertificatedelegations;extensionservices;contourconfigurations,verbs=get;list;watch
-// +kubebuilder:rbac:groups=projectcontour.io,resources=httpproxies/status;extensionservices/status;contourconfigurations/status,verbs=create;get;update
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;delete;create;update;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;delete;create;update
-// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;delete;create;update
+// This file only contains entries for RBAC that the Provisioner needs itself directly.
+// Transitive requirements, i.e. RBAC the Provisioner needs in order to be able to create
+// the Contour ClusterRoles/Roles, are handled at YAML generation time by pulling in Contour's
+// RBAC entries as well.
 
-// Add RBAC policy to support leader election.
+// RBAC for Gateway API.
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status,verbs=update
+// ---
+
+// RBAC for core Contour resources to be provisioned.
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;delete
+// ---
+
+// RBAC for leader election for the provisioner.
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;get;update,namespace=projectcontour
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update,namespace=projectcontour
+// ---
+
+// Contour itself has leader election RBAC scoped to a single namespace, but the provisioner
+// needs it for all namespaces in order to be able to create those Roles.
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;get;update
+// +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=create;get;update
+// ---


### PR DESCRIPTION
Tidies up provisioner RBAC markers and reuses
the Contour RBAC file when generating the
provisioner RBAC YAML instead of requiring all
markers to be duplicated in the provisioner's
file.

Signed-off-by: Steve Kriss <krisss@vmware.com>