### PR TITLE
Gateway API: fix bug with routes having multiple listener refs

### DIFF
--- a/changelogs/unreleased/4558-skriss-small.md
+++ b/changelogs/unreleased/4558-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: fixes a bug where routes with multiple parent refs to listeners would not attach to all listeners correctly.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -785,7 +785,9 @@ func routeSelectsGatewayListener(gateway *gatewayapi_v1alpha2.Gateway, listener 
 			}
 
 			// section name specified: it must match the listener name
-			return *ref.SectionName == listener.Name
+			if *ref.SectionName == listener.Name {
+				return true
+			}
 		}
 	}
 

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -539,6 +539,22 @@ func TestRouteSelectsGatewayListener(t *testing.T) {
 			listener: gatewayapi_v1alpha2.Listener{Name: *gatewayapi.SectionNamePtr("http-listener")},
 			want:     false,
 		},
+		"multiple parentRefs with section names specified, first listener": {
+			routeParentRefs: []gatewayapi_v1alpha2.ParentRef{
+				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1"),
+				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-2"),
+			},
+			listener: gatewayapi_v1alpha2.Listener{Name: *gatewayapi.SectionNamePtr("listener-1")},
+			want:     true,
+		},
+		"multiple parentRefs with section names specified, second listener": {
+			routeParentRefs: []gatewayapi_v1alpha2.ParentRef{
+				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1"),
+				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-2"),
+			},
+			listener: gatewayapi_v1alpha2.Listener{Name: *gatewayapi.SectionNamePtr("listener-2")},
+			want:     true,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Fixes a bug where a route with multiple parent
refs to listeners would not attach to all
listeners correctly.

Signed-off-by: Steve Kriss <krisss@vmware.com>