### PR TITLE
internal/provisioner: support using ContourDeployment.Config

### DIFF
--- a/changelogs/unreleased/4459-skriss-small.md
+++ b/changelogs/unreleased/4459-skriss-small.md
@@ -1,0 +1,1 @@
+Uses the `ContourConfigurationSpec` defined as part of a `GatewayClass's` `ContourDeployment` parameters when provisioning a `ContourConfiguration` for a `Gateway`.

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects/contourconfig"
 	"github.com/projectcontour/contour/internal/provisioner/objects/daemonset"
@@ -235,6 +236,14 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		gatewayContour.Spec.NetworkPublishing.Envoy.ServicePorts = append(gatewayContour.Spec.NetworkPublishing.Envoy.ServicePorts, port)
 	}
 
+	gcParams, err := r.getGatewayClassParams(ctx, gatewayClass)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting gateway's gateway class parameters: %w", err)
+	}
+	if gcParams != nil {
+		gatewayContour.Spec.Config = gcParams.Spec.Config
+	}
+
 	if errs := r.ensureContour(ctx, gatewayContour, log); len(errs) > 0 {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure resources for gateway: %w", retryable.NewMaybeRetryableAggregate(errs))
 	}
@@ -322,4 +331,23 @@ func (r *gatewayReconciler) ensureContourDeleted(ctx context.Context, contour *m
 	handleResult("rbac", rbac.EnsureRBACDeleted(ctx, r.client, contour))
 
 	return errs
+}
+
+func (r *gatewayReconciler) getGatewayClassParams(ctx context.Context, gatewayClass *gatewayapi_v1alpha2.GatewayClass) (*contour_api_v1alpha1.ContourDeployment, error) {
+	if !isContourDeploymentRef(gatewayClass.Spec.ParametersRef) {
+		return nil, nil
+	}
+
+	gcParams := &contour_api_v1alpha1.ContourDeployment{}
+	key := client.ObjectKey{
+		Namespace: string(*gatewayClass.Spec.ParametersRef.Namespace),
+		Name:      gatewayClass.Spec.ParametersRef.Name,
+	}
+
+	if err := r.client.Get(ctx, key, gcParams); err != nil {
+		return nil, fmt.Errorf("error getting gateway class's parameters: %w", err)
+	}
+
+	return gcParams, nil
+
 }

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -334,6 +334,15 @@ func (r *gatewayReconciler) ensureContourDeleted(ctx context.Context, contour *m
 }
 
 func (r *gatewayReconciler) getGatewayClassParams(ctx context.Context, gatewayClass *gatewayapi_v1alpha2.GatewayClass) (*contour_api_v1alpha1.ContourDeployment, error) {
+	// Check if there is a parametersRef to ContourDeployment with
+	// a namespace specified. Theoretically, we should only be reconciling
+	// Gateways for GatewayClasses that have valid parameter refs (or no refs),
+	// making this check mostly redundant other than checking for a nil params
+	// ref, but there is potentially a race condition where a GatewayClass's
+	// parameters ref is updated from valid to invalid, and then a Gateway reconcile
+	// is triggered before the GatewayClass's status is updated, that
+	// would lead to this code being executed for a GatewayClass with an
+	// invalid parametersRef.
 	if !isContourDeploymentRef(gatewayClass.Spec.ParametersRef) {
 		return nil, nil
 	}

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -69,6 +69,17 @@ func TestGatewayReconcile(t *testing.T) {
 		return gc
 	}
 
+	reconcilableGatewayClassWithInvalidParams := func(name, controller string) *gatewayv1alpha2.GatewayClass {
+		gc := reconcilableGatewayClass(name, controller)
+		gc.Spec.ParametersRef = &gatewayv1alpha2.ParametersReference{
+			Group:     gatewayv1alpha2.Group(contourv1alpha1.GroupVersion.Group),
+			Kind:      "InvalidKind",
+			Namespace: gatewayapi.NamespacePtr("projectcontour"),
+			Name:      name + "-params",
+		}
+		return gc
+	}
+
 	tests := map[string]struct {
 		gatewayClass       *gatewayv1alpha2.GatewayClass
 		gatewayClassParams *contourv1alpha1.ContourDeployment
@@ -417,6 +428,69 @@ func TestGatewayReconcile(t *testing.T) {
 							Service: &contourv1alpha1.NamespacedName{
 								Namespace: "some-other-namespace",
 								Name:      "some-other-service",
+							},
+						},
+					},
+				},
+			},
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify the Gateway has a "Scheduled: true" condition
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Len(t, gw.Status.Conditions, 1)
+				assert.Equal(t, string(gatewayv1alpha2.GatewayConditionScheduled), gw.Status.Conditions[0].Type)
+				assert.Equal(t, metav1.ConditionTrue, gw.Status.Conditions[0].Status)
+
+				// Verify the ContourConfiguration has been created
+				contourConfig := &contourv1alpha1.ContourConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contourconfig-gateway-1",
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(contourConfig), contourConfig))
+
+				want := contourv1alpha1.ContourConfigurationSpec{
+					Gateway: &contourv1alpha1.GatewayConfig{
+						GatewayRef: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Name,
+							Name:      gw.Name,
+						},
+					},
+					Envoy: &contourv1alpha1.EnvoyConfig{
+						Service: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Namespace,
+							Name:      "envoy-" + gw.Name,
+						},
+					},
+				}
+
+				assert.Equal(t, want, contourConfig.Spec)
+			},
+		},
+		"If the Gateway's GatewayClass parametersRef is invalid it's ignored and the Gateway gets a default ContourConfiguration": {
+			gatewayClass: reconcilableGatewayClassWithInvalidParams("gatewayclass-1", controller),
+			gatewayClassParams: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-1-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Config: &contourv1alpha1.ContourConfigurationSpec{
+						EnableExternalNameService: pointer.Bool(true),
+						Envoy: &contourv1alpha1.EnvoyConfig{
+							Listener: &contourv1alpha1.EnvoyListenerConfig{
+								DisableMergeSlashes: pointer.Bool(true),
 							},
 						},
 					},

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/provisioner"
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -56,11 +58,23 @@ func TestGatewayReconcile(t *testing.T) {
 		}
 	}
 
