### PR TITLE
CORSPolicy AllowOrigin can be configured as a regex

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -293,27 +293,32 @@ type CORSHeaderValue string
 // CORSPolicy allows setting the CORS policy
 type CORSPolicy struct {
 	// Specifies whether the resource allows credentials.
-	//  +optional
+	// +optional
 	AllowCredentials bool `json:"allowCredentials,omitempty"`
 	// AllowOrigin specifies the origins that will be allowed to do CORS requests. "*" means
 	// allow any origin.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	AllowOrigin []string `json:"allowOrigin"`
 	// AllowMethods specifies the content for the *access-control-allow-methods* header.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	AllowMethods []CORSHeaderValue `json:"allowMethods"`
 	// AllowHeaders specifies the content for the *access-control-allow-headers* header.
-	//  +optional
+	// +optional
+	// +kubebuilder:validation:MinItems=1
 	AllowHeaders []CORSHeaderValue `json:"allowHeaders,omitempty"`
 	// ExposeHeaders Specifies the content for the *access-control-expose-headers* header.
-	//  +optional
+	// +optional
+	// +kubebuilder:validation:MinItems=1
 	ExposeHeaders []CORSHeaderValue `json:"exposeHeaders,omitempty"`
 	// MaxAge indicates for how long the results of a preflight request can be cached.
 	// MaxAge durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// Only positive values are allowed while 0 disables the cache requiring a preflight OPTIONS
 	// check for all cross-origin requests.
-	//  +optional
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$`
 	MaxAge string `json:"maxAge,omitempty"`
 }
 

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -295,8 +295,13 @@ type CORSPolicy struct {
 	// Specifies whether the resource allows credentials.
 	// +optional
 	AllowCredentials bool `json:"allowCredentials,omitempty"`
-	// AllowOrigin specifies the origins that will be allowed to do CORS requests. "*" means
-	// allow any origin.
+	// AllowOrigin specifies the origins that will be allowed to do CORS requests.
+	// Allowed values include "*" which signifies any origin is allowed, an exact
+	// origin of the form "scheme://host[:port]" (where port is optional), or a valid
+	// regex pattern.
+	// Note that regex patterns are validated and a simple "glob" pattern (e.g. *.foo.com)
+	// will be rejected or produce unexpected matches when applied as a regex.
+	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems=1
 	AllowOrigin []string `json:"allowOrigin"`

--- a/changelogs/unreleased/4710-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4710-sunjayBhatia-minor.md
@@ -1,4 +1,4 @@
 ## HTTPProxy CORS policy supports regex matching on Allowed Origins
 
-The AllowedOrigin field of the HTTPProxy CORSPolicy can be configured as a regex to enable more flexibility for users.
+The AllowOrigin field of the HTTPProxy CORSPolicy can be configured as a regex to enable more flexibility for users.
 More advanced matching can now be performed on the `Origin` header of HTTP requests, instead of restricting users to allow all origins, or enumerating all possible values.

--- a/changelogs/unreleased/4710-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4710-sunjayBhatia-minor.md
@@ -1,0 +1,4 @@
+## HTTPProxy CORS policy supports regex matching on Allowed Origins
+
+The AllowedOrigin field of the HTTPProxy CORSPolicy can be configured as a regex to enable more flexibility for users.
+More advanced matching can now be performed on the `Origin` header of HTTP requests, instead of restricting users to allow all origins, or enumerating all possible values.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -3604,6 +3604,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowMethods:
                         description: AllowMethods specifies the content for the *access-control-allow-methods*
@@ -3613,12 +3614,14 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
                           allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
+                        minItems: 1
                         type: array
                       exposeHeaders:
                         description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
@@ -3628,6 +3631,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       maxAge:
                         description: MaxAge indicates for how long the results of
@@ -3637,6 +3641,7 @@ spec:
                           "h". Only positive values are allowed while 0 disables the
                           cache requiring a preflight OPTIONS check for all cross-origin
                           requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
                         type: string
                     required:
                     - allowMethods

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -3618,7 +3618,12 @@ spec:
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
+                          allowed to do CORS requests. Allowed values include "*"
+                          which signifies any origin is allowed, an exact origin of
+                          the form "scheme://host[:port]" (where port is optional),
+                          or a valid regex pattern. Note that regex patterns are validated
+                          and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                          or produce unexpected matches when applied as a regex.
                         items:
                           type: string
                         minItems: 1

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -3827,7 +3827,12 @@ spec:
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
+                          allowed to do CORS requests. Allowed values include "*"
+                          which signifies any origin is allowed, an exact origin of
+                          the form "scheme://host[:port]" (where port is optional),
+                          or a valid regex pattern. Note that regex patterns are validated
+                          and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                          or produce unexpected matches when applied as a regex.
                         items:
                           type: string
                         minItems: 1

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -3813,6 +3813,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowMethods:
                         description: AllowMethods specifies the content for the *access-control-allow-methods*
@@ -3822,12 +3823,14 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
                           allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
+                        minItems: 1
                         type: array
                       exposeHeaders:
                         description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
@@ -3837,6 +3840,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       maxAge:
                         description: MaxAge indicates for how long the results of
@@ -3846,6 +3850,7 @@ spec:
                           "h". Only positive values are allowed while 0 disables the
                           cache requiring a preflight OPTIONS check for all cross-origin
                           requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
                         type: string
                     required:
                     - allowMethods

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -3631,7 +3631,12 @@ spec:
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
+                          allowed to do CORS requests. Allowed values include "*"
+                          which signifies any origin is allowed, an exact origin of
+                          the form "scheme://host[:port]" (where port is optional),
+                          or a valid regex pattern. Note that regex patterns are validated
+                          and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                          or produce unexpected matches when applied as a regex.
                         items:
                           type: string
                         minItems: 1

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -3617,6 +3617,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowMethods:
                         description: AllowMethods specifies the content for the *access-control-allow-methods*
@@ -3626,12 +3627,14 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
                           allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
+                        minItems: 1
                         type: array
                       exposeHeaders:
                         description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
@@ -3641,6 +3644,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       maxAge:
                         description: MaxAge indicates for how long the results of
@@ -3650,6 +3654,7 @@ spec:
                           "h". Only positive values are allowed while 0 disables the
                           cache requiring a preflight OPTIONS check for all cross-origin
                           requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
                         type: string
                     required:
                     - allowMethods

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3818,6 +3818,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowMethods:
                         description: AllowMethods specifies the content for the *access-control-allow-methods*
@@ -3827,12 +3828,14 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
                           allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
+                        minItems: 1
                         type: array
                       exposeHeaders:
                         description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
@@ -3842,6 +3845,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       maxAge:
                         description: MaxAge indicates for how long the results of
@@ -3851,6 +3855,7 @@ spec:
                           "h". Only positive values are allowed while 0 disables the
                           cache requiring a preflight OPTIONS check for all cross-origin
                           requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
                         type: string
                     required:
                     - allowMethods

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3832,7 +3832,12 @@ spec:
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
+                          allowed to do CORS requests. Allowed values include "*"
+                          which signifies any origin is allowed, an exact origin of
+                          the form "scheme://host[:port]" (where port is optional),
+                          or a valid regex pattern. Note that regex patterns are validated
+                          and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                          or produce unexpected matches when applied as a regex.
                         items:
                           type: string
                         minItems: 1

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3827,7 +3827,12 @@ spec:
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
+                          allowed to do CORS requests. Allowed values include "*"
+                          which signifies any origin is allowed, an exact origin of
+                          the form "scheme://host[:port]" (where port is optional),
+                          or a valid regex pattern. Note that regex patterns are validated
+                          and a simple "glob" pattern (e.g. *.foo.com) will be rejected
+                          or produce unexpected matches when applied as a regex.
                         items:
                           type: string
                         minItems: 1

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3813,6 +3813,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowMethods:
                         description: AllowMethods specifies the content for the *access-control-allow-methods*
@@ -3822,12 +3823,14 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       allowOrigin:
                         description: AllowOrigin specifies the origins that will be
                           allowed to do CORS requests. "*" means allow any origin.
                         items:
                           type: string
+                        minItems: 1
                         type: array
                       exposeHeaders:
                         description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
@@ -3837,6 +3840,7 @@ spec:
                             string headers returned by a cross-domain request.
                           pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                           type: string
+                        minItems: 1
                         type: array
                       maxAge:
                         description: MaxAge indicates for how long the results of
@@ -3846,6 +3850,7 @@ spec:
                           "h". Only positive values are allowed while 0 disables the
                           cache requiring a preflight OPTIONS check for all cross-origin
                           requests.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|0)$
                         type: string
                     required:
                     - allowMethods

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -466,12 +466,37 @@ type HeaderValueMatchDescriptorEntry struct {
 // that contains the remote address (i.e. client IP).
 type RemoteAddressDescriptorEntry struct{}
 
+// CORSAllowOriginMatchType differentiates different CORS origin matching
+// methods.
+type CORSAllowOriginMatchType int
+
+const (
+	// CORSAllowOriginMatchExact will match an origin exactly.
+	// Wildcard "*" matches should be configured as exact matches.
+	CORSAllowOriginMatchExact CORSAllowOriginMatchType = iota
+
+	// CORSAllowOriginMatchRegex denote a regex pattern will be used
+	// to match the origin in a request.
+	CORSAllowOriginMatchRegex
+)
+
+// CORSAllowOriginMatch specifies how allowed origins should be matched.
+type CORSAllowOriginMatch struct {
+	// Type is the type of matching to perform.
+	// Wildcard matches are treated as exact matches.
+	Type CORSAllowOriginMatchType
+
+	// Value is the pattern to match against, the specifics of which
+	// will depend on the type of match.
+	Value string
+}
+
 // CORSPolicy allows setting the CORS policy
 type CORSPolicy struct {
 	// Specifies whether the resource allows credentials.
 	AllowCredentials bool
 	// AllowOrigin specifies the origins that will be allowed to do CORS requests.
-	AllowOrigin []string
+	AllowOrigin []CORSAllowOriginMatch
 	// AllowMethods specifies the content for the *access-control-allow-methods* header.
 	AllowMethods []string
 	// AllowHeaders specifies the content for the *access-control-allow-headers* header.

--- a/internal/dag/httpproxy_processor_test.go
+++ b/internal/dag/httpproxy_processor_test.go
@@ -15,8 +15,12 @@ package dag
 
 import (
 	"testing"
+	"time"
 
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetermineSNI(t *testing.T) {
@@ -130,4 +134,161 @@ func TestEnforceRoute(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestToCORSPolicy(t *testing.T) {
+	tests := map[string]struct {
+		cp      *contour_api_v1.CORSPolicy
+		want    *CORSPolicy
+		wantErr bool
+	}{
+		"no CORS policy": {
+			cp:   nil,
+			want: nil,
+		},
+		"all fields present and valid": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowCredentials: true,
+				AllowHeaders:     []contour_api_v1.CORSHeaderValue{"X-Some-Header-A", "X-Some-Header-B"},
+				AllowMethods:     []contour_api_v1.CORSHeaderValue{"GET", "PUT"},
+				AllowOrigin:      []string{"*"},
+				ExposeHeaders:    []contour_api_v1.CORSHeaderValue{"X-Expose-A", "X-Expose-B"},
+				MaxAge:           "5h",
+			},
+			want: &CORSPolicy{
+				AllowCredentials: true,
+				AllowHeaders:     []string{"X-Some-Header-A", "X-Some-Header-B"},
+				AllowMethods:     []string{"GET", "PUT"},
+				AllowOrigin:      []CORSAllowOriginMatch{{Type: CORSAllowOriginMatchExact, Value: "*"}},
+				ExposeHeaders:    []string{"X-Expose-A", "X-Expose-B"},
+				MaxAge:           timeout.DurationSetting(5 * time.Hour),
+			},
+		},
+		"allow origin wildcard": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{"*"},
+			},
+			want: &CORSPolicy{
+				AllowHeaders:  []string{},
+				AllowMethods:  []string{"GET"},
+				AllowOrigin:   []CORSAllowOriginMatch{{Type: CORSAllowOriginMatchExact, Value: "*"}},
+				ExposeHeaders: []string{},
+			},
+		},
+		"allow origin specific valid": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{"http://foo-1.bar.com", "https://foo-2.com:443"},
+			},
+			want: &CORSPolicy{
+				AllowHeaders: []string{},
+				AllowMethods: []string{"GET"},
+				AllowOrigin: []CORSAllowOriginMatch{
+					{Type: CORSAllowOriginMatchExact, Value: "http://foo-1.bar.com"},
+					{Type: CORSAllowOriginMatchExact, Value: "https://foo-2.com:443"},
+				},
+				ExposeHeaders: []string{},
+			},
+		},
+		"allow origin invalid specific but valid regex": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin: []string{
+					"no-scheme.bar.com",
+					"http://bar.com/foo",
+					"http://baz.com?query1=2",
+					"http://example.org#fragment",
+				},
+			},
+			want: &CORSPolicy{
+				AllowHeaders: []string{},
+				AllowMethods: []string{"GET"},
+				AllowOrigin: []CORSAllowOriginMatch{
+					{Type: CORSAllowOriginMatchRegex, Value: "no-scheme.bar.com"},
+					{Type: CORSAllowOriginMatchRegex, Value: "http://bar.com/foo"},
+					{Type: CORSAllowOriginMatchRegex, Value: "http://baz.com?query1=2"},
+					{Type: CORSAllowOriginMatchRegex, Value: "http://example.org#fragment"},
+				},
+				ExposeHeaders: []string{},
+			},
+		},
+		"allow origin regex valid": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{`.*\.foo\.com`, `https://example\.bar-[0-9]+\.org`},
+			},
+			want: &CORSPolicy{
+				AllowHeaders: []string{},
+				AllowMethods: []string{"GET"},
+				AllowOrigin: []CORSAllowOriginMatch{
+					{Type: CORSAllowOriginMatchRegex, Value: `.*\.foo\.com`},
+					{Type: CORSAllowOriginMatchRegex, Value: `https://example\.bar-[0-9]+\.org`},
+				},
+				ExposeHeaders: []string{},
+			},
+		},
+		"allow origin regex invalid": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{"**"},
+			},
+			wantErr: true,
+		},
+		"nil allow origin": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  nil,
+			},
+			wantErr: true,
+		},
+		"nil allow methods": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: nil,
+				AllowOrigin:  []string{"*"},
+			},
+			wantErr: true,
+		},
+		"empty allow origin": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{},
+			},
+			wantErr: true,
+		},
+		"empty allow methods": {
+			cp: &contour_api_v1.CORSPolicy{
+				AllowMethods: []contour_api_v1.CORSHeaderValue{},
+				AllowOrigin:  []string{"*"},
+			},
+			wantErr: true,
+		},
+		"invalid max age": {
+			cp: &contour_api_v1.CORSPolicy{
+				MaxAge:       "xxm",
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{"*"},
+			},
+			wantErr: true,
+		},
+		"negative max age": {
+			cp: &contour_api_v1.CORSPolicy{
+				MaxAge:       "-5s",
+				AllowMethods: []contour_api_v1.CORSHeaderValue{"GET"},
+				AllowOrigin:  []string{"*"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, gotErr := toCORSPolicy(tc.cp)
+			if tc.wantErr {
+				require.Error(t, gotErr)
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+
 }

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -980,7 +980,7 @@ func TestCORSPolicy(t *testing.T) {
 	}{
 		"only required properties set": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:  []string{"*"},
+				AllowOrigin:  []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods: []string{"GET", "POST", "PUT"},
 			},
 			want: &envoy_route_v3.CorsPolicy{
@@ -995,9 +995,37 @@ func TestCORSPolicy(t *testing.T) {
 				AllowMethods:     "GET,POST,PUT",
 			},
 		},
+		"allow origin regex and specific": {
+			cp: &dag.CORSPolicy{
+				AllowOrigin: []dag.CORSAllowOriginMatch{
+					{Type: dag.CORSAllowOriginMatchRegex, Value: `.*\.foo\.com`},
+					{Type: dag.CORSAllowOriginMatchExact, Value: "https://bar.com"},
+				},
+				AllowMethods: []string{"GET"},
+			},
+			want: &envoy_route_v3.CorsPolicy{
+				AllowOriginStringMatch: []*matcher.StringMatcher{
+					{
+						MatchPattern: &matcher.StringMatcher_SafeRegex{
+							SafeRegex: &matcher.RegexMatcher{
+								Regex: `.*\.foo\.com`,
+							},
+						},
+					},
+					{
+						MatchPattern: &matcher.StringMatcher_Exact{
+							Exact: "https://bar.com",
+						},
+						IgnoreCase: true,
+					},
+				},
+				AllowCredentials: protobuf.Bool(false),
+				AllowMethods:     "GET",
+			},
+		},
 		"allow credentials": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:      []string{"*"},
+				AllowOrigin:      []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods:     []string{"GET", "POST", "PUT"},
 				AllowCredentials: true,
 			},
@@ -1015,7 +1043,7 @@ func TestCORSPolicy(t *testing.T) {
 		},
 		"allow headers": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:  []string{"*"},
+				AllowOrigin:  []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods: []string{"GET", "POST", "PUT"},
 				AllowHeaders: []string{"header-1", "header-2"},
 			},
@@ -1034,7 +1062,7 @@ func TestCORSPolicy(t *testing.T) {
 		},
 		"expose headers": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:   []string{"*"},
+				AllowOrigin:   []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods:  []string{"GET", "POST", "PUT"},
 				ExposeHeaders: []string{"header-1", "header-2"},
 			},
