### PR TITLE
test/e2e/httpproxy: Retry gRPC calls on Unimplemented status

### DIFF
--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -99,7 +99,9 @@ func testGRPCServicePlaintext(namespace string) {
 			retryOpts := []grpc_retry.CallOption{
 				// Retry if Envoy returns unavailable, the upstream
 				// may not be healthy yet.
-				grpc_retry.WithCodes(codes.Unavailable),
+				// Also retry if we get the unimplemented status, see:
+				// https://github.com/projectcontour/contour/issues/4707
+				grpc_retry.WithCodes(codes.Unavailable, codes.Unimplemented),
 				grpc_retry.WithBackoff(grpc_retry.BackoffExponential(time.Millisecond * 10)),
 				grpc_retry.WithMax(20),
 			}


### PR DESCRIPTION
To hopefully address
https://github.com/projectcontour/contour/issues/4707