### PR TITLE
Gateway API: add support for ReferenceGrant

### DIFF
--- a/changelogs/unreleased/4580-skriss-deprecation.md
+++ b/changelogs/unreleased/4580-skriss-deprecation.md
@@ -1,0 +1,5 @@
+## Gateway API: ReferencePolicy is deprecated, will be removed next release
+
+Gateway API has renamed ReferencePolicy to ReferenceGrant in the v0.5.0 release, while retaining the former for one release to ease migration.
+Contour currently supports both, but will drop support for ReferencePolicy in the next release.
+Users of ReferencePolicies must migrate their resources to ReferenceGrants ahead of the next Contour release.

--- a/changelogs/unreleased/4580-skriss-small.md
+++ b/changelogs/unreleased/4580-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: adds support for ReferenceGrant, which was formerly known as ReferencePolicy. To ease migration, _both_ resources are supported for this release, but ReferencePolicy support will be removed next release.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -809,6 +809,11 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 			s.log.WithError(err).WithField("resource", "referencepolicies").Fatal("failed to create informer")
 		}
 
+		// Inform on ReferenceGrants.
+		if err := informOnResource(&gatewayapi_v1alpha2.ReferenceGrant{}, eventHandler, mgr.GetCache()); err != nil {
+			s.log.WithError(err).WithField("resource", "referencegrants").Fatal("failed to create informer")
+		}
+
 		// Inform on Namespaces.
 		if err := informOnResource(&corev1.Namespace{}, eventHandler, mgr.GetCache()); err != nil {
 			s.log.WithError(err).WithField("resource", "namespaces").Fatal("failed to create informer")

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -26,6 +26,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/gateway-provisioner/01-roles.yaml
+++ b/examples/gateway-provisioner/01-roles.yaml
@@ -76,6 +76,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -4852,6 +4852,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -11626,6 +11626,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4857,6 +4857,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4852,6 +4852,7 @@ rules:
   - gatewayclasses
   - gateways
   - httproutes
+  - referencegrants
   - referencepolicies
   - tlsroutes
   verbs:

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1424,7 +1424,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"HTTPRoute references a backend in a different namespace, no ReferencePolicy": {
+		"HTTPRoute references a backend in a different namespace, no ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1463,7 +1463,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with valid ReferencePolicy": {
+		"HTTPRoute references a backend in a different namespace, with valid ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1493,7 +1493,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -1516,7 +1516,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				VirtualHosts: virtualhosts(virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService)))),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with valid ReferencePolicy (service-specific)": {
+		"HTTPRoute references a backend in a different namespace, with valid ReferenceGrant (service-specific)": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1546,7 +1546,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -1570,7 +1570,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				VirtualHosts: virtualhosts(virtualhost("*", prefixrouteHTTPRoute("/", service(kuardService)))),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong Kind)": {
+		"HTTPRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong Kind)": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1600,7 +1600,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -1625,7 +1625,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with invalid ReferencePolicy (policy in wrong namespace)": {
+		"HTTPRoute references a backend in a different namespace, with invalid ReferenceGrant (grant in wrong namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1655,7 +1655,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "some-other-namespace", // would need to be "projectcontour" to be valid
@@ -1680,7 +1680,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong from namespace)": {
+		"HTTPRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong from namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1710,7 +1710,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -1735,7 +1735,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				),
 			}),
 		},
-		"HTTPRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong service name)": {
+		"HTTPRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong service name)": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
@@ -1765,7 +1765,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -2089,15 +2089,15 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			want: listeners(),
 		},
 
