### PR TITLE
internal/dag: compute Listener supported kinds sooner

### DIFF
--- a/changelogs/unreleased/4523-skriss-small.md
+++ b/changelogs/unreleased/4523-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: compute Listener supported kinds sooner, so it's populated in all cases where it can be computed.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -338,6 +338,10 @@ func (p *GatewayAPIProcessor) computeListener(listener gatewayapi_v1alpha2.Liste
 		return nil, nil, nil
 	}
 
+	// Get a list of the route kinds that the listener accepts.
+	listenerRouteKinds := p.getListenerRouteKinds(listener, gwAccessor)
+	gwAccessor.SetListenerSupportedKinds(string(listener.Name), listenerRouteKinds)
+
 	var listenerSecret *Secret
 
 	// Validate TLS details for HTTPS/TLS protocol listeners.
@@ -397,10 +401,6 @@ func (p *GatewayAPIProcessor) computeListener(listener gatewayapi_v1alpha2.Liste
 			}
 		}
 	}
-
-	// Get a list of the route kinds that the listener accepts.
-	listenerRouteKinds := p.getListenerRouteKinds(listener, gwAccessor)
-	gwAccessor.SetListenerSupportedKinds(string(listener.Name), listenerRouteKinds)
 
 	var httpRoutes []*gatewayapi_v1alpha2.HTTPRoute
 	var tlsRoutes []*gatewayapi_v1alpha2.TLSRoute

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3656,8 +3656,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -3798,8 +3800,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -3884,8 +3888,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -3970,8 +3976,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -4056,8 +4064,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -4143,8 +4153,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5012,8 +5024,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"https": {
-					Name:           "https",
-					SupportedKinds: nil,
+					Name: "https",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "HTTPRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5071,8 +5085,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"https": {
-					Name:           "https",
-					SupportedKinds: nil,
+					Name: "https",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "HTTPRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5134,8 +5150,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5194,8 +5212,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5302,8 +5322,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"https": {
-					Name:           "https",
-					SupportedKinds: nil,
+					Name: "https",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "HTTPRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5350,8 +5372,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",
@@ -5404,8 +5428,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			ListenerStatus: map[string]*gatewayapi_v1alpha2.ListenerStatus{
 				"tls": {
-					Name:           "tls",
-					SupportedKinds: nil,
+					Name: "tls",
+					SupportedKinds: []gatewayapi_v1alpha2.RouteGroupKind{
+						{Group: gatewayapi.GroupPtr(gatewayapi_v1alpha2.GroupName), Kind: "TLSRoute"},
+					},
 					Conditions: []metav1.Condition{
 						{
 							Type:    "Ready",


### PR DESCRIPTION
Computes Gateway API Listener supported kinds
sooner, so it's populated in all cases where
it can be computed.

Signed-off-by: Steve Kriss <krisss@vmware.com>

(FYI this will be needed in order to pass an upcoming conformance test, and I think makes sense regardless).