### PR TITLE
fix DisableMergeSlashes propagation, add tests

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -448,6 +448,7 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 			Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
 				UseProxyProto:             &ctx.useProxyProto,
 				DisableAllowChunkedLength: &ctx.Config.DisableAllowChunkedLength,
+				DisableMergeSlashes:       &ctx.Config.DisableMergeSlashes,
 				ConnectionBalancer:        ctx.Config.Listener.ConnectionBalancer,
 				TLS: &contour_api_v1alpha1.EnvoyTLS{
 					MinimumProtocolVersion: ctx.Config.TLS.MinimumProtocolVersion,

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -411,6 +411,7 @@ func TestConvertServeContext(t *testing.T) {
 				Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
 					UseProxyProto:             pointer.Bool(false),
 					DisableAllowChunkedLength: pointer.Bool(false),
+					DisableMergeSlashes:       pointer.Bool(false),
 					TLS: &contour_api_v1alpha1.EnvoyTLS{
 						MinimumProtocolVersion: "",
 					},
@@ -674,6 +675,16 @@ func TestConvertServeContext(t *testing.T) {
 						"custom_field",
 					}),
 				}
+				return cfg
+			},
+		},
+		"disable merge slashes": {
+			getServeContext: func(ctx *serveContext) *serveContext {
+				ctx.Config.DisableMergeSlashes = true
+				return ctx
+			},
+			getContourConfiguration: func(cfg contour_api_v1alpha1.ContourConfigurationSpec) contour_api_v1alpha1.ContourConfigurationSpec {
+				cfg.Envoy.Listener.DisableMergeSlashes = pointer.Bool(true)
 				return cfg
 			},
 		},

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -119,7 +119,20 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-pod-restart", testPodRestart)
 
-	f.NamespacedTest("httpproxy-merge-slash", testMergeSlash)
+	Context("disableMergeSlashes option", func() {
+		Context("default value of false", func() {
+			f.NamespacedTest("httpproxy-enable-merge-slashes", testDisableMergeSlashes(false))
+		})
+
+		Context("set to true", func() {
+			BeforeEach(func() {
+				contourConfig.DisableMergeSlashes = true
+				contourConfiguration.Spec.Envoy.Listener.DisableMergeSlashes = pointer.Bool(true)
+			})
+
+			f.NamespacedTest("httpproxy-disable-merge-slashes", testDisableMergeSlashes(true))
+		})
+	})
 
 	f.NamespacedTest("httpproxy-client-cert-auth", testClientCertAuth)
 

--- a/test/e2e/httpproxy/merge_slash_test.go
+++ b/test/e2e/httpproxy/merge_slash_test.go
@@ -20,53 +20,109 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testMergeSlash(namespace string) {
-	Specify("requests with many slashes are merged and matched", func() {
-		t := f.T()
+func testDisableMergeSlashes(disableMergeSlashes bool) e2e.NamespacedTestBody {
+	var testName string
+	if disableMergeSlashes {
+		testName = "when disable merge slashes is true, consecutive slashes in requests are not merged"
+	} else {
+		testName = "when disable merge slashes is false, consecutive slashes in requests are merged"
+	}
+	return func(namespace string) {
+		Specify(testName, func() {
+			t := f.T()
 
-		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
+			f.Fixtures.Echo.Deploy(namespace, "echo-1")
+			f.Fixtures.Echo.Deploy(namespace, "echo-2")
 
-		p := &contourv1.HTTPProxy{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo",
-			},
-			Spec: contourv1.HTTPProxySpec{
-				VirtualHost: &contourv1.VirtualHost{
-					Fqdn: "mergeslash.projectcontour.io",
+			var fqdn string
+			if disableMergeSlashes {
+				fqdn = "disable.mergeslashes.projectcontour.io"
+			} else {
+				fqdn = "enable.mergeslashes.projectcontour.io"
+			}
+
+			p := &contourv1.HTTPProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "echo",
 				},
-				Routes: []contourv1.Route{
-					{
-						Services: []contourv1.Service{
-							{
-								Name: "ingress-conformance-echo",
-								Port: 80,
+				Spec: contourv1.HTTPProxySpec{
+					VirtualHost: &contourv1.VirtualHost{
+						Fqdn: fqdn,
+					},
+					Routes: []contourv1.Route{
+						{
+							Services: []contourv1.Service{
+								{
+									Name: "echo-1",
+									Port: 80,
+								},
+							},
+							Conditions: []contourv1.MatchCondition{
+								{
+									Prefix: "/foo",
+								},
 							},
 						},
-						Conditions: []contourv1.MatchCondition{
-							{
-								Prefix: "/",
+						{
+							Services: []contourv1.Service{
+								{
+									Name: "echo-2",
+									Port: 80,
+								},
+							},
+							Conditions: []contourv1.MatchCondition{
+								{
+									Prefix: "/",
+								},
 							},
 						},
 					},
 				},
-			},
-		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			}
+			_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			require.True(t, ok)
 
-		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
-			Host:      p.Spec.VirtualHost.Fqdn,
-			Path:      "/anything/this//has//lots////of/slashes",
-			Condition: e2e.HasStatusCode(200),
+			var testCases map[string]string
+			if disableMergeSlashes {
+				testCases = map[string]string{
+					"/foo":  "echo-1",
+					"//foo": "echo-2", // since the slashes aren't merged, this request won't match the first route, so will default to the second
+				}
+			} else {
+				testCases = map[string]string{
+					"/foo":  "echo-1",
+					"//foo": "echo-1", // since the slashes *are* merged, this request will match the first route
+				}
+			}
+
+			for path, svc := range testCases {
+				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+					Host: p.Spec.VirtualHost.Fqdn,
+					Path: path,
+					Condition: func(res *e2e.HTTPResponse) bool {
+						if !e2e.HasStatusCode(200)(res) {
+							t.Logf("Got response code %d", res.StatusCode)
+							return false
+						}
+
+						responseBody := f.GetEchoResponseBody(res.Body)
+
+						if responseBody.Service != svc {
+							t.Logf("Got service %s", responseBody.Service)
+							return false
+						}
+
+						return true
+					},
+				})
+				require.NotNil(t, res, "request never succeeded")
+				require.True(t, ok)
+			}
 		})
-		require.NotNil(t, res, "request never succeeded")
-		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
-
-		assert.Contains(t, f.GetEchoResponseBody(res.Body).Path, "/this/has/lots/of/slashes")
-	})
+	}
 }


### PR DESCRIPTION
Fixes a bug where the DisableMergeSlashes option
was not being propagated from the config file and
adds unit and E2E tests.

Signed-off-by: Steve Kriss <krisss@vmware.com>
Co-authored-by: Máté Szabó <mszabo@fandom.com>

cc @mszabo-wikia, got this updated so we can get it in for the upcoming release. I've included you as a co-author here.