### PR TITLE
cmd/contour: change shutdown --check-delay default to 0s

### DIFF
--- a/changelogs/unreleased/4548-skriss-small.md
+++ b/changelogs/unreleased/4548-skriss-small.md
@@ -1,0 +1,1 @@
+Changes the `contour envoy shutdown` command's `--check-delay` default to `0s` from `60s`, allowing Envoy pods to shut down more quickly when there are no open connections.

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -319,7 +319,7 @@ func registerShutdown(cmd *kingpin.CmdClause, log logrus.FieldLogger) (*kingpin.
 	shutdown.Flag("admin-port", "DEPRECATED: Envoy admin interface port.").IntVar(&ctx.adminPort)
 	shutdown.Flag("admin-address", "Envoy admin interface address.").Default("/admin/admin.sock").StringVar(&ctx.adminAddress)
 	shutdown.Flag("check-interval", "Time to poll Envoy for open connections.").DurationVar(&ctx.checkInterval)
-	shutdown.Flag("check-delay", "Time to wait before polling Envoy for open connections.").Default("60s").DurationVar(&ctx.checkDelay)
+	shutdown.Flag("check-delay", "Time to wait before polling Envoy for open connections.").Default("0s").DurationVar(&ctx.checkDelay)
 	shutdown.Flag("drain-delay", "Time to wait before draining Envoy connections.").Default("0s").DurationVar(&ctx.drainDelay)
 	shutdown.Flag("min-open-connections", "Min number of open connections when polling Envoy.").IntVar(&ctx.minOpenConnections)
 	shutdown.Flag("ready-file", "File to write when shutdown is completed.").Default(shutdownReadyFile).StringVar(&ctx.shutdownReadyFile)

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -96,7 +96,7 @@ func newShutdownManagerContext() *shutdownmanagerContext {
 func newShutdownContext() *shutdownContext {
 	return &shutdownContext{
 		checkInterval:      5 * time.Second,
-		checkDelay:         60 * time.Second,
+		checkDelay:         0,
 		drainDelay:         0,
 		minOpenConnections: 0,
 	}

--- a/site/content/docs/main/redeploy-envoy.md
+++ b/site/content/docs/main/redeploy-envoy.md
@@ -71,8 +71,8 @@ The shutdown command has a few arguments that can be passed to change how it beh
 | Name | Type | Default | Description |
 |------------|------|---------|-------------|
 | <nobr>check-interval</nobr> | duration | 5s | Time interval to poll Envoy for open connections. |
-| <nobr>check-delay</nobr> | duration | 60s | Time wait before polling Envoy for open connections. |
-| <nobr>drain-delay</nobr> | duration | 60s | Time wait before draining Envoy connections. |
+| <nobr>check-delay</nobr> | duration | 0s | Time wait before polling Envoy for open connections. |
+| <nobr>drain-delay</nobr> | duration | 0s | Time wait before draining Envoy connections. |
 | <nobr>min-open-connections</nobr> | integer | 0 | Min number of open connections when polling Envoy. |
 | <nobr>admin-port (Deprecated)</nobr> | integer | 9001 | Deprecated: No longer used, Envoy admin interface runs as a unix socket.  |
 | <nobr>admin-address</nobr> | string | /admin/admin.sock | Path to Envoy admin unix domain socket. |

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -833,8 +833,6 @@ func (d *Deployment) EnsureResourcesForInclusterContour(startContourDeployment b
 	}
 	envoyPodSpec.Containers[0].Image = d.contourImage
 	envoyPodSpec.Containers[0].ImagePullPolicy = v1.PullIfNotPresent
-	// Set shutdown check-delay to 0s to ensure cleanup is fast.
-	envoyPodSpec.Containers[0].Lifecycle.PreStop.Exec.Command = append(envoyPodSpec.Containers[0].Lifecycle.PreStop.Exec.Command, "--check-delay=0s")
 
 	if d.EnvoyDeploymentMode == DeploymentMode {
 		// The envoy deployment uses host ports, so can have at most


### PR DESCRIPTION
Changes the default check delay on the
shutdown command from 60s to 0s, since there
is no harm in checking immediately for
all connections to be closed, and it may
lead to faster shutdown when there are no
connections.

Closes #4422.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Reviewers, please check me on logic here; I don't see any harm in starting to check for no open connections immediately, but maybe I'm missing something.