### PR TITLE
Revert back to HTTPConnectionManager XFFNumTrustedHops

### DIFF
--- a/changelogs/unreleased/4470-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4470-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Fix improper use of OriginalIPDetectionFilter in HTTPConnectionManager. Reverts back to XffNumTrustedHops setting which was un-deprecated in Envoy 1.20.

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -400,6 +400,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 		connectionShutdownGracePeriod timeout.Setting
 		allowChunkedLength            bool
 		mergeSlashes                  bool
+		xffNumTrustedHops             uint32
 		want                          *envoy_listener_v3.Filter
 	}{
 		"default": {
@@ -1402,6 +1403,106 @@ func TestHTTPConnectionManager(t *testing.T) {
 				},
 			},
 		},
+		"enable XffNumTrustedHops": {
+			routename:         "default/kuard",
+			accesslogger:      FileAccessLogEnvoy("/dev/stdout", "", nil, v1alpha1.LogLevelInfo),
+			xffNumTrustedHops: 1,
+			want: &envoy_listener_v3.Filter{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &envoy_listener_v3.Filter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&http.HttpConnectionManager{
+						StatPrefix: "default/kuard",
+						RouteSpecifier: &http.HttpConnectionManager_Rds{
+							Rds: &http.Rds{
+								RouteConfigName: "default/kuard",
+								ConfigSource: &envoy_core_v3.ConfigSource{
+									ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+									ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
+										ApiConfigSource: &envoy_core_v3.ApiConfigSource{
+											ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+											TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+											GrpcServices: []*envoy_core_v3.GrpcService{{
+												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+														ClusterName: "contour",
+													},
+												},
+											}},
+										},
+									},
+								},
+							},
+						},
+						HttpFilters: []*http.HttpFilter{{
+							Name: "compressor",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: protobuf.MustMarshalAny(&envoy_compressor_v3.Compressor{
+									CompressorLibrary: &envoy_core_v3.TypedExtensionConfig{
+										Name: "gzip",
+										TypedConfig: &any.Any{
+											TypeUrl: HTTPFilterGzip,
+										},
+									},
+									ContentType: compressorContentTypes,
+								}),
+							},
+						}, {
+							Name: "grpcweb",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: &any.Any{
+									TypeUrl: HTTPFilterGrpcWeb,
+								},
+							},
+						}, {
+							Name: "cors",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: &any.Any{
+									TypeUrl: HTTPFilterCORS,
+								},
+							},
+						}, {
+							Name: "local_ratelimit",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: protobuf.MustMarshalAny(
+									&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
+										StatPrefix: "http",
+									},
+								),
+							},
+						}, {
+							Name: "envoy.filters.http.lua",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: protobuf.MustMarshalAny(&lua.Lua{
+									InlineCode: "-- Placeholder for per-Route or per-Cluster overrides.",
+								}),
+							},
+						}, {
+							Name: "router",
+							ConfigType: &http.HttpFilter_TypedConfig{
+								TypedConfig: &any.Any{
+									TypeUrl: HTTPFilterRouter,
+								},
+							},
+						}},
+						HttpProtocolOptions: &envoy_core_v3.Http1ProtocolOptions{
+							// Enable support for HTTP/1.0 requests that carry
+							// a Host: header. See #537.
+							AcceptHttp_10: true,
+						},
+						CommonHttpProtocolOptions: &envoy_core_v3.HttpProtocolOptions{},
+						AccessLog:                 FileAccessLogEnvoy("/dev/stdout", "", nil, v1alpha1.LogLevelInfo),
+						UseRemoteAddress:          protobuf.Bool(true),
+						NormalizePath:             protobuf.Bool(true),
+						StripPortMode: &http.HttpConnectionManager_StripAnyHostPort{
+							StripAnyHostPort: true,
+						},
+						PreserveExternalRequestId: true,
+						MergeSlashes:              false,
+						XffNumTrustedHops:         uint32(1),
+					}),
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -1417,6 +1518,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 				ConnectionShutdownGracePeriod(tc.connectionShutdownGracePeriod).
 				AllowChunkedLength(tc.allowChunkedLength).
 				MergeSlashes(tc.mergeSlashes).
+				NumTrustedHops(tc.xffNumTrustedHops).
 				DefaultFilters().
 				Get()
 

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -1283,8 +1283,8 @@ func TestHTTPProxyXffNumTrustedHops(t *testing.T) {
 		MetricsPrefix("ingress_http").
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
 		RequestTimeout(timeout.DurationSetting(0)).
+		NumTrustedHops(1).
 		DefaultFilters().
-		AddFilter(envoy_v3.OriginalIPDetectionFilter(1)).
 		Get())
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -387,7 +387,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					ConnectionShutdownGracePeriod(cfg.Timeouts.ConnectionShutdownGracePeriod).
 					AllowChunkedLength(cfg.AllowChunkedLength).
 					MergeSlashes(cfg.MergeSlashes).
-					AddFilter(envoy_v3.OriginalIPDetectionFilter(cfg.XffNumTrustedHops)).
+					NumTrustedHops(cfg.XffNumTrustedHops).
 					AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 					Get()
 
@@ -439,7 +439,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					ConnectionShutdownGracePeriod(cfg.Timeouts.ConnectionShutdownGracePeriod).
 					AllowChunkedLength(cfg.AllowChunkedLength).
 					MergeSlashes(cfg.MergeSlashes).
-					AddFilter(envoy_v3.OriginalIPDetectionFilter(cfg.XffNumTrustedHops)).
+					NumTrustedHops(cfg.XffNumTrustedHops).
 					AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 					Get()
 
@@ -504,7 +504,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					ConnectionShutdownGracePeriod(cfg.Timeouts.ConnectionShutdownGracePeriod).
 					AllowChunkedLength(cfg.AllowChunkedLength).
 					MergeSlashes(cfg.MergeSlashes).
-					AddFilter(envoy_v3.OriginalIPDetectionFilter(cfg.XffNumTrustedHops)).
+					NumTrustedHops(cfg.XffNumTrustedHops).
 					AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 					Get()
 

--- a/internal/xdscache/v3/listener_test.go
+++ b/internal/xdscache/v3/listener_test.go
@@ -2678,7 +2678,7 @@ func TestListenerVisit(t *testing.T) {
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
-						AddFilter(envoy_v3.OriginalIPDetectionFilter(1)).
+						NumTrustedHops(1).
 						Get(),
 				),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),


### PR DESCRIPTION
OriginalIPDetectionFilter is not compatible with the UseRemoteAddress
field, revert to the previous implementation which was un-deprecated in
Envoy 1.20.

See: https://github.com/envoyproxy/envoy/issues/17554 and https://github.com/projectcontour/contour/issues/4449

Reverts part of https://github.com/projectcontour/contour/pull/4142