### PR TITLE
Add support for AppProtocol as well as service annotations

### DIFF
--- a/changelogs/unreleased/4603-evankanderson-small.md
+++ b/changelogs/unreleased/4603-evankanderson-small.md
@@ -1,0 +1,1 @@
+Upstream protocol: contour now respects the  Service `AppProtocol` field when determining the upstream protocol

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -99,6 +99,9 @@ func upstreamProtocol(svc *v1.Service, port v1.ServicePort) string {
 	if protocol == "" {
 		protocol = up[strconv.Itoa(int(port.Port))]
 	}
+	if protocol == "" && port.AppProtocol != nil {
+		protocol = *port.AppProtocol
+	}
 	return protocol
 }
 

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -89,10 +89,11 @@ func TestBuilderLookupService(t *testing.T) {
 				Port:       6441,
 				TargetPort: intstr.FromInt(26441),
 			}, {
-				Name:       "ssl",
-				Protocol:   "TCP",
-				Port:       6443,
-				TargetPort: intstr.FromInt(26443),
+				Name:        "ssl",
+				Protocol:    "TCP",
+				Port:        6443,
+				TargetPort:  intstr.FromInt(26443),
+				AppProtocol: pointer.String("http"), // Should be ignored
 			}, {
 				Name:        "happy",
 				Protocol:    "TCP",


### PR DESCRIPTION
---
name: Pull request
about: Support using AppProtocol to detect backend protocol (pass-through current "tls", "h2", "h2c" values) in addition to projectcontour.io/upstream-protocol.X annotations
labels: ["release-note/small"]
---

Fixes #2431

Note that this does not do any particular validation of the AppProtocol field, but it does add tests. :grin:

