### PR TITLE
pkg/config: Migrate from gopkg.in/yaml.v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,7 @@ require (
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.0
 	k8s.io/apiextensions-apiserver v0.24.0
 	k8s.io/apimachinery v0.24.0

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -14,7 +14,7 @@
 package build
 
 import (
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // BuildInfo is a struct for build information.

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -868,7 +868,7 @@ func Parse(in io.Reader) (*Parameters, error) {
 	conf := Defaults()
 	decoder := yaml.NewDecoder(in)
 
-	decoder.SetStrict(true)
+	decoder.KnownFields(true)
 
 	if err := decoder.Decode(&conf); err != nil {
 		// The YAML decoder will return EOF if there are

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGetenvOr(t *testing.T) {
@@ -47,42 +47,42 @@ func TestParseDefaults(t *testing.T) {
 debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
-  xds-server-type: contour
+    xds-server-type: contour
 accesslog-format: envoy
 json-fields:
-- '@timestamp'
-- authority
-- bytes_received
-- bytes_sent
-- downstream_local_address
-- downstream_remote_address
-- duration
-- method
-- path
-- protocol
-- request_id
-- requested_server_name
-- response_code
-- response_flags
-- uber_trace_id
-- upstream_cluster
-- upstream_host
-- upstream_local_address
-- upstream_service_time
-- user_agent
-- x_forwarded_for
-- grpc_status
+    - '@timestamp'
+    - authority
+    - bytes_received
+    - bytes_sent
+    - downstream_local_address
+    - downstream_remote_address
+    - duration
+    - method
+    - path
+    - protocol
+    - request_id
+    - requested_server_name
+    - response_code
+    - response_flags
+    - uber_trace_id
+    - upstream_cluster
+    - upstream_host
+    - upstream_local_address
+    - upstream_service_time
+    - user_agent
+    - x_forwarded_for
+    - grpc_status
 accesslog-level: info
 timeouts:
-  connection-idle-timeout: 60s
-  connect-timeout: 2s
+    connection-idle-timeout: 60s
+    connect-timeout: 2s
 envoy-service-namespace: projectcontour
 envoy-service-name: envoy
 default-http-versions: []
 cluster:
-  dns-lookup-family: auto
+    dns-lookup-family: auto
 network:
-  admin-port: 9001
+    admin-port: 9001
 `
 	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(data)))
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -34,7 +34,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/pkg/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	apps_v1 "k8s.io/api/apps/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"


### PR DESCRIPTION
Use gopkg.in/yaml.v3 for config file parsing.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>