### PR TITLE
Markdown Typos

### DIFF
--- a/design/session-affinity.md
+++ b/design/session-affinity.md
@@ -97,8 +97,8 @@ Statistically requests without a session cookie will eventually land on service-
 Session affinity is based on the premise that the backend servers are robust, do not change ordering, or grow and shrink according to load.
 None of these properties are guaranteed by a Kubernetes cluster and will be visible to applications that rely heavily on session affinity.
 
-Any pertibation in the set of pods backing a service risks redistributing backends around the hash ring.
-This is an unavoidable consiquence of Envoy's session affinity implementation and the pods-as-cattle approach of Kubernetes.
+Any perturbation in the set of pods backing a service risks redistributing backends around the hash ring.
+This is an unavoidable consequence of Envoy's session affinity implementation and the pods-as-cattle approach of Kubernetes.
 
 ## Detailed Design
 
@@ -139,7 +139,7 @@ See the following section on bootstrapping for more information.
 This seems reasonable as the fragility with session affinity means there is little value in persisting this cookie for days or weeks -- it does not represent a login token -- only a handle to in memory state on the target backend.
 Further, there is no reasonable `Expires` value as none are correct;
 If the cookie expires too shortly then sessions will be abruptly lost.
-If the cookie's expiry is too long then we risk imbalancing the backend as sessions will be naturally attracted to the longest living server in the group.
+If the cookie's expiry is too long then we risk unbalancing the backend as sessions will be naturally attracted to the longest living server in the group.
 Making this value configurable simply pushes this insoluble problem to our users. 
 - Path: `/`.
 The cookie applies to all routes on this virtual host in the hope that other `strategy: Cookie` backends, assuming they dispatch to the same set of servers will share the same affinity cookie.

--- a/design/tls-backend-verification.md
+++ b/design/tls-backend-verification.md
@@ -70,7 +70,7 @@ The store of CA information is an opaque kubernetes secret.
 The secret will be stored in the same namespace as the corresponding IngressRoute.
 TLS certificate delegation is not in scope for this proposal.
 
-The secret object should contain one entry named `ca.key`, the constents will be the CA public key material.
+The secret object should contain one entry named `ca.key`, the contents will be the CA public key material.
 
 Example:
 ```
@@ -125,7 +125,7 @@ An alternative to storing CA information in Secrets is to store it in ConfigMaps
 This was rejected for two reasons
 
 1. Contour already watches Secret objects, so we get this for free without having to watch a new set of objects.
-2. Using ConfigMaps creates a precident for storing other information in ConfigMaps. As ConfigMaps are just homeless annotations, their potential for misuse is endless.
+2. Using ConfigMaps creates a precedent for storing other information in ConfigMaps. As ConfigMaps are just homeless annotations, their potential for misuse is endless.
 
 ## Security Considerations
 

--- a/design/tls-certificate-delegation.md
+++ b/design/tls-certificate-delegation.md
@@ -76,7 +76,7 @@ If the appropriate secret delegation is in place Contour will use the fully qual
 
 Alternative designs that extended the IngressRoute specification to allow referencing Secrets by name _and_ namespace were rejected because there was no way to effectively prevent anyone with the permission to construct an IngressRoute object in their own namespace from utilizing the TLS certificate from another namespace.
 While it would not be possible for the author to read the contents of the other namespace's secret--only Contour would have that permission--this would allow an attacker to present a certificate from a namespace they do not have permission to read as their own.
-In the case of a wildcard certificate this is benficial--it's actually what we want--but also opens up the possibility, when combined with DNS spoofing, of presenting an alternate site using the _real_ SSL certificate, leading to cookie hijacking and MITM attacks.
+In the case of a wildcard certificate this is beneficial--it's actually what we want--but also opens up the possibility, when combined with DNS spoofing, of presenting an alternate site using the _real_ SSL certificate, leading to cookie hijacking and MITM attacks.
 	
 ## Security Considerations
 

--- a/design/tls-client-verification.md
+++ b/design/tls-client-verification.md
@@ -65,7 +65,7 @@ The same approach shall be followed for configuring trusted CA certificates as i
 The CA certificate is stored in an opaque Kubernetes secret.
 The secret will be stored in the same namespace as the corresponding `HTTPProxy` object.
 The secret object shall contain entry named `ca.crt`.
-The constents shall be the CA certificate in PEM format.
+The contents shall be the CA certificate in PEM format.
 The file may contain "PEM bundle", that is, a list of CA certificates concatenated in single file.
 
 Example:


### PR DESCRIPTION
Landed on the session affinity page from a google search, spotted a few typos in the markdown.

Think I've got VSCode properly doing the -s Signed-off-by now. 😠