### PR TITLE
test/e2e: add flake retries for request mirror test

### DIFF
--- a/test/e2e/gateway/request_mirror_test.go
+++ b/test/e2e/gateway/request_mirror_test.go
@@ -33,7 +33,8 @@ import (
 )
 
 func testRequestMirrorRule(namespace string) {
-	Specify("mirrors can be specified on route rule", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4650
+	Specify("mirrors can be specified on route rule", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-primary")


### PR DESCRIPTION
Updates #4650.

Signed-off-by: Steve Kriss <krisss@vmware.com>