### PR TITLE
hack/release: exclude yages repo from label sync

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -10,6 +10,8 @@ on:
     types: [closed]
     paths:
     - "site/_data/github-labels.yaml"
+  # Allow manual runs
+  workflow_dispatch:
 
 jobs:
   sync:

--- a/hack/release/sync-repo-labels.sh
+++ b/hack/release/sync-repo-labels.sh
@@ -52,6 +52,6 @@ labelsync \
     --debug \
     --confirm \
     --orgs projectcontour \
-    --skip projectcontour/toc \
+    --skip projectcontour/toc,projectcontour/yages \
     --config "${yaml}" \
     --token "${token}"


### PR DESCRIPTION
Also allows label sync to be run manually for testing.

Signed-off-by: Steve Kriss <krisss@vmware.com>