### PR TITLE
Markdown Typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.21.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.22.0
 GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4488-skriss-small.md
+++ b/changelogs/unreleased/4488-skriss-small.md
@@ -1,0 +1,1 @@
+Updates to Envoy 1.22.0. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current) for more information.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -33,7 +33,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	config := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.21.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.22.0",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/design/session-affinity.md
+++ b/design/session-affinity.md
@@ -97,8 +97,8 @@ Statistically requests without a session cookie will eventually land on service-
 Session affinity is based on the premise that the backend servers are robust, do not change ordering, or grow and shrink according to load.
 None of these properties are guaranteed by a Kubernetes cluster and will be visible to applications that rely heavily on session affinity.
 
-Any pertibation in the set of pods backing a service risks redistributing backends around the hash ring.
-This is an unavoidable consiquence of Envoy's session affinity implementation and the pods-as-cattle approach of Kubernetes.
+Any perturbation in the set of pods backing a service risks redistributing backends around the hash ring.
+This is an unavoidable consequence of Envoy's session affinity implementation and the pods-as-cattle approach of Kubernetes.
 
 ## Detailed Design
 
@@ -139,7 +139,7 @@ See the following section on bootstrapping for more information.
 This seems reasonable as the fragility with session affinity means there is little value in persisting this cookie for days or weeks -- it does not represent a login token -- only a handle to in memory state on the target backend.
 Further, there is no reasonable `Expires` value as none are correct;
 If the cookie expires too shortly then sessions will be abruptly lost.
-If the cookie's expiry is too long then we risk imbalancing the backend as sessions will be naturally attracted to the longest living server in the group.
+If the cookie's expiry is too long then we risk unbalancing the backend as sessions will be naturally attracted to the longest living server in the group.
 Making this value configurable simply pushes this insoluble problem to our users. 
 - Path: `/`.
 The cookie applies to all routes on this virtual host in the hope that other `strategy: Cookie` backends, assuming they dispatch to the same set of servers will share the same affinity cookie.

--- a/design/tls-backend-verification.md
+++ b/design/tls-backend-verification.md
@@ -70,7 +70,7 @@ The store of CA information is an opaque kubernetes secret.
 The secret will be stored in the same namespace as the corresponding IngressRoute.
 TLS certificate delegation is not in scope for this proposal.
 
-The secret object should contain one entry named `ca.key`, the constents will be the CA public key material.
+The secret object should contain one entry named `ca.key`, the contents will be the CA public key material.
 
 Example:
 ```
@@ -125,7 +125,7 @@ An alternative to storing CA information in Secrets is to store it in ConfigMaps
 This was rejected for two reasons
 
 1. Contour already watches Secret objects, so we get this for free without having to watch a new set of objects.
-2. Using ConfigMaps creates a precident for storing other information in ConfigMaps. As ConfigMaps are just homeless annotations, their potential for misuse is endless.
+2. Using ConfigMaps creates a precedent for storing other information in ConfigMaps. As ConfigMaps are just homeless annotations, their potential for misuse is endless.
 
 ## Security Considerations
 

--- a/design/tls-certificate-delegation.md
+++ b/design/tls-certificate-delegation.md
@@ -76,7 +76,7 @@ If the appropriate secret delegation is in place Contour will use the fully qual
 
 Alternative designs that extended the IngressRoute specification to allow referencing Secrets by name _and_ namespace were rejected because there was no way to effectively prevent anyone with the permission to construct an IngressRoute object in their own namespace from utilizing the TLS certificate from another namespace.
 While it would not be possible for the author to read the contents of the other namespace's secret--only Contour would have that permission--this would allow an attacker to present a certificate from a namespace they do not have permission to read as their own.
-In the case of a wildcard certificate this is benficial--it's actually what we want--but also opens up the possibility, when combined with DNS spoofing, of presenting an alternate site using the _real_ SSL certificate, leading to cookie hijacking and MITM attacks.
+In the case of a wildcard certificate this is beneficial--it's actually what we want--but also opens up the possibility, when combined with DNS spoofing, of presenting an alternate site using the _real_ SSL certificate, leading to cookie hijacking and MITM attacks.
 	
 ## Security Considerations
 

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.1
+        image: docker.io/envoyproxy/envoy:v1.22.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.21.1
+          image: docker.io/envoyproxy/envoy:v1.22.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5140,7 +5140,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.21.1
+          image: docker.io/envoyproxy/envoy:v1.22.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5130,7 +5130,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.1
+        image: docker.io/envoyproxy/envoy:v1.22.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5127,7 +5127,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.21.1
+        image: docker.io/envoyproxy/envoy:v1.22.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.21.1][15]         | 1.23, 1.22, 1.21    | [main][50]       | v1alpha2            |
+| main            | [1.22.0][16]         | 1.23, 1.22, 1.21    | [main][50]       | v1alpha2            |
 | 1.20.1          | [1.21.1][15]         | 1.23, 1.22, 1.21    | [1.20.1][68]     | v1alpha2            |
 | 1.20.0          | [1.21.0][14]         | 1.23, 1.22, 1.21    | [1.20.0][67]     | v1alpha2            |
 | 1.19.1          | [1.19.1][13]         | 1.22, 1.21, 1.20    | [1.19.1][65]     | v1alpha1            |
@@ -111,6 +111,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [13]: https://www.envoyproxy.io/docs/envoy/v1.19.1/version_history/current
 [14]: https://www.envoyproxy.io/docs/envoy/v1.21.0/version_history/current
 [15]: https://www.envoyproxy.io/docs/envoy/v1.21.1/version_history/current
+[15]: https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.21.1"
+      envoy: "1.22.0"
       kubernetes:
         - "1.23"
         - "1.22"


### PR DESCRIPTION
Landed on the session affinity page from a google search and spotted a few typos in the markdown.