-		// BEGIN TLS CertificateRef + ReferencePolicy tests
-		"Gateway references TLS cert in different namespace, with valid ReferencePolicy": {
+		// BEGIN TLS CertificateRef + ReferenceGrant tests
+		"Gateway references TLS cert in different namespace, with valid ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2132,7 +2132,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"Gateway references TLS cert in different namespace, with no ReferencePolicy": {
+		"Gateway references TLS cert in different namespace, with no ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
@@ -2142,14 +2142,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"Gateway references TLS cert in different namespace, with valid ReferencePolicy (secret-specific)": {
+		"Gateway references TLS cert in different namespace, with valid ReferenceGrant (secret-specific)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2185,14 +2185,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"Gateway references TLS cert in different namespace, with invalid ReferencePolicy (policy in wrong namespace)": {
+		"Gateway references TLS cert in different namespace, with invalid ReferenceGrant (grant in wrong namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: "wrong-namespace",
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2211,14 +2211,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong From namespace)": {
+		"Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2237,14 +2237,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong From kind)": {
+		"Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From kind)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2263,14 +2263,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong To kind)": {
+		"Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong To kind)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2289,14 +2289,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong secret name)": {
+		"Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong secret name)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSTerminateCertInDifferentNamespace,
 			objs: []interface{}{
 				sec2,
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-cert-reference-policy",
+						Name:      "tls-cert-reference-grant",
 						Namespace: sec2.Namespace,
 					},
 					Spec: gatewayapi_v1alpha2.ReferenceGrantSpec{
@@ -2317,7 +2317,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			want: listeners(),
 		},
 
-		// END CertificateRef ReferencePolicy tests
+		// END CertificateRef ReferenceGrant tests
 
 		"No valid hostnames defined": {
 			gatewayclass: validClass,
@@ -3311,7 +3311,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"TLSRoute references a backend in a different namespace, no ReferencePolicy": {
+		"TLSRoute references a backend in a different namespace, no ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3334,7 +3334,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"TLSRoute references a backend in a different namespace, with valid ReferencePolicy": {
+		"TLSRoute references a backend in a different namespace, with valid ReferenceGrant": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3364,7 +3364,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -3398,7 +3398,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"TLSRoute references a backend in a different namespace, with valid ReferencePolicy (service-specific)": {
+		"TLSRoute references a backend in a different namespace, with valid ReferenceGrant (service-specific)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3428,7 +3428,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -3463,7 +3463,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
-		"TLSRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong Kind)": {
+		"TLSRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong Kind)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3493,7 +3493,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -3512,7 +3512,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"TLSRoute references a backend in a different namespace, with invalid ReferencePolicy (policy in wrong namespace)": {
+		"TLSRoute references a backend in a different namespace, with invalid ReferenceGrant (grant in wrong namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3542,7 +3542,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "some-other-namespace", // would have to be "projectcontour" to be valid
@@ -3561,7 +3561,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"TLSRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong from namespace)": {
+		"TLSRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong from namespace)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3591,7 +3591,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,
@@ -3610,7 +3610,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			want: listeners(),
 		},
-		"TLSRoute references a backend in a different namespace, with invalid ReferencePolicy (wrong service name)": {
+		"TLSRoute references a backend in a different namespace, with invalid ReferenceGrant (wrong service name)": {
 			gatewayclass: validClass,
 			gateway:      gatewayTLSPassthroughAllNamespaces,
 			objs: []interface{}{
@@ -3640,7 +3640,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.ReferencePolicy{
+				&gatewayapi_v1alpha2.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: kuardService.Namespace,

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -67,6 +67,7 @@ type KubernetesCache struct {
 	httproutes                map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute
 	tlsroutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute
 	referencepolicies         map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy
+	referencegrants           map[types.NamespacedName]*gatewayapi_v1alpha2.ReferenceGrant
 	extensions                map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService
 
 	Client client.Reader
@@ -86,6 +87,7 @@ func (kc *KubernetesCache) init() {
 	kc.namespaces = make(map[string]*v1.Namespace)
 	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute)
 	kc.referencepolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy)
+	kc.referencegrants = make(map[types.NamespacedName]*gatewayapi_v1alpha2.ReferenceGrant)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute)
 	kc.extensions = make(map[types.NamespacedName]*contour_api_v1alpha1.ExtensionService)
 }
@@ -201,6 +203,9 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			return true
 		case *gatewayapi_v1alpha2.ReferencePolicy:
 			kc.referencepolicies[k8s.NamespacedNameOf(obj)] = obj
+			return true
+		case *gatewayapi_v1alpha2.ReferenceGrant:
+			kc.referencegrants[k8s.NamespacedNameOf(obj)] = obj
 			return true
 		case *contour_api_v1alpha1.ExtensionService:
 			kc.extensions[k8s.NamespacedNameOf(obj)] = obj
@@ -327,6 +332,11 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.referencepolicies[m]
 		delete(kc.referencepolicies, m)
+		return ok
+	case *gatewayapi_v1alpha2.ReferenceGrant:
+		m := k8s.NamespacedNameOf(obj)
+		_, ok := kc.referencegrants[m]
+		delete(kc.referencegrants, m)
 		return ok
 	case *contour_api_v1alpha1.ExtensionService:
 		m := k8s.NamespacedNameOf(obj)

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -873,10 +873,10 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert gateway-api ReferencePolicy": {
-			obj: &gatewayapi_v1alpha2.ReferencePolicy{
+		"insert gateway-api ReferenceGrant": {
+			obj: &gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "referencepolicy-1",
+					Name:      "referencegrant-1",
 					Namespace: "default",
 				},
 			},
@@ -1233,16 +1233,16 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			},
 			want: true,
 		},
-		"remove gateway-api ReferencePolicy": {
-			cache: cache(&gatewayapi_v1alpha2.ReferencePolicy{
+		"remove gateway-api ReferenceGrant": {
+			cache: cache(&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "referencepolicy",
+					Name:      "referencegrant",
 					Namespace: "default",
 				},
 			}),
-			obj: &gatewayapi_v1alpha2.ReferencePolicy{
+			obj: &gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "referencepolicy",
+					Name:      "referencegrant",
 					Namespace: "default",
 				},
 			},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3600,7 +3600,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1alpha2.ListenerReasonRefNotPermitted),
-					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy",
+					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 				},
 				gatewayapi_v1alpha2.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
@@ -3614,8 +3614,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 
-	// BEGIN TLS CertificateRef + ReferencePolicy tests
-	run(t, "Gateway references TLS cert in different namespace, with valid ReferencePolicy", testcase{
+	// BEGIN TLS CertificateRef + ReferenceGrant tests
+	run(t, "Gateway references TLS cert in different namespace, with valid ReferenceGrant", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -3650,7 +3650,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -3670,7 +3670,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("tls", "TLSRoute", 0),
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with no ReferencePolicy", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with no ReferenceGrant", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -3734,7 +3734,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -3742,7 +3742,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with valid ReferencePolicy (secret-specific)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with valid ReferenceGrant (secret-specific)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -3777,7 +3777,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -3798,7 +3798,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("tls", "TLSRoute", 0),
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with invalid ReferencePolicy (policy in wrong namespace)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (policy in wrong namespace)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -3833,7 +3833,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "wrong-namespace",
@@ -3878,7 +3878,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -3886,7 +3886,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong From namespace)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From namespace)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -3921,7 +3921,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -3966,7 +3966,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -3974,7 +3974,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong From kind)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From kind)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -4009,7 +4009,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -4054,7 +4054,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -4062,7 +4062,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong To kind)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong To kind)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -4097,7 +4097,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -4142,7 +4142,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -4150,7 +4150,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	run(t, "Gateway references TLS cert in different namespace, with invalid ReferencePolicy (wrong secret name)", testcase{
+	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong secret name)", testcase{
 		gateway: &gatewayapi_v1alpha2.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "contour",
@@ -4185,7 +4185,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Type: v1.SecretTypeTLS,
 				Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 			},
-			&gatewayapi_v1alpha2.ReferencePolicy{
+			&gatewayapi_v1alpha2.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tls-cert-reference-policy",
 					Namespace: "tls-cert-namespace",
@@ -4231,7 +4231,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1alpha2.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1alpha2.ListenerReasonInvalidCertificateRef),
-							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy",
+							Message: "Spec.VirtualHost.TLS.CertificateRefs \"secret\" namespace must match the Gateway's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 						},
 					},
 				},
@@ -4239,7 +4239,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		}},
 	})
 
