### PR TITLE
Use non-deprecated Content-Type field in compressor filter

### DIFF
--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -246,15 +246,19 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 							TypeUrl: HTTPFilterGzip,
 						},
 					},
-					ContentType: []string{
-						// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
-						"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
-						"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
-						"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
-						"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
-						// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
-						"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
-						"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
+					ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+						CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+							ContentType: []string{
+								// Default content-types https://github.com/envoyproxy/envoy/blob/e74999dbdb12aa4d6b7a5d62d51731ea86bf72be/source/extensions/filters/http/compressor/compressor_filter.cc#L35-L38
+								"text/html", "text/plain", "text/css", "application/javascript", "application/x-javascript",
+								"text/javascript", "text/x-javascript", "text/ecmascript", "text/js", "text/jscript",
+								"text/x-js", "application/ecmascript", "application/x-json", "application/xml",
+								"application/json", "image/svg+xml", "text/xml", "application/xhtml+xml",
+								// Additional content-types for grpc-web https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
+								"application/grpc-web", "application/grpc-web+proto", "application/grpc-web+json", "application/grpc-web+thrift",
+								"application/grpc-web-text", "application/grpc-web-text+proto", "application/grpc-web-text+thrift",
+							},
+						},
 					},
 				}),
 			},

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -441,7 +441,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -540,7 +544,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -640,7 +648,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -741,7 +753,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -841,7 +857,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -942,7 +962,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -1041,7 +1065,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -1141,7 +1169,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -1242,7 +1274,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -1343,7 +1379,11 @@ func TestHTTPConnectionManager(t *testing.T) {
 											TypeUrl: HTTPFilterGzip,
 										},
 									},
-									ContentType: compressorContentTypes,
+									ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+										CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+											ContentType: compressorContentTypes,
+										},
+									},
 								}),
 							},
 						}, {
@@ -1793,7 +1833,11 @@ func TestAddFilter(t *testing.T) {
 									TypeUrl: HTTPFilterGzip,
 								},
 							},
-							ContentType: compressorContentTypes,
+							ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+								CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+									ContentType: compressorContentTypes,
+								},
+							},
 						}),
 					},
 				},
@@ -1861,7 +1905,11 @@ func TestAddFilter(t *testing.T) {
 									TypeUrl: HTTPFilterGzip,
 								},
 							},
-							ContentType: compressorContentTypes,
+							ResponseDirectionConfig: &envoy_compressor_v3.Compressor_ResponseDirectionConfig{
+								CommonConfig: &envoy_compressor_v3.Compressor_CommonDirectionConfig{
+									ContentType: compressorContentTypes,
+								},
+							},
 						}),
 					},
 				},


### PR DESCRIPTION
Follow up to https://github.com/projectcontour/contour/pull/4403 which
started using a deprecated field

Signed-off-by: Sunjay Bhatia <sunjayb@vmware.com>