### PR TITLE
internal/provisioner: Use local variable  to replace the long access chain of fields

### DIFF
--- a/changelogs/unreleased/4586-izturn-minor.md
+++ b/changelogs/unreleased/4586-izturn-minor.md
@@ -1,0 +1,3 @@
+## Use local variable to replace the long access chain of fields
+
+The access chain of fields is too long, so use local variable to replace them.

--- a/internal/provisioner/objects/service/service.go
+++ b/internal/provisioner/objects/service/service.go
@@ -443,7 +443,7 @@ func subnetNeeded(spec *model.ContourSpec) bool {
 // is needed based on provided spec.
 func loadBalancerAddressNeeded(spec *model.ContourSpec) bool {
 	providerParams := &spec.NetworkPublishing.Envoy.LoadBalancer.ProviderParameters
-	
+
 	return spec.NetworkPublishing.Envoy.Type == model.LoadBalancerServicePublishingType &&
 		((providerParams.Type == model.AzureLoadBalancerProvider &&
 			providerParams.Azure != nil &&

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -339,9 +339,6 @@ func (d *Deployment) WaitForContourDeploymentUpdated() error {
 		if err := d.client.List(context.TODO(), pods, labelSelectAppContour); err != nil {
 			return false, err
 		}
-		if pods == nil {
-			return false, errors.New("failed to fetch Contour Deployment pods")
-		}
 
 		updatedPods := 0
 		for _, pod := range pods.Items {


### PR DESCRIPTION
it seems the fields of object nest too deeply, so use  a local variable to replace it to make read code easy

Signed-off-by: Gang Liu <gang.liu@daocloud.io>