-	// END TLS CertificateRef + ReferencePolicy tests
+	// END TLS CertificateRef + ReferenceGrant tests
 
 	run(t, "spec.rules.hostname: invalid wildcard", testcase{
 		objs: []interface{}{
@@ -4887,7 +4887,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1alpha2.ListenerReasonRefNotPermitted),
-					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy",
+					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 				},
 				gatewayapi_v1alpha2.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -19,7 +19,7 @@ package k8s
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies;tlscertificatedelegations;extensionservices;contourconfigurations,verbs=get;list;watch
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies/status;extensionservices/status;contourconfigurations/status,verbs=create;get;update
 
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;referencepolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;referencepolicies;referencegrants,verbs=get;list;watch
 // +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status,verbs=update
 
 // +kubebuilder:rbac:groups="",resources=secrets;endpoints;services;namespaces,verbs=get;list;watch

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
@@ -86,8 +86,8 @@ func desiredClusterRole(name string, contour *model.Contour) *rbacv1.ClusterRole
 			policyRuleFor(corev1.GroupName, getListWatch, "secrets", "endpoints", "services", "namespaces"),
 
 			// Gateway API resources.
-			// Note, ReferencePolicy does not currently have a .status field so it's omitted from the status rule.
-			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencepolicies"),
+			// Note, ReferencePolicy/ReferenceGrant does not currently have a .status field so it's omitted from the status rule.
+			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencepolicies", "referencegrants"),
 			policyRuleFor(gatewayv1alpha2.GroupName, update, "gatewayclasses/status", "gateways/status", "httproutes/status", "tlsroutes/status"),
 
 			// Ingress resources.

--- a/site/content/resources/security-threat-model.md
+++ b/site/content/resources/security-threat-model.md
@@ -54,7 +54,7 @@ Contour is unable to do much about this, and we expect administrators the use th
 #### Multitenancy
 Contour is designed to be used in a multitenant fashion - it's an expected use case that a Contour install would service teams that have completely different security contexts, and should not be able to access each others config.
 Contour mitigates this as far as we can, using our HTTPProxy and TSLCertificateDelegation CRDs to enable more-secure cross-namespace references.
-The ReferencePolicy object in the Gateway API is also based on this idea, that cross-namespace references are only valid when the *owner of the namespace* accepts them.
+The ReferenceGrant object in the Gateway API is also based on this idea, that cross-namespace references are only valid when the *owner of the namespace* accepts them.
 #### Insider access
 In general, Contour adheres to the Kubernetes security model, that makes the minimum size security boundary the namespace (or at least, the RBAC around objects in that namespace).
 For Contour's primary use cases to work, application developers and other ingress configuration owners *must* have access to create or modify ingress config objects (whether they are Ingress, HTTPProxy, or Gateway API) inside their own namespace.


### PR DESCRIPTION
Adds support for the renamed ReferenceGrant
resource while retaining support for
ReferencePolicy, to allow for a seamless
migration. ReferencePolicy support will
be removed in a subsequent release.

Updates https://github.com/projectcontour/contour/issues/4555.

Signed-off-by: Steve Kriss <krisss@vmware.com>