### PR TITLE
Gateway API: adjust conformance runs 

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -114,3 +114,38 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#contour-ci-notifications'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
+  gateway-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          # * Module download cache
+          # * Build cache (Linux)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.job }}-go-
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: add deps to path
+        run: |
+          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: Gateway API conformance tests (latest)
+        env:
+          CONTOUR_E2E_IMAGE: ghcr.io/projectcontour/contour:main
+          GATEWAY_API_VERSION: "master"
+        run: |
+          # Skip the `load-contour-image-kind` target, pull the `main` image instead.
+          make setup-kind-cluster run-gateway-conformance cleanup-kind
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#contour-ci-notifications'
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
 ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.22.2
-GATEWAY_API_VERSION = $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
+GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running
 # 'contour serve'. On MacOS this will work, but may not on other OSes. Defining
@@ -340,7 +340,7 @@ gateway-conformance: | setup-kind-cluster load-contour-image-kind run-gateway-co
 
 .PHONY: run-gatway-conformance
 run-gateway-conformance: ## Run Gateway API conformance tests against the current cluster.
-	./test/scripts/run-gateway-conformance.sh
+	GATEWAY_API_VERSION=$(GATEWAY_API_VERSION) ./test/scripts/run-gateway-conformance.sh
 
 .PHONY: deploy-gcp-bench-cluster
 deploy-gcp-bench-cluster:

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -22,6 +22,7 @@ readonly KUBECTL=${KUBECTL:-kubectl}
 export CONTOUR_IMG=${CONTOUR_E2E_IMAGE:-ghcr.io/projectcontour/contour:main}
 
 echo "Using Contour image: ${CONTOUR_IMG}"
+echo "Using Gateway API version: ${GATEWAY_API_VERSION}"
 
 ${KUBECTL} apply -f examples/gateway-provisioner/00-common.yaml
 ${KUBECTL} apply -f examples/gateway-provisioner/01-roles.yaml
@@ -43,4 +44,5 @@ EOF
 cd $(mktemp -d)
 git clone https://github.com/kubernetes-sigs/gateway-api
 cd gateway-api
+git checkout "${GATEWAY_API_VERSION}"
 go test ./conformance -gateway-class=contour


### PR DESCRIPTION
Changes the PR/push run of Gateway API
conformance to run using the go.mod
version of Gateway API, and adds a daily
run of the latest conformance tests.

Closes https://github.com/projectcontour/contour/issues/4513.

Signed-off-by: Steve Kriss <krisss@vmware.com>