### PR TITLE
Each path in an Ingress is required to have a corresponding path type.

### DIFF
--- a/changelogs/unreleased/4446-lou-lan-docs.md
+++ b/changelogs/unreleased/4446-lou-lan-docs.md
@@ -1,0 +1,1 @@
+Add `pathType` field to Ingress resource.

--- a/site/content/docs/main/config/fundamentals.md
+++ b/site/content/docs/main/config/fundamentals.md
@@ -33,6 +33,7 @@ spec:
             name: s1
             port:
               number: 80
+        pathType: Prefix
 ```
 
 This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.

--- a/site/content/docs/main/config/virtual-hosts.md
+++ b/site/content/docs/main/config/virtual-hosts.md
@@ -29,6 +29,7 @@ spec:
             name: s1
             port:
               number: 80
+        pathType: Prefix              
   - host: bar1.bar.com
     http:
       paths:
@@ -37,6 +38,7 @@ spec:
             name: s2
             port:
               number: 80
+        pathType: Prefix
 ```
 
 must be represented by two different HTTPProxy objects:

--- a/site/content/docs/v1.20.1/config/fundamentals.md
+++ b/site/content/docs/v1.20.1/config/fundamentals.md
@@ -33,6 +33,7 @@ spec:
             name: s1
             port:
               number: 80
+        pathType: Prefix
 ```
 
 This Ingress object, named `basic`, will route incoming HTTP traffic with a `Host:` header for `foo-basic.bar.com` to a Service named `s1` on port `80`.

--- a/site/content/docs/v1.20.1/config/virtual-hosts.md
+++ b/site/content/docs/v1.20.1/config/virtual-hosts.md
@@ -29,6 +29,7 @@ spec:
             name: s1
             port:
               number: 80
+        pathType: Prefix
   - host: bar1.bar.com
     http:
       paths:
@@ -37,6 +38,7 @@ spec:
             name: s2
             port:
               number: 80
+        pathType: Prefix
 ```
 
 must be represented by two different HTTPProxy objects:


### PR DESCRIPTION
Each path in an Ingress is required to have a corresponding path type. Paths that do not include an explicit pathType will fail validation. 

Fix #4447