### PR TITLE
Update contour cli commands to be a more correct xDS implementation

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -51,6 +51,9 @@ func main() {
 	cli.Flag("cafile", "CA bundle file for connecting to a TLS-secured Contour.").Envar("CLI_CAFILE").StringVar(&client.CAFile)
 	cli.Flag("cert-file", "Client certificate file for connecting to a TLS-secured Contour.").Envar("CLI_CERT_FILE").StringVar(&client.ClientCert)
 	cli.Flag("key-file", "Client key file for connecting to a TLS-secured Contour.").Envar("CLI_KEY_FILE").StringVar(&client.ClientKey)
+	cli.Flag("node-id", "Node ID for the CLI client to use").Envar("CLI_NODE_ID").Default("ContourCLI").StringVar(&client.NodeId)
+	cli.Flag("nack", "NACK all responses (for testing)").BoolVar(&client.Nack)
+	cli.Flag("delta", "Use incremental xDS").BoolVar(&client.Delta)
 
 	var resources []string
 	cds := cli.Command("cds", "Watch services.")
@@ -99,20 +102,45 @@ func main() {
 	case certgenApp.FullCommand():
 		doCertgen(certgenConfig, log)
 	case cds.FullCommand():
-		stream := client.ClusterStream()
-		watchstream(stream, resource_v3.ClusterType, resources)
+		if client.Delta {
+			stream := client.DeltaClusterStream()
+			watchDeltaStream(log, stream, resource_v3.ClusterType, resources, client.Nack, client.NodeId)
+		} else {
+			stream := client.ClusterStream()
+			watchstream(log, stream, resource_v3.ClusterType, resources, client.Nack, client.NodeId)
+		}
 	case eds.FullCommand():
-		stream := client.EndpointStream()
-		watchstream(stream, resource_v3.EndpointType, resources)
+		if client.Delta {
+			stream := client.DeltaEndpointStream()
+			watchDeltaStream(log, stream, resource_v3.EndpointType, resources, client.Nack, client.NodeId)
+		} else {
+			stream := client.EndpointStream()
+			watchstream(log, stream, resource_v3.EndpointType, resources, client.Nack, client.NodeId)
+		}
 	case lds.FullCommand():
-		stream := client.ListenerStream()
-		watchstream(stream, resource_v3.ListenerType, resources)
+		if client.Delta {
+			stream := client.DeltaListenerStream()
+			watchDeltaStream(log, stream, resource_v3.ListenerType, resources, client.Nack, client.NodeId)
+		} else {
+			stream := client.ListenerStream()
+			watchstream(log, stream, resource_v3.ListenerType, resources, client.Nack, client.NodeId)
+		}
 	case rds.FullCommand():
-		stream := client.RouteStream()
-		watchstream(stream, resource_v3.RouteType, resources)
+		if client.Delta {
+			stream := client.DeltaRouteStream()
+			watchDeltaStream(log, stream, resource_v3.RouteType, resources, client.Nack, client.NodeId)
+		} else {
+			stream := client.RouteStream()
+			watchstream(log, stream, resource_v3.RouteType, resources, client.Nack, client.NodeId)
+		}
 	case sds.FullCommand():
-		stream := client.RouteStream()
-		watchstream(stream, resource_v3.SecretType, resources)
+		if client.Delta {
+			stream := client.DeltaRouteStream()
+			watchDeltaStream(log, stream, resource_v3.SecretType, resources, client.Nack, client.NodeId)
+		} else {
+			stream := client.RouteStream()
+			watchstream(log, stream, resource_v3.SecretType, resources, client.Nack, client.NodeId)
+		}
 	case serve.FullCommand():
 		// Parse args a second time so cli flags are applied
 		// on top of any values sourced from -c's config file.


### PR DESCRIPTION
This PR updates `contour cli` with better logging and a correct implementation of the full ACK and NACK flow for both SOTW and Delta xDS types.

The `watchstream` and `watchDeltaStream` functions in `contour/cmd/cli.go` are extremely similar, but the types required (`DiscoveryRequest` and `DiscoveryResponse` for SOTW and `DeltaDiscoveryRequest` and `DeltaDiscoveryResponse` for Delta) are juuuust different enough that I felt that the brevity loss is made up for in readability.

Signed-off-by: Nick Young <ynick@vmware.com>