### PR TITLE
validate Gateway listener protocols/ports/hostnames

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -198,13 +198,13 @@ func (p *GatewayAPIProcessor) computeListener(listener gatewayapi_v1alpha2.Liste
 	}()
 
 	if _, ok := validateListenersResult.InvalidListenerConditions[listener.Name]; ok {
-		// listener was found to be invalid
+		// Listener had an invalid protocol/port/hostname, don't need to inspect further.
 		return
 	}
 
 	var listenerSecret *Secret
 
-	// Validate the listener protocol is a supported type.
+	// Validate TLS details for HTTPS/TLS protocol listeners.
 	switch listener.Protocol {
 	case gatewayapi_v1alpha2.HTTPSProtocolType:
 		// Validate that if protocol is type HTTPS, that TLS is defined.
@@ -260,17 +260,6 @@ func (p *GatewayAPIProcessor) computeListener(listener gatewayapi_v1alpha2.Liste
 				}
 			}
 		}
-	case gatewayapi_v1alpha2.HTTPProtocolType:
-		// Nothing further to validate.
-	default:
-		gwAccessor.AddListenerCondition(
-			string(listener.Name),
-			gatewayapi_v1alpha2.ListenerConditionDetached,
-			metav1.ConditionTrue,
-			gatewayapi_v1alpha2.ListenerReasonUnsupportedProtocol,
-			fmt.Sprintf("Listener.Protocol %q is not supported.", listener.Protocol),
-		)
-		return
 	}
 
 	// Get a list of the route kinds that the listener accepts.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -103,7 +103,8 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 		}
 	}
 
-	// Add conditions for invalid listeners
+	// Validate listener protocols, ports and hostnames and add conditions
+	// for all invalid listeners.
 	validateListenersResult := gatewayapi.ValidateListeners(p.source.gateway.Spec.Listeners)
 	for name, cond := range validateListenersResult.InvalidListenerConditions {
 		gwAccessor.AddListenerCondition(
@@ -197,8 +198,9 @@ func (p *GatewayAPIProcessor) computeListener(listener gatewayapi_v1alpha2.Liste
 		}
 	}()
 
+	// If the listener had an invalid protocol/port/hostname, we don't need to go
+	// any further.
 	if _, ok := validateListenersResult.InvalidListenerConditions[listener.Name]; ok {
-		// Listener had an invalid protocol/port/hostname, don't need to inspect further.
 		return
 	}
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5030,7 +5030,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
 							Status:  metav1.ConditionTrue,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonUnsupportedProtocol),
-							Message: "Listener.Protocol \"invalid\" is not supported.",
+							Message: "Listener protocol \"invalid\" is unsupported, must be one of HTTP, HTTPS or TLS",
 						},
 					},
 				},

