### PR TITLE
internal/provisioner: add Reconcile tests for controllers

### DIFF
--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -14,86 +14,208 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func TestIsGatewayClassReconcilable(t *testing.T) {
+func TestGatewayReconcile(t *testing.T) {
+	const controller = "projectcontour.io/gateway-provisioner"
+
+	reconcilableGatewayClass := func(name, controller string) *gatewayv1alpha2.GatewayClass {
+		return &gatewayv1alpha2.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: gatewayv1alpha2.GatewayClassSpec{
+				ControllerName: gatewayv1alpha2.GatewayController(controller),
+			},
+			// the fake client lets us create resources with a status set
+			Status: gatewayv1alpha2.GatewayClassStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+						Status: metav1.ConditionTrue,
+						Reason: string(gatewayv1alpha2.GatewayClassReasonAccepted),
+					},
+				},
+			},
+		}
+	}
+
 	tests := map[string]struct {
-		obj               client.Object
-		gatewayController string
-		want              bool
+		gatewayClass *gatewayv1alpha2.GatewayClass
+		gateway      *gatewayv1alpha2.Gateway
+		req          *reconcile.Request
+		assertions   func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error)
 	}{
-		"GatewayClass is reconcilable": {
-			obj: &gatewayv1alpha2.GatewayClass{
-				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: gatewayv1alpha2.GatewayController("projectcontour.io/gateway-provisioner"),
+		"A gateway for a reconcilable gatewayclass is reconciled": {
+			gatewayClass: reconcilableGatewayClass("gatewayclass-1", controller),
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
 				},
-				Status: gatewayv1alpha2.GatewayClassStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
-							Status: metav1.ConditionTrue,
-						},
-					},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
 				},
 			},
-			gatewayController: "projectcontour.io/gateway-provisioner",
-			want:              true,
-		},
-		"object is not a GatewayClass": {
-			obj:  &corev1.Service{},
-			want: false,
-		},
-		"GatewayClass has a non-matching controller": {
-			obj: &gatewayv1alpha2.GatewayClass{
-				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: gatewayv1alpha2.GatewayController("projectcontour.io/some-other-controller"),
-				},
-				Status: gatewayv1alpha2.GatewayClassStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
-							Status: metav1.ConditionTrue,
-						},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify the Gateway has a "Scheduled: true" condition
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Len(t, gw.Status.Conditions, 1)
+				assert.Equal(t, string(gatewayv1alpha2.GatewayConditionScheduled), gw.Status.Conditions[0].Type)
+				assert.Equal(t, metav1.ConditionTrue, gw.Status.Conditions[0].Status)
+
+				// Verify the Contour deployment has been created
+				deploy := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contour-gateway-1",
 					},
-				},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(deploy), deploy))
 			},
-			gatewayController: "projectcontour.io/gateway-provisioner",
-			want:              false,
 		},
-		"GatewayClass has a condition of Accepted: false": {
-			obj: &gatewayv1alpha2.GatewayClass{
+		"A gateway for a non-reconcilable gatewayclass (not accepted) is not reconciled": {
+			gatewayClass: &gatewayv1alpha2.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gatewayclass-1",
+				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: gatewayv1alpha2.GatewayController("projectcontour.io/gateway-provisioner"),
+					ControllerName: gatewayv1alpha2.GatewayController(controller),
 				},
 				Status: gatewayv1alpha2.GatewayClassStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
 							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 						},
 					},
 				},
 			},
