### PR TITLE
remove all ContourDeployment CRD kubebuilder defaults

### DIFF
--- a/apis/projectcontour/v1alpha1/contourdeployment.go
+++ b/apis/projectcontour/v1alpha1/contourdeployment.go
@@ -52,7 +52,6 @@ type ContourSettings struct {
 	// Replicas is the desired number of Contour replicas. If unset,
 	// defaults to 2.
 	//
-	// +kubebuilder:default=2
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas,omitempty"`
 
@@ -66,9 +65,9 @@ type ContourSettings struct {
 // i.e. the xDS client/data plane and associated resources.
 type EnvoySettings struct {
 	// WorkloadType is the type of workload to install Envoy
-	// as. Choices are DaemonSet and Deployment.
+	// as. Choices are DaemonSet and Deployment. If unset, defaults
+	// to DaemonSet.
 	//
-	// +kubebuilder:default=Deployment
 	// +optional
 	WorkloadType WorkloadType `json:"workloadType,omitempty"`
 
@@ -76,7 +75,6 @@ type EnvoySettings struct {
 	// is not "Deployment", this field is ignored. Otherwise, if unset,
 	// defaults to 2.
 	//
-	// +kubebuilder:default=2
 	// +kubebuilder:validation:Minimum=0
 	Replicas int32 `json:"replicas,omitempty"`
 
@@ -92,8 +90,6 @@ type EnvoySettings struct {
 }
 
 // WorkloadType is the type of Kubernetes workload to use for a component.
-//
-// +kubebuilder:validation:Enum=DaemonSet;Deployment
 type WorkloadType string
 
 const (
@@ -134,7 +130,8 @@ type NetworkPublishing struct {
 	//
 	// See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 	//
-	// +kubebuilder:default=LoadBalancerService
+	// If unset, defaults to LoadBalancerService.
+	//
 	// +optional
 	Type NetworkPublishingType `json:"type,omitempty"`
 
@@ -146,8 +143,6 @@ type NetworkPublishing struct {
 }
 
 // NetworkPublishingType is a way to publish network endpoints.
-//
-// +kubebuilder:validation:Enum=LoadBalancerService;NodePortService;ClusterIPService
 type NetworkPublishingType string
 
 const (

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -952,7 +952,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Contour replicas.
                       If unset, defaults to 2.
                     format: int32
@@ -977,7 +976,6 @@ spec:
                           to the provisioned Envoy service.
                         type: object
                       type:
-                        default: LoadBalancerService
                         description: "NetworkPublishingType is the type of publishing
                           strategy to use. Valid values are: \n * LoadBalancerService
                           \n In this configuration, network endpoints for Envoy use
@@ -992,11 +990,8 @@ spec:
                           using a Kubernetes ClusterIP Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           ClusterIP Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
-                        enum:
-                        - LoadBalancerService
-                        - NodePortService
-                        - ClusterIPService
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
                         type: string
                     type: object
                   nodePlacement:
@@ -1062,7 +1057,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Envoy replicas.
                       If WorkloadType is not "Deployment", this field is ignored.
                       Otherwise, if unset, defaults to 2.
@@ -1070,12 +1064,9 @@ spec:
                     minimum: 0
                     type: integer
                   workloadType:
-                    default: Deployment
                     description: WorkloadType is the type of workload to install Envoy
-                      as. Choices are DaemonSet and Deployment.
-                    enum:
-                    - DaemonSet
-                    - Deployment
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
                     type: string
                 type: object
               runtimeSettings:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1148,7 +1148,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Contour replicas.
                       If unset, defaults to 2.
                     format: int32
@@ -1173,7 +1172,6 @@ spec:
                           to the provisioned Envoy service.
                         type: object
                       type:
-                        default: LoadBalancerService
                         description: "NetworkPublishingType is the type of publishing
                           strategy to use. Valid values are: \n * LoadBalancerService
                           \n In this configuration, network endpoints for Envoy use
@@ -1188,11 +1186,8 @@ spec:
                           using a Kubernetes ClusterIP Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           ClusterIP Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
-                        enum:
-                        - LoadBalancerService
-                        - NodePortService
-                        - ClusterIPService
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
                         type: string
                     type: object
                   nodePlacement:
@@ -1258,7 +1253,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Envoy replicas.
                       If WorkloadType is not "Deployment", this field is ignored.
                       Otherwise, if unset, defaults to 2.
@@ -1266,12 +1260,9 @@ spec:
                     minimum: 0
                     type: integer
                   workloadType:
-                    default: Deployment
                     description: WorkloadType is the type of workload to install Envoy
-                      as. Choices are DaemonSet and Deployment.
-                    enum:
-                    - DaemonSet
-                    - Deployment
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
                     type: string
                 type: object
               runtimeSettings:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -963,7 +963,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Contour replicas.
                       If unset, defaults to 2.
                     format: int32
@@ -988,7 +987,6 @@ spec:
                           to the provisioned Envoy service.
                         type: object
                       type:
-                        default: LoadBalancerService
                         description: "NetworkPublishingType is the type of publishing
                           strategy to use. Valid values are: \n * LoadBalancerService
                           \n In this configuration, network endpoints for Envoy use
@@ -1003,11 +1001,8 @@ spec:
                           using a Kubernetes ClusterIP Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           ClusterIP Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
-                        enum:
-                        - LoadBalancerService
-                        - NodePortService
-                        - ClusterIPService
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
                         type: string
                     type: object
                   nodePlacement:
@@ -1073,7 +1068,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Envoy replicas.
                       If WorkloadType is not "Deployment", this field is ignored.
                       Otherwise, if unset, defaults to 2.
@@ -1081,12 +1075,9 @@ spec:
                     minimum: 0
                     type: integer
                   workloadType:
-                    default: Deployment
                     description: WorkloadType is the type of workload to install Envoy
-                      as. Choices are DaemonSet and Deployment.
-                    enum:
-                    - DaemonSet
-                    - Deployment
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
                     type: string
                 type: object
               runtimeSettings:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1151,7 +1151,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Contour replicas.
                       If unset, defaults to 2.
                     format: int32
@@ -1176,7 +1175,6 @@ spec:
                           to the provisioned Envoy service.
                         type: object
                       type:
-                        default: LoadBalancerService
                         description: "NetworkPublishingType is the type of publishing
                           strategy to use. Valid values are: \n * LoadBalancerService
                           \n In this configuration, network endpoints for Envoy use
@@ -1191,11 +1189,8 @@ spec:
                           using a Kubernetes ClusterIP Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           ClusterIP Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
-                        enum:
-                        - LoadBalancerService
-                        - NodePortService
-                        - ClusterIPService
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
                         type: string
                     type: object
                   nodePlacement:
@@ -1261,7 +1256,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Envoy replicas.
                       If WorkloadType is not "Deployment", this field is ignored.
                       Otherwise, if unset, defaults to 2.
@@ -1269,12 +1263,9 @@ spec:
                     minimum: 0
                     type: integer
                   workloadType:
-                    default: Deployment
                     description: WorkloadType is the type of workload to install Envoy
-                      as. Choices are DaemonSet and Deployment.
-                    enum:
-                    - DaemonSet
-                    - Deployment
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
                     type: string
                 type: object
               runtimeSettings:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1148,7 +1148,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Contour replicas.
                       If unset, defaults to 2.
                     format: int32
@@ -1173,7 +1172,6 @@ spec:
                           to the provisioned Envoy service.
                         type: object
                       type:
-                        default: LoadBalancerService
                         description: "NetworkPublishingType is the type of publishing
                           strategy to use. Valid values are: \n * LoadBalancerService
                           \n In this configuration, network endpoints for Envoy use
@@ -1188,11 +1186,8 @@ spec:
                           using a Kubernetes ClusterIP Service. \n In this configuration,
                           Envoy network endpoints use container networking. A Kubernetes
                           ClusterIP Service is created to publish the network endpoints.
-                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types"
-                        enum:
-                        - LoadBalancerService
-                        - NodePortService
-                        - ClusterIPService
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
                         type: string
                     type: object
                   nodePlacement:
@@ -1258,7 +1253,6 @@ spec:
                         type: array
                     type: object
                   replicas:
-                    default: 2
                     description: Replicas is the desired number of Envoy replicas.
                       If WorkloadType is not "Deployment", this field is ignored.
                       Otherwise, if unset, defaults to 2.
@@ -1266,12 +1260,9 @@ spec:
                     minimum: 0
                     type: integer
                   workloadType:
-                    default: Deployment
                     description: WorkloadType is the type of workload to install Envoy
-                      as. Choices are DaemonSet and Deployment.
-                    enum:
-                    - DaemonSet
-                    - Deployment
+                      as. Choices are DaemonSet and Deployment. If unset, defaults
+                      to DaemonSet.
                     type: string
                 type: object
               runtimeSettings:

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -236,7 +236,9 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		if gatewayClassParams.Spec.Contour != nil {
 			// Deployment replicas
-			contourModel.Spec.ContourReplicas = gatewayClassParams.Spec.Contour.Replicas
+			if gatewayClassParams.Spec.Contour.Replicas > 0 {
+				contourModel.Spec.ContourReplicas = gatewayClassParams.Spec.Contour.Replicas
+			}
 
 			// Node placement
 			if nodePlacement := gatewayClassParams.Spec.Contour.NodePlacement; nodePlacement != nil {
@@ -260,7 +262,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			// Deployment replicas
-			if gatewayClassParams.Spec.Envoy.WorkloadType == contour_api_v1alpha1.WorkloadTypeDeployment {
+			if gatewayClassParams.Spec.Envoy.WorkloadType == contour_api_v1alpha1.WorkloadTypeDeployment &&
+				gatewayClassParams.Spec.Envoy.Replicas > 0 {
 				contourModel.Spec.EnvoyReplicas = gatewayClassParams.Spec.Envoy.Replicas
 			}
 

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -5230,7 +5230,8 @@ WorkloadType
 <td>
 <em>(Optional)</em>
 <p>WorkloadType is the type of workload to install Envoy
-as. Choices are DaemonSet and Deployment.</p>
+as. Choices are DaemonSet and Deployment. If unset, defaults
+to DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -6099,6 +6100,7 @@ NodePort Service is created to publish the network endpoints.</p>
 <p>In this configuration, Envoy network endpoints use container networking. A Kubernetes
 ClusterIP Service is created to publish the network endpoints.</p>
 <p>See: <a href="https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types">https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types</a></p>
+<p>If unset, defaults to LoadBalancerService.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Removes kubebuilder defaults from the ContourDeployment
CRD; defaults are applied internally by the provisioner.

Closes https://github.com/projectcontour/contour/issues/4471.

Signed-off-by: Steve Kriss <krisss@vmware.com>