### PR TITLE
Bump go-control-plane to commit that mirrors Envoy v1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.0+incompatible
-	github.com/envoyproxy/go-control-plane v0.10.2-0.20220415162322-2533dce4323f
+	github.com/envoyproxy/go-control-plane v0.10.3-0.20220715065308-8bcd7ee0191a
 	github.com/go-logr/logr v1.2.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220415162322-2533dce4323f h1:ljEckD5F+DGXgANgwQoto6Ikkas6/qpsGhVexqPPfe0=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220415162322-2533dce4323f/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220715065308-8bcd7ee0191a h1:iClO1QP0hhnHBl9W4yZsTReCasdmQnRiopr+Dek25O0=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20220715065308-8bcd7ee0191a/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=


### PR DESCRIPTION
See commits:
- https://github.com/envoyproxy/go-control-plane/commit/8bcd7ee0191add0cec98e58202bf2950f8ac25b0
- https://github.com/envoyproxy/envoy/commit/2222039d775c45c583f5eef833a482e2be150d21