-			gatewayController: "projectcontour.io/gateway-provisioner",
-			want:              false,
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify that the Gateway has not had a "Scheduled: true" condition set
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Empty(t, gw.Status.Conditions, 0)
+
+				// Verify the Contour deployment has not been created
+				deploy := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contour-gateway-1",
+					},
+				}
+				err := r.client.Get(context.Background(), keyFor(deploy), deploy)
+				assert.True(t, errors.IsNotFound(err))
+			},
+		},
+		"A gateway for a non-reconcilable gatewayclass (non-matching controller) is not reconciled": {
+			gatewayClass: &gatewayv1alpha2.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gatewayclass-1",
+				},
+				Spec: gatewayv1alpha2.GatewayClassSpec{
+					ControllerName: "someothercontroller.io/controller",
+				},
+				Status: gatewayv1alpha2.GatewayClassStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1alpha2.GatewayClassReasonAccepted),
+						},
+					},
+				},
+			},
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify that the Gateway has not had a "Scheduled: true" condition set
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Empty(t, gw.Status.Conditions, 0)
+
+				// Verify the Contour deployment has not been created
+				deploy := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contour-gateway-1",
+					},
+				}
+				err := r.client.Get(context.Background(), keyFor(deploy), deploy)
+				assert.True(t, errors.IsNotFound(err))
+			},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			r := &gatewayReconciler{
-				gatewayController: v1alpha2.GatewayController(tc.gatewayController),
+			scheme := runtime.NewScheme()
+			require.NoError(t, kubernetesscheme.AddToScheme(scheme))
+			require.NoError(t, gatewayv1alpha2.AddToScheme(scheme))
+			require.NoError(t, contourv1alpha1.AddToScheme(scheme))
+
+			client := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.gatewayClass != nil {
+				client.WithObjects(tc.gatewayClass)
+			}
+			if tc.gateway != nil {
+				client.WithObjects(tc.gateway)
 			}
 
-			assert.Equal(t, tc.want, r.isGatewayClassReconcilable(tc.obj))
+			r := &gatewayReconciler{
+				gatewayController: controller,
+				client:            client.Build(),
+				log:               logr.Discard(),
+			}
+
+			var req reconcile.Request
+			if tc.req != nil {
+				req = *tc.req
+			} else {
+				req = reconcile.Request{
+					NamespacedName: keyFor(tc.gateway),
+				}
+			}
+
+			_, err := r.Reconcile(context.Background(), req)
+
+			tc.assertions(t, r, tc.gateway, err)
 		})
 	}
 }

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -18,14 +18,12 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/provisioner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -185,10 +183,8 @@ func TestGatewayReconcile(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			require.NoError(t, kubernetesscheme.AddToScheme(scheme))
-			require.NoError(t, gatewayv1alpha2.AddToScheme(scheme))
-			require.NoError(t, contourv1alpha1.AddToScheme(scheme))
+			scheme, err := provisioner.CreateScheme()
+			require.NoError(t, err)
 
 			client := fake.NewClientBuilder().WithScheme(scheme)
 			if tc.gatewayClass != nil {
@@ -213,7 +209,7 @@ func TestGatewayReconcile(t *testing.T) {
 				}
 			}
 
-			_, err := r.Reconcile(context.Background(), req)
+			_, err = r.Reconcile(context.Background(), req)
 
 			tc.assertions(t, r, tc.gateway, err)
 		})

--- a/internal/provisioner/controller/gatewayclass_test.go
+++ b/internal/provisioner/controller/gatewayclass_test.go
@@ -33,10 +33,11 @@ import (
 
 func TestGatewayClassReconcile(t *testing.T) {
 	tests := map[string]struct {
-		gatewayClass *gatewayv1alpha2.GatewayClass
-		params       *contourv1alpha1.ContourDeployment
-		req          *reconcile.Request
-		assertions   func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error)
+		gatewayClass  *gatewayv1alpha2.GatewayClass
+		params        *contourv1alpha1.ContourDeployment
+		req           *reconcile.Request
+		wantCondition *metav1.Condition
+		assertions    func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error)
 	}{
 		"reconcile request for non-existent gatewayclass results in no error": {
 			req: &reconcile.Request{
@@ -77,16 +78,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					ControllerName: "projectcontour.io/gateway-provisioner",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionTrue, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonAccepted), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonAccepted),
 			},
 		},
 		"gatewayclass controlled by us with an invalid parametersRef (target does not exist) gets Accepted: false condition": {
@@ -104,16 +99,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					},
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionFalse, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonInvalidParameters), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 			},
 		},
 		"gatewayclass controlled by us with an invalid parametersRef (invalid group) gets Accepted: false condition": {
@@ -137,16 +126,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name:      "gatewayclass-params",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionFalse, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonInvalidParameters), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 			},
 		},
 		"gatewayclass controlled by us with an invalid parametersRef (invalid kind) gets Accepted: false condition": {
@@ -170,16 +153,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name:      "gatewayclass-params",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionFalse, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonInvalidParameters), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 			},
 		},
 		"gatewayclass controlled by us with an invalid parametersRef (invalid name) gets Accepted: false condition": {
@@ -203,16 +180,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name:      "gatewayclass-params",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionFalse, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonInvalidParameters), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 			},
 		},
 		"gatewayclass controlled by us with an invalid parametersRef (invalid namespace) gets Accepted: false condition": {
@@ -236,16 +207,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name:      "gatewayclass-params",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionFalse, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonInvalidParameters), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonInvalidParameters),
 			},
 		},
 		"gatewayclass controlled by us with a valid parametersRef gets Accepted: true condition": {
@@ -269,16 +234,10 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name:      "gatewayclass-params",
 				},
 			},
-			assertions: func(t *testing.T, r *gatewayClassReconciler, gc *gatewayv1alpha2.GatewayClass, reconcileErr error) {
-				assert.NoError(t, reconcileErr)
-
-				res := &gatewayv1alpha2.GatewayClass{}
-				require.NoError(t, r.client.Get(context.Background(), keyFor(gc), res))
-
-				assert.Len(t, res.Status.Conditions, 1)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassConditionStatusAccepted), res.Status.Conditions[0].Type)
-				assert.Equal(t, metav1.ConditionTrue, res.Status.Conditions[0].Status)
-				assert.Equal(t, string(gatewayv1alpha2.GatewayClassReasonAccepted), res.Status.Conditions[0].Reason)
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1alpha2.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionTrue,
+				Reason: string(gatewayv1alpha2.GatewayClassReasonAccepted),
 			},
 		},
 	}
@@ -313,7 +272,19 @@ func TestGatewayClassReconcile(t *testing.T) {
 
 			_, err = r.Reconcile(context.Background(), req)
 
-			tc.assertions(t, r, tc.gatewayClass, err)
+			if tc.wantCondition != nil {
+				res := &gatewayv1alpha2.GatewayClass{}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(tc.gatewayClass), res))
+
+				require.Len(t, res.Status.Conditions, 1)
+				assert.Equal(t, tc.wantCondition.Type, res.Status.Conditions[0].Type)
+				assert.Equal(t, tc.wantCondition.Status, res.Status.Conditions[0].Status)
+				assert.Equal(t, tc.wantCondition.Reason, res.Status.Conditions[0].Reason)
+			}
+
+			if tc.assertions != nil {
+				tc.assertions(t, r, tc.gatewayClass, err)
+			}
 		})
 	}
 }

--- a/internal/provisioner/controller/gatewayclass_test.go
+++ b/internal/provisioner/controller/gatewayclass_test.go
@@ -20,12 +20,11 @@ import (
 	"github.com/go-logr/logr"
 	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/internal/provisioner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -286,10 +285,8 @@ func TestGatewayClassReconcile(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			require.NoError(t, kubernetesscheme.AddToScheme(scheme))
-			require.NoError(t, gatewayv1alpha2.AddToScheme(scheme))
-			require.NoError(t, contourv1alpha1.AddToScheme(scheme))
+			scheme, err := provisioner.CreateScheme()
+			require.NoError(t, err)
 
 			client := fake.NewClientBuilder().WithScheme(scheme)
 			if tc.gatewayClass != nil {
@@ -314,7 +311,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 				}
 			}
 
-			_, err := r.Reconcile(context.Background(), req)
+			_, err = r.Reconcile(context.Background(), req)
 
 			tc.assertions(t, r, tc.gatewayClass, err)
 		})

--- a/internal/provisioner/scheme.go
+++ b/internal/provisioner/scheme.go
@@ -1,0 +1,40 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioner
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+)
+
+// CreateScheme returns a scheme with all the API types necessary for the gateway
+// provisioner's client to work. Any new API groups must be added here.
+func CreateScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := gateway_api_v1alpha2.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := contour_api_v1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	return scheme, nil
+}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Replaces small unit tests of some of the individual helpers with full tests of the Reconcile() method that use a fake controller-runtime client.