--- a/internal/gatewayapi/listeners.go
+++ b/internal/gatewayapi/listeners.go
@@ -1,0 +1,96 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayapi
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type ValidateListenersResult struct {
+	HTTPPort                      int
+	ValidHTTPListeners            []gatewayapi_v1alpha2.Listener
+	InvalidHTTPListenerConditions map[gatewayapi_v1alpha2.SectionName]metav1.Condition
+}
+
+func ValidateListeners(listeners []gatewayapi_v1alpha2.Listener) ValidateListenersResult {
+
+	// All listeners with a protocol of "HTTP" must use the same port number
+	// Heuristic: the first port number encountered is allowed, any other listeners with a different port number are marked "Detached" with "PortUnavailable"
+	// All listeners with a protocol of "HTTP" using the one allowed port must have a unique hostname
+	// Any listener with a duplicate hostname is marked "Conflicted" with "HostnameConflict"
+
+	httpPort := 0
+	hostnames := map[string]int{}
+
+	for _, listener := range listeners {
+		if listener.Protocol != gatewayapi_v1alpha2.HTTPProtocolType {
+			continue
+		}
+
+		// First listener with "HTTP" protocol we've seen: keep its port
+		if httpPort == 0 {
+			httpPort = int(listener.Port)
+		}
+
+		// Count hostnames among HTTP listeners with the "valid" port.
+		// For other HTTP listeners with an "invalid" port, the
+		// "PortUnavailable" reason will take precedence.
+		if int(listener.Port) == httpPort {
+			hostnames[listenerHostname(listener)]++
+		}
+	}
+
+	var validListeners []gatewayapi_v1alpha2.Listener
+	invalidListenerConditions := map[gatewayapi_v1alpha2.SectionName]metav1.Condition{}
+
+	for _, listener := range listeners {
+		if listener.Protocol != gatewayapi_v1alpha2.HTTPProtocolType {
+			continue
+		}
+
+		switch {
+		case int(listener.Port) != httpPort:
+			invalidListenerConditions[listener.Name] = metav1.Condition{
+				Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
+				Message: "Only one HTTP port is supported",
+			}
+		case hostnames[listenerHostname(listener)] > 1:
+			invalidListenerConditions[listener.Name] = metav1.Condition{
+				Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
+				Message: "Hostname must be unique among HTTP listeners",
+			}
+		default:
+			validListeners = append(validListeners, listener)
+		}
+
+	}
+
+	return ValidateListenersResult{
+		HTTPPort:                      httpPort,
+		ValidHTTPListeners:            validListeners,
+		InvalidHTTPListenerConditions: invalidListenerConditions,
+	}
+}
+
+func listenerHostname(listener gatewayapi_v1alpha2.Listener) string {
+	if listener.Hostname != nil {
+		return string(*listener.Hostname)
+	}
+	return ""
+}

--- a/internal/gatewayapi/listeners.go
+++ b/internal/gatewayapi/listeners.go
@@ -14,6 +14,8 @@
 package gatewayapi
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
@@ -106,10 +108,12 @@ func ValidateListeners(listeners []gatewayapi_v1alpha2.Listener) ValidateListene
 				}
 			}
 		default:
-			// Unsupported protocol: ignore (will be handled in DAG processing)
-			// TODO(sk) probably makes sense to move the handling of unsupported
-			// protocols in here for cohesion.
-			continue
+			result.InvalidListenerConditions[listener.Name] = metav1.Condition{
+				Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gatewayapi_v1alpha2.ListenerReasonUnsupportedProtocol),
+				Message: fmt.Sprintf("Listener protocol %q is unsupported, must be one of HTTP, HTTPS or TLS", listener.Protocol),
+			}
 		}
 	}
 

