### PR TITLE
Gateway API: use upstream condition types and values

### DIFF
--- a/changelogs/unreleased/4598-skriss-small.md
+++ b/changelogs/unreleased/4598-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: replace usage of Contour-specific condition types and reasons with upstream Gateway API ones where possible

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -843,7 +843,7 @@ func (p *GatewayAPIProcessor) computeGatewayConditions(gwAccessor *status.Gatewa
 	gwAccessor.AddCondition(
 		gatewayapi_v1beta1.GatewayConditionScheduled,
 		metav1.ConditionTrue,
-		status.GatewayReasonType(gatewayapi_v1beta1.GatewayReasonScheduled),
+		gatewayapi_v1beta1.GatewayReasonScheduled,
 		"Gateway is scheduled",
 	)
 
@@ -852,7 +852,7 @@ func (p *GatewayAPIProcessor) computeGatewayConditions(gwAccessor *status.Gatewa
 		gwAccessor.AddCondition(
 			gatewayapi_v1beta1.GatewayConditionType(gatewayNotReadyCondition.Type),
 			gatewayNotReadyCondition.Status,
-			status.GatewayReasonType(gatewayNotReadyCondition.Reason),
+			gatewayapi_v1beta1.GatewayConditionReason(gatewayNotReadyCondition.Reason),
 			gatewayNotReadyCondition.Message,
 		)
 	default:
@@ -877,10 +877,10 @@ func (p *GatewayAPIProcessor) computeGatewayConditions(gwAccessor *status.Gatewa
 
 		if !allListenersReady {
 			// If we have invalid listeners, set Ready=false.
-			gwAccessor.AddCondition(gatewayapi_v1beta1.GatewayConditionReady, metav1.ConditionFalse, status.GatewayReasonType(gatewayapi_v1beta1.GatewayReasonListenersNotValid), "Listeners are not valid")
+			gwAccessor.AddCondition(gatewayapi_v1beta1.GatewayConditionReady, metav1.ConditionFalse, gatewayapi_v1beta1.GatewayReasonListenersNotValid, "Listeners are not valid")
 		} else {
 			// Otherwise, Ready=true.
-			gwAccessor.AddCondition(gatewayapi_v1beta1.GatewayConditionReady, metav1.ConditionTrue, status.ReasonValidGateway, "Valid Gateway")
+			gwAccessor.AddCondition(gatewayapi_v1beta1.GatewayConditionReady, metav1.ConditionTrue, gatewayapi_v1beta1.GatewayReasonReady, status.MessageValidGateway)
 		}
 	}
 }

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -179,13 +179,13 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			}
 
 			if hostCount == 0 {
-				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, status.ReasonNoIntersectingHostnames, "No intersecting hostnames were found between the listener and the route.")
+				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname, "No intersecting hostnames were found between the listener and the route.")
 			} else {
 				// Determine if any errors exist in conditions and set the "Accepted"
 				// condition accordingly.
 				switch len(routeAccessor.Conditions) {
 				case 0:
-					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionTrue, status.ReasonValid, "Valid HTTPRoute")
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionTrue, gatewayapi_v1beta1.RouteReasonAccepted, "Valid HTTPRoute")
 				default:
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
 				}
@@ -228,13 +228,13 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 			}
 
 			if hostCount == 0 {
-				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, status.ReasonNoIntersectingHostnames, "No intersecting hostnames were found between the listener and the route.")
+				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname, "No intersecting hostnames were found between the listener and the route.")
 			} else {
 				// Determine if any errors exist in conditions and set the "Accepted"
 				// condition accordingly.
 				switch len(routeAccessor.Conditions) {
 				case 0:
-					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionTrue, status.ReasonValid, "Valid TLSRoute")
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionTrue, gatewayapi_v1beta1.RouteReasonAccepted, "Valid TLSRoute")
 				default:
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, status.ReasonErrorsExist, "Errors found, check other Conditions for details.")
 				}
