### PR TITLE
Gateway API: return a 404 when no valid backend refs

### DIFF
--- a/changelogs/unreleased/4545-skriss-small.md
+++ b/changelogs/unreleased/4545-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: return a 404 instead of a 503 when there are no valid backend refs for an HTTPRoute rule, to match the [revised Gateway API spec](https://github.com/kubernetes-sigs/gateway-api/pull/1151).

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1358,7 +1358,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			want: listeners(),
 		},
 		// If the ServiceName referenced from an HTTPRoute is missing,
-		// the route should return an HTTP503.
+		// the route should return an HTTP 404.
 		"missing service": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
@@ -1384,12 +1384,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+						virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 					),
 				},
 			),
 		},
-		// If port is not defined the route will return an HTTP503.
+		// If port is not defined the route will return an HTTP 404.
 		"missing port": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
@@ -1422,7 +1422,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+						virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 					),
 				},
 			),
@@ -1462,7 +1462,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
-					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+					virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 				),
 			}),
 		},
@@ -1624,7 +1624,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
-					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+					virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 				),
 			}),
 		},
@@ -1679,7 +1679,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
-					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+					virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 				),
 			}),
 		},
@@ -1734,7 +1734,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
-					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+					virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 				),
 			}),
 		},
@@ -1790,7 +1790,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				Name: HTTP_LISTENER_NAME,
 				Port: 80,
 				VirtualHosts: virtualhosts(
-					virtualhost("*", directResponseRoute("/", http.StatusServiceUnavailable)),
+					virtualhost("*", directResponseRoute("/", http.StatusNotFound)),
 				),
 			}),
 		},
@@ -3151,7 +3151,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"weight of zero for a single forwardTo results in 503": {
+		"weight of zero for a single forwardTo results in 404": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -3179,7 +3179,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Name: HTTP_LISTENER_NAME,
 					Port: 80,
 					VirtualHosts: virtualhosts(
-						virtualhost("*", directResponseRouteService("/", http.StatusServiceUnavailable, &Service{
+						virtualhost("*", directResponseRouteService("/", http.StatusNotFound, &Service{
 							Weighted: WeightedService{
 								Weight:           0,
 								ServiceName:      kuardService.Name,

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1251,13 +1251,13 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 
 	for _, route := range routes {
 		// If there aren't any valid services, or the total weight of all of
-		// them equal zero, then return 503 responses to the caller.
+		// them equal zero, then return 404 responses to the caller.
 		if len(clusters) == 0 || totalWeight == 0 {
-			// Configure a direct response HTTP status code of 503 so the
+			// Configure a direct response HTTP status code of 404 so the
 			// route still matches the configured conditions since the
 			// service is missing or invalid.
 			route.DirectResponse = &DirectResponse{
-				StatusCode: http.StatusServiceUnavailable,
+				StatusCode: http.StatusNotFound,
 			}
 		}
 	}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3337,7 +3337,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// This still results in an attached route because it returns a 503.
+		// This still results in an attached route because it returns a 404.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 
@@ -3394,7 +3394,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// This still results in an attached route because it returns a 503.
+		// This still results in an attached route because it returns a 404.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 
@@ -3448,7 +3448,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// This still results in an attached route because it returns a 503.
+		// This still results in an attached route because it returns a 404.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 
@@ -3547,7 +3547,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// This still results in an attached route because it returns a 503.
+		// This still results in an attached route because it returns a 404.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -202,7 +202,7 @@ func runGatewayTests() {
 
 		f.NamespacedTest("gateway-header-condition-match", testWithHTTPGateway(testGatewayHeaderConditionMatch))
 
-		f.NamespacedTest("gateway-invalid-forward-to", testWithHTTPGateway(testInvalidForwardTo))
+		f.NamespacedTest("gateway-invalid-forward-to", testWithHTTPGateway(testInvalidBackendRef))
 
 		f.NamespacedTest("gateway-request-header-modifier-forward-to", testWithHTTPGateway(testRequestHeaderModifierForwardTo))
 

--- a/test/e2e/gateway/invalid_backend_ref_test.go
+++ b/test/e2e/gateway/invalid_backend_ref_test.go
@@ -27,8 +27,8 @@ import (
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func testInvalidForwardTo(namespace string) {
-	Specify("invalid forward to returns 503 status code", func() {
+func testInvalidBackendRef(namespace string) {
+	Specify("invalid backend ref returns 404 status code", func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-slash-default")
@@ -39,7 +39,7 @@ func testInvalidForwardTo(namespace string) {
 				Name:      "http-filter-1",
 			},
 			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"invalidforwardto.projectcontour.io"},
+				Hostnames: []gatewayapi_v1alpha2.Hostname{"invalidbackendref.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1alpha2.ParentRef{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
@@ -145,11 +145,11 @@ func testInvalidForwardTo(namespace string) {
 			},
 			{
 				path:           "/invalidref",
-				expectResponse: 503,
+				expectResponse: 404,
 			},
 			{
 				path:           "/invalidservicename",
-				expectResponse: 503,
+				expectResponse: 404,
 			},
 		}
 


### PR DESCRIPTION
The Gateway API spec has been updated to
require returning a 404 instead of a 503
when there are no valid backend refs on
an HTTPRoute rule. Updates Contour to match
the revised spec.

Gateway API ref: https://github.com/kubernetes-sigs/gateway-api/pull/1151

Updates #4543.

Signed-off-by: Steve Kriss <krisss@vmware.com>