### PR TITLE
test/scripts: fix upgrade from version logic when on a tag

### DIFF
--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 if CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
   # We are on a tag, so find previous tag to this one.
-  git tag -l --sort=-v:refname | grep -A10 $CURRENT_TAG | grep -v 'alpha\|beta\|rc' | head -1
+  git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | grep -A1 -x $CURRENT_TAG | grep -v "$CURRENT_TAG" | head -1
 elif git branch --show-current | grep -q release; then
   # We are on a release branch, so find tag.
   git describe --tags --abbrev=0

--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 if CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
   # We are on a tag, so find previous tag to this one.
-  git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | grep -A1 -x $CURRENT_TAG | grep -v "$CURRENT_TAG" | head -1
+  git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | grep -A1 -x $CURRENT_TAG | tail -1
 elif git branch --show-current | grep -q release; then
   # We are on a release branch, so find tag.
   git describe --tags --abbrev=0


### PR DESCRIPTION
Updates the "upgrade from" version logic for when
on a tag to get the correct previous tag.

Signed-off-by: Steve Kriss <krisss@vmware.com>