### PR TITLE
Gateway API: use v1beta1 API for HTTPRoute

### DIFF
--- a/internal/controller/httproute.go
+++ b/internal/controller/httproute.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type httpRouteReconciler struct {
@@ -52,16 +52,16 @@ func RegisterHTTPRouteController(log logrus.FieldLogger, mgr manager.Manager, ev
 		return err
 	}
 
-	return c.Watch(&source.Kind{Type: &gatewayapi_v1alpha2.HTTPRoute{}}, &handler.EnqueueRequestForObject{})
+	return c.Watch(&source.Kind{Type: &gatewayapi_v1beta1.HTTPRoute{}}, &handler.EnqueueRequestForObject{})
 }
 
 func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 
 	// Fetch the HTTPRoute from the cache.
-	httpRoute := &gatewayapi_v1alpha2.HTTPRoute{}
+	httpRoute := &gatewayapi_v1beta1.HTTPRoute{}
 	err := r.client.Get(ctx, request.NamespacedName, httpRoute)
 	if errors.IsNotFound(err) {
-		r.eventHandler.OnDelete(&gatewayapi_v1alpha2.HTTPRoute{
+		r.eventHandler.OnDelete(&gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      request.Name,
 				Namespace: request.Namespace,

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -466,20 +466,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	basicHTTPRoute := &gatewayapi_v1alpha2.HTTPRoute{
+	basicHTTPRoute := &gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 			},
-			Hostnames: []gatewayapi_v1alpha2.Hostname{
+			Hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 			}},
 		},
@@ -492,7 +492,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -563,20 +563,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPSameNamespace,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "different-ns-than-gateway",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -598,20 +598,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 				kuardServiceCustomNs,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "custom",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -641,20 +641,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 				kuardServiceCustomNs,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "custom",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -668,23 +668,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{
 								gatewayapi.GatewayParentRef("projectcontour", "some-other-gateway"),
 								gatewayapi.GatewayParentRef("projectcontour", "some-other-gateway-2"),
 							},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -706,7 +706,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -744,7 +744,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -782,7 +782,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -811,7 +811,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -855,7 +855,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -889,7 +889,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("some-other-namespace", "some-other-gateway-name")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("some-other-namespace", "some-other-gateway-name")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -1038,20 +1038,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []interface{}{
 				kuardService,
 				basicHTTPRoute,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic-two",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"another.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1136,23 +1136,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []interface{}{
 				kuardService,
 				blogService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}, {
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/blog"),
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/blog"),
 							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
 						}},
 					},
@@ -1174,23 +1174,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 							"test2.projectcontour.io",
 							"test3.projectcontour.io",
 							"test4.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1214,17 +1214,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1245,20 +1245,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"*.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1282,20 +1282,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"192.168.122.1",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1308,20 +1308,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io:80",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1334,20 +1334,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"*",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1361,17 +1361,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1392,21 +1392,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind: gatewayapi.KindPtr("Service"),
 										Name: "kuard",
 									},
 								},
@@ -1431,23 +1431,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1470,23 +1470,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1523,23 +1523,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1577,23 +1577,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1632,23 +1632,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1687,23 +1687,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1742,23 +1742,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -1798,20 +1798,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/blog"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/blog"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -1834,32 +1834,32 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
 							}, {
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/blog"),
 								},
 							}, {
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/tech"),
 								},
 							}},
@@ -2325,20 +2325,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"*.*.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
 						}},
 					},
@@ -2419,43 +2419,43 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				sec1,
 				kuardService,
 				blogService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{
 								gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http-listener"),
 							},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
 				},
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basictls",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
 
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{
 								gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "https-listener"),
 							},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
 						}},
 					},
