### PR TITLE
internal/contour: ignore status-only Gateway API updates

### DIFF
--- a/changelogs/unreleased/4744-skriss-small.md
+++ b/changelogs/unreleased/4744-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: status-only updates to resources no longer trigger DAG reprocessing and xDS updates.

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -27,6 +27,8 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type EventHandlerConfig struct {
@@ -188,6 +190,10 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 	case opUpdate:
 		if cmp.Equal(op.oldObj, op.newObj,
 			cmpopts.IgnoreFields(contour_api_v1.HTTPProxy{}, "Status"),
+			cmpopts.IgnoreFields(gatewayapi_v1beta1.GatewayClass{}, "Status"),
+			cmpopts.IgnoreFields(gatewayapi_v1beta1.Gateway{}, "Status"),
+			cmpopts.IgnoreFields(gatewayapi_v1beta1.HTTPRoute{}, "Status"),
+			cmpopts.IgnoreFields(gatewayapi_v1alpha2.TLSRoute{}, "Status"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields"),
 		) {


### PR DESCRIPTION
Ignores status-only updates on Gateway API
resources when determining whether to
re-process the DAG. This avoids unnecessary
processing and xDS traffic.

Signed-off-by: Steve Kriss <krisss@vmware.com>