### PR TITLE
Support new access log operators from Envoy 1.23.0

### DIFF
--- a/apis/projectcontour/v1alpha1/accesslog_test.go
+++ b/apis/projectcontour/v1alpha1/accesslog_test.go
@@ -97,6 +97,7 @@ func TestAccessLogFormatString(t *testing.T) {
 		"%REQ_WITHOUT_QUERY%\n",
 		"%START_TIME(%s.%6f):10%\n",
 		"no newline at the end",
+		"%METADATA%\n",
 	}
 
 	for _, c := range errorCases {
@@ -108,6 +109,7 @@ func TestAccessLogFormatString(t *testing.T) {
 		"%DURATION%.0\n",
 		"My duration %DURATION%.0\n",
 		"%START_TIME(%s.%6f)%\n",
+		"%START_TIME%\n",
 		"%REQ(X-CONTENT-ID)%\n",
 		"%REQ(X-CONTENT-ID):10%\n",
 		"%RESP(CONTENT-LENGTH):10%\n",
@@ -116,6 +118,17 @@ func TestAccessLogFormatString(t *testing.T) {
 		"queries %REQ_WITHOUT_QUERY(X-ENVOY-ORIGINAL-PATH?:PATH)% removed\n",
 		"just a string\n",
 		"%GRPC_STATUS%\n",
+		"%METADATA(ROUTE:com.test.my_filter:test_key):20%\n",
+		"%UPSTREAM_PROTOCOL%\n",
+		"%UPSTREAM_PEER_SUBJECT%\n",
+		"%UPSTREAM_PEER_ISSUER%\n",
+		"%UPSTREAM_TLS_SESSION_ID%\n",
+		"%UPSTREAM_TLS_CIPHER%\n",
+		"%UPSTREAM_TLS_VERSION%\n",
+		"%UPSTREAM_PEER_CERT_V_START%\n",
+		"%UPSTREAM_PEER_CERT_V_END%\n",
+		"%UPSTREAM_PEER_CERT%\n",
+		"%UPSTREAM_FILTER_STATE%\n",
 	}
 
 	for _, c := range successCases {

--- a/changelogs/unreleased/4627-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4627-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Adds support for access log operators introduced in Envoy 1.23.0. See [here](https://www.envoyproxy.io/docs/envoy/v1.23.0/version_history/v1.23/v1.23.0#new-features) for more details.


### PR DESCRIPTION
 See https://www.envoyproxy.io/docs/envoy/v1.23.0/version_history/v1.23/v1.23.0#new-features

Adds support for %METADATA% complex operator (not %UPSTREAM_METADATA% since
that is deprecated apparently) and simple operators:
%UPSTREAM_PROTOCOL%, %UPSTREAM_PEER_SUBJECT%, %UPSTREAM_PEER_ISSUER%,
%UPSTREAM_TLS_SESSION_ID%, %UPSTREAM_TLS_CIPHER%,
%UPSTREAM_TLS_VERSION%, %UPSTREAM_PEER_CERT_V_START%,
%UPSTREAM_PEER_CERT_V_END%, %UPSTREAM_PEER_CERT% and
%UPSTREAM_FILTER_STATE%

Fixes https://github.com/projectcontour/contour/issues/4624