### PR TITLE
internal/provisioner: Bind create label operation for contour's deployment to the object

### DIFF
--- a/changelogs/unreleased/4585-izturn-minor.md
+++ b/changelogs/unreleased/4585-izturn-minor.md
@@ -1,0 +1,3 @@
+##  Bind create label operation for contour's deployment to the struct
+
+There are now three places to create the same label(s), so let the operation to be a method of the Contour struct.

--- a/internal/provisioner/model/names.go
+++ b/internal/provisioner/model/names.go
@@ -79,8 +79,8 @@ func (c *Contour) EnvoyRBACNames() RBACNames {
 	}
 }
 
-// ContourDeploymentLabels returns labels for a Contour deployment.
-func (c *Contour) ContourDeploymentLabels() map[string]string {
+// ComponentLabels returns labels for a Contour component.
+func (c *Contour) ComponentLabels() map[string]string {
 	labels := map[string]string{
 		"app.kubernetes.io/name":       "contour",
 		"app.kubernetes.io/instance":   c.Name,

--- a/internal/provisioner/model/names.go
+++ b/internal/provisioner/model/names.go
@@ -79,6 +79,23 @@ func (c *Contour) EnvoyRBACNames() RBACNames {
 	}
 }
 
+// ContourDeploymentLabels returns labels for a Contour deployment.
+func (c *Contour) ContourDeploymentLabels() map[string]string {
+	labels := map[string]string{
+		"app.kubernetes.io/name":       "contour",
+		"app.kubernetes.io/instance":   c.Name,
+		"app.kubernetes.io/component":  "ingress-controller",
+		"app.kubernetes.io/managed-by": "contour-gateway-provisioner",
+	}
+
+	// Add owner labels
+	for k, v := range OwnerLabels(c) {
+		labels[k] = v
+	}
+
+	return labels
+}
+
 // RBACNames holds a set of names of related RBAC resources.
 type RBACNames struct {
 	ServiceAccount     string

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -326,22 +326,11 @@ func desiredContainers(contour *model.Contour, contourImage, envoyImage string) 
 func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *appsv1.DaemonSet {
 	initContainers, containers := desiredContainers(contour, contourImage, envoyImage)
 
-	labels := map[string]string{
-		"app.kubernetes.io/name":       "contour",
-		"app.kubernetes.io/instance":   contour.Name,
-		"app.kubernetes.io/component":  "ingress-controller",
-		"app.kubernetes.io/managed-by": "contour-gateway-provisioner",
-	}
-	// Add owner labels
-	for k, v := range model.OwnerLabels(contour) {
-		labels[k] = v
-	}
-
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.EnvoyDataPlaneName(),
-			Labels:    labels,
+			Labels:    contour.ContourDeploymentLabels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			RevisionHistoryLimit: pointer.Int32Ptr(int32(10)),
@@ -416,22 +405,11 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 func desiredDeployment(contour *model.Contour, contourImage, envoyImage string) *appsv1.Deployment {
 	initContainers, containers := desiredContainers(contour, contourImage, envoyImage)
 
-	labels := map[string]string{
-		"app.kubernetes.io/name":       "contour",
-		"app.kubernetes.io/instance":   contour.Name,
-		"app.kubernetes.io/component":  "ingress-controller",
-		"app.kubernetes.io/managed-by": "contour-gateway-provisioner",
-	}
-	// Add owner labels
-	for k, v := range model.OwnerLabels(contour) {
-		labels[k] = v
-	}
-
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.EnvoyDataPlaneName(),
-			Labels:    labels,
+			Labels:    contour.ContourDeploymentLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas:             pointer.Int32(contour.Spec.EnvoyReplicas),

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -330,7 +330,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.EnvoyDataPlaneName(),
-			Labels:    contour.ContourDeploymentLabels(),
+			Labels:    contour.ComponentLabels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			RevisionHistoryLimit: pointer.Int32Ptr(int32(10)),
@@ -409,7 +409,7 @@ func desiredDeployment(contour *model.Contour, contourImage, envoyImage string) 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.EnvoyDataPlaneName(),
-			Labels:    contour.ContourDeploymentLabels(),
+			Labels:    contour.ComponentLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas:             pointer.Int32(contour.Spec.EnvoyReplicas),

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -207,7 +207,7 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.ContourDeploymentName(),
-			Labels:    makeDeploymentLabels(contour),
+			Labels:    contour.ContourDeploymentLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			ProgressDeadlineSeconds: pointer.Int32(600),
@@ -317,23 +317,6 @@ func updateDeploymentIfNeeded(ctx context.Context, cli client.Client, contour *m
 		}
 	}
 	return nil
-}
-
-// makeDeploymentLabels returns labels for a Contour deployment.
-func makeDeploymentLabels(contour *model.Contour) map[string]string {
-	labels := map[string]string{
-		"app.kubernetes.io/name":       "contour",
-		"app.kubernetes.io/instance":   contour.Name,
-		"app.kubernetes.io/component":  "ingress-controller",
-		"app.kubernetes.io/managed-by": "contour-gateway-provisioner",
-	}
-
-	// Add owner labels
-	for k, v := range model.OwnerLabels(contour) {
-		labels[k] = v
-	}
-
-	return labels
 }
 
 // ContourDeploymentPodSelector returns a label selector using "app: contour" as the

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -207,7 +207,7 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: contour.Namespace,
 			Name:      contour.ContourDeploymentName(),
-			Labels:    contour.ContourDeploymentLabels(),
+			Labels:    contour.ComponentLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			ProgressDeadlineSeconds: pointer.Int32(600),


### PR DESCRIPTION
bind create label operation for contour's deployment to the object self for management easy

Signed-off-by: Gang Liu <gang.liu@daocloud.io>