@@ -2489,25 +2489,25 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1alpha2.HeaderMatchExact, "foo", "bar"),
+								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1beta1.HeaderMatchExact, "foo", "bar"),
 							}},
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
@@ -2535,32 +2535,32 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 							{
-								Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+								Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 									{
-										Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-											Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+										Path: &gatewayapi_v1beta1.HTTPPathMatch{
+											Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 											Value: pointer.StringPtr("/blog"),
 										},
 									}, {
-										Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-											Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+										Path: &gatewayapi_v1beta1.HTTPPathMatch{
+											Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 											Value: pointer.StringPtr("/tech"),
 										},
-										Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1alpha2.HeaderMatchExact, "foo", "bar"),
+										Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1beta1.HeaderMatchExact, "foo", "bar"),
 									},
 								},
 								BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -2593,21 +2593,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1alpha2.HeaderMatchExact, "foo", "bar"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1beta1.HeaderMatchExact, "foo", "bar"),
 							}},
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
@@ -2635,21 +2635,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Headers: []gatewayapi_v1alpha2.HTTPHeaderMatch{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
 									{Name: "header-1", Value: "value-1"},
 									{Name: "header-2", Value: "value-2"},
 									{Name: "header-1", Value: "value-3"},
@@ -2683,25 +2683,25 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								Method: gatewayapi.HTTPMethodPtr(gatewayapi_v1alpha2.HTTPMethodGet),
+								Method: gatewayapi.HTTPMethodPtr(gatewayapi_v1beta1.HTTPMethodGet),
 							}},
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
@@ -2729,25 +2729,25 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								QueryParams: []gatewayapi_v1alpha2.HTTPQueryParamMatch{
+								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
 										Name:  "param-1",
 										Value: "value-1",
@@ -2780,27 +2780,27 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								QueryParams: []gatewayapi_v1alpha2.HTTPQueryParamMatch{
+								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
-										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 										Name:  "param-1",
 										Value: "value-1",
 									},
@@ -2832,42 +2832,42 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								QueryParams: []gatewayapi_v1alpha2.HTTPQueryParamMatch{
+								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
-										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 										Name:  "param-1",
 										Value: "value-1",
 									},
 									{
-										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 										Name:  "param-2",
 										Value: "value-2",
 									},
 									{
-										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 										Name:  "param-1",
 										Value: "value-3",
 									},
 									{
-										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+										Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 										Name:  "Param-1",
 										Value: "value-4",
 									},
@@ -2901,29 +2901,29 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-									Set: []gatewayapi_v1alpha2.HTTPHeader{
-										{Name: gatewayapi_v1alpha2.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-										{Name: gatewayapi_v1alpha2.HTTPHeaderName("Host"), Value: "bar.com"},
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+									Set: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+										{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
 									},
-									Add: []gatewayapi_v1alpha2.HTTPHeader{
+									Add: []gatewayapi_v1beta1.HTTPHeader{
 										{Name: "custom-header-add", Value: "foo-bar"},
 									},
 								},
@@ -2959,34 +2959,34 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 								{
-									BackendRef: gatewayapi_v1alpha2.BackendRef{
+									BackendRef: gatewayapi_v1beta1.BackendRef{
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 										Weight:                 pointer.Int32(1),
 									},
-									Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-										Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-											Set: []gatewayapi_v1alpha2.HTTPHeader{
-												{Name: gatewayapi_v1alpha2.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-												{Name: gatewayapi_v1alpha2.HTTPHeaderName("Host"), Value: "bar.com"},
+									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+										Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+											Set: []gatewayapi_v1beta1.HTTPHeader{
+												{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+												{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
 											},
-											Add: []gatewayapi_v1alpha2.HTTPHeader{
+											Add: []gatewayapi_v1beta1.HTTPHeader{
 												{Name: "custom-header-add", Value: "foo-bar"},
 											},
 										},
@@ -3015,30 +3015,30 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 							{
-								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 								BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-								Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-									Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayapi_v1alpha2.HTTPHeader{
-											{Name: gatewayapi_v1alpha2.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-											{Name: gatewayapi_v1alpha2.HTTPHeaderName("Host"), Value: "bar.com"},
+								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
 										},
-										Add: []gatewayapi_v1alpha2.HTTPHeader{
+										Add: []gatewayapi_v1beta1.HTTPHeader{
 											{Name: "!invalid-header-add", Value: "foo-bar"},
 										},
 									},
@@ -3070,35 +3070,35 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 							{
-								Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-								BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+								Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+								BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 									{
-										BackendRef: gatewayapi_v1alpha2.BackendRef{
+										BackendRef: gatewayapi_v1beta1.BackendRef{
 											BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 											Weight:                 pointer.Int32(1),
 										},
-										Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-											Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-											RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-												Set: []gatewayapi_v1alpha2.HTTPHeader{
-													{Name: gatewayapi_v1alpha2.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-													{Name: gatewayapi_v1alpha2.HTTPHeaderName("Host"), Value: "bar.com"},
+										Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+											Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+												Set: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
 												},
-												Add: []gatewayapi_v1alpha2.HTTPHeader{
+												Add: []gatewayapi_v1beta1.HTTPHeader{
 													{Name: "!invalid-header-add", Value: "foo-bar"},
 												},
 											},
@@ -3127,23 +3127,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
 									Scheme:     pointer.String("https"),
 									Hostname:   gatewayapi.PreciseHostname("envoyproxy.io"),
 									Port:       gatewayapi.PortNumPtr(443),
@@ -3177,26 +3177,26 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 							Matches: append(
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/another-match")...,
+								gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+								gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/another-match")...,
 							),
-							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
 									Scheme:     pointer.String("https"),
 									Hostname:   gatewayapi.PreciseHostname("envoyproxy.io"),
 									Port:       gatewayapi.PortNumPtr(443),
@@ -3240,24 +3240,24 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []interface{}{
 				kuardService,
 				kuardService2,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 								},
 							}},
@@ -3280,27 +3280,27 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []interface{}{
 				kuardService,
 				kuardService2,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 							Matches: append(
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/another-match")...,
+								gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+								gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/another-match")...,
 							),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 								},
 							}},
@@ -3326,17 +3326,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRefs(
 								gatewayapi.HTTPBackendRef("kuard", 8080, 5),
 								gatewayapi.HTTPBackendRef("kuard2", 8080, 10),
@@ -3388,17 +3388,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRefs(
 								gatewayapi.HTTPBackendRef("kuard", 8080, 5),
 								gatewayapi.HTTPBackendRef("kuard2", 8080, 0),
@@ -3450,17 +3450,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 0),
 						}},
 					},
@@ -3495,7 +3495,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3533,7 +3533,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3556,7 +3556,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3566,7 +3566,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3620,7 +3620,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3630,7 +3630,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3685,7 +3685,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3695,7 +3695,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3734,7 +3734,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3744,7 +3744,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3783,7 +3783,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3793,7 +3793,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3832,7 +3832,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -3842,7 +3842,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
 										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      gatewayapi.PortNumPtr(8080),
+										Port:      gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 									Weight: pointer.Int32(1),
 								},
@@ -3882,7 +3882,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{
 							"tcp.projectcontour.io",
@@ -3940,7 +3940,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{
 							"tcp.projectcontour.io",
@@ -3990,7 +3990,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{
 							"tcp.*.projectcontour.io",
@@ -4017,7 +4017,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
 							BackendRefs: gatewayapi.TLSRouteBackendRef("kuard", 8080, nil),
@@ -4053,7 +4053,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -4078,7 +4078,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -4127,7 +4127,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -4176,7 +4176,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour")},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -4216,17 +4216,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPWithHostname,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/blog"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/blog"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
@@ -4248,20 +4248,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPWithWildcardHostname,
 			objs: []interface{}{
 				kuardService,
-				&gatewayapi_v1alpha2.HTTPRoute{
+				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
 							"http.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/blog"),
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/blog"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -65,7 +65,7 @@ type KubernetesCache struct {
 	namespaces                map[string]*v1.Namespace
 	gatewayclass              *gatewayapi_v1beta1.GatewayClass
 	gateway                   *gatewayapi_v1beta1.Gateway
-	httproutes                map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute
+	httproutes                map[types.NamespacedName]*gatewayapi_v1beta1.HTTPRoute
 	tlsroutes                 map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute
 	referencepolicies         map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy
 	referencegrants           map[types.NamespacedName]*gatewayapi_v1alpha2.ReferenceGrant
@@ -86,7 +86,7 @@ func (kc *KubernetesCache) init() {
 	kc.tlscertificatedelegations = make(map[types.NamespacedName]*contour_api_v1.TLSCertificateDelegation)
 	kc.services = make(map[types.NamespacedName]*v1.Service)
 	kc.namespaces = make(map[string]*v1.Namespace)
-	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.HTTPRoute)
+	kc.httproutes = make(map[types.NamespacedName]*gatewayapi_v1beta1.HTTPRoute)
 	kc.referencepolicies = make(map[types.NamespacedName]*gatewayapi_v1alpha2.ReferencePolicy)
 	kc.referencegrants = make(map[types.NamespacedName]*gatewayapi_v1alpha2.ReferenceGrant)
 	kc.tlsroutes = make(map[types.NamespacedName]*gatewayapi_v1alpha2.TLSRoute)
@@ -196,7 +196,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 				kc.gateway = obj
 				return true
 			}
-		case *gatewayapi_v1alpha2.HTTPRoute:
+		case *gatewayapi_v1beta1.HTTPRoute:
 			kc.httproutes[k8s.NamespacedNameOf(obj)] = obj
 			return true
 		case *gatewayapi_v1alpha2.TLSRoute:
@@ -319,7 +319,7 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 			kc.gateway = nil
 			return true
 		}
-	case *gatewayapi_v1alpha2.HTTPRoute:
+	case *gatewayapi_v1beta1.HTTPRoute:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.httproutes[m]
 		delete(kc.httproutes, m)
@@ -412,10 +412,10 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 	return false
 }
 
-func isRefToService(ref gatewayapi_v1alpha2.BackendObjectReference, service *v1.Service, routeNamespace string) bool {
+func isRefToService(ref gatewayapi_v1beta1.BackendObjectReference, service *v1.Service, routeNamespace string) bool {
 	return ref.Group != nil && *ref.Group == "" &&
 		ref.Kind != nil && *ref.Kind == "Service" &&
-		((ref.Namespace != nil && *ref.Namespace == gatewayapi_v1alpha2.Namespace(service.Namespace)) || (ref.Namespace == nil && routeNamespace == service.Namespace)) &&
+		((ref.Namespace != nil && string(*ref.Namespace) == service.Namespace) || (ref.Namespace == nil && routeNamespace == service.Namespace)) &&
 		string(ref.Name) == service.Name
 }
 

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -857,7 +857,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert gateway-api HTTPRoute": {
-			obj: &gatewayapi_v1alpha2.HTTPRoute{
+			obj: &gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
@@ -1205,13 +1205,13 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api HTTPRoute": {
-			cache: cache(&gatewayapi_v1alpha2.HTTPRoute{
+			cache: cache(&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
 				},
 			}),
-			obj: &gatewayapi_v1alpha2.HTTPRoute{
+			obj: &gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
@@ -1562,14 +1562,14 @@ func TestServiceTriggersRebuild(t *testing.T) {
 		}
 	}
 
-	httpRoute := func(namespace, name string) *gatewayapi_v1alpha2.HTTPRoute {
-		return &gatewayapi_v1alpha2.HTTPRoute{
+	httpRoute := func(namespace, name string) *gatewayapi_v1beta1.HTTPRoute {
+		return &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 					BackendRefs: gatewayapi.HTTPBackendRef(name, 80, 1),
 				}},
 			},

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -23,20 +23,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestComputeHosts(t *testing.T) {
 	tests := map[string]struct {
 		listenerHost string
-		hostnames    []gatewayapi_v1alpha2.Hostname
+		hostnames    []gatewayapi_v1beta1.Hostname
 		want         sets.String
 		wantError    []error
 	}{
 		"single host": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 			},
 			want:      sets.NewString("test.projectcontour.io"),
@@ -44,7 +43,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"single DNS label hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"projectcontour",
 			},
 			want:      sets.NewString("projectcontour"),
@@ -52,7 +51,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"multiple hosts": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 				"test1.projectcontour.io",
 				"test2.projectcontour.io",
@@ -68,13 +67,13 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"no host": {
 			listenerHost: "",
-			hostnames:    []gatewayapi_v1alpha2.Hostname{},
+			hostnames:    []gatewayapi_v1beta1.Hostname{},
 			want:         sets.NewString("*"),
 			wantError:    []error(nil),
 		},
 		"IP in host": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"1.2.3.4",
 			},
 			want: nil,
@@ -84,7 +83,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"valid wildcard hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.NewString("*.projectcontour.io"),
@@ -92,7 +91,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid wildcard hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.*.projectcontour.io",
 			},
 			want: nil,
@@ -102,7 +101,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid wildcard hostname *": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*",
 			},
 			want:      nil,
@@ -110,7 +109,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"#projectcontour.io",
 			},
 			want: nil,
@@ -120,7 +119,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host do not exactly match": {
 			listenerHost: "listener.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      nil,
@@ -128,7 +127,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host exactly match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      sets.NewString("http.projectcontour.io"),
@@ -136,7 +135,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & multi hostnames host exactly match one host": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"http.projectcontour.io",
 				"http2.projectcontour.io",
 				"http3.projectcontour.io",
@@ -146,7 +145,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host match wildcard host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      sets.NewString("http.projectcontour.io"),
@@ -154,7 +153,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host do not match wildcard host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"http.example.com",
 			},
 			want:      nil,
@@ -162,7 +161,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostnames host do not match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.NewString("http.projectcontour.io"),
@@ -170,7 +169,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostname and matching hostname match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 				"http.projectcontour.io",
 			},
@@ -179,7 +178,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostname and non-matching hostname don't match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 				"not.matching.io",
 			},
@@ -188,7 +187,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host wildcard & wildcard hostnames host match": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.NewString("*.projectcontour.io"),
@@ -196,13 +195,13 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostname not defined match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames:    []gatewayapi_v1alpha2.Hostname{},
+			hostnames:    []gatewayapi_v1beta1.Hostname{},
 			want:         sets.NewString("http.projectcontour.io"),
 			wantError:    nil,
 		},
 		"listener host with many labels matches hostnames wildcard host": {
 			listenerHost: "very.many.labels.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.NewString("very.many.labels.projectcontour.io"),
@@ -210,7 +209,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener wildcard host matches hostnames with many labels host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"very.many.labels.projectcontour.io",
 			},
 			want:      sets.NewString("very.many.labels.projectcontour.io"),
@@ -218,7 +217,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener wildcard host doesn't match bare hostname": {
 			listenerHost: "*.foo",
-			hostnames: []gatewayapi_v1alpha2.Hostname{
+			hostnames: []gatewayapi_v1beta1.Hostname{
 				"foo",
 			},
 			want:      nil,
@@ -488,60 +487,60 @@ func TestNamespaceMatches(t *testing.T) {
 
 func TestRouteSelectsGatewayListener(t *testing.T) {
 	tests := map[string]struct {
-		routeParentRefs []gatewayapi_v1alpha2.ParentReference
+		routeParentRefs []gatewayapi_v1beta1.ParentReference
 		routeNamespace  string
 		listener        gatewayapi_v1beta1.Listener
 		want            bool
 	}{
 		"gateway namespace specified, no listener specified, gateway in same namespace as route": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayParentRef("projectcontour", "contour"),
 			},
 			want: true,
 		},
 		"gateway namespace specified, no listener specified, gateway in different namespace than route": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayParentRef("different-ns-than-gateway", "contour"),
 			},
 			want: false,
 		},
 		"no gateway namespace specified, no listener specified, gateway in same namespace as route": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayParentRef("", "contour"),
 			},
 			routeNamespace: "projectcontour",
 			want:           true,
 		},
 		"no gateway namespace specified, no listener specified, gateway in different namespace than route": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayParentRef("", "contour"),
 			},
 			routeNamespace: "different-ns-than-gateway",
 			want:           false,
 		},
 		"parentRef name doesn't match gateway name": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayParentRef("projectcontour", "different-name-than-gateway"),
 			},
 			want: false,
 		},
 
 		"section name specified, matches listener": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http-listener"),
 			},
 			listener: gatewayapi_v1beta1.Listener{Name: "http-listener"},
 			want:     true,
 		},
 		"section name specified, does not match listener": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "different-listener-name"),
 			},
 			listener: gatewayapi_v1beta1.Listener{Name: "http-listener"},
 			want:     false,
 		},
 		"multiple parentRefs with section names specified, first listener": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1"),
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-2"),
 			},
@@ -549,7 +548,7 @@ func TestRouteSelectsGatewayListener(t *testing.T) {
 			want:     true,
 		},
 		"multiple parentRefs with section names specified, second listener": {
-			routeParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			routeParentRefs: []gatewayapi_v1beta1.ParentReference{
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1"),
 				gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-2"),
 			},

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -23,7 +23,7 @@ import (
 
 	networking_v1 "k8s.io/api/networking/v1"
 	"k8s.io/utils/pointer"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
@@ -204,7 +204,7 @@ func headersPolicyRoute(policy *contour_api_v1.HeadersPolicy, allowHostRewrite b
 
 // headersPolicyGatewayAPI builds a *HeaderPolicy for the supplied HTTPRequestHeaderFilter.
 // TODO: Take care about the order of operators once https://github.com/kubernetes-sigs/gateway-api/issues/480 was solved.
-func headersPolicyGatewayAPI(hf *gatewayapi_v1alpha2.HTTPRequestHeaderFilter) (*HeadersPolicy, error) {
+func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPRequestHeaderFilter) (*HeadersPolicy, error) {
 	var (
 		set         = make(map[string]string, len(hf.Set))
 		add         = make(map[string]string, len(hf.Add))

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2794,7 +2794,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			// set the expected controller string here for all
 			// test cases.
 			for _, u := range tc.wantRouteConditions {
-				u.GatewayController = gatewayapi_v1alpha2.GatewayController(builder.Source.gatewayclass.Spec.ControllerName)
+				u.GatewayController = builder.Source.gatewayclass.Spec.ControllerName
 			}
 
 			if diff := cmp.Diff(tc.wantRouteConditions, gotRouteUpdates, ops...); diff != "" {
@@ -2855,7 +2855,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "simple httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -2863,24 +2863,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ValidCondition),
 					Message: "Valid HTTPRoute",
@@ -2893,7 +2893,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "simple httproute with backendref namespace matching route's explicitly specified", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -2901,22 +2901,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2(kuardService.Namespace),
-										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr(kuardService.Namespace),
+										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
 									Weight: pointer.Int32(1),
@@ -2928,9 +2928,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ValidCondition),
 					Message: "Valid HTTPRoute",
@@ -2943,38 +2943,38 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "multiple httproutes", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic-2",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
@@ -2982,9 +2982,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionTrue,
 						Reason:  string(status.ValidCondition),
 						Message: "Valid HTTPRoute",
@@ -2993,9 +2993,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic-2"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionTrue,
 						Reason:  string(status.ValidCondition),
 						Message: "Valid HTTPRoute",
@@ -3009,7 +3009,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "prefix path match not starting with '/' for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3017,17 +3017,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("doesnt-start-with-slash"),
 							},
 						}},
@@ -3037,9 +3037,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3058,7 +3058,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "exact path match not starting with '/' for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3066,17 +3066,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchExact),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchExact),
 								Value: pointer.StringPtr("doesnt-start-with-slash"),
 							},
 						}},
@@ -3086,9 +3086,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3107,7 +3107,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "prefix path match with consecutive '/' characters for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3115,17 +3115,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/foo///bar"),
 							},
 						}},
@@ -3135,9 +3135,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3156,7 +3156,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "exact path match with consecutive '/' characters for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3164,17 +3164,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchExact),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchExact),
 								Value: pointer.StringPtr("//foo/bar"),
 							},
 						}},
@@ -3184,9 +3184,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3205,7 +3205,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "invalid path match type for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3213,16 +3213,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  gatewayapi.PathMatchTypePtr("UNKNOWN"), // <---- unknown type to break the test
 								Value: pointer.StringPtr("/"),
 							},
@@ -3233,9 +3233,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3254,7 +3254,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "regular expression match not yet supported for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3262,24 +3262,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchRegularExpression, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchRegularExpression, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3298,7 +3298,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "RegularExpression header match not yet supported for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3306,23 +3306,23 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/"),
 							},
-							Headers: []gatewayapi_v1alpha2.HTTPHeaderMatch{
+							Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
 								{
-									Type:  gatewayapi.HeaderMatchTypePtr(gatewayapi_v1alpha2.HeaderMatchRegularExpression), // <---- RegularExpression type not yet supported
-									Name:  gatewayapi_v1alpha2.HTTPHeaderName("foo"),
+									Type:  gatewayapi.HeaderMatchTypePtr(gatewayapi_v1beta1.HeaderMatchRegularExpression), // <---- RegularExpression type not yet supported
+									Name:  gatewayapi_v1beta1.HTTPHeaderName("foo"),
 									Value: "bar",
 								},
 							},
@@ -3333,9 +3333,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3354,27 +3354,27 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "RegularExpression query param match not supported for httproute", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/"),
 							},
-							QueryParams: []gatewayapi_v1alpha2.HTTPQueryParamMatch{
+							QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 								{
-									Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchRegularExpression), // <---- RegularExpression type not yet supported
+									Type:  gatewayapi.QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchRegularExpression), // <---- RegularExpression type not yet supported
 									Name:  "param-1",
 									Value: "value-1",
 								},
@@ -3386,9 +3386,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3407,7 +3407,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.name not specified", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3415,20 +3415,20 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind: gatewayapi.KindPtr("Service"),
 										Port: gatewayapi.PortNumPtr(8080),
 									},
 								},
@@ -3439,15 +3439,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.BackendRef.Name must be specified",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3460,7 +3460,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.backendRef.serviceName invalid on two matches", testcase{
 		objs: []interface{}{
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3468,25 +3468,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("invalid-one", 8080, 1),
 					}, {
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/blog"),
 							},
 						}},
@@ -3496,15 +3496,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3518,7 +3518,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.port not specified", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3526,20 +3526,20 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind: gatewayapi.KindPtr("Service"),
 										Name: "kuard",
 									},
 								},
@@ -3550,15 +3550,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.BackendRef.Port must be specified",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3572,7 +3572,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRefs not specified", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3580,29 +3580,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "At least one Spec.Rules.BackendRef must be specified.",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -3615,7 +3615,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.namespace does not match route", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -3623,21 +3623,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-										Namespace: gatewayapi.NamespacePtrV1Alpha2("some-other-namespace"),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind:      gatewayapi.KindPtr("Service"),
+										Namespace: gatewayapi.NamespacePtr("some-other-namespace"),
 										Name:      "service",
 										Port:      gatewayapi.PortNumPtr(8080),
 									},
@@ -3649,15 +3649,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1beta1.ListenerReasonRefNotPermitted),
 					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4298,7 +4298,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid wildcard", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4306,29 +4306,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"*.*.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonNoIntersectingHostnames),
 					Message: "No intersecting hostnames were found between the listener and the route.",
@@ -4341,7 +4341,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid hostname", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4349,29 +4349,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"#projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonNoIntersectingHostnames),
 					Message: "No intersecting hostnames were found between the listener and the route.",
@@ -4384,7 +4384,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid hostname, ip address", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4392,29 +4392,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"1.2.3.4",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 					}},
 				},
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"1.2.3.4\": must be a DNS name, not an IP address",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonNoIntersectingHostnames),
 					Message: "No intersecting hostnames were found between the listener and the route.",
@@ -4427,18 +4427,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "two HTTP listeners, route's hostname intersects with one of them", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
@@ -4477,9 +4477,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ValidCondition),
 					Message: "Valid HTTPRoute",
@@ -4543,18 +4543,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "two HTTP listeners, route's hostname intersects with neither of them", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{"foo.randomdomain.io"},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.randomdomain.io"},
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
@@ -4593,9 +4593,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonNoIntersectingHostnames),
 					Message: "No intersecting hostnames were found between the listener and the route.",
@@ -4661,7 +4661,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			kuardService,
 			kuardService2,
 			kuardService3,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4669,24 +4669,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 							},
 						}, {
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
 							}},
 						},
@@ -4695,15 +4695,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionNotImplemented: {
 					Type:    string(status.ConditionNotImplemented),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ReasonNotImplemented),
 					Message: "HTTPRoute.Spec.Rules.Filters: Only one mirror filter is supported.",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4718,7 +4718,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []interface{}{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4726,22 +4726,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1alpha2.BackendObjectReference{
-									Group: gatewayapi.GroupPtrV1Alpha2(""),
-									Kind:  gatewayapi.KindPtrV1Alpha2("Service"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
+									Group: gatewayapi.GroupPtr(""),
+									Kind:  gatewayapi.KindPtr("Service"),
 									Port:  gatewayapi.PortNumPtr(8080),
 								},
 							},
@@ -4751,15 +4751,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Name must be specified",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4774,7 +4774,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []interface{}{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4782,23 +4782,23 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1alpha2.BackendObjectReference{
-									Group: gatewayapi.GroupPtrV1Alpha2(""),
-									Kind:  gatewayapi.KindPtrV1Alpha2("Service"),
-									Name:  gatewayapi_v1alpha2.ObjectName("kuard2"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
+									Group: gatewayapi.GroupPtr(""),
+									Kind:  gatewayapi.KindPtr("Service"),
+									Name:  gatewayapi_v1beta1.ObjectName("kuard2"),
 								},
 							},
 						}},
@@ -4807,15 +4807,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Port must be specified",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4830,7 +4830,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []interface{}{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4838,38 +4838,38 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("invalid-one", 8080),
 							},
 						}},
 					}, {
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard2", 8080, 1),
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{{
-							Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 								Value: pointer.StringPtr("/blog"),
 							},
 						}},
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("invalid-two", 8080),
 							},
 						}},
@@ -4878,15 +4878,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4901,7 +4901,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []interface{}{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4909,24 +4909,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1alpha2.BackendObjectReference{
-									Group:     gatewayapi.GroupPtrV1Alpha2(""),
-									Kind:      gatewayapi.KindPtrV1Alpha2("Service"),
-									Namespace: gatewayapi.NamespacePtrV1Alpha2("some-other-namespace"),
-									Name:      gatewayapi_v1alpha2.ObjectName("kuard2"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
+									Group:     gatewayapi.GroupPtr(""),
+									Kind:      gatewayapi.KindPtr("Service"),
+									Namespace: gatewayapi.NamespacePtr("some-other-namespace"),
+									Name:      gatewayapi_v1beta1.ObjectName("kuard2"),
 									Port:      gatewayapi.PortNumPtr(8080),
 								},
 							},
@@ -4936,15 +4936,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1beta1.ListenerReasonRefNotPermitted),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -4959,7 +4959,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []interface{}{
 
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -4967,22 +4967,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
-								Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-									Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror, // HTTPRouteFilterRequestMirror is not supported yet.
+								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror, // HTTPRouteFilterRequestMirror is not supported yet.
 								}},
 							},
 						},
@@ -4991,15 +4991,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionNotImplemented: {
 					Type:    string(status.ConditionNotImplemented),
 					Status:  contour_api_v1.ConditionTrue,
 					Reason:  string(status.ReasonHTTPRouteFilterType),
 					Message: "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier type is supported.",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -5013,7 +5013,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid RequestHeaderModifier due to duplicated headers", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -5021,20 +5021,20 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-							Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-								Set: []gatewayapi_v1alpha2.HTTPHeader{
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
 									{Name: "custom", Value: "duplicated"},
 									{Name: "Custom", Value: "duplicated"},
 								},
@@ -5045,15 +5045,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "duplicate header addition: \"Custom\" on request headers",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -5067,7 +5067,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid RequestHeaderModifier after forward due to invalid headers", testcase{
 		objs: []interface{}{
 			kuardService,
-			&gatewayapi_v1alpha2.HTTPRoute{
+			&gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
@@ -5075,24 +5075,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"app": "contour",
 					},
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1alpha2.Hostname{
+					Hostnames: []gatewayapi_v1beta1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
-								Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{{
-									Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-										Set: []gatewayapi_v1alpha2.HTTPHeader{
+								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
 											{Name: "!invalid-header", Value: "foo"},
 										},
 									},
@@ -5104,15 +5104,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			}},
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 				status.ConditionResolvedRefs: {
 					Type:    string(status.ConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid set header \"!invalid-Header\": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')] on request headers",
 				},
-				gatewayapi_v1alpha2.RouteConditionAccepted: {
-					Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+				gatewayapi_v1beta1.RouteConditionAccepted: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonErrorsExist),
 					Message: "Errors found, check other Conditions for details.",
@@ -5891,7 +5891,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			// set the expected controller string here for all
 			// test cases.
 			for _, u := range tc.wantRouteConditions {
-				u.GatewayController = gatewayapi_v1alpha2.GatewayController(builder.Source.gatewayclass.Spec.ControllerName)
+				u.GatewayController = builder.Source.gatewayclass.Spec.ControllerName
 			}
 
 			if diff := cmp.Diff(tc.wantRouteConditions, gotRouteUpdates, ops...); diff != "" {
@@ -6008,7 +6008,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
@@ -6017,7 +6017,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
 										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
-										Port: gatewayapi.PortNumPtr(8080),
+										Port: gatewayapi.PortNumPtrV1Alpha2(8080),
 									},
 								},
 							},
@@ -6026,15 +6026,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "Spec.Rules.BackendRef.Name must be specified",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  "ErrorsExist",
 						Message: "Errors found, check other Conditions for details.",
@@ -6058,7 +6058,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
@@ -6070,15 +6070,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  "ErrorsExist",
 						Message: "Errors found, check other Conditions for details.",
@@ -6103,7 +6103,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
@@ -6121,15 +6121,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "Spec.Rules.BackendRef.Port must be specified",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  "ErrorsExist",
 						Message: "Errors found, check other Conditions for details.",
@@ -6154,7 +6154,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{
@@ -6165,15 +6165,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "At least one Spec.Rules.BackendRef must be specified.",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  "ErrorsExist",
 						Message: "Errors found, check other Conditions for details.",
@@ -6198,7 +6198,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"*.*.projectcontour.io"},
@@ -6209,15 +6209,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonNoIntersectingHostnames),
 						Message: "No intersecting hostnames were found between the listener and the route.",
@@ -6242,7 +6242,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"#projectcontour.io"},
@@ -6253,15 +6253,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonNoIntersectingHostnames),
 						Message: "No intersecting hostnames were found between the listener and the route.",
@@ -6286,7 +6286,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+								gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"1.2.3.4"},
@@ -6297,15 +6297,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionResolvedRefs: {
 						Type:    string(status.ConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"1.2.3.4\": must be a DNS name, not an IP address",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonNoIntersectingHostnames),
 						Message: "No intersecting hostnames were found between the listener and the route.",
@@ -6327,7 +6327,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-								gatewayapi.GatewayParentRef(gw.Namespace, gw.Name),
+								gatewayapi.GatewayParentRefV1Alpha2(gw.Namespace, gw.Name),
 							},
 						},
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
@@ -6338,15 +6338,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 				}},
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				Conditions: map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition{
+				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
 					status.ConditionValidBackendRefs: {
 						Type:    string(status.ConditionValidBackendRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonAllBackendRefsHaveZeroWeights),
 						Message: "At least one Spec.Rules.BackendRef must have a non-zero weight.",
 					},
-					gatewayapi_v1alpha2.RouteConditionAccepted: {
-						Type:    string(gatewayapi_v1alpha2.RouteConditionAccepted),
+					gatewayapi_v1beta1.RouteConditionAccepted: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  "ErrorsExist",
 						Message: "Errors found, check other Conditions for details.",

--- a/internal/featuretests/v3/httproute_test.go
+++ b/internal/featuretests/v3/httproute_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -111,7 +110,7 @@ func TestGateway_TLS(t *testing.T) {
 
 	rh.OnAdd(gateway)
 
-	rh.OnAdd(&gatewayapi_v1alpha2.HTTPRoute{
+	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
@@ -120,20 +119,20 @@ func TestGateway_TLS(t *testing.T) {
 				"type": "controller",
 			},
 		},
-		Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1alpha2.Hostname{
+			Hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/blog"),
+			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc2", 80, 1),
 			}, {
-				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc1", 80, 10),
 			}},
 		},

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -400,7 +400,7 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 	})
 
 	// HTTPRoute with a single weight.
-	route1 := &gatewayapi_v1alpha2.HTTPRoute{
+	route1 := &gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
@@ -409,17 +409,17 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 				"type": "controller",
 			},
 		},
-		Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1alpha2.Hostname{
+			Hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/blog"),
+			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc1", 80, 1),
 			}},
 		},
@@ -437,7 +437,7 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 	), nil)
 
 	// HTTPRoute with multiple weights.
-	route2 := &gatewayapi_v1alpha2.HTTPRoute{
+	route2 := &gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
@@ -446,17 +446,17 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 				"type": "controller",
 			},
 		},