@@ -892,7 +892,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 		// invalid hostnames make it through, we're using our best judgment here.
 		// Theoretically these should be prevented by the combination of kubebuilder
 		// and admission webhook validations.
-		routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
+		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
 	}
 
 	// If there were no intersections between the listener hostname and the
@@ -904,7 +904,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 	var programmed bool
 	for _, rule := range route.Spec.Rules {
 		if len(rule.BackendRefs) == 0 {
-			routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
+			routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
 			continue
 		}
 
@@ -915,7 +915,7 @@ func (p *GatewayAPIProcessor) computeTLSRoute(route *gatewayapi_v1alpha2.TLSRout
 
 			service, cond := p.validateBackendRef(gatewayapi.UpgradeBackendRef(backendRef), KindTLSRoute, route.Namespace)
 			if cond != nil {
-				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, status.RouteReasonType(cond.Reason), cond.Message)
+				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
 				continue
 			}
 
@@ -975,7 +975,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 		// invalid hostnames make it through, we're using our best judgment here.
 		// Theoretically these should be prevented by the combination of kubebuilder
 		// and admission webhook validations.
-		routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
+		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
 	}
 
 	// If there were no intersections between the listener hostname and the
@@ -1046,7 +1046,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				var err error
 				headerPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier)
 				if err != nil {
-					routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect:
 				// Get the redirect filter if there is one. Note that per Gateway API
@@ -1067,7 +1067,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				if filter.RequestMirror != nil {
 					mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindHTTPRoute, route.Namespace)
 					if cond != nil {
-						routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, status.RouteReasonType(cond.Reason), cond.Message)
+						routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
 						continue
 					}
 					mirrorPolicy = &MirrorPolicy{
@@ -1296,7 +1296,7 @@ func gatewayQueryParamMatchConditions(matches []gatewayapi_v1beta1.HTTPQueryPara
 // clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicy and backendRefs.
 func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, headerPolicy *HeadersPolicy, mirrorPolicy *MirrorPolicy, backendRefs []gatewayapi_v1beta1.HTTPBackendRef, routeAccessor *status.RouteConditionsUpdate) []*Route {
 	if len(backendRefs) == 0 {
-		routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
+		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
 		return nil
 	}
 
@@ -1307,7 +1307,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 	for _, backendRef := range backendRefs {
 		service, cond := p.validateBackendRef(backendRef.BackendRef, KindHTTPRoute, routeNamespace)
 		if cond != nil {
-			routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, status.RouteReasonType(cond.Reason), cond.Message)
+			routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
 			continue
 		}
 
@@ -1318,7 +1318,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 				var err error
 				headerPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier)
 				if err != nil {
-					routeAccessor.AddCondition(status.ConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			default:
 				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier type is supported.")

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2668,7 +2668,7 @@ func validGatewayStatusUpdate(listenerName string, kind gatewayapi_v1beta1.Kind,
 				gatewayapi_v1beta1.GatewayConditionReady: {
 					Type:    string(gatewayapi_v1beta1.GatewayConditionReady),
 					Status:  contour_api_v1.ConditionTrue,
-					Reason:  status.ReasonValidGateway,
+					Reason:  string(gatewayapi_v1beta1.GatewayReasonReady),
 					Message: status.MessageValidGateway,
 				},
 			},
@@ -4494,7 +4494,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.GatewayConditionReady: {
 						Type:    string(gatewayapi_v1beta1.GatewayConditionReady),
 						Status:  contour_api_v1.ConditionTrue,
-						Reason:  status.ReasonValidGateway,
+						Reason:  string(gatewayapi_v1beta1.GatewayReasonReady),
 						Message: status.MessageValidGateway,
 					},
 				},
@@ -4610,7 +4610,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.GatewayConditionReady: {
 						Type:    string(gatewayapi_v1beta1.GatewayConditionReady),
 						Status:  contour_api_v1.ConditionTrue,
-						Reason:  status.ReasonValidGateway,
+						Reason:  string(gatewayapi_v1beta1.GatewayReasonReady),
 						Message: status.MessageValidGateway,
 					},
 				},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2882,7 +2882,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
-					Reason:  string(status.ValidCondition),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 					Message: "Valid HTTPRoute",
 				},
 			},
