### PR TITLE
Gateway API: allow wildcard hostnames to match more than one DNS label

### DIFF
--- a/changelogs/unreleased/4559-skriss-small.md
+++ b/changelogs/unreleased/4559-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: wildcard hostnames can now match more than one DNS label, per https://github.com/kubernetes-sigs/gateway-api/pull/1173.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1270,10 +1270,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("*.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/"),
-							HeaderMatchConditions: []HeaderMatchCondition{
-								{Name: ":authority", Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.projectcontour\\.io", MatchType: "regex", Invert: false},
-							},
-							Clusters: clustersWeight(service(kuardService)),
+							Clusters:           clustersWeight(service(kuardService)),
 						}),
 					),
 				},

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -207,7 +207,7 @@ func TestComputeHosts(t *testing.T) {
 			want:      sets.NewString("very.many.labels.projectcontour.io"),
 			wantError: nil,
 		},
-		"listener wildcard host doesn't match hostnames with many labels host": {
+		"listener wildcard host matches hostnames with many labels host": {
 			listenerHost: "*.projectcontour.io",
 			hostnames: []gatewayapi_v1alpha2.Hostname{
 				"very.many.labels.projectcontour.io",

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -199,20 +199,20 @@ func TestComputeHosts(t *testing.T) {
 			want:         sets.NewString("http.projectcontour.io"),
 			wantError:    nil,
 		},
-		"listener host with many labels doesn't match hostnames wildcard host": {
-			listenerHost: "too.many.labels.projectcontour.io",
+		"listener host with many labels matches hostnames wildcard host": {
+			listenerHost: "very.many.labels.projectcontour.io",
 			hostnames: []gatewayapi_v1alpha2.Hostname{
 				"*.projectcontour.io",
 			},
-			want:      nil,
+			want:      sets.NewString("very.many.labels.projectcontour.io"),
 			wantError: nil,
 		},
 		"listener wildcard host doesn't match hostnames with many labels host": {
 			listenerHost: "*.projectcontour.io",
 			hostnames: []gatewayapi_v1alpha2.Hostname{
-				"too.many.labels.projectcontour.io",
+				"very.many.labels.projectcontour.io",
 			},
-			want:      nil,
+			want:      sets.NewString("very.many.labels.projectcontour.io"),
 			wantError: nil,
 		},
 		"listener wildcard host doesn't match bare hostname": {

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -77,7 +77,7 @@ func testTLSWildcardHost(namespace string) {
 			{
 				hostname:   "a.random3." + hostSuffix,
 				sni:        "a.random3." + hostSuffix,
-				wantStatus: 404,
+				wantStatus: 200,
 			},
 			{
 				hostname:   "random4." + hostSuffix,


### PR DESCRIPTION
Changes Gateway API hostname logic to allow
wildcard hostnames to match more than one
DNS label per clarification in the upstream
spec.

Closes #4554.

Signed-off-by: Steve Kriss <krisss@vmware.com>