### PR TITLE
internal/envoy/v3: Stop using deprecated regex engine field of regexmatch

### DIFF
--- a/changelogs/unreleased/4652-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4652-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Transition to using new bootstrap field `default_regex_engine` instead of deprecated per-regex match engine selection.

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_file_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	envoy_regex_engines_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/regex_engines/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -240,6 +241,10 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 					),
 				},
 			}},
+		},
+		DefaultRegexEngine: &envoy_core_v3.TypedExtensionConfig{
+			Name:        "envoy.regex_engines.google_re2",
+			TypedConfig: protobuf.MustMarshalAny(&envoy_regex_engines_v3.GoogleRE2{}),
 		},
 		Admin: &envoy_bootstrap_v3.Admin{
 			AccessLog: adminAccessLog(c.GetAdminAccessLogPath()),

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -157,6 +157,12 @@ func TestBootstrap(t *testing.T) {
  	  "resource_api_version": "V3"
     }
   },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
+    }
+  },
   "admin": {
     "access_log": [
       {
@@ -337,6 +343,12 @@ func TestBootstrap(t *testing.T) {
       "resource_api_version": "V3"
     }
   },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
+    }
+  },
   "admin": {
     "access_log": [
       {
@@ -515,6 +527,12 @@ func TestBootstrap(t *testing.T) {
         ]
       },
       "resource_api_version": "V3"
+    }
+  },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
     }
   },
   "admin": {
@@ -698,6 +716,12 @@ func TestBootstrap(t *testing.T) {
 	  "resource_api_version": "V3"
     }
   },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
+    }
+  },
   "admin": {
     "access_log": [
       {
@@ -877,6 +901,12 @@ func TestBootstrap(t *testing.T) {
         ]
       },
 	  "resource_api_version": "V3"
+    }
+  },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
     }
   },
   "admin": {
@@ -1060,6 +1090,12 @@ func TestBootstrap(t *testing.T) {
 	  "resource_api_version": "V3"
     }
   },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
+    }
+  },
   "admin": {
     "access_log": [
       {
@@ -1241,6 +1277,12 @@ func TestBootstrap(t *testing.T) {
         ]
       },
 	  "resource_api_version": "V3"
+    }
+  },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
     }
   },
   "admin": {
@@ -1460,6 +1502,12 @@ func TestBootstrap(t *testing.T) {
 	  "resource_api_version": "V3"
     }
   },
+  "default_regex_engine": {
+    "name": "envoy.regex_engines.google_re2",
+    "typed_config": {
+      "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
+    }
+  },
   "admin": {
     "access_log": [
       {
@@ -1673,6 +1721,12 @@ func TestBootstrap(t *testing.T) {
               ]
             },
             "resource_api_version": "V3"
+          }
+        },
+        "default_regex_engine": {
+          "name": "envoy.regex_engines.google_re2",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.extensions.regex_engines.v3.GoogleRE2"
           }
         },
         "admin": {

--- a/internal/envoy/v3/regex.go
+++ b/internal/envoy/v3/regex.go
@@ -21,9 +21,6 @@ import (
 // SafeRegexMatch does not escape regex meta characters.
 func SafeRegexMatch(regex string) *matcher.RegexMatcher {
 	return &matcher.RegexMatcher{
-		EngineType: &matcher.RegexMatcher_GoogleRe2{
-			GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-		},
 		Regex: regex,
 	}
 }

--- a/internal/envoy/v3/regex_test.go
+++ b/internal/envoy/v3/regex_test.go
@@ -27,27 +27,17 @@ func TestSafeRegexMatch(t *testing.T) {
 	}{
 		"blank regex": {
 			regex: "",
-			want: &matcher.RegexMatcher{
-				EngineType: &matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-				},
-			},
+			want:  &matcher.RegexMatcher{},
 		},
 		"simple": {
 			regex: "chrome",
 			want: &matcher.RegexMatcher{
-				EngineType: &matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-				},
 				Regex: "chrome",
 			},
 		},
 		"regex meta": {
 			regex: "[a-z]+$",
 			want: &matcher.RegexMatcher{
-				EngineType: &matcher.RegexMatcher_GoogleRe2{
-					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-				},
 				Regex: "[a-z]+$", // meta characters are not escaped.
 			},
 		},

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1275,9 +1275,6 @@ func TestRouteMatch(t *testing.T) {
 						StringMatch: &matcher.StringMatcher{
 							MatchPattern: &matcher.StringMatcher_SafeRegex{
 								SafeRegex: &matcher.RegexMatcher{
-									EngineType: &matcher.RegexMatcher_GoogleRe2{
-										GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-									},
 									Regex: "[a-z0-9][a-z0-9-]+someniceregex",
 								},
 							},

--- a/internal/featuretests/v3/wildcardhost_test.go
+++ b/internal/featuretests/v3/wildcardhost_test.go
@@ -93,9 +93,6 @@ func TestIngressWildcardHostHTTP(t *testing.T) {
 									StringMatch: &matcher.StringMatcher{
 										MatchPattern: &matcher.StringMatcher_SafeRegex{
 											SafeRegex: &matcher.RegexMatcher{
-												EngineType: &matcher.RegexMatcher_GoogleRe2{
-													GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-												},
 												Regex: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.foo\\.com",
 											},
 										},
@@ -157,9 +154,6 @@ func TestHTTPProxyWildcardFQDN(t *testing.T) {
 								StringMatch: &matcher.StringMatcher{
 									MatchPattern: &matcher.StringMatcher_SafeRegex{
 										SafeRegex: &matcher.RegexMatcher{
-											EngineType: &matcher.RegexMatcher_GoogleRe2{
-												GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-											},
 											Regex: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.projectcontour\\.io",
 										},
 									},
@@ -265,9 +259,6 @@ func TestIngressWildcardHostHTTPSWildcardSecret(t *testing.T) {
 									StringMatch: &matcher.StringMatcher{
 										MatchPattern: &matcher.StringMatcher_SafeRegex{
 											SafeRegex: &matcher.RegexMatcher{
-												EngineType: &matcher.RegexMatcher_GoogleRe2{
-													GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-												},
 												Regex: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.foo-tls\\.com",
 											},
 										},
@@ -296,9 +287,6 @@ func TestIngressWildcardHostHTTPSWildcardSecret(t *testing.T) {
 									StringMatch: &matcher.StringMatcher{
 										MatchPattern: &matcher.StringMatcher_SafeRegex{
 											SafeRegex: &matcher.RegexMatcher{
-												EngineType: &matcher.RegexMatcher_GoogleRe2{
-													GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-												},
 												Regex: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.foo-tls\\.com",
 											},
 										},


### PR DESCRIPTION
Should now use default regex engine in bootstrap

Deprecation introduced in Envoy 1.23.0 which Contour 1.22.0 was released with so
safe to merge