### PR TITLE
All gRPC Services have a sanitized authority

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -609,8 +609,14 @@ func (s *Server) setupRateLimitService(contourConfiguration contour_api_v1alpha1
 		}
 	}
 
+	var sni string
+	if extensionSvc.Spec.UpstreamValidation != nil {
+		sni = extensionSvc.Spec.UpstreamValidation.SubjectName
+	}
+
 	return &xdscache_v3.RateLimitConfig{
 		ExtensionService:        key,
+		SNI:                     sni,
 		Domain:                  contourConfiguration.RateLimitService.Domain,
 		Timeout:                 responseTimeout,
 		FailOpen:                pointer.BoolDeref(contourConfiguration.RateLimitService.FailOpen, false),

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -133,7 +133,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -147,7 +148,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -192,7 +194,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -310,7 +313,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -324,7 +328,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -369,7 +374,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -487,7 +493,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -501,7 +508,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -546,7 +554,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -665,7 +674,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -679,7 +689,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -724,7 +735,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -843,7 +855,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -857,7 +870,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -902,7 +916,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1021,7 +1036,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1035,7 +1051,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1080,7 +1097,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1201,7 +1219,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1215,7 +1234,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1260,7 +1280,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1415,7 +1436,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1429,7 +1451,8 @@ func TestBootstrap(t *testing.T) {
         "grpc_services": [
           {
             "envoy_grpc": {
-              "cluster_name": "contour"
+              "cluster_name": "contour",
+              "authority": "contour"
             }
           }
         ]
@@ -1474,7 +1497,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1627,7 +1651,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1641,7 +1666,8 @@ func TestBootstrap(t *testing.T) {
               "grpc_services": [
                 {
                   "envoy_grpc": {
-                    "cluster_name": "contour"
+                    "cluster_name": "contour",
+                    "authority": "contour"
                   }
                 }
               ]
@@ -1686,7 +1712,8 @@ func TestBootstrap(t *testing.T) {
                     "grpc_services": [
                       {
                         "envoy_grpc": {
-                          "cluster_name": "contour"
+                          "cluster_name": "contour",
+                          "authority": "contour"
                         }
                       }
                     ]

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -231,7 +231,7 @@ func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
 				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
 				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 				GrpcServices: []*envoy_core_v3.GrpcService{
-					GrpcService(cluster, timeout.DefaultSetting()),
+					GrpcService(cluster, "", timeout.DefaultSetting()),
 				},
 			},
 		},

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -230,13 +230,9 @@ func ConfigSource(cluster string) *envoy_core_v3.ConfigSource {
 			ApiConfigSource: &envoy_core_v3.ApiConfigSource{
 				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
 				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				GrpcServices: []*envoy_core_v3.GrpcService{{
-					TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
-						EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
-							ClusterName: cluster,
-						},
-					},
-				}},
+				GrpcServices: []*envoy_core_v3.GrpcService{
+					GrpcService(cluster, timeout.DefaultSetting()),
+				},
 			},
 		},
 	}

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -680,18 +680,7 @@ end
 func FilterExternalAuthz(authzClusterName string, failOpen bool, timeout timeout.Setting, bufferSettings *dag.AuthorizationServerBufferSettings) *http.HttpFilter {
 	authConfig := envoy_config_filter_http_ext_authz_v3.ExtAuthz{
 		Services: &envoy_config_filter_http_ext_authz_v3.ExtAuthz_GrpcService{
-			GrpcService: &envoy_core_v3.GrpcService{
-				TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
-					EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
-						ClusterName: authzClusterName,
-					},
-				},
-				Timeout: envoy.Timeout(timeout),
-				// We don't need to configure metadata here, since we allow
-				// operators to specify authorization context parameters at
-				// the virtual host and route.
-				InitialMetadata: []*envoy_core_v3.HeaderValue{},
-			},
+			GrpcService: GrpcService(authzClusterName, timeout),
 		},
 		// Pretty sure we always want this. Why have an
 		// external auth service if it is not going to affect
@@ -766,6 +755,18 @@ func FilterChainTLSFallback(downstream *envoy_tls_v3.DownstreamTlsContext, filte
 		fc.TransportSocket = DownstreamTLSTransportSocket(downstream)
 	}
 	return fc
+}
+
+// GRPCService returns a envoy_core_v3.GrpcService for the given parameters.
+func GrpcService(clusterName string, timeout timeout.Setting) *envoy_core_v3.GrpcService {
+	return &envoy_core_v3.GrpcService{
+		TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+			EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+				ClusterName: clusterName,
+			},
+		},
+		Timeout: envoy.Timeout(timeout),
+	}
 }
 
 // ListenerFilters returns a []*envoy_listener_v3.ListenerFilter for the supplied listener filters.

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -240,6 +240,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 						TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 							EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 								ClusterName: "contour",
+								Authority:   "contour",
 							},
 						},
 					}},
@@ -429,6 +430,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -536,6 +538,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -644,6 +647,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -753,6 +757,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -861,6 +866,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -970,6 +976,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1077,6 +1084,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1185,6 +1193,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1294,6 +1303,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1403,6 +1413,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1510,6 +1521,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 												TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 													EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 														ClusterName: "contour",
+														Authority:   "contour",
 													},
 												},
 											}},
@@ -1960,7 +1972,7 @@ func TestAddFilter(t *testing.T) {
 		},
 		"Add to the default filters": {
 			builder: HTTPConnectionManagerBuilder().DefaultFilters(),
-			add:     FilterExternalAuthz("test", false, timeout.Setting{}, nil),
+			add:     FilterExternalAuthz("test", "", false, timeout.Setting{}, nil),
 			want: []*http.HttpFilter{
 				{
 					Name: "compressor",
@@ -2021,7 +2033,7 @@ func TestAddFilter(t *testing.T) {
 						}),
 					},
 				},
-				FilterExternalAuthz("test", false, timeout.Setting{}, nil),
+				FilterExternalAuthz("test", "", false, timeout.Setting{}, nil),
 				{
 					Name: "router",
 					ConfigType: &http.HttpFilter_TypedConfig{
@@ -2033,7 +2045,7 @@ func TestAddFilter(t *testing.T) {
 		"Add to the default filters with AuthorizationServerBufferSettings": {
 			builder: HTTPConnectionManagerBuilder().DefaultFilters(),
 			add: FilterExternalAuthz(
-				"test", false, timeout.Setting{}, &dag.AuthorizationServerBufferSettings{
+				"test", "ext-auth-server.com", false, timeout.Setting{}, &dag.AuthorizationServerBufferSettings{
 					MaxRequestBytes:     10,
 					AllowPartialMessage: true,
 					PackAsBytes:         true,
@@ -2108,6 +2120,7 @@ func TestAddFilter(t *testing.T) {
 										TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 											EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 												ClusterName: "test",
+												Authority:   "ext-auth-server.com",
 											},
 										},
 										Timeout:         envoy.Timeout(timeout.Setting{}),

--- a/internal/envoy/v3/ratelimit.go
+++ b/internal/envoy/v3/ratelimit.go
@@ -123,6 +123,7 @@ func GlobalRateLimits(descriptors []*dag.RateLimitDescriptor) []*envoy_route_v3.
 // an HTTP global rate limiting filter.
 type GlobalRateLimitConfig struct {
 	ExtensionService        types.NamespacedName
+	SNI                     string
 	FailOpen                bool
 	Timeout                 timeout.Setting
 	Domain                  string
@@ -144,7 +145,7 @@ func GlobalRateLimitFilter(config *GlobalRateLimitConfig) *http.HttpFilter {
 				Timeout:         envoy.Timeout(config.Timeout),
 				FailureModeDeny: !config.FailOpen,
 				RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
-					GrpcService:         GrpcService(dag.ExtensionClusterName(config.ExtensionService), timeout.DefaultSetting()),
+					GrpcService:         GrpcService(dag.ExtensionClusterName(config.ExtensionService), config.SNI, timeout.DefaultSetting()),
 					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 				},
 				EnableXRatelimitHeaders: enableXRateLimitHeaders(config.EnableXRateLimitHeaders),

--- a/internal/envoy/v3/ratelimit.go
+++ b/internal/envoy/v3/ratelimit.go
@@ -144,13 +144,7 @@ func GlobalRateLimitFilter(config *GlobalRateLimitConfig) *http.HttpFilter {
 				Timeout:         envoy.Timeout(config.Timeout),
 				FailureModeDeny: !config.FailOpen,
 				RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
-					GrpcService: &envoy_core_v3.GrpcService{
-						TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
-							EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
-								ClusterName: dag.ExtensionClusterName(config.ExtensionService),
-							},
-						},
-					},
+					GrpcService:         GrpcService(dag.ExtensionClusterName(config.ExtensionService), timeout.DefaultSetting()),
 					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 				},
 				EnableXRatelimitHeaders: enableXRateLimitHeaders(config.EnableXRateLimitHeaders),

--- a/internal/envoy/v3/ratelimit_test.go
+++ b/internal/envoy/v3/ratelimit_test.go
@@ -271,6 +271,7 @@ func TestGlobalRateLimitFilter(t *testing.T) {
 								TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 									EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 										ClusterName: "extension/projectcontour/ratelimit",
+										Authority:   "extension.projectcontour.ratelimit",
 									},
 								},
 							},
@@ -299,6 +300,37 @@ func TestGlobalRateLimitFilter(t *testing.T) {
 								TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 									EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 										ClusterName: "extension/projectcontour/ratelimit",
+										Authority:   "extension.projectcontour.ratelimit",
+									},
+								},
+							},
+							TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+						},
+					}),
+				},
+			},
+		},
+		"when rate limit server has SNI set": {
+			cfg: &GlobalRateLimitConfig{
+				ExtensionService: k8s.NamespacedNameFrom("projectcontour/ratelimit"),
+				SNI:              "some-server.com",
+				Timeout:          timeout.DurationSetting(7 * time.Second),
+				Domain:           "domain",
+				FailOpen:         false,
+			},
+			want: &http.HttpFilter{
+				Name: wellknown.HTTPRateLimit,
+				ConfigType: &http.HttpFilter_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&ratelimit_filter_v3.RateLimit{
+						Domain:          "domain",
+						Timeout:         protobuf.Duration(7 * time.Second),
+						FailureModeDeny: true,
+						RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
+							GrpcService: &envoy_core_v3.GrpcService{
+								TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+									EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+										ClusterName: "extension/projectcontour/ratelimit",
+										Authority:   "some-server.com",
 									},
 								},
 							},
@@ -328,6 +360,7 @@ func TestGlobalRateLimitFilter(t *testing.T) {
 								TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 									EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 										ClusterName: "extension/projectcontour/ratelimit",
+										Authority:   "extension.projectcontour.ratelimit",
 									},
 								},
 							},

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -15,6 +15,7 @@ package v3
 
 import (
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -42,6 +43,7 @@ func grpcCluster(name string) *envoy_config_filter_http_ext_authz_v3.ExtAuthz_Gr
 			TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 				EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 					ClusterName: name,
+					Authority:   strings.ReplaceAll(name, "/", "."),
 				},
 			},
 			Timeout: protobuf.Duration(defaultResponseTimeout),

--- a/internal/featuretests/v3/globalratelimit_test.go
+++ b/internal/featuretests/v3/globalratelimit_test.go
@@ -82,6 +82,7 @@ func globalRateLimitFilterExists(t *testing.T, rh cache.ResourceEventHandler, c 
 							TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 								EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 									ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+									Authority:   "extension.projectcontour.ratelimit",
 								},
 							},
 						},

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -141,6 +141,7 @@ type ListenerConfig struct {
 
 type RateLimitConfig struct {
 	ExtensionService        types.NamespacedName
+	SNI                     string
 	Domain                  string
 	Timeout                 timeout.Setting
 	FailOpen                bool
@@ -411,6 +412,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 				if vh.AuthorizationService != nil {
 					authFilter = envoy_v3.FilterExternalAuthz(
 						vh.AuthorizationService.Name,
+						vh.AuthorizationService.SNI,
 						vh.AuthorizationFailOpen,
 						vh.AuthorizationResponseTimeout,
 						vh.AuthorizationServerWithRequestBody,
@@ -548,6 +550,7 @@ func envoyGlobalRateLimitConfig(config *RateLimitConfig) *envoy_v3.GlobalRateLim
 
 	return &envoy_v3.GlobalRateLimitConfig{
 		ExtensionService:        config.ExtensionService,
+		SNI:                     config.SNI,
 		FailOpen:                config.FailOpen,
 		Timeout:                 config.Timeout,
 		Domain:                  config.Domain,

--- a/internal/xdscache/v3/listener_test.go
+++ b/internal/xdscache/v3/listener_test.go
@@ -3085,6 +3085,7 @@ func TestListenerVisit(t *testing.T) {
 										TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 											EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 												ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+												Authority:   "extension.projectcontour.ratelimit",
 											},
 										},
 									},
@@ -3101,6 +3102,7 @@ func TestListenerVisit(t *testing.T) {
 			ListenerConfig: ListenerConfig{
 				RateLimitConfig: &RateLimitConfig{
 					ExtensionService:        types.NamespacedName{Namespace: "projectcontour", Name: "ratelimit"},
+					SNI:                     "ratelimit-example.com",
 					Domain:                  "contour",
 					Timeout:                 timeout.DurationSetting(7 * time.Second),
 					FailOpen:                false,
@@ -3170,6 +3172,7 @@ func TestListenerVisit(t *testing.T) {
 										TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 											EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 												ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+												Authority:   "ratelimit-example.com",
 											},
 										},
 									},
@@ -3208,6 +3211,7 @@ func TestListenerVisit(t *testing.T) {
 											TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 												EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 													ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													Authority:   "ratelimit-example.com",
 												},
 											},
 										},
@@ -3315,6 +3319,7 @@ func TestListenerVisit(t *testing.T) {
 											TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 												EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 													ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													Authority:   "extension.projectcontour.ratelimit",
 												},
 											},
 										},
@@ -3353,6 +3358,7 @@ func TestListenerVisit(t *testing.T) {
 											TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 												EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 													ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													Authority:   "extension.projectcontour.ratelimit",
 												},
 											},
 										},
@@ -3386,6 +3392,7 @@ func TestListenerVisit(t *testing.T) {
 											TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
 												EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
 													ClusterName: dag.ExtensionClusterName(k8s.NamespacedNameFrom("projectcontour/ratelimit")),
+													Authority:   "extension.projectcontour.ratelimit",
 												},
 											},
 										},


### PR DESCRIPTION
- so that cluster name, which may not be a valid host, is not used
- if SNI is set on ExtensionService, it is passed through as authority
- otherwise, / is replaced with . in extension cluster name to be used
    as authority

Fixes: #4278