@@ -1053,7 +1081,7 @@ func TestCORSPolicy(t *testing.T) {
 		},
 		"max age": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:  []string{"*"},
+				AllowOrigin:  []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods: []string{"GET", "POST", "PUT"},
 				MaxAge:       timeout.DurationSetting(10 * time.Minute),
 			},
@@ -1072,7 +1100,7 @@ func TestCORSPolicy(t *testing.T) {
 		},
 		"default max age": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:  []string{"*"},
+				AllowOrigin:  []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods: []string{"GET", "POST", "PUT"},
 				MaxAge:       timeout.DefaultSetting(),
 			},
@@ -1090,7 +1118,7 @@ func TestCORSPolicy(t *testing.T) {
 		},
 		"max age disabled": {
 			cp: &dag.CORSPolicy{
-				AllowOrigin:  []string{"*"},
+				AllowOrigin:  []dag.CORSAllowOriginMatch{{Type: dag.CORSAllowOriginMatchExact, Value: "*"}},
 				AllowMethods: []string{"GET", "POST", "PUT"},
 				MaxAge:       timeout.DisabledSetting(),
 			},

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -528,8 +528,12 @@ bool
 </em>
 </td>
 <td>
-<p>AllowOrigin specifies the origins that will be allowed to do CORS requests. &ldquo;*&rdquo; means
-allow any origin.</p>
+<p>AllowOrigin specifies the origins that will be allowed to do CORS requests.
+Allowed values include &ldquo;*&rdquo; which signifies any origin is allowed, an exact
+origin of the form &ldquo;scheme://host[:port]&rdquo; (where port is optional), or a valid
+regex pattern.
+Note that regex patterns are validated and a simple &ldquo;glob&rdquo; pattern (e.g. *.foo.com)
+will be rejected or produce unexpected matches when applied as a regex.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/cors.md
+++ b/site/content/docs/main/config/cors.md
@@ -3,8 +3,11 @@
 A CORS (Cross-origin resource sharing) policy can be set for a HTTPProxy in order to allow cross-domain requests for trusted sources.
 If a policy is set, it will be applied to all the routes of the virtual host.
 
-Contour allows configuring the headers involved in cross-domain requests.
-In this example, cross-domain requests will be allowed for any domain (note the `*` value).
+Contour allows configuring the headers involved in responses to cross-domain requests.
+These include the `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Expose-Headers`, `Access-Control-Max-Age`, and `Access-Control-Allow-Credentials` headers in responses.
+
+In this example, cross-domain requests will be allowed for any domain (note the `*` value), with the methods `GET`, `POST`, or `OPTIONS`.
+Headers `Authorization` and `Cache-Control` will be passed to the upstream server and headers `Content-Length` and `Content-Range` will be made available to the cross-origin request client.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -37,7 +40,10 @@ spec:
           port: 80
 ```
 
-In the following example, cross-domain requests are restricted to `https://client.example.com` only.
+The `allowOrigin` list may also be configured with exact origin matches or regex patterns.
+In the following example, cross-domain requests must originate from the domain `https://client.example.com` or domains that match the regex `http[s]?:\/\/some-site-[a-z0-9]+\.example\.com` (e.g. request with `Origin` header `https://some-site-abc456.example.com`)
+
+*Note:* Patterns for matching `Origin` headers must be valid regex, simple "globbing" patterns (e.g. `*.foo.com`) will not be accepted or may produce incorrect matches.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -50,7 +56,8 @@ spec:
     corsPolicy:
         allowCredentials: true
         allowOrigin:
-          - "https://client.example.com"
+          - https://client.example.com
+          - http[s]?:\/\/some-site-[a-z0-9]+\.example\.com
         allowMethods:
           - GET
           - POST


### PR DESCRIPTION
This will allow more flexible CORS Allowed Origins with a regex pattern, rather than having to allow all (w/ "*") or enumerating all exact matches.

We attempt to parse each allow origin match as an Origin header (using go url parsing) to check if we get a scheme://host[:port]. If the string doesnt parse as a URL or the format is invalid for an Origin header exact match, then we attempt to parse it as a regex.

Fixes: https://github.com/projectcontour/contour/issues/4666