-		Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1alpha2.Hostname{
+			Hostnames: []gatewayapi_v1beta1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1alpha2.HTTPRouteRule{{
-				Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/blog"),
+			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRefs(
 					gatewayapi.HTTPBackendRef("svc1", 80, 60),
 					gatewayapi.HTTPBackendRef("svc2", 80, 90),
@@ -540,7 +540,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
@@ -596,7 +596,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -92,7 +92,7 @@ func TestTLSRoute(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
@@ -144,7 +144,7 @@ func TestTLSRoute(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -194,7 +194,7 @@ func TestTLSRoute(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
@@ -212,7 +212,7 @@ func TestTLSRoute(t *testing.T) {
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					gatewayapi.GatewayParentRefV1Alpha2("projectcontour", "contour"),
 				},
 			},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -19,12 +19,24 @@ import (
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func SectionNamePtr(sectionName string) *gatewayapi_v1alpha2.SectionName {
+func SectionNamePtr(sectionName string) *gatewayapi_v1beta1.SectionName {
+	gwSectionName := gatewayapi_v1beta1.SectionName(sectionName)
+	return &gwSectionName
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func SectionNamePtrV1Alpha2(sectionName string) *gatewayapi_v1alpha2.SectionName {
 	gwSectionName := gatewayapi_v1alpha2.SectionName(sectionName)
 	return &gwSectionName
 }
 
-func PortNumPtr(port int) *gatewayapi_v1alpha2.PortNumber {
+func PortNumPtr(port int) *gatewayapi_v1beta1.PortNumber {
+	pn := gatewayapi_v1beta1.PortNumber(port)
+	return &pn
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func PortNumPtrV1Alpha2(port int) *gatewayapi_v1alpha2.PortNumber {
 	pn := gatewayapi_v1alpha2.PortNumber(port)
 	return &pn
 }
@@ -33,15 +45,15 @@ func FromNamespacesPtr(val gatewayapi_v1beta1.FromNamespaces) *gatewayapi_v1beta
 	return &val
 }
 
-func PathMatchTypePtr(val gatewayapi_v1alpha2.PathMatchType) *gatewayapi_v1alpha2.PathMatchType {
+func PathMatchTypePtr(val gatewayapi_v1beta1.PathMatchType) *gatewayapi_v1beta1.PathMatchType {
 	return &val
 }
 
-func HeaderMatchTypePtr(val gatewayapi_v1alpha2.HeaderMatchType) *gatewayapi_v1alpha2.HeaderMatchType {
+func HeaderMatchTypePtr(val gatewayapi_v1beta1.HeaderMatchType) *gatewayapi_v1beta1.HeaderMatchType {
 	return &val
 }
 
-func QueryParamMatchTypePtr(val gatewayapi_v1alpha2.QueryParamMatchType) *gatewayapi_v1alpha2.QueryParamMatchType {
+func QueryParamMatchTypePtr(val gatewayapi_v1beta1.QueryParamMatchType) *gatewayapi_v1beta1.QueryParamMatchType {
 	return &val
 }
 
@@ -49,7 +61,7 @@ func TLSModeTypePtr(mode gatewayapi_v1beta1.TLSModeType) *gatewayapi_v1beta1.TLS
 	return &mode
 }
 
-func HTTPMethodPtr(method gatewayapi_v1alpha2.HTTPMethod) *gatewayapi_v1alpha2.HTTPMethod {
+func HTTPMethodPtr(method gatewayapi_v1beta1.HTTPMethod) *gatewayapi_v1beta1.HTTPMethod {
 	return &method
 }
 
@@ -62,8 +74,8 @@ func ListenerHostname(host string) *gatewayapi_v1beta1.Hostname {
 	return &h
 }
 
-func PreciseHostname(host string) *gatewayapi_v1alpha2.PreciseHostname {
-	h := gatewayapi_v1alpha2.PreciseHostname(host)
+func PreciseHostname(host string) *gatewayapi_v1beta1.PreciseHostname {
+	h := gatewayapi_v1beta1.PreciseHostname(host)
 	return &h
 }
 
@@ -81,7 +93,22 @@ func CertificateRef(name, namespace string) gatewayapi_v1beta1.SecretObjectRefer
 	return ref
 }
 
-func GatewayParentRef(namespace, name string) gatewayapi_v1alpha2.ParentReference {
+func GatewayParentRef(namespace, name string) gatewayapi_v1beta1.ParentReference {
+	parentRef := gatewayapi_v1beta1.ParentReference{
+		Group: GroupPtr(gatewayapi_v1alpha2.GroupName),
+		Kind:  KindPtr("Gateway"),
+		Name:  gatewayapi_v1beta1.ObjectName(name),
+	}
+
+	if namespace != "" {
+		parentRef.Namespace = NamespacePtr(namespace)
+	}
+
+	return parentRef
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func GatewayParentRefV1Alpha2(namespace, name string) gatewayapi_v1alpha2.ParentReference {
 	parentRef := gatewayapi_v1alpha2.ParentReference{
 		Group: GroupPtrV1Alpha2(gatewayapi_v1alpha2.GroupName),
 		Kind:  KindPtrV1Alpha2("Gateway"),
@@ -95,7 +122,7 @@ func GatewayParentRef(namespace, name string) gatewayapi_v1alpha2.ParentReferenc
 	return parentRef
 }
 
-func GatewayListenerParentRef(namespace, name, listener string) gatewayapi_v1alpha2.ParentReference {
+func GatewayListenerParentRef(namespace, name, listener string) gatewayapi_v1beta1.ParentReference {
 	parentRef := GatewayParentRef(namespace, name)
 
 	if listener != "" {
@@ -143,11 +170,11 @@ func ObjectNamePtr(name string) *gatewayapi_v1alpha2.ObjectName {
 	return &objectName
 }
 
-func ServiceBackendObjectRef(name string, port int) gatewayapi_v1alpha2.BackendObjectReference {
-	return gatewayapi_v1alpha2.BackendObjectReference{
-		Group: GroupPtrV1Alpha2(""),
-		Kind:  KindPtrV1Alpha2("Service"),
-		Name:  gatewayapi_v1alpha2.ObjectName(name),
+func ServiceBackendObjectRef(name string, port int) gatewayapi_v1beta1.BackendObjectReference {
+	return gatewayapi_v1beta1.BackendObjectReference{
+		Group: GroupPtr(""),
+		Kind:  KindPtr("Service"),
+		Name:  gatewayapi_v1beta1.ObjectName(name),
 		Port:  PortNumPtr(port),
 	}
 }
@@ -156,10 +183,10 @@ func GatewayAddressTypePtr(addr gatewayapi_v1beta1.AddressType) *gatewayapi_v1be
 	return &addr
 }
 
-func HTTPRouteMatch(pathType gatewayapi_v1alpha2.PathMatchType, value string) []gatewayapi_v1alpha2.HTTPRouteMatch {
-	return []gatewayapi_v1alpha2.HTTPRouteMatch{
+func HTTPRouteMatch(pathType gatewayapi_v1beta1.PathMatchType, value string) []gatewayapi_v1beta1.HTTPRouteMatch {
+	return []gatewayapi_v1beta1.HTTPRouteMatch{
 		{
-			Path: &gatewayapi_v1alpha2.HTTPPathMatch{
+			Path: &gatewayapi_v1beta1.HTTPPathMatch{
 				Type:  PathMatchTypePtr(pathType),
 				Value: pointer.StringPtr(value),
 			},
@@ -167,22 +194,22 @@ func HTTPRouteMatch(pathType gatewayapi_v1alpha2.PathMatchType, value string) []
 	}
 }
 
-func HTTPHeaderMatch(matchType gatewayapi_v1alpha2.HeaderMatchType, name, value string) []gatewayapi_v1alpha2.HTTPHeaderMatch {
-	return []gatewayapi_v1alpha2.HTTPHeaderMatch{
+func HTTPHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value string) []gatewayapi_v1beta1.HTTPHeaderMatch {
+	return []gatewayapi_v1beta1.HTTPHeaderMatch{
 		{
-			Type:  HeaderMatchTypePtr(gatewayapi_v1alpha2.HeaderMatchExact),
-			Name:  gatewayapi_v1alpha2.HTTPHeaderName(name),
+			Type:  HeaderMatchTypePtr(gatewayapi_v1beta1.HeaderMatchExact),
+			Name:  gatewayapi_v1beta1.HTTPHeaderName(name),
 			Value: value,
 		},
 	}
 }
 
-func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1alpha2.HTTPQueryParamMatch {
-	var matches []gatewayapi_v1alpha2.HTTPQueryParamMatch
+func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1beta1.HTTPQueryParamMatch {
+	var matches []gatewayapi_v1beta1.HTTPQueryParamMatch
 
 	for name, val := range namesAndValues {
-		matches = append(matches, gatewayapi_v1alpha2.HTTPQueryParamMatch{
-			Type:  QueryParamMatchTypePtr(gatewayapi_v1alpha2.QueryParamMatchExact),
+		matches = append(matches, gatewayapi_v1beta1.HTTPQueryParamMatch{
+			Type:  QueryParamMatchTypePtr(gatewayapi_v1beta1.QueryParamMatchExact),
 			Name:  name,
 			Value: val,
 		})
@@ -191,8 +218,8 @@ func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1alph
 	return matches
 }
 
-func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1alpha2.HTTPBackendRef) []gatewayapi_v1alpha2.HTTPBackendRef {
-	var res []gatewayapi_v1alpha2.HTTPBackendRef
+func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1beta1.HTTPBackendRef) []gatewayapi_v1beta1.HTTPBackendRef {
+	var res []gatewayapi_v1beta1.HTTPBackendRef
 
 	for _, ref := range backendRefs {
 		res = append(res, ref...)
@@ -200,10 +227,10 @@ func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1alpha2.HTTPBackendRef) []gate
 	return res
 }
 
-func HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1alpha2.HTTPBackendRef {
-	return []gatewayapi_v1alpha2.HTTPBackendRef{
+func HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1beta1.HTTPBackendRef {
+	return []gatewayapi_v1beta1.HTTPBackendRef{
 		{
-			BackendRef: gatewayapi_v1alpha2.BackendRef{
+			BackendRef: gatewayapi_v1beta1.BackendRef{
 				BackendObjectReference: ServiceBackendObjectRef(serviceName, port),
 				Weight:                 &weight,
 			},
@@ -223,8 +250,148 @@ func TLSRouteBackendRefs(backendRefs ...[]gatewayapi_v1alpha2.BackendRef) []gate
 func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayapi_v1alpha2.BackendRef {
 	return []gatewayapi_v1alpha2.BackendRef{
 		{
-			BackendObjectReference: ServiceBackendObjectRef(serviceName, port),
-			Weight:                 weight,
+			BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+				Group: GroupPtrV1Alpha2(""),
+				Kind:  KindPtrV1Alpha2("Service"),
+				Name:  gatewayapi_v1alpha2.ObjectName(serviceName),
+				Port:  PortNumPtrV1Alpha2(port),
+			},
+			Weight: weight,
 		},
 	}
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func UpgradeParentRefs(parentRefs []gatewayapi_v1alpha2.ParentReference) []gatewayapi_v1beta1.ParentReference {
+	var res []gatewayapi_v1beta1.ParentReference
+
+	for _, parentRef := range parentRefs {
+		res = append(res, upgradeParentRef(parentRef))
+	}
+
+	return res
+}
+
+func upgradeParentRef(parentRef gatewayapi_v1alpha2.ParentReference) gatewayapi_v1beta1.ParentReference {
+	upgraded := gatewayapi_v1beta1.ParentReference{}
+
+	if parentRef.Group != nil {
+		upgraded.Group = GroupPtr(string(*parentRef.Group))
+	}
+
+	if parentRef.Kind != nil {
+		upgraded.Kind = KindPtr(string(*parentRef.Kind))
+	}
+
+	if parentRef.Namespace != nil {
+		upgraded.Namespace = NamespacePtr(string(*parentRef.Namespace))
+	}
+
+	upgraded.Name = gatewayapi_v1beta1.ObjectName(parentRef.Name)
+
+	if parentRef.SectionName != nil {
+		upgraded.SectionName = SectionNamePtr(string(*parentRef.SectionName))
+	}
+
+	if parentRef.Port != nil {
+		upgraded.Port = PortNumPtr(int(*parentRef.Port))
+	}
+
+	return upgraded
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func UpgradeRouteParentStatuses(routeParentStatuses []gatewayapi_v1alpha2.RouteParentStatus) []gatewayapi_v1beta1.RouteParentStatus {
+	var res []gatewayapi_v1beta1.RouteParentStatus
+
+	for _, rps := range routeParentStatuses {
+		res = append(res, gatewayapi_v1beta1.RouteParentStatus{
+			ParentRef:      upgradeParentRef(rps.ParentRef),
+			ControllerName: gatewayapi_v1beta1.GatewayController(rps.ControllerName),
+			Conditions:     rps.Conditions,
+		})
+	}
+
+	return res
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func DowngradeRouteParentStatuses(routeParentStatuses []gatewayapi_v1beta1.RouteParentStatus) []gatewayapi_v1alpha2.RouteParentStatus {
+	var res []gatewayapi_v1alpha2.RouteParentStatus
+
+	for _, rps := range routeParentStatuses {
+		res = append(res, gatewayapi_v1alpha2.RouteParentStatus{
+			ParentRef:      downgradeParentRef(rps.ParentRef),
+			ControllerName: gatewayapi_v1alpha2.GatewayController(rps.ControllerName),
+			Conditions:     rps.Conditions,
+		})
+	}
+
+	return res
+}
+
+func downgradeParentRef(parentRef gatewayapi_v1beta1.ParentReference) gatewayapi_v1alpha2.ParentReference {
+	downgraded := gatewayapi_v1alpha2.ParentReference{}
+
+	if parentRef.Group != nil {
+		downgraded.Group = GroupPtrV1Alpha2(string(*parentRef.Group))
+	}
+
+	if parentRef.Kind != nil {
+		downgraded.Kind = KindPtrV1Alpha2(string(*parentRef.Kind))
+	}
+
+	if parentRef.Namespace != nil {
+		downgraded.Namespace = NamespacePtrV1Alpha2(string(*parentRef.Namespace))
+	}
+
+	downgraded.Name = gatewayapi_v1alpha2.ObjectName(parentRef.Name)
+
+	if parentRef.SectionName != nil {
+		downgraded.SectionName = SectionNamePtrV1Alpha2(string(*parentRef.SectionName))
+	}
+
+	if parentRef.Port != nil {
+		downgraded.Port = PortNumPtrV1Alpha2(int(*parentRef.Port))
+	}
+
+	return downgraded
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func UpgradeHostnames(hostnames []gatewayapi_v1alpha2.Hostname) []gatewayapi_v1beta1.Hostname {
+	var res []gatewayapi_v1beta1.Hostname
+
+	for _, hostname := range hostnames {
+		res = append(res, gatewayapi_v1beta1.Hostname(hostname))
+	}
+
+	return res
+}
+
+// TODO(sk): delete when Gateway API v1alpha2 support is dropped
+func UpgradeBackendRef(backendRef gatewayapi_v1alpha2.BackendRef) gatewayapi_v1beta1.BackendRef {
+	upgraded := gatewayapi_v1beta1.BackendRef{}
+
+	if backendRef.Group != nil {
+		upgraded.Group = GroupPtr(string(*backendRef.Group))
+	}
+
+	if backendRef.Kind != nil {
+		upgraded.Kind = KindPtr(string(*backendRef.Kind))
+	}
+
+	upgraded.Name = gatewayapi_v1beta1.ObjectName(backendRef.Name)
+
+	if backendRef.Namespace != nil {
+		upgraded.Namespace = NamespacePtr(string(*backendRef.Namespace))
+	}
+
+	if backendRef.Port != nil {
+		upgraded.Port = PortNumPtr(int(*backendRef.Port))
+	}
+
+	upgraded.Weight = backendRef.Weight
+
+	return upgraded
 }

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // KindOf returns the kind string for the given Kubernetes object.
@@ -43,7 +43,7 @@ func KindOf(obj interface{}) string {
 			return "Ingress"
 		case *contour_api_v1.HTTPProxy:
 			return "HTTPProxy"
-		case *gatewayapi_v1alpha2.HTTPRoute:
+		case *gatewayapi_v1beta1.HTTPRoute:
 			return "HTTPRoute"
 		case *contour_api_v1.TLSCertificateDelegation:
 			return "TLSCertificateDelegation"

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -226,13 +225,13 @@ func (c *Cache) ProxyAccessor(proxy *contour_api_v1.HTTPProxy) (*ProxyUpdate, fu
 // metav1.Conditions as well as a function to commit the change back to the cache when everything
 // is done. The commit function pattern is used so that the RouteConditionsUpdate does not need
 // to know anything the cache internals.
-func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation int64, resource client.Object, gateways []gatewayapi_v1alpha2.RouteParentStatus) (*RouteConditionsUpdate, func()) {
+func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation int64, resource client.Object, gateways []gatewayapi_v1beta1.RouteParentStatus) (*RouteConditionsUpdate, func()) {
 	pu := &RouteConditionsUpdate{
 		FullName:           nsName,
-		Conditions:         make(map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition),
+		Conditions:         make(map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition),
 		ExistingConditions: c.getRouteGatewayConditions(gateways),
 		GatewayRef:         c.gatewayRef,
-		GatewayController:  gatewayapi_v1alpha2.GatewayController(c.gatewayController),
+		GatewayController:  c.gatewayController,
 		Generation:         generation,
 		TransitionTime:     metav1.NewTime(clock.Now()),
 		Resource:           resource,

--- a/internal/status/cache_test.go
+++ b/internal/status/cache_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type testCacheEntry struct {
@@ -49,7 +49,7 @@ func TestCacheAcquisition(t *testing.T) {
 	proxy := &contour_api_v1.HTTPProxy{
 		ObjectMeta: fixture.ObjectMeta("test/proxy"),
 	}
-	httpRoute := &gatewayapi_v1alpha2.HTTPRoute{
+	httpRoute := &gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: fixture.ObjectMeta("test/httproute"),
 	}
 	cache := NewCache(types.NamespacedName{Name: "contour", Namespace: "projectcontour"}, "")

--- a/internal/status/routeconditions_test.go
+++ b/internal/status/routeconditions_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestHTTPRouteAddCondition(t *testing.T) {
@@ -30,7 +30,7 @@ func TestHTTPRouteAddCondition(t *testing.T) {
 	var testGeneration int64 = 7
 
 	simpleValidCondition := metav1.Condition{
-		Type:               string(gatewayapi_v1alpha2.RouteConditionAccepted),
+		Type:               string(gatewayapi_v1beta1.RouteConditionAccepted),
 		Status:             projectcontour.ConditionTrue,
 		Reason:             "Valid",
 		Message:            "Valid HTTPRoute",
@@ -40,10 +40,10 @@ func TestHTTPRouteAddCondition(t *testing.T) {
 	httpRouteUpdate := RouteConditionsUpdate{
 		FullName:   k8s.NamespacedNameFrom("test/test"),
 		Generation: testGeneration,
-		Conditions: make(map[gatewayapi_v1alpha2.RouteConditionType]metav1.Condition),
+		Conditions: make(map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition),
 	}
 
-	got := httpRouteUpdate.AddCondition(gatewayapi_v1alpha2.RouteConditionAccepted, metav1.ConditionTrue, "Valid", "Valid HTTPRoute")
+	got := httpRouteUpdate.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionTrue, "Valid", "Valid HTTPRoute")
 
 	assert.Equal(t, simpleValidCondition.Message, got.Message)
 	assert.Equal(t, simpleValidCondition.Reason, got.Reason)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -321,10 +321,10 @@ func (f *Framework) CreateHTTPProxyAndWaitFor(proxy *contourv1.HTTPProxy, condit
 
 // CreateHTTPRouteAndWaitFor creates the provided HTTPRoute in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1alpha2.HTTPRoute, condition func(*gatewayapi_v1alpha2.HTTPRoute) bool) (*gatewayapi_v1alpha2.HTTPRoute, bool) {
+func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1beta1.HTTPRoute, condition func(*gatewayapi_v1beta1.HTTPRoute) bool) (*gatewayapi_v1beta1.HTTPRoute, bool) {
 	require.NoError(f.t, f.Client.Create(context.TODO(), route))
 
-	res := &gatewayapi_v1alpha2.HTTPRoute{}
+	res := &gatewayapi_v1beta1.HTTPRoute{}
 
 	if err := wait.PollImmediate(f.RetryInterval, f.RetryTimeout, func() (bool, error) {
 		if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(route), res); err != nil {

--- a/test/e2e/gateway/gateway_allow_type_test.go
+++ b/test/e2e/gateway/gateway_allow_type_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testRouteParentRefs(namespace string) {
@@ -37,21 +37,21 @@ func testRouteParentRefs(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
 		// This route has a parentRef to the gateway.
-		gatewayInParentRefsRoute := &gatewayapi_v1alpha2.HTTPRoute{
+		gatewayInParentRefsRoute := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "gateway-in-parent-refs",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"routeparentrefs.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"routeparentrefs.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/gateway-in-parent-refs"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/gateway-in-parent-refs"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-blue", 80, 1),
 					},
 				},
@@ -70,21 +70,21 @@ func testRouteParentRefs(namespace string) {
 		assert.Equal(t, "echo-blue", body.Service)
 
 		// This route does not have a parentRef to the gateway.
-		gatewayNotInParentRefsRoute := &gatewayapi_v1alpha2.HTTPRoute{
+		gatewayNotInParentRefsRoute := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "gateway-not-in-parent-refs",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"routeparentrefs.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"routeparentrefs.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "invalid-name"),
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/gateway-not-in-parent-refs"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/gateway-not-in-parent-refs"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-blue", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -440,14 +440,14 @@ func runGatewayTests() {
 
 // httpRouteAccepted returns true if the route has a .status.conditions
 // entry of "Accepted: true".
-func httpRouteAccepted(route *gatewayapi_v1alpha2.HTTPRoute) bool {
+func httpRouteAccepted(route *gatewayapi_v1beta1.HTTPRoute) bool {
 	if route == nil {
 		return false
 	}
 
 	for _, gw := range route.Status.Parents {
 		for _, cond := range gw.Conditions {
-			if cond.Type == string(gatewayapi_v1alpha2.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
+			if cond.Type == string(gatewayapi_v1beta1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
 				return true
 			}
 		}

--- a/test/e2e/gateway/header_condition_match_test.go
+++ b/test/e2e/gateway/header_condition_match_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testGatewayHeaderConditionMatch(namespace string) {
@@ -34,30 +34,30 @@ func testGatewayHeaderConditionMatch(namespace string) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-exact")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"gatewayheaderconditions.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"gatewayheaderconditions.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
-								Headers: []gatewayapi_v1alpha2.HTTPHeaderMatch{
+								Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
 									{
-										Type:  gatewayapi.HeaderMatchTypePtr(gatewayapi_v1alpha2.HeaderMatchExact),
-										Name:  gatewayapi_v1alpha2.HTTPHeaderName("My-Header"),
+										Type:  gatewayapi.HeaderMatchTypePtr(gatewayapi_v1beta1.HeaderMatchExact),
+										Name:  gatewayapi_v1beta1.HTTPHeaderName("My-Header"),
 										Value: "Foo",
 									},
 								},

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testHostRewrite(namespace string) {
@@ -33,34 +33,34 @@ func testHostRewrite(namespace string) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "host-rewrite",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"hostrewrite.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"hostrewrite.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
 							},
 						},
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 							{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-									Add: []gatewayapi_v1alpha2.HTTPHeader{
-										{Name: gatewayapi_v1alpha2.HTTPHeaderName("Host"), Value: "rewritten.com"},
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+									Add: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "rewritten.com"},
 									},
 								},
 							},

--- a/test/e2e/gateway/invalid_backend_ref_test.go
+++ b/test/e2e/gateway/invalid_backend_ref_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testInvalidBackendRef(namespace string) {
@@ -33,50 +33,50 @@ func testInvalidBackendRef(namespace string) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-slash-default")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"invalidbackendref.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"invalidbackendref.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/invalidref"),
 								},
 							},
 						},
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("invalid", 80),
 								},
 							},
 						},
 					},
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/invalidservicename"),
 								},
 							},
 						},
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind: gatewayapi.KindPtr("Service"),
 										Name: "non-existent-service",
 										Port: gatewayapi.PortNumPtr(80),
 									},
@@ -85,19 +85,19 @@ func testInvalidBackendRef(namespace string) {
 						},
 					},
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1alpha2.HTTPPathMatch{
-									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1alpha2.PathMatchPathPrefix),
+								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+									Type:  gatewayapi.PathMatchTypePtr(gatewayapi_v1beta1.PathMatchPathPrefix),
 									Value: pointer.StringPtr("/"),
 								},
 							},
 						},
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind: gatewayapi.KindPtrV1Alpha2("Service"),
+								BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+										Kind: gatewayapi.KindPtr("Service"),
 										Name: "echo-slash-default",
 										Port: gatewayapi.PortNumPtr(80),
 									},
@@ -109,7 +109,7 @@ func testInvalidBackendRef(namespace string) {
 			},
 		}
 
-		f.CreateHTTPRouteAndWaitFor(route, func(route *gatewayapi_v1alpha2.HTTPRoute) bool {
+		f.CreateHTTPRouteAndWaitFor(route, func(route *gatewayapi_v1beta1.HTTPRoute) bool {
 			if len(route.Status.Parents) != 1 {
 				return false
 			}
@@ -120,7 +120,7 @@ func testInvalidBackendRef(namespace string) {
 
 			var hasAccepted, hasResolvedRefs bool
 			for _, cond := range route.Status.Parents[0].Conditions {
-				if cond.Type == string(gatewayapi_v1alpha2.RouteConditionAccepted) && cond.Status == metav1.ConditionFalse {
+				if cond.Type == string(gatewayapi_v1beta1.RouteConditionAccepted) && cond.Status == metav1.ConditionFalse {
 					hasAccepted = true
 				}
 				if cond.Type == string(status.ConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testMultipleHTTPSListeners(namespace string) {
@@ -39,20 +39,20 @@ func testMultipleHTTPSListeners(namespace string) {
 		for _, tc := range []string{"1", "2", "3"} {
 			f.Fixtures.Echo.Deploy(namespace, "echo-"+tc)
 
-			route := &gatewayapi_v1alpha2.HTTPRoute{
+			route := &gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-" + tc,
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{
 							gatewayapi.GatewayListenerParentRef("", "multiple-https-listeners", "https-"+tc),
 						},
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 						{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo-"+tc, 80, 1),
 						},
 					},

--- a/test/e2e/gateway/path_condition_match_test.go
+++ b/test/e2e/gateway/path_condition_match_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testGatewayPathConditionMatch(namespace string) {
@@ -33,31 +33,31 @@ func testGatewayPathConditionMatch(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-slash-default")
 		f.Fixtures.Echo.Deploy(namespace, "echo-slash-exact")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"gatewaypathconditions.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"gatewaypathconditions.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/path/prefix"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/path/prefix"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-prefix", 80, 1),
 					},
 
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchExact, "/path/exact"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/path/exact"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-exact", 80, 1),
 					},
 
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-default", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testGatewayQueryParamMatch(namespace string) {
@@ -34,39 +34,39 @@ func testGatewayQueryParamMatch(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-3")
 		f.Fixtures.Echo.Deploy(namespace, "echo-4")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "httproute-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"queryparams.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"),
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
 					},
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "dolphin"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),
 					},
 					{
-						Matches: []gatewayapi_v1alpha2.HTTPRouteMatch{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
 							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "dolphin", "color": "red"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-3", 80, 1),
 					},
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-4", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testRequestHeaderModifierForwardTo(namespace string) {
@@ -35,35 +35,35 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/filter"),
-						BackendRefs: []gatewayapi_v1alpha2.HTTPBackendRef{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/filter"),
+						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1alpha2.BackendRef{
+								BackendRef: gatewayapi_v1beta1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("echo-header-filter", 80),
 								},
-								Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 									{
-										Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-											Add: []gatewayapi_v1alpha2.HTTPHeader{
-												{Name: gatewayapi_v1alpha2.HTTPHeaderName("My-Header"), Value: "Foo"},
+										Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+										RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+											Add: []gatewayapi_v1beta1.HTTPHeader{
+												{Name: gatewayapi_v1beta1.HTTPHeaderName("My-Header"), Value: "Foo"},
 											},
-											Set: []gatewayapi_v1alpha2.HTTPHeader{
-												{Name: gatewayapi_v1alpha2.HTTPHeaderName("Replace-Header"), Value: "Bar"},
+											Set: []gatewayapi_v1beta1.HTTPHeader{
+												{Name: gatewayapi_v1beta1.HTTPHeaderName("Replace-Header"), Value: "Bar"},
 											},
 											Remove: []string{"Other-Header"},
 										},
@@ -73,7 +73,7 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 						},
 					},
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/nofilter"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/nofilter"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-header-nofilter", 80, 1),
 					},
 				},
@@ -134,30 +134,30 @@ func testRequestHeaderModifierRule(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/filter"),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/filter"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 							{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1alpha2.HTTPRequestHeaderFilter{
-									Add: []gatewayapi_v1alpha2.HTTPHeader{
-										{Name: gatewayapi_v1alpha2.HTTPHeaderName("My-Header"), Value: "Foo"},
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPRequestHeaderFilter{
+									Add: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1beta1.HTTPHeaderName("My-Header"), Value: "Foo"},
 									},
-									Set: []gatewayapi_v1alpha2.HTTPHeader{
-										{Name: gatewayapi_v1alpha2.HTTPHeaderName("Replace-Header"), Value: "Bar"},
+									Set: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1beta1.HTTPHeaderName("Replace-Header"), Value: "Bar"},
 									},
 									Remove: []string{"Other-Header"},
 								},
@@ -166,7 +166,7 @@ func testRequestHeaderModifierRule(namespace string) {
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-header-filter", 80, 1),
 					},
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/nofilter"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/nofilter"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-header-nofilter", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/request_mirror_test.go
+++ b/test/e2e/gateway/request_mirror_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testRequestMirrorRule(namespace string) {
@@ -39,25 +39,25 @@ func testRequestMirrorRule(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-primary")
 		f.Fixtures.Echo.DeployN(namespace, "echo-shadow", 2)
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "httproute-mirror",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"requestmirrorrule.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"requestmirrorrule.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/mirror"),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/mirror"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 							{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1alpha2.HTTPRequestMirrorFilter{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestMirror,
+								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("echo-shadow", 80),
 								},
 							},

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testRequestRedirectRule(namespace string) {
@@ -35,25 +35,25 @@ func testRequestRedirectRule(namespace string) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "httproute-redirect",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"requestredirectrule.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"requestredirectrule.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/basic-redirect"),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/basic-redirect"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 							{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
 									Hostname: gatewayapi.PreciseHostname("projectcontour.io"),
 								},
 							},
@@ -61,11 +61,11 @@ func testRequestRedirectRule(namespace string) {
 						BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
 					},
 					{
-						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/complex-redirect"),
-						Filters: []gatewayapi_v1alpha2.HTTPRouteFilter{
+						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/complex-redirect"),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 							{
-								Type: gatewayapi_v1alpha2.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1alpha2.HTTPRequestRedirectFilter{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
+								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
 									Hostname:   gatewayapi.PreciseHostname("envoyproxy.io"),
 									StatusCode: pointer.Int(301),
 									Scheme:     pointer.String("https"),

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testTLSGateway(namespace string) {
@@ -32,25 +32,25 @@ func testTLSGateway(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-insecure")
 		f.Fixtures.Echo.Deploy(namespace, "echo-secure")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"tls-gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"tls-gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
 							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
 							SectionName: gatewayapi.SectionNamePtr("insecure"),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
 
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-insecure", 80, 1),
 					},
 				},
@@ -58,24 +58,24 @@ func testTLSGateway(namespace string) {
 		}
 		f.CreateHTTPRouteAndWaitFor(route, httpRouteAccepted)
 
-		route = &gatewayapi_v1alpha2.HTTPRoute{
+		route = &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-2",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"tls-gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"tls-gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
 							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
 							SectionName: gatewayapi.SectionNamePtr("secure"),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-secure", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func testTLSWildcardHost(namespace string) {
@@ -34,24 +34,24 @@ func testTLSWildcardHost(namespace string) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1alpha2.HTTPRoute{
+		route := &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-1",
 			},
-			Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1alpha2.Hostname{"*.wildcardhost.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"*.wildcardhost.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
 							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
 							SectionName: gatewayapi.SectionNamePtr("secure"),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
 					},
 				},

--- a/test/e2e/gateway/tlsroute_test.go
+++ b/test/e2e/gateway/tlsroute_test.go
@@ -44,7 +44,7 @@ func testTLSRoutePassthrough(namespace string) {
 			Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-						gatewayapi.GatewayParentRef("", "tls-passthrough"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRefV1Alpha2("", "tls-passthrough"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
 				Hostnames: []gatewayapi_v1alpha2.Hostname{"passthrough.tlsroute.gatewayapi.projectcontour.io"},
@@ -87,7 +87,7 @@ func testTLSRouteTerminate(namespace string) {
 			Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-						gatewayapi.GatewayParentRef("", "tls-terminate"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRefV1Alpha2("", "tls-terminate"), // TODO need a better way to inform the test case of the Gateway it should use
 					},
 				},
 				Hostnames: []gatewayapi_v1alpha2.Hostname{"terminate.tlsroute.gatewayapi.projectcontour.io"},

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -168,21 +167,21 @@ var _ = Describe("Gateway provisioner", func() {
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
-			route := &gatewayapi_v1alpha2.HTTPRoute{
+			route := &gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-1",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha2.Hostname{"provisioner.projectcontour.io"},
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1beta1.Hostname{"provisioner.projectcontour.io"},
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{
 							gatewayapi.GatewayParentRef("", gateway.Name),
 						},
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 						{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/prefix"),
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
 						},
 					},
@@ -249,25 +248,25 @@ var _ = Describe("Gateway provisioner", func() {
 			}
 
 			// Create two HTTPRoutes, one for each Gateway, and wait for them to be accepted
-			var routes []*gatewayapi_v1alpha2.HTTPRoute
+			var routes []*gatewayapi_v1beta1.HTTPRoute
 			for i := 0; i < gatewayCount; i++ {
-				route := &gatewayapi_v1alpha2.HTTPRoute{
+				route := &gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
 						Name:      fmt.Sprintf("httproute-%d", i),
 					},
-					Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-						Hostnames: []gatewayapi_v1alpha2.Hostname{
-							gatewayapi_v1alpha2.Hostname(fmt.Sprintf("http-%d.provisioner.projectcontour.io", i)),
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							gatewayapi_v1beta1.Hostname(fmt.Sprintf("http-%d.provisioner.projectcontour.io", i)),
 						},
-						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{
 								gatewayapi.GatewayParentRef("", fmt.Sprintf("http-%d", i)),
 							},
 						},
-						Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 							{
-								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, fmt.Sprintf("/http-%d", i)),
+								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, fmt.Sprintf("/http-%d", i)),
 								BackendRefs: gatewayapi.HTTPBackendRef(fmt.Sprintf("echo-%d", i), 80, 1),
 							},
 						},
@@ -418,21 +417,21 @@ var _ = Describe("Gateway provisioner", func() {
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
-			route := &gatewayapi_v1alpha2.HTTPRoute{
+			route := &gatewayapi_v1beta1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-1",
 				},
-				Spec: gatewayapi_v1alpha2.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1alpha2.Hostname{"provisioner.projectcontour.io"},
-					CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1beta1.Hostname{"provisioner.projectcontour.io"},
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{
 							gatewayapi.GatewayParentRef("", gateway.Name),
 						},
 					},
-					Rules: []gatewayapi_v1alpha2.HTTPRouteRule{
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
 						{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1alpha2.PathMatchPathPrefix, "/prefix"),
+							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
 						},
 					},
@@ -527,13 +526,13 @@ func gatewayHasAddress(gateway *gatewayapi_v1beta1.Gateway) bool {
 
 // httpRouteAccepted returns true if the route has a .status.conditions
 // entry of "Accepted: true".
-func httpRouteAccepted(route *gatewayapi_v1alpha2.HTTPRoute) bool {
+func httpRouteAccepted(route *gatewayapi_v1beta1.HTTPRoute) bool {
 	if route == nil {
 		return false
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExists(gw.Conditions, string(gatewayapi_v1alpha2.RouteConditionAccepted), metav1.ConditionTrue) {
+		if conditionExists(gw.Conditions, string(gatewayapi_v1beta1.RouteConditionAccepted), metav1.ConditionTrue) {
 			return true
 		}
 	}


### PR DESCRIPTION
Updates HTTPRoute code to use the v1beta1
API since this resource has moved to beta
in the v0.5.0 Gateway API release.

Updates #4560.

Signed-off-by: Steve Kriss <krisss@vmware.com>