### PR TITLE
Set grpc fixture imagepullpolicy to ifnotpresent

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -423,8 +423,9 @@ func (g *GRPC) Deploy(ns, name string) func() {
 					},
 					Containers: []corev1.Container{
 						{
-							Name:  "grpc-echo",
-							Image: GRPCServerImage,
+							Name:            "grpc-echo",
+							Image:           GRPCServerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "INGRESS_NAME",


### PR DESCRIPTION
A shot in the dark as to why CI randomly fails w/ gRPC error code unimplemented