### PR TITLE
[release-1.22] update Envoy to v1.23.1 (#4691)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.0
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.1
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4691-skriss-small.md
+++ b/changelogs/unreleased/4691-skriss-small.md
@@ -1,0 +1,1 @@
+Update Envoy to v1.23.1. This fixes an issue where the arm64 variant of the Envoy image was not built properly. See the [release notes](https://www.envoyproxy.io/docs/envoy/v1.23.1/version_history/v1.23/v1.23.1) for additional information.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -33,7 +33,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	config := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.22.0",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.0",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.1",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.0
+        image: docker.io/envoyproxy/envoy:v1.23.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5161,7 +5161,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.0
+        image: docker.io/envoyproxy/envoy:v1.23.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5156,7 +5156,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.0
+        image: docker.io/envoyproxy/envoy:v1.23.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.23.0][19]         | 1.24, 1.23, 1.22    | [main][50]       | v1alpha2, v1beta1   |
+| main            | [1.23.1][20]         | 1.24, 1.23, 1.22    | [main][50]       | v1alpha2, v1beta1   |
 | 1.22.0          | [1.23.0][19]         | 1.24, 1.23, 1.22    | [1.22.0][72]     | v1alpha2, v1beta1   |
 | 1.21.1          | [1.22.2][17]         | 1.23, 1.22, 1.21    | [1.21.1][70]     | v1alpha2            |
 | 1.21.0          | [1.22.0][16]         | 1.23, 1.22, 1.21    | [1.21.0][69]     | v1alpha2            |
@@ -119,6 +119,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [17]: https://www.envoyproxy.io/docs/envoy/v1.22.2/version_history/current
 [18]: https://www.envoyproxy.io/docs/envoy/v1.21.3/version_history/current
 [19]: https://www.envoyproxy.io/docs/envoy/v1.23.0/version_history/v1.23/v1.23.0
+[20]: https://www.envoyproxy.io/docs/envoy/v1.23.1/version_history/v1.23/v1.23.1
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.23.0"
+      envoy: "1.23.1"
       kubernetes:
         - "1.24"
         - "1.23"


### PR DESCRIPTION
Closes #4685.

Signed-off-by: Steve Kriss <krisss@vmware.com>