### PR TITLE
main: Bump Envoy to 1.22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.22.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.22.2
 GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4567-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4567-sunjayBhatia-minor.md
@@ -1,5 +1,0 @@
-## Bump Envoy to v1.22.1
-
-Bumps Envoy to security patch version 1.22.1.
-Envoy announcement [here](https://groups.google.com/g/envoy-announce/c/QxI6z6wdL7M).
-See Envoy release notes [here](https://www.envoyproxy.io/docs/envoy/v1.22.1/version_history/current).

--- a/changelogs/unreleased/4572-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4572-sunjayBhatia-minor.md
@@ -1,0 +1,6 @@
+## Bump Envoy to v1.22.2
+
+Bumps Envoy to security patch version 1.22.2.
+Envoy CI had a few issues releasing 1.22.1 so a subsequent patch, 1.22.2 was released.
+Envoy announcement [here](https://groups.google.com/g/envoy-announce/c/QxI6z6wdL7M).
+See Envoy release notes [for 1.22.1 here](https://www.envoyproxy.io/docs/envoy/v1.22.2/version_history/v1.22.1) and [1.22.2 here](https://www.envoyproxy.io/docs/envoy/v1.22.2/version_history/current).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -33,7 +33,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	config := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.22.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.22.2",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.22.1
+        image: docker.io/envoyproxy/envoy:v1.22.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.22.1
+          image: docker.io/envoyproxy/envoy:v1.22.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5151,7 +5151,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.22.1
+          image: docker.io/envoyproxy/envoy:v1.22.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5143,7 +5143,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.22.1
+        image: docker.io/envoyproxy/envoy:v1.22.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5138,7 +5138,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.22.1
+        image: docker.io/envoyproxy/envoy:v1.22.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.22.1][17]         | 1.24, 1.23, 1.22    | [main][50]       | v1alpha2            |
+| main            | [1.22.2][17]         | 1.24, 1.23, 1.22    | [main][50]       | v1alpha2            |
 | 1.21.0          | [1.22.0][16]         | 1.23, 1.22, 1.21    | [1.21.0][69]     | v1alpha2            |
 | 1.20.1          | [1.21.1][15]         | 1.23, 1.22, 1.21    | [1.20.1][68]     | v1alpha2            |
 | 1.20.0          | [1.21.0][14]         | 1.23, 1.22, 1.21    | [1.20.0][67]     | v1alpha2            |
@@ -113,7 +113,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [14]: https://www.envoyproxy.io/docs/envoy/v1.21.0/version_history/current
 [15]: https://www.envoyproxy.io/docs/envoy/v1.21.1/version_history/current
 [16]: https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current
-[17]: https://www.envoyproxy.io/docs/envoy/v1.22.1/version_history/current
+[17]: https://www.envoyproxy.io/docs/envoy/v1.22.2/version_history/current
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.22.1"
+      envoy: "1.22.2"
       kubernetes:
         - "1.24"
         - "1.23"


### PR DESCRIPTION
Envoy released a 1.22.2 because of CI issues they were having