### PR TITLE
test/e2e/upgrade: remove WaitForEnvoyDaemonSetOutOfDate check

### DIFF
--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -107,7 +107,6 @@ var _ = Describe("upgrading Contour", func() {
 			require.NoError(f.T(), f.Deployment.WaitForContourDeploymentUpdated())
 
 			By("waiting for envoy daemonset to be updated")
-			require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetOutOfDate())
 			require.NoError(f.T(), f.Deployment.WaitForEnvoyUpdated())
 
 			By("ensuring app is still routable")


### PR DESCRIPTION
Removes the check that the Envoy DaemonSet
has become out-of-date after the upgrade,
since during the time that we're waiting
for the Contour deployment to update, the
Envoy DS is likely to become up-to-date
again.

Closes #4647.

Signed-off-by: Steve Kriss <krisss@vmware.com>