### PR TITLE
internal/status: Avoid meaningless Condition changes

### DIFF
--- a/changelogs/unreleased/4607-evankanderson-small.md
+++ b/changelogs/unreleased/4607-evankanderson-small.md
@@ -1,0 +1,1 @@
+`LastTransitionTime` should only update for object transitions when the Condition has actually changed value.

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -60,6 +60,11 @@ type RouteConditionsUpdate struct {
 
 // AddCondition returns a metav1.Condition for a given ConditionType.
 func (routeUpdate *RouteConditionsUpdate) AddCondition(cond gatewayapi_v1beta1.RouteConditionType, status metav1.ConditionStatus, reason gatewayapi_v1beta1.RouteConditionReason, message string) metav1.Condition {
+	ec := routeUpdate.ExistingConditions[cond]
+	if ec.Reason == string(reason) && ec.Status == status && ec.Message == message &&
+		ec.ObservedGeneration == routeUpdate.Generation {
+		return ec
+	}
 
 	if c, ok := routeUpdate.Conditions[cond]; ok {
 		message = fmt.Sprintf("%s, %s", c.Message, message)


### PR DESCRIPTION
No longer automatically perform a Status update on _any_ call to AddCondition.

I recently noticed in my cluster that my HTTPRoute objects had updates to `status.parents.conditions[Valid].LastTransitionTime` once per second. In turn, this triggered my own reconcilers to check out the changes, adding load to the cluster and churn on etcd.

I could see an argument for updating the anonymous function in `RouteConditionsAccessor` in `cache.go` instead of `AddCondition` -- I don't have a strong feeling one way or the other.