@@ -2932,7 +2932,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
-					Reason:  string(status.ValidCondition),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 					Message: "Valid HTTPRoute",
 				},
 			},
@@ -2986,7 +2986,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.RouteConditionAccepted: {
 						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionTrue,
-						Reason:  string(status.ValidCondition),
+						Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 						Message: "Valid HTTPRoute",
 					},
 				},
@@ -2997,7 +2997,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.RouteConditionAccepted: {
 						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionTrue,
-						Reason:  string(status.ValidCondition),
+						Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 						Message: "Valid HTTPRoute",
 					},
 				},
@@ -3440,8 +3440,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.BackendRef.Name must be specified",
@@ -3497,8 +3497,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
@@ -3551,8 +3551,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.BackendRef.Port must be specified",
@@ -3595,8 +3595,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "At least one Spec.Rules.BackendRef must be specified.",
@@ -3650,8 +3650,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1beta1.ListenerReasonRefNotPermitted),
 					Message: "Spec.Rules.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
@@ -4321,8 +4321,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
@@ -4330,7 +4330,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
-					Reason:  string(status.ReasonNoIntersectingHostnames),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 					Message: "No intersecting hostnames were found between the listener and the route.",
 				},
 			},
@@ -4364,8 +4364,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
@@ -4373,7 +4373,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
-					Reason:  string(status.ReasonNoIntersectingHostnames),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 					Message: "No intersecting hostnames were found between the listener and the route.",
 				},
 			},
@@ -4407,8 +4407,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid hostname \"1.2.3.4\": must be a DNS name, not an IP address",
@@ -4416,7 +4416,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
-					Reason:  string(status.ReasonNoIntersectingHostnames),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 					Message: "No intersecting hostnames were found between the listener and the route.",
 				},
 			},
@@ -4481,7 +4481,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionTrue,
-					Reason:  string(status.ValidCondition),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 					Message: "Valid HTTPRoute",
 				},
 			},
@@ -4597,7 +4597,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				gatewayapi_v1beta1.RouteConditionAccepted: {
 					Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 					Status:  contour_api_v1.ConditionFalse,
-					Reason:  string(status.ReasonNoIntersectingHostnames),
+					Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 					Message: "No intersecting hostnames were found between the listener and the route.",
 				},
 			},
@@ -4752,8 +4752,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Name must be specified",
@@ -4808,8 +4808,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Port must be specified",
@@ -4879,8 +4879,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
@@ -4937,8 +4937,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(gatewayapi_v1beta1.ListenerReasonRefNotPermitted),
 					Message: "Spec.Rules.Filters.RequestMirror.BackendRef.Namespace must match the route's namespace or be covered by a ReferencePolicy/ReferenceGrant",
@@ -5046,8 +5046,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "duplicate header addition: \"Custom\" on request headers",
@@ -5105,8 +5105,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteConditionsUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 			Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-				status.ConditionResolvedRefs: {
-					Type:    string(status.ConditionResolvedRefs),
+				gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+					Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 					Status:  contour_api_v1.ConditionFalse,
 					Reason:  string(status.ReasonDegraded),
 					Message: "invalid set header \"!invalid-Header\": [a valid HTTP header must consist of alphanumeric characters or '-' (e.g. 'X-Header-Name', regex used for validation is '[-A-Za-z0-9]+')] on request headers",
@@ -6027,8 +6027,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "Spec.Rules.BackendRef.Name must be specified",
@@ -6071,8 +6071,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "service \"invalid-one\" is invalid: service \"default/invalid-one\" not found, service \"invalid-two\" is invalid: service \"default/invalid-two\" not found",
@@ -6122,8 +6122,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "Spec.Rules.BackendRef.Port must be specified",
@@ -6166,8 +6166,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "At least one Spec.Rules.BackendRef must be specified.",
@@ -6210,8 +6210,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"*.*.projectcontour.io\": [a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character (e.g. '*.example.com', regex used for validation is '\\*\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
@@ -6219,7 +6219,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.RouteConditionAccepted: {
 						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
-						Reason:  string(status.ReasonNoIntersectingHostnames),
+						Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 						Message: "No intersecting hostnames were found between the listener and the route.",
 					},
 				},
@@ -6254,8 +6254,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"#projectcontour.io\": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]",
@@ -6263,7 +6263,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.RouteConditionAccepted: {
 						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
-						Reason:  string(status.ReasonNoIntersectingHostnames),
+						Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 						Message: "No intersecting hostnames were found between the listener and the route.",
 					},
 				},
@@ -6298,8 +6298,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 			wantRouteConditions: []*status.RouteConditionsUpdate{{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
 				Conditions: map[gatewayapi_v1beta1.RouteConditionType]metav1.Condition{
-					status.ConditionResolvedRefs: {
-						Type:    string(status.ConditionResolvedRefs),
+					gatewayapi_v1beta1.RouteConditionResolvedRefs: {
+						Type:    string(gatewayapi_v1beta1.RouteConditionResolvedRefs),
 						Status:  contour_api_v1.ConditionFalse,
 						Reason:  string(status.ReasonDegraded),
 						Message: "invalid hostname \"1.2.3.4\": must be a DNS name, not an IP address",
@@ -6307,7 +6307,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					gatewayapi_v1beta1.RouteConditionAccepted: {
 						Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 						Status:  contour_api_v1.ConditionFalse,
-						Reason:  string(status.ReasonNoIntersectingHostnames),
+						Reason:  string(gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname),
 						Message: "No intersecting hostnames were found between the listener and the route.",
 					},
 				},

--- a/internal/status/gatewayclassconditions.go
+++ b/internal/status/gatewayclassconditions.go
@@ -21,8 +21,7 @@ import (
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-const reasonValidGatewayClass = "Valid"
-const reasonInvalidGatewayClass = "Invalid"
+const ReasonOlderGatewayClassExists gatewayapi_v1beta1.GatewayClassConditionReason = "OlderGatewayClassExists"
 
 // computeGatewayClassAcceptedCondition computes the GatewayClass Accepted status condition.
 func computeGatewayClassAcceptedCondition(gatewayClass *gatewayapi_v1beta1.GatewayClass, accepted bool) metav1.Condition {
@@ -31,7 +30,7 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gatewayapi_v1beta1.Gatew
 		return metav1.Condition{
 			Type:               string(gatewayapi_v1beta1.GatewayClassConditionStatusAccepted),
 			Status:             metav1.ConditionTrue,
-			Reason:             "Valid",
+			Reason:             string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
 			Message:            "Valid GatewayClass",
 			ObservedGeneration: gatewayClass.Generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
@@ -40,7 +39,7 @@ func computeGatewayClassAcceptedCondition(gatewayClass *gatewayapi_v1beta1.Gatew
 		return metav1.Condition{
 			Type:               string(gatewayapi_v1beta1.GatewayClassConditionStatusAccepted),
 			Status:             metav1.ConditionFalse,
-			Reason:             "Invalid",
+			Reason:             string(ReasonOlderGatewayClassExists),
 			Message:            "Invalid GatewayClass: another older GatewayClass with the same Spec.Controller exists",
 			ObservedGeneration: gatewayClass.Generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),

--- a/internal/status/gatewayclassconditions_test.go
+++ b/internal/status/gatewayclassconditions_test.go
@@ -31,22 +31,21 @@ func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
 		expect   metav1.Condition
 	}{
 		{
-			name: "valid gatewayclass",
-
+			name:     "accepted gatewayclass",
 			accepted: true,
 			expect: metav1.Condition{
 				Type:   string(gatewayapi_v1beta1.GatewayClassConditionStatusAccepted),
 				Status: metav1.ConditionTrue,
-				Reason: reasonValidGatewayClass,
+				Reason: string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
 			},
 		},
 		{
-			name:     "invalid gatewayclass",
+			name:     "not accepted gatewayclass",
 			accepted: false,
 			expect: metav1.Condition{
 				Type:   string(gatewayapi_v1beta1.GatewayClassConditionStatusAccepted),
 				Status: metav1.ConditionFalse,
-				Reason: reasonInvalidGatewayClass,
+				Reason: string(ReasonOlderGatewayClassExists),
 			},
 		},
 	}

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -23,10 +23,6 @@ import (
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-type GatewayReasonType string
-
-const ReasonValidGateway = "Valid"
-
 const MessageValidGateway = "Valid Gateway"
 
 // GatewayStatusUpdate represents an atomic update to a
@@ -44,7 +40,7 @@ type GatewayStatusUpdate struct {
 func (gatewayUpdate *GatewayStatusUpdate) AddCondition(
 	cond gatewayapi_v1beta1.GatewayConditionType,
 	status metav1.ConditionStatus,
-	reason GatewayReasonType,
+	reason gatewayapi_v1beta1.GatewayConditionReason,
 	message string,
 ) metav1.Condition {
 

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -26,7 +26,6 @@ import (
 type GatewayReasonType string
 
 const ReasonValidGateway = "Valid"
-const ReasonInvalidGateway = "Invalid"
 
 const MessageValidGateway = "Valid Gateway"
 

--- a/internal/status/gatewaystatus_test.go
+++ b/internal/status/gatewaystatus_test.go
@@ -31,8 +31,8 @@ func TestGatewayAddCondition(t *testing.T) {
 	simpleValidCondition := metav1.Condition{
 		Type:               string(gatewayapi_v1beta1.GatewayConditionScheduled),
 		Status:             metav1.ConditionTrue,
-		Reason:             ReasonValidGateway,
-		Message:            "Valid Gateway",
+		Reason:             string(gatewayapi_v1beta1.GatewayReasonScheduled),
+		Message:            MessageValidGateway,
 		ObservedGeneration: testGeneration,
 	}
 
@@ -44,8 +44,12 @@ func TestGatewayAddCondition(t *testing.T) {
 		TransitionTime:     metav1.Time{},
 	}
 
-	got := gatewayUpdate.AddCondition(gatewayapi_v1beta1.GatewayConditionScheduled, metav1.ConditionTrue, ReasonValidGateway,
-		"Valid Gateway")
+	got := gatewayUpdate.AddCondition(
+		gatewayapi_v1beta1.GatewayConditionScheduled,
+		metav1.ConditionTrue,
+		gatewayapi_v1beta1.GatewayReasonScheduled,
+		MessageValidGateway,
+	)
 
 	assert.Equal(t, simpleValidCondition.Message, got.Message)
 	assert.Equal(t, simpleValidCondition.Reason, got.Reason)

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -27,26 +27,21 @@ import (
 
 const (
 	ConditionNotImplemented   gatewayapi_v1beta1.RouteConditionType = "NotImplemented"
-	ConditionResolvedRefs     gatewayapi_v1beta1.RouteConditionType = "ResolvedRefs"
 	ConditionValidBackendRefs gatewayapi_v1beta1.RouteConditionType = "ValidBackendRefs"
 	ConditionValidMatches     gatewayapi_v1beta1.RouteConditionType = "ValidMatches"
 )
 
-type RouteReasonType string
-
 const (
-	ReasonNotImplemented                RouteReasonType = "NotImplemented"
-	ReasonPathMatchType                 RouteReasonType = "PathMatchType"
-	ReasonHeaderMatchType               RouteReasonType = "HeaderMatchType"
-	ReasonQueryParamMatchType           RouteReasonType = "QueryParamMatchType"
-	ReasonHTTPRouteFilterType           RouteReasonType = "HTTPRouteFilterType"
-	ReasonDegraded                      RouteReasonType = "Degraded"
-	ReasonValid                         RouteReasonType = "Valid"
-	ReasonErrorsExist                   RouteReasonType = "ErrorsExist"
-	ReasonGatewayAllowMismatch          RouteReasonType = "GatewayAllowMismatch"
-	ReasonAllBackendRefsHaveZeroWeights RouteReasonType = "AllBackendRefsHaveZeroWeights"
-	ReasonInvalidPathMatch              RouteReasonType = "InvalidPathMatch"
-	ReasonNoIntersectingHostnames       RouteReasonType = "NoIntersectingHostnames"
+	ReasonNotImplemented                gatewayapi_v1beta1.RouteConditionReason = "NotImplemented"
+	ReasonPathMatchType                 gatewayapi_v1beta1.RouteConditionReason = "PathMatchType"
+	ReasonHeaderMatchType               gatewayapi_v1beta1.RouteConditionReason = "HeaderMatchType"
+	ReasonQueryParamMatchType           gatewayapi_v1beta1.RouteConditionReason = "QueryParamMatchType"
+	ReasonHTTPRouteFilterType           gatewayapi_v1beta1.RouteConditionReason = "HTTPRouteFilterType"
+	ReasonDegraded                      gatewayapi_v1beta1.RouteConditionReason = "Degraded"
+	ReasonErrorsExist                   gatewayapi_v1beta1.RouteConditionReason = "ErrorsExist"
+	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
+	ReasonInvalidPathMatch              gatewayapi_v1beta1.RouteConditionReason = "InvalidPathMatch"
+	ReasonInvalidGateway                gatewayapi_v1beta1.RouteConditionReason = "InvalidGateway"
 )
 
 // clock is used to set lastTransitionTime on status conditions.
@@ -64,7 +59,7 @@ type RouteConditionsUpdate struct {
 }
 
 // AddCondition returns a metav1.Condition for a given ConditionType.
-func (routeUpdate *RouteConditionsUpdate) AddCondition(cond gatewayapi_v1beta1.RouteConditionType, status metav1.ConditionStatus, reason RouteReasonType, message string) metav1.Condition {
+func (routeUpdate *RouteConditionsUpdate) AddCondition(cond gatewayapi_v1beta1.RouteConditionType, status metav1.ConditionStatus, reason gatewayapi_v1beta1.RouteConditionReason, message string) metav1.Condition {
 
 	if c, ok := routeUpdate.Conditions[cond]; ok {
 		message = fmt.Sprintf("%s, %s", c.Message, message)

--- a/test/e2e/gateway/invalid_backend_ref_test.go
+++ b/test/e2e/gateway/invalid_backend_ref_test.go
@@ -19,7 +19,6 @@ package gateway
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/projectcontour/contour/internal/gatewayapi"
-	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,7 +122,7 @@ func testInvalidBackendRef(namespace string) {
 				if cond.Type == string(gatewayapi_v1beta1.RouteConditionAccepted) && cond.Status == metav1.ConditionFalse {
 					hasAccepted = true
 				}
-				if cond.Type == string(status.ConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {
+				if cond.Type == string(gatewayapi_v1beta1.RouteConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {
 					hasResolvedRefs = true
 				}
 			}

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -26,6 +26,7 @@ import (
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
@@ -118,7 +119,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 				for _, cond := range gc.Status.Conditions {
 					if cond.Type == string(gatewayapi_v1beta1.GatewayClassConditionStatusAccepted) &&
 						cond.Status == metav1.ConditionFalse &&
-						cond.Reason == "Invalid" &&
+						cond.Reason == string(status.ReasonOlderGatewayClassExists) &&
 						cond.Message == "Invalid GatewayClass: another older GatewayClass with the same Spec.Controller exists" {
 						return true
 					}


### PR DESCRIPTION
Replaces usage of internal Contour types
and values for Gateway API conditions with
upstream ones where available.

Updates #4560.