--- a/internal/gatewayapi/listeners.go
+++ b/internal/gatewayapi/listeners.go
@@ -19,73 +19,101 @@ import (
 )
 
 type ValidateListenersResult struct {
-	HTTPPort                      int
-	ValidHTTPListeners            []gatewayapi_v1alpha2.Listener
-	InvalidHTTPListenerConditions map[gatewayapi_v1alpha2.SectionName]metav1.Condition
+	InsecurePort int
+	SecurePort   int
+
+	InvalidListenerConditions map[gatewayapi_v1alpha2.SectionName]metav1.Condition
 }
 
 func ValidateListeners(listeners []gatewayapi_v1alpha2.Listener) ValidateListenersResult {
+	result := ValidateListenersResult{
+		InvalidListenerConditions: map[gatewayapi_v1alpha2.SectionName]metav1.Condition{},
+	}
 
 	// All listeners with a protocol of "HTTP" must use the same port number
 	// Heuristic: the first port number encountered is allowed, any other listeners with a different port number are marked "Detached" with "PortUnavailable"
 	// All listeners with a protocol of "HTTP" using the one allowed port must have a unique hostname
 	// Any listener with a duplicate hostname is marked "Conflicted" with "HostnameConflict"
 
-	httpPort := 0
-	hostnames := map[string]int{}
+	var (
+		insecureHostnames = map[string]int{}
+		secureHostnames   = map[string]int{}
+	)
 
 	for _, listener := range listeners {
-		if listener.Protocol != gatewayapi_v1alpha2.HTTPProtocolType {
-			continue
-		}
+		switch listener.Protocol {
+		case gatewayapi_v1alpha2.HTTPProtocolType:
+			// Keep the first insecure listener port we see
+			if result.InsecurePort == 0 {
+				result.InsecurePort = int(listener.Port)
+			}
 
-		// First listener with "HTTP" protocol we've seen: keep its port
-		if httpPort == 0 {
-			httpPort = int(listener.Port)
-		}
+			// Count hostnames among insecure listeners with the "valid" port.
+			// For other insecure listeners with an "invalid" port, the
+			// "PortUnavailable" reason will take precedence.
+			if int(listener.Port) == result.InsecurePort {
+				insecureHostnames[listenerHostname(listener)]++
+			}
+		case gatewayapi_v1alpha2.HTTPSProtocolType, gatewayapi_v1alpha2.TLSProtocolType:
+			// Keep the first secure listener port we see
+			if result.SecurePort == 0 {
+				result.SecurePort = int(listener.Port)
+			}
 
-		// Count hostnames among HTTP listeners with the "valid" port.
-		// For other HTTP listeners with an "invalid" port, the
-		// "PortUnavailable" reason will take precedence.
-		if int(listener.Port) == httpPort {
-			hostnames[listenerHostname(listener)]++
+			// Count hostnames among secure listeners with the "valid" port.
+			// For other secure listeners with an "invalid" port, the
+			// "PortUnavailable" reason will take precedence.
+			if int(listener.Port) == result.SecurePort {
+				secureHostnames[listenerHostname(listener)]++
+			}
 		}
 	}
 
-	var validListeners []gatewayapi_v1alpha2.Listener
-	invalidListenerConditions := map[gatewayapi_v1alpha2.SectionName]metav1.Condition{}
-
 	for _, listener := range listeners {
-		if listener.Protocol != gatewayapi_v1alpha2.HTTPProtocolType {
-			continue
-		}
-
-		switch {
-		case int(listener.Port) != httpPort:
-			invalidListenerConditions[listener.Name] = metav1.Condition{
-				Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
-				Message: "Only one HTTP port is supported",
+		switch listener.Protocol {
+		case gatewayapi_v1alpha2.HTTPProtocolType:
+			switch {
+			case int(listener.Port) != result.InsecurePort:
+				result.InvalidListenerConditions[listener.Name] = metav1.Condition{
+					Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
+					Message: "Only one HTTP port is supported",
+				}
+			case insecureHostnames[listenerHostname(listener)] > 1:
+				result.InvalidListenerConditions[listener.Name] = metav1.Condition{
+					Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
+					Message: "Hostname must be unique among HTTP listeners",
+				}
 			}
-		case hostnames[listenerHostname(listener)] > 1:
-			invalidListenerConditions[listener.Name] = metav1.Condition{
-				Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
-				Message: "Hostname must be unique among HTTP listeners",
+		case gatewayapi_v1alpha2.HTTPSProtocolType, gatewayapi_v1alpha2.TLSProtocolType:
+			switch {
+			case int(listener.Port) != result.SecurePort:
+				result.InvalidListenerConditions[listener.Name] = metav1.Condition{
+					Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
+					Message: "Only one HTTPS/TLS port is supported",
+				}
+			case secureHostnames[listenerHostname(listener)] > 1:
+				result.InvalidListenerConditions[listener.Name] = metav1.Condition{
+					Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
+					Status:  metav1.ConditionTrue,
+					Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
+					Message: "Hostname must be unique among HTTPS/TLS listeners",
+				}
 			}
 		default:
-			validListeners = append(validListeners, listener)
+			// Unsupported protocol: ignore (will be handled in DAG processing)
+			// TODO(sk) probably makes sense to move the handling of unsupported
+			// protocols in here for cohesion.
+			continue
 		}
-
 	}
 
-	return ValidateListenersResult{
-		HTTPPort:                      httpPort,
-		ValidHTTPListeners:            validListeners,
-		InvalidHTTPListenerConditions: invalidListenerConditions,
-	}
+	return result
 }
 
 func listenerHostname(listener gatewayapi_v1alpha2.Listener) string {

--- a/internal/gatewayapi/listeners.go
+++ b/internal/gatewayapi/listeners.go
@@ -27,6 +27,14 @@ type ValidateListenersResult struct {
 	InvalidListenerConditions map[gatewayapi_v1alpha2.SectionName]metav1.Condition
 }
 
+// ValidateListeners validates protocols, ports and hostnames on a set of listeners.
+// It ensures that:
+//	- all protocols are supported
+//	- each listener group (grouped by protocol, with HTTPS & TLS going together) uses a single port
+//  - hostnames within each listener group are unique
+// It returns the insecure & secure ports to use, as well as conditions for all invalid listeners.
+// If a listener is not in the "InvalidListenerConditions" map, it is assumed to be valid according
+// to the above rules.
 func ValidateListeners(listeners []gatewayapi_v1alpha2.Listener) ValidateListenersResult {
 	result := ValidateListenersResult{
 		InvalidListenerConditions: map[gatewayapi_v1alpha2.SectionName]metav1.Condition{},

--- a/internal/gatewayapi/listeners_test.go
+++ b/internal/gatewayapi/listeners_test.go
@@ -1,0 +1,173 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestValidateListeners(t *testing.T) {
+	// All HTTP listeners are valid, some non-HTTP listeners
+	// as well.
+	listeners := []gatewayapi_v1alpha2.Listener{
+		{
+			Name:     "listener-1",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+		},
+		{
+			Name:     "listener-2",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+		{
+			Name:     "listener-3",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("*.projectcontour.io"),
+		},
+		{
+			Name:     "listener-4",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.envoyproxy.io"),
+		},
+		{
+			Name:     "non-http-listener-1",
+			Protocol: gatewayapi_v1alpha2.TLSProtocolType,
+			Port:     443,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+	}
+
+	res := ValidateListeners(listeners)
+	assert.Equal(t, 80, res.HTTPPort)
+	assert.Equal(t, listeners[0:4], res.ValidHTTPListeners)
+	assert.Empty(t, res.InvalidHTTPListenerConditions)
+
+	// One HTTP listener with an invalid port number, some
+	// non-HTTP listeners as well.
+	listeners = []gatewayapi_v1alpha2.Listener{
+		{
+			Name:     "listener-1",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+		},
+		{
+			Name:     "listener-2",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+		{
+			Name:     "listener-3",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("*.projectcontour.io"),
+		},
+		{
+			Name:     "listener-4",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     8080,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+		{
+			Name:     "non-http-listener-1",
+			Protocol: gatewayapi_v1alpha2.TLSProtocolType,
+			Port:     443,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+	}
+
+	res = ValidateListeners(listeners)
+	assert.Equal(t, 80, res.HTTPPort)
+	assert.Equal(t, listeners[0:3], res.ValidHTTPListeners)
+	assert.Equal(t, map[gatewayapi_v1alpha2.SectionName]metav1.Condition{
+		"listener-4": {
+			Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
+			Message: "Only one HTTP port is supported",
+		},
+	}, res.InvalidHTTPListenerConditions)
+
+	// Two HTTP listeners with the same hostname, some HTTP
+	// listeners with invalid port, some non-HTTP listeners as well.
+	listeners = []gatewayapi_v1alpha2.Listener{
+		{
+			Name:     "listener-1",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+		},
+		{
+			Name:     "listener-2",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.projectcontour.io"), // duplicate hostname
+		},
+		{
+			Name:     "listener-3",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.projectcontour.io"), // duplicate hostname
+		},
+		{
+			Name:     "listener-4",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     80,
+			Hostname: ListenerHostname("local.envoyproxy.io"),
+		},
+		{
+			Name:     "listener-5",
+			Protocol: gatewayapi_v1alpha2.HTTPProtocolType,
+			Port:     8080, // invalid port
+			Hostname: ListenerHostname("local.envoyproxy.io"),
+		},
+		{
+			Name:     "non-http-listener-1",
+			Protocol: gatewayapi_v1alpha2.TLSProtocolType, // non-HTTP
+			Port:     443,
+			Hostname: ListenerHostname("local.projectcontour.io"),
+		},
+	}
+
+	res = ValidateListeners(listeners)
+	assert.Equal(t, 80, res.HTTPPort)
+	assert.Equal(t, []gatewayapi_v1alpha2.Listener{listeners[0], listeners[3]}, res.ValidHTTPListeners)
+	assert.Equal(t, map[gatewayapi_v1alpha2.SectionName]metav1.Condition{
+		"listener-2": {
+			Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
+			Message: "Hostname must be unique among HTTP listeners",
+		},
+		"listener-3": {
+			Type:    string(gatewayapi_v1alpha2.ListenerConditionConflicted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayapi_v1alpha2.ListenerReasonHostnameConflict),
+			Message: "Hostname must be unique among HTTP listeners",
+		},
+		"listener-5": {
+			Type:    string(gatewayapi_v1alpha2.ListenerConditionDetached),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayapi_v1alpha2.ListenerReasonPortUnavailable),
+			Message: "Only one HTTP port is supported",
+		},
+	}, res.InvalidHTTPListenerConditions)
+}

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -284,10 +284,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Message:            "Gateway is scheduled",
 	})
 
-	// TODO set Listener conditions -- need to coordinate with gatewayapi_processor to avoid fighting.
-	//	- maybe we shouldn't even set conditions here -- run the validation logic to see what to program
-	// 	  on the service, but defer the condition setting to the gatewayapi_processor.
-
 	if err := r.client.Status().Update(ctx, gateway); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set gateway %s scheduled condition: %w", req, err)
 	}

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -539,6 +540,142 @@ func TestGatewayReconcile(t *testing.T) {
 				}
 
 				assert.Equal(t, want, contourConfig.Spec)
+			},
+		},
+		"The Envoy service's ports are derived from the Gateway's listeners (http & https)": {
+			gatewayClass: reconcilableGatewayClass("gatewayclass-1", controller),
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: "gatewayclass-1",
+					Listeners: []gatewayv1alpha2.Listener{
+						{
+							Name:     "listener-1",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     82,
+						},
+						{
+							Name:     "listener-2",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     82,
+							Hostname: gatewayapi.ListenerHostname("foo.bar"),
+						},
+						// listener-3's port will be ignored because it's different than the previous HTTP listeners'
+						{
+							Name:     "listener-3",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     80,
+						},
+						// listener-4 will be ignored because it's an unsupported protocol
+						{
+							Name:     "listener-4",
+							Protocol: gatewayv1alpha2.TCPProtocolType,
+							Port:     83,
+						},
+						{
+							Name:     "listener-5",
+							Protocol: gatewayv1alpha2.HTTPSProtocolType,
+							Port:     8443,
+						},
+						{
+							Name:     "listener-6",
+							Protocol: gatewayv1alpha2.TLSProtocolType,
+							Port:     8443,
+							Hostname: gatewayapi.ListenerHostname("foo.bar"),
+						},
+						// listener-7's port will be ignored because it's different than the previous HTTPS/TLS listeners'
+						{
+							Name:     "listener-7",
+							Protocol: gatewayv1alpha2.HTTPSProtocolType,
+							Port:     8444,
+							Hostname: gatewayapi.ListenerHostname("foo.baz"),
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+				// Get the expected Envoy service from the client.
+				envoyService := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: gw.Namespace,
+						Name:      "envoy-" + gw.Name,
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(envoyService), envoyService))
+
+				require.Len(t, envoyService.Spec.Ports, 2)
+				assert.Contains(t, envoyService.Spec.Ports, corev1.ServicePort{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       82,
+					TargetPort: intstr.IntOrString{IntVal: 8080},
+				})
+				assert.Contains(t, envoyService.Spec.Ports, corev1.ServicePort{
+					Name:       "https",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8443,
+					TargetPort: intstr.IntOrString{IntVal: 8443},
+				})
+			},
+		},
+		"The Envoy service's ports are derived from the Gateway's listeners (http only)": {
+			gatewayClass: reconcilableGatewayClass("gatewayclass-1", controller),
+			gateway: &gatewayv1alpha2.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway-1",
+				},
+				Spec: gatewayv1alpha2.GatewaySpec{
+					GatewayClassName: "gatewayclass-1",
+					Listeners: []gatewayv1alpha2.Listener{
+						{
+							Name:     "listener-1",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     82,
+						},
+						{
+							Name:     "listener-2",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     82,
+							Hostname: gatewayapi.ListenerHostname("foo.bar"),
+						},
+						// listener-3's port will be ignored because it's different than the previous HTTP listeners'
+						{
+							Name:     "listener-3",
+							Protocol: gatewayv1alpha2.HTTPProtocolType,
+							Port:     80,
+						},
+						// listener-4 will be ignored because it's an unsupported protocol
+						{
+							Name:     "listener-4",
+							Protocol: gatewayv1alpha2.TCPProtocolType,
+							Port:     83,
+						},
+					},
+				},
+			},
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1alpha2.Gateway, reconcileErr error) {
+				require.NoError(t, reconcileErr)
+				// Get the expected Envoy service from the client.
+				envoyService := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: gw.Namespace,
+						Name:      "envoy-" + gw.Name,
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(envoyService), envoyService))
+
+				require.Len(t, envoyService.Spec.Ports, 1)
+				assert.Contains(t, envoyService.Spec.Ports, corev1.ServicePort{
+					Name:       "http",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       82,
+					TargetPort: intstr.IntOrString{IntVal: 8080},
+				})
 			},
 		},
 	}

