### PR TITLE
internal/dag: use RefNotPermitted reason when applicable

### DIFF
--- a/changelogs/unreleased/4482-skriss-small.md
+++ b/changelogs/unreleased/4482-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: when an `HTTPRoute` or `TLSRoute` has a cross-namespace backend ref that's not permitted by a `ReferencePolicy`, set the reason for the `ResolvedRefs: false` condition to `RefNotPermitted` instead of `Degraded`.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3537,7 +3537,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
-					Reason:  string(status.ReasonDegraded),
+					Reason:  string(gatewayapi_v1alpha2.ListenerReasonRefNotPermitted),
 					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy",
 				},
 				gatewayapi_v1alpha2.ConditionRouteAccepted: {


### PR DESCRIPTION
When an HTTPRoute or TLSRoute has a cross-namespace
backend ref that's not permitted by a ReferencePolicy,
use the RefNotPermitted condition reason.

Closes #4479.

Signed-off-by: Steve Kriss <krisss@vmware.com>

ref. https://github.com/kubernetes-sigs/gateway-api/pull/1081#discussion_r851537809