### PR TITLE
example-workload/httpproxy: Add missing README.md

### DIFF
--- a/examples/example-workload/httpproxy/README.md
+++ b/examples/example-workload/httpproxy/README.md
@@ -1,0 +1,5 @@
+# HTTPProxy
+
+This directory contains example code for run contour with HTTPProxy.
+
+Most subdirectories contain a (complete) set of Kubernetes YAML that can be applied to a cluster.


### PR DESCRIPTION
Add missing README.md for example-workload/httpproxy to fix broken link
Signed-off-by: Gang Liu <gang.liu@daocloud.io>