### PR TITLE
fix changelog links

### DIFF
--- a/changelogs/CHANGELOG-v1.22.0-rc.1.md
+++ b/changelogs/CHANGELOG-v1.22.0-rc.1.md
@@ -180,12 +180,12 @@ The simplest way to install v1.22.0-rc.1 is to apply one of the example configur
 
 With Gateway API:
 ```bash
-kubectl apply -f https://github.com/projectcontour/contour/blob/v1.22.0-rc.1/examples/render/contour-gateway.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/v1.22.0-rc.1/examples/render/contour-gateway.yaml
 ```
 
 Without Gateway API:
 ```bash
-kubectl apply -f https://github.com/projectcontour/contour/blob/v1.22.0-rc.1/examples/render/contour.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/v1.22.0-rc.1/examples/render/contour.yaml
 ```
 
 

--- a/hack/release/release-notes-template.md
+++ b/hack/release/release-notes-template.md
@@ -51,12 +51,12 @@ The simplest way to install {{ .Version }} is to apply one of the example config
 
 With Gateway API:
 ```bash
-kubectl apply -f https://github.com/projectcontour/contour/blob/{{ .Version }}/examples/render/contour-gateway.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/{{ .Version }}/examples/render/contour-gateway.yaml
 ```
 
 Without Gateway API:
 ```bash
-kubectl apply -f https://github.com/projectcontour/contour/blob/{{ .Version }}/examples/render/contour.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcontour/contour/{{ .Version }}/examples/render/contour.yaml
 ```
 {{ else }}
 For a fresh install of Contour, consult the [getting started documentation](https://projectcontour.io/getting-started/).


### PR DESCRIPTION
Fixes links in the changelog template
and the v1.22.0-rc.1 changelog.

Signed-off-by: Steve Kriss <krisss@vmware.com>