--- a/internal/provisioner/equality/equality_test.go
+++ b/internal/provisioner/equality/equality_test.go
@@ -475,6 +475,16 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			cntr.Spec.NetworkPublishing.Envoy.LoadBalancer.ProviderParameters.Type = model.GCPLoadBalancerProvider
 			cntr.Spec.NetworkPublishing.Envoy.LoadBalancer.ProviderParameters.GCP.Address = &loadBalancerIP
 		}
+		cntr.Spec.NetworkPublishing.Envoy.ServicePorts = []model.ServicePort{
+			{
+				Name:       "http",
+				PortNumber: service.EnvoyServiceHTTPPort,
+			},
+			{
+				Name:       "https",
+				PortNumber: service.EnvoyServiceHTTPPort,
+			},
+		}
 		cntr.Spec.NetworkPublishing.Envoy.ContainerPorts = []model.ContainerPort{
 			{
 				Name:       "http",

--- a/internal/provisioner/objects/service/service_test.go
+++ b/internal/provisioner/objects/service/service_test.go
@@ -161,6 +161,17 @@ func TestDesiredEnvoyService(t *testing.T) {
 		NodePorts:   model.MakeNodePorts(map[string]int{"http": 30081, "https": 30444}),
 	}
 	cntr := model.New(cfg)
+	cntr.Spec.NetworkPublishing.Envoy.ServicePorts = []model.ServicePort{
+		{
+			Name:       "http",
+			PortNumber: EnvoyServiceHTTPPort,
+		},
+		{
+			Name:       "https",
+			PortNumber: EnvoyServiceHTTPSPort,
+		},
+	}
+
 	svc := DesiredEnvoyService(cntr)
 	checkServiceHasType(t, svc, corev1.ServiceTypeNodePort)
 	checkServiceHasExternalTrafficPolicy(t, svc, corev1.ServiceExternalTrafficPolicyTypeLocal)


### PR DESCRIPTION
Ensures that there is at most one insecure
port and one secure port across all Gateway
listeners, and that hostnames are unique
within the groups of insecure and secure
listeners, respectively.

Leaving as a draft for now to do some more manual testing + ensure coverage is good, also feel free to poke holes in the model, definitely possible I've misinterpreted something.