### PR TITLE
update default controller name to projectcontour.io/gateway-controller

### DIFF
--- a/changelogs/unreleased/4474-skriss-small.md
+++ b/changelogs/unreleased/4474-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway provisioner: change default controller name to `projectcontour.io/gateway-controller`.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -37,7 +37,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",
-		gatewayControllerName: "projectcontour.io/gateway-provisioner",
+		gatewayControllerName: "projectcontour.io/gateway-controller",
 	}
 
 	cmd.Flag("contour-image", "The container image used for the managed Contour.").

--- a/design/automated-provisioning-design.md
+++ b/design/automated-provisioning-design.md
@@ -51,7 +51,7 @@ This also allows the Contour team to focus on implementing *one* standardized pr
 We believe this is a more effective use of our efforts.
 
 The Gateway provisioner will run as a Deployment in-cluster.
-It will watch for GatewayClasses that have a `spec.controller` value matching what the Gateway provisioner has been configured with (e.g. `projectcontour.io/gateway-provisioner`).
+It will watch for GatewayClasses that have a `spec.controller` value matching what the Gateway provisioner has been configured with (e.g. `projectcontour.io/gateway-controller`).
 It will set the `Accepted: true` condition on these GatewayClasses, if their `spec.parametersRef` is valid (more on GatewayClass parameters below).
 
 It will also watch for Gateways that use a GatewayClass controlled by it.

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestGatewayReconcile(t *testing.T) {
-	const controller = "projectcontour.io/gateway-provisioner"
+	const controller = "projectcontour.io/gateway-controller"
 
 	reconcilableGatewayClass := func(name, controller string) *gatewayv1alpha2.GatewayClass {
 		return &gatewayv1alpha2.GatewayClass{

--- a/internal/provisioner/controller/gatewayclass_test.go
+++ b/internal/provisioner/controller/gatewayclass_test.go
@@ -75,7 +75,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 				},
 			},
 			wantCondition: &metav1.Condition{
@@ -90,7 +90,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
@@ -111,7 +111,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "invalidgroup.io",
 						Kind:      "ContourDeployment",
@@ -138,7 +138,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "InvalidKind",
@@ -165,7 +165,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
@@ -192,7 +192,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
@@ -219,7 +219,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 					Name: "gatewayclass-1",
 				},
 				Spec: gatewayv1alpha2.GatewayClassSpec{
-					ControllerName: "projectcontour.io/gateway-provisioner",
+					ControllerName: "projectcontour.io/gateway-controller",
 					ParametersRef: &gatewayv1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
@@ -256,7 +256,7 @@ func TestGatewayClassReconcile(t *testing.T) {
 			}
 
 			r := &gatewayClassReconciler{
-				gatewayController: "projectcontour.io/gateway-provisioner",
+				gatewayController: "projectcontour.io/gateway-controller",
 				client:            client.Build(),
 				log:               logr.Discard(),
 			}

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 			Name: "contour",
 		},
 		Spec: gatewayapi_v1alpha2.GatewayClassSpec{
-			ControllerName: gatewayapi_v1alpha2.GatewayController("projectcontour.io/gateway-provisioner"),
+			ControllerName: gatewayapi_v1alpha2.GatewayController("projectcontour.io/gateway-controller"),
 		},
 	}
 
@@ -242,7 +242,7 @@ var _ = Describe("Gateway provisioner", func() {
 					Name: "contour-with-params",
 				},
 				Spec: gatewayapi_v1alpha2.GatewayClassSpec{
-					ControllerName: gatewayapi_v1alpha2.GatewayController("projectcontour.io/gateway-provisioner"),
+					ControllerName: gatewayapi_v1alpha2.GatewayController("projectcontour.io/gateway-controller"),
 					ParametersRef: &gatewayapi_v1alpha2.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -37,7 +37,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 metadata:
   name: contour
 spec:
-  controllerName: projectcontour.io/gateway-provisioner
+  controllerName: projectcontour.io/gateway-controller
 EOF
 
 cd $(mktemp -d)


### PR DESCRIPTION
This more general controller name makes sense
given that the provisioner is just one piece
of Gateway control logic; the xDS server also
plays a major role.

Signed-off-by: Steve Kriss <krisss@vmware.com>