### PR TITLE
internal/provisioner: drop New func for creating a model

### DIFF
--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -661,59 +661,6 @@ const (
 	ContourAvailableConditionType = "Available"
 )
 
-// Config is the configuration of a Contour.
-type Config struct {
-	Name                      string
-	Namespace                 string
-	Replicas                  int32
-	NetworkType               NetworkPublishingType
-	NodePorts                 []NodePort
-	GatewayControllerName     *string
-	EnableExternalNameService *bool
-}
-
-// New makes a Contour object using the provided ns/name for the object's
-// namespace/name, pubType for the network publishing type of Envoy, and
-// Envoy container ports 8080/8443.
-func New(cfg Config) *Contour {
-	cntr := &Contour{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cfg.Namespace,
-			Name:      cfg.Name,
-		},
-		Spec: ContourSpec{
-			ContourReplicas: cfg.Replicas,
-			LogLevel:        contourv1alpha1.InfoLog,
-			NetworkPublishing: NetworkPublishing{
-				Envoy: EnvoyNetworkPublishing{
-					Type: cfg.NetworkType,
-					ContainerPorts: []ContainerPort{
-						{
-							Name:       "http",
-							PortNumber: int32(8080),
-						},
-						{
-							Name:       "https",
-							PortNumber: int32(8443),
-						},
-					},
-				},
-			},
-			KubernetesLogLevel: 0,
-		},
-	}
-	if cfg.NetworkType == NodePortServicePublishingType && len(cfg.NodePorts) > 0 {
-		cntr.Spec.NetworkPublishing.Envoy.NodePorts = cfg.NodePorts
-	}
-	if cfg.GatewayControllerName != nil {
-		cntr.Spec.GatewayControllerName = cfg.GatewayControllerName
-	}
-	if cfg.EnableExternalNameService != nil {
-		cntr.Spec.EnableExternalNameService = cfg.EnableExternalNameService
-	}
-	return cntr
-}
-
 // OwningSelector returns a label selector using "projectcontour.io/owning-gateway-name".
 func OwningSelector(contour *Contour) *metav1.LabelSelector {
 	return &metav1.LabelSelector{

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -153,12 +153,8 @@ func checkDaemonSecurityContext(t *testing.T, ds *appsv1.DaemonSet) {
 
 func TestDesiredDaemonSet(t *testing.T) {
 	name := "ds-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
+
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
 	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
@@ -182,6 +178,8 @@ func TestDesiredDaemonSet(t *testing.T) {
 
 func TestNodePlacementDaemonSet(t *testing.T) {
 	name := "selector-test"
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
+
 	selectors := map[string]string{"node-role": "envoy"}
 	tolerations := []corev1.Toleration{
 		{
@@ -191,12 +189,7 @@ func TestNodePlacementDaemonSet(t *testing.T) {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+
 	cntr.Spec.NodePlacement = &model.NodePlacement{
 		Envoy: &model.EnvoyNodePlacement{
 			NodeSelector: selectors,

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects"
 
@@ -78,16 +79,6 @@ func checkContainerHasArg(t *testing.T, container *corev1.Container, arg string)
 	t.Errorf("container is missing argument %q", arg)
 }
 
-func checkContainerHasNoArg(t *testing.T, container *corev1.Container, arg string) {
-	t.Helper()
-
-	for _, a := range container.Args {
-		if a == arg {
-			t.Errorf("container shouldn't have argument %q", arg)
-		}
-	}
-}
-
 func checkContainerHasImage(t *testing.T, container *corev1.Container, image string) {
 	t.Helper()
 
@@ -132,8 +123,11 @@ func TestDesiredDeployment(t *testing.T) {
 		}
 	}
 
-	// Change the default Kubernetes log level to test --kubernetes-debug.
+	// Change the Kubernetes log level to test --kubernetes-debug.
 	cntr.Spec.KubernetesLogLevel = 7
+
+	// Change the Contour log level to test --debug.
+	cntr.Spec.LogLevel = v1alpha1.DebugLog
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	deploy := DesiredDeployment(cntr, testContourImage)
@@ -155,7 +149,7 @@ func TestDesiredDeployment(t *testing.T) {
 		}
 	}
 
-	checkContainerHasNoArg(t, container, "--debug")
+	checkContainerHasArg(t, container, "--debug")
 
 	arg := fmt.Sprintf("--ingress-class-name=%s", *cntr.Spec.IngressClassName)
 	checkContainerHasArg(t, container, arg)

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -132,6 +132,9 @@ func TestDesiredDeployment(t *testing.T) {
 		}
 	}
 
+	// Change the default Kubernetes log level to test --kubernetes-debug.
+	cntr.Spec.KubernetesLogLevel = 7
+
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	deploy := DesiredDeployment(cntr, testContourImage)
 

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -117,12 +117,7 @@ func checkDeploymentHasTolerations(t *testing.T, deploy *appsv1.Deployment, expe
 
 func TestDesiredDeployment(t *testing.T) {
 	name := "deploy-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	icName := "test-ic"
 	cntr.Spec.IngressClassName = &icName
 	// Change the default ports to test Envoy service port args.
@@ -171,6 +166,8 @@ func TestDesiredDeployment(t *testing.T) {
 
 func TestNodePlacementDeployment(t *testing.T) {
 	name := "selector-test"
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
+
 	selectors := map[string]string{"node-role": "contour"}
 	tolerations := []corev1.Toleration{
 		{
@@ -180,12 +177,7 @@ func TestNodePlacementDeployment(t *testing.T) {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+
 	cntr.Spec.NodePlacement = &model.NodePlacement{
 		Contour: &model.ContourNodePlacement{
 			NodeSelector: selectors,

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role_test.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role_test.go
@@ -45,12 +45,7 @@ func checkClusterRoleLabels(t *testing.T, cr *rbacv1.ClusterRole, expected map[s
 
 func TestDesiredClusterRole(t *testing.T) {
 	name := "test-cr"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	cr := desiredClusterRole(name, cntr)
 	checkClusterRoleName(t, cr, name)
 	ownerLabels := map[string]string{

--- a/internal/provisioner/objects/rbac/clusterrolebinding/cluster_role_binding_test.go
+++ b/internal/provisioner/objects/rbac/clusterrolebinding/cluster_role_binding_test.go
@@ -64,17 +64,12 @@ func checkClusterRoleBindingRole(t *testing.T, crb *rbacv1.ClusterRoleBinding, e
 }
 
 func TestDesiredClusterRoleBinding(t *testing.T) {
-	crbName := "test-crb"
-	cfg := model.Config{
-		Name:        crbName,
-		Namespace:   fmt.Sprintf("%s-ns", crbName),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	name := "test-crb"
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	testSvcAcct := "test-svc-acct-ref"
 	testRoleRef := "test-role-ref"
-	crb := desiredClusterRoleBinding(crbName, testRoleRef, testSvcAcct, cntr)
-	checkClusterRoleBindingName(t, crb, crbName)
+	crb := desiredClusterRoleBinding(name, testRoleRef, testSvcAcct, cntr)
+	checkClusterRoleBindingName(t, crb, name)
 	ownerLabels := map[string]string{
 		model.OwningGatewayNameLabel: cntr.Name,
 	}

--- a/internal/provisioner/objects/rbac/role/role_test.go
+++ b/internal/provisioner/objects/rbac/role/role_test.go
@@ -45,12 +45,7 @@ func checkRoleLabels(t *testing.T, role *rbacv1.Role, expected map[string]string
 
 func TestDesiredControllerRole(t *testing.T) {
 	name := "role-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	role := desiredControllerRole(name, cntr)
 	checkRoleName(t, role, name)
 	ownerLabels := map[string]string{

--- a/internal/provisioner/objects/rbac/rolebinding/role_binding_test.go
+++ b/internal/provisioner/objects/rbac/rolebinding/role_binding_test.go
@@ -65,12 +65,7 @@ func checkRoleBindingRole(t *testing.T, rb *rbacv1.RoleBinding, expected string)
 
 func TestDesiredRoleBinding(t *testing.T) {
 	name := "job-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	rbName := "test-rb"
 	svcAcct := "test-svc-acct-ref"
 	roleRef := "test-role-ref"

--- a/internal/provisioner/objects/service/service_test.go
+++ b/internal/provisioner/objects/service/service_test.go
@@ -134,12 +134,7 @@ func checkServiceHasLoadBalancerAddress(t *testing.T, svc *corev1.Service, addre
 
 func TestDesiredContourService(t *testing.T) {
 	name := "svc-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.LoadBalancerServicePublishingType,
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
 	svc := DesiredContourService(cntr)
 	xdsPort := objects.XDSPort
 	checkServiceHasPort(t, svc, xdsPort)
@@ -154,13 +149,9 @@ func TestDesiredEnvoyService(t *testing.T) {
 	allocationIDs := []string{"eipalloc-0123456789", "eipalloc-1234567890"}
 	resourceGroup := "contour-rg-test"
 	subnet := "contour-subnet-test"
-	cfg := model.Config{
-		Name:        name,
-		Namespace:   fmt.Sprintf("%s-ns", name),
-		NetworkType: model.NodePortServicePublishingType,
-		NodePorts:   model.MakeNodePorts(map[string]int{"http": 30081, "https": 30444}),
-	}
-	cntr := model.New(cfg)
+	cntr := model.Default(fmt.Sprintf("%s-ns", name), name)
+	cntr.Spec.NetworkPublishing.Envoy.Type = model.NodePortServicePublishingType
+	cntr.Spec.NetworkPublishing.Envoy.NodePorts = model.MakeNodePorts(map[string]int{"http": 30081, "https": 30444})
 	cntr.Spec.NetworkPublishing.Envoy.ServicePorts = []model.ServicePort{
 		{
 			Name:       "http",


### PR DESCRIPTION
The New function for creating a model was only
used in test code and was largely redundant
with the newer Default function. Replaces the
former with the latter and inlines any
customizations needed by individual tests.

Signed-off-by: Steve Kriss <krisss@vmware.com>