+	reconcilableGatewayClassWithParams := func(name, controller string) *gatewayv1alpha2.GatewayClass {
+		gc := reconcilableGatewayClass(name, controller)
+		gc.Spec.ParametersRef = &gatewayv1alpha2.ParametersReference{
+			Group:     gatewayv1alpha2.Group(contourv1alpha1.GroupVersion.Group),
+			Kind:      "ContourDeployment",
+			Namespace: gatewayapi.NamespacePtr("projectcontour"),
+			Name:      name + "-params",
+		}
+		return gc
+	}
+
 	tests := map[string]struct {
-		gatewayClass *gatewayv1alpha2.GatewayClass
-		gateway      *gatewayv1alpha2.Gateway
-		req          *reconcile.Request
-		assertions   func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error)
+		gatewayClass       *gatewayv1alpha2.GatewayClass
+		gatewayClassParams *contourv1alpha1.ContourDeployment
+		gateway            *gatewayv1alpha2.Gateway
+		req                *reconcile.Request
+		assertions         func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error)
 	}{
 		"A gateway for a reconcilable gatewayclass is reconciled": {
 			gatewayClass: reconcilableGatewayClass("gatewayclass-1", controller),
@@ -316,6 +330,143 @@ func TestGatewayReconcile(t *testing.T) {
 				assertEnvoyServiceLoadBalancerIP(t, gw, r.client, "")
 			},
 		},
+		"Config from the Gateway's GatewayClass params is applied to the provisioned ContourConfiguration": {
+			gatewayClass: reconcilableGatewayClassWithParams("gatewayclass-1", controller),
+			gatewayClassParams: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-1-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Config: &contourv1alpha1.ContourConfigurationSpec{
+						EnableExternalNameService: pointer.Bool(true),
+						Envoy: &contourv1alpha1.EnvoyConfig{
+							Listener: &contourv1alpha1.EnvoyListenerConfig{
+								DisableMergeSlashes: pointer.Bool(true),
+							},
+						},
+					},
+				},
+			},
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify the Gateway has a "Scheduled: true" condition
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Len(t, gw.Status.Conditions, 1)
+				assert.Equal(t, string(gatewayv1alpha2.GatewayConditionScheduled), gw.Status.Conditions[0].Type)
+				assert.Equal(t, metav1.ConditionTrue, gw.Status.Conditions[0].Status)
+
+				// Verify the ContourConfiguration has been created
+				contourConfig := &contourv1alpha1.ContourConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contourconfig-gateway-1",
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(contourConfig), contourConfig))
+
+				want := contourv1alpha1.ContourConfigurationSpec{
+					EnableExternalNameService: pointer.Bool(true),
+					Gateway: &contourv1alpha1.GatewayConfig{
+						GatewayRef: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Name,
+							Name:      gw.Name,
+						},
+					},
+					Envoy: &contourv1alpha1.EnvoyConfig{
+						Listener: &contourv1alpha1.EnvoyListenerConfig{
+							DisableMergeSlashes: pointer.Bool(true),
+						},
+						Service: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Namespace,
+							Name:      "envoy-" + gw.Name,
+						},
+					},
+				}
+
+				assert.Equal(t, want, contourConfig.Spec)
+			},
+		},
+		"Gateway-related config from the Gateway's GatewayClass params is overridden": {
+			gatewayClass: reconcilableGatewayClassWithParams("gatewayclass-1", controller),
+			gatewayClassParams: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-1-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Config: &contourv1alpha1.ContourConfigurationSpec{
+						Gateway: &contourv1alpha1.GatewayConfig{
+							ControllerName: "some-controller",
+							GatewayRef: &contourv1alpha1.NamespacedName{
+								Namespace: "some-other-namespace",
+								Name:      "some-other-gateway",
+							},
+						},
+						Envoy: &contourv1alpha1.EnvoyConfig{
+							Service: &contourv1alpha1.NamespacedName{
+								Namespace: "some-other-namespace",
+								Name:      "some-other-service",
+							},
+						},
+					},
+				},
+			},
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "gateway-1",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: gatewayv1alpha2.ObjectName("gatewayclass-1"),
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+
+				// Verify the Gateway has a "Scheduled: true" condition
+				require.NoError(t, r.client.Get(context.Background(), keyFor(gw), gw))
+				require.Len(t, gw.Status.Conditions, 1)
+				assert.Equal(t, string(gatewayv1alpha2.GatewayConditionScheduled), gw.Status.Conditions[0].Type)
+				assert.Equal(t, metav1.ConditionTrue, gw.Status.Conditions[0].Status)
+
+				// Verify the ContourConfiguration has been created
+				contourConfig := &contourv1alpha1.ContourConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "contourconfig-gateway-1",
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(contourConfig), contourConfig))
+
+				want := contourv1alpha1.ContourConfigurationSpec{
+					Gateway: &contourv1alpha1.GatewayConfig{
+						GatewayRef: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Name,
+							Name:      gw.Name,
+						},
+					},
+					Envoy: &contourv1alpha1.EnvoyConfig{
+						Service: &contourv1alpha1.NamespacedName{
+							Namespace: gw.Namespace,
+							Name:      "envoy-" + gw.Name,
+						},
+					},
+				}
+
+				assert.Equal(t, want, contourConfig.Spec)
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -326,6 +477,9 @@ func TestGatewayReconcile(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme)
 			if tc.gatewayClass != nil {
 				client.WithObjects(tc.gatewayClass)
+			}
+			if tc.gatewayClassParams != nil {
+				client.WithObjects(tc.gatewayClassParams)
 			}
 			if tc.gateway != nil {
 				client.WithObjects(tc.gateway)

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -131,6 +132,9 @@ type ContourSpec struct {
 	//
 	// +optional
 	EnableExternalNameService *bool `json:"enableExternalNameService,omitempty"`
+
+	// Config is any user-defined Config for the Contour instance.
+	Config *contourv1alpha1.ContourConfigurationSpec
 }
 
 // NodePlacement describes node scheduling configuration of Contour and Envoy pods.


### PR DESCRIPTION
When a GatewayClass has a parametersRef
to a ContourDeployment resource that has
Config specified, use that Config when
provisioning Gateways and their associated
ContourConfigurations.

Signed-off-by: Steve Kriss <krisss@vmware.com>