### PR TITLE
cmd/contour: Add support for json log formatter

### DIFF
--- a/changelogs/unreleased/4486-tsaarni-small.md
+++ b/changelogs/unreleased/4486-tsaarni-small.md
@@ -1,0 +1,1 @@
+Add support for Contour to produce logs in JSON format by specifying `--log-format=json` command line switch.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -32,6 +32,9 @@ func main() {
 	app := kingpin.New("contour", "Contour Kubernetes ingress controller.")
 	app.HelpFlag.Short('h')
 
+	// Log-format applies to log format of all sub-commands.
+	logFormat := app.Flag("log-format", "Log output format for Contour. Either text or json.").Default("text").Enum("text", "json")
+
 	envoyCmd := app.Command("envoy", "Sub-command for envoy actions.")
 	sdm, shutdownManagerCtx := registerShutdownManager(envoyCmd, log)
 
@@ -67,7 +70,16 @@ func main() {
 	gatewayProvisioner, gatewayProvisionerConfig := registerGatewayProvisioner(app)
 
 	args := os.Args[1:]
-	switch kingpin.MustParse(app.Parse(args)) {
+	cmd := kingpin.MustParse(app.Parse(args))
+
+	switch *logFormat {
+	case "text":
+		log.SetFormatter(&logrus.TextFormatter{})
+	case "json":
+		log.SetFormatter(&logrus.JSONFormatter{})
+	}
+
+	switch cmd {
 	case gatewayProvisioner.FullCommand():
 		runGatewayProvisioner(gatewayProvisionerConfig)
 	case sdm.FullCommand():

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -57,6 +57,7 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | `--leader-election-resource-namespace`                   | The namespace of the resource (Lease) leader election will lease.      |
 | `-d, --debug`                                            | Enable debug logging                                                   |
 | `--kubernetes-debug=<log level>`                         | Enable Kubernetes client debug logging                                 |
+| `--log-format=<text|json>`                               | Log output format for Contour. Either text (default) or json.          |
 
 ## Configuration File
 
@@ -446,6 +447,7 @@ connects to Contour:
 | <nobr>--namespace</nobr>               | projectcontour    | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the bootstrap configuration file. |
 | <nobr>--xds-resource-version</nobr>    | v3                | Currently, the only valid xDS API resource version is `v3`.                                                                                                                                                  |
 | <nobr>--dns-lookup-family</nobr>       | auto              | Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6 or auto.                                                                                                   |
+| <nobr>--log-format                     | text              | Log output format for Contour. Either text or json. |
 
 
 [1]: {{< param github_url>}}/tree/{{< param version >}}/examples/contour/01-contour-config.yaml


### PR DESCRIPTION
This change enables Contour logs in JSON format as discussed in https://github.com/projectcontour/contour/issues/4414#issuecomment-1087109701.

The PR proposes new command line argument `--log-format` over generally preferred configuration CRD or config file field. The reasoning for new command line argument is to allow setting formatter for all sub-commands, not only `serve`, and setting it as early as possible, before CR is fetched from the API server or before config file is read from filesystem.

Fixes #4414 

Signed-off-by: Tero Saarni <tero.saarni@est.tech>