### PR TITLE
test/e2e: pass Gateway to use to test funcs

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -39,6 +39,7 @@ import (
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -274,6 +275,7 @@ func (f *Framework) T() ginkgo.GinkgoTInterface {
 	return f.t
 }
 
+type NamespacedGatewayTestBody func(ns string, gw types.NamespacedName)
 type NamespacedTestBody func(string)
 type TestBody func()
 

--- a/test/e2e/gateway/gateway_allow_type_test.go
+++ b/test/e2e/gateway/gateway_allow_type_test.go
@@ -25,10 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testRouteParentRefs(namespace string) {
+func testRouteParentRefs(namespace string, gateway types.NamespacedName) {
 	Specify("route parentRefs are respected", func() {
 		t := f.T()
 
@@ -46,7 +47,7 @@ func testRouteParentRefs(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"routeparentrefs.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/header_condition_match_test.go
+++ b/test/e2e/gateway/header_condition_match_test.go
@@ -24,11 +24,12 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testGatewayHeaderConditionMatch(namespace string) {
+func testGatewayHeaderConditionMatch(namespace string, gateway types.NamespacedName) {
 	Specify("header match routing works", func() {
 		t := f.T()
 
@@ -43,7 +44,7 @@ func testGatewayHeaderConditionMatch(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"gatewayheaderconditions.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testHostRewrite(namespace string) {
+func testHostRewrite(namespace string, gateway types.NamespacedName) {
 	Specify("host can be rewritten in route filter", func() {
 		t := f.T()
 
@@ -42,7 +43,7 @@ func testHostRewrite(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"hostrewrite.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/invalid_backend_ref_test.go
+++ b/test/e2e/gateway/invalid_backend_ref_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testInvalidBackendRef(namespace string) {
+func testInvalidBackendRef(namespace string, gateway types.NamespacedName) {
 	Specify("invalid backend ref returns 500 status code", func() {
 		t := f.T()
 
@@ -41,7 +42,7 @@ func testInvalidBackendRef(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"invalidbackendref.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/path_condition_match_test.go
+++ b/test/e2e/gateway/path_condition_match_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testGatewayPathConditionMatch(namespace string) {
+func testGatewayPathConditionMatch(namespace string, gateway types.NamespacedName) {
 	Specify("path match routing works", func() {
 		t := f.T()
 
@@ -42,7 +43,7 @@ func testGatewayPathConditionMatch(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"gatewaypathconditions.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testGatewayQueryParamMatch(namespace string) {
+func testGatewayQueryParamMatch(namespace string, gateway types.NamespacedName) {
 	Specify("query param matching works", func() {
 		t := f.T()
 
@@ -43,7 +44,7 @@ func testGatewayQueryParamMatch(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"queryparams.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"),
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -25,10 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testRequestHeaderModifierForwardTo(namespace string) {
+func testRequestHeaderModifierForwardTo(namespace string, gateway types.NamespacedName) {
 	Specify("request headers can be modified on forward to", func() {
 		t := f.T()
 
@@ -44,7 +45,7 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"requestheadermodifierforwardto.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
@@ -127,7 +128,7 @@ func testRequestHeaderModifierForwardTo(namespace string) {
 	})
 }
 
-func testRequestHeaderModifierRule(namespace string) {
+func testRequestHeaderModifierRule(namespace string, gateway types.NamespacedName) {
 	Specify("request headers can be modified on route rule", func() {
 		t := f.T()
 
@@ -143,7 +144,7 @@ func testRequestHeaderModifierRule(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"requestheadermodifierrule.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/request_mirror_test.go
+++ b/test/e2e/gateway/request_mirror_test.go
@@ -32,7 +32,7 @@ import (
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testRequestMirrorRule(namespace string) {
+func testRequestMirrorRule(namespace string, gateway types.NamespacedName) {
 	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4650
 	Specify("mirrors can be specified on route rule", FlakeAttempts(3), func() {
 		t := f.T()
@@ -49,7 +49,7 @@ func testRequestMirrorRule(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"requestmirrorrule.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -25,11 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testRequestRedirectRule(namespace string) {
+func testRequestRedirectRule(namespace string, gateway types.NamespacedName) {
 	Specify("redirects can be specified on route rule", func() {
 		t := f.T()
 
@@ -44,7 +45,7 @@ func testRequestRedirectRule(namespace string) {
 				Hostnames: []gatewayapi_v1beta1.Hostname{"requestredirectrule.gateway.projectcontour.io"},
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef("", "http"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testTLSGateway(namespace string) {
+func testTLSGateway(namespace string, gateway types.NamespacedName) {
 	Specify("routes bound to port 443 listener are HTTPS and routes bound to port 80 listener are HTTP", func() {
 		t := f.T()
 
@@ -42,7 +43,8 @@ func testTLSGateway(namespace string) {
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
-							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
+							Namespace:   gatewayapi.NamespacePtr(gateway.Namespace),
+							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
 							SectionName: gatewayapi.SectionNamePtr("insecure"),
 						},
 					},
@@ -68,7 +70,8 @@ func testTLSGateway(namespace string) {
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
-							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
+							Namespace:   gatewayapi.NamespacePtr(gateway.Namespace),
+							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
 							SectionName: gatewayapi.SectionNamePtr("secure"),
 						},
 					},

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -24,10 +24,11 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func testTLSWildcardHost(namespace string) {
+func testTLSWildcardHost(namespace string, gateway types.NamespacedName) {
 	Specify("wildcard hostname matching works with TLS", func() {
 		t := f.T()
 		hostSuffix := "wildcardhost.gateway.projectcontour.io"
@@ -44,7 +45,8 @@ func testTLSWildcardHost(namespace string) {
 				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1beta1.ParentReference{
 						{
-							Name:        "https", // TODO need a better way to inform the test case of the Gateway it should use
+							Namespace:   gatewayapi.NamespacePtr(gateway.Namespace),
+							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
 							SectionName: gatewayapi.SectionNamePtr("secure"),
 						},
 					},

--- a/test/e2e/gateway/tlsroute_test.go
+++ b/test/e2e/gateway/tlsroute_test.go
@@ -25,10 +25,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-func testTLSRoutePassthrough(namespace string) {
+func testTLSRoutePassthrough(namespace string, gateway types.NamespacedName) {
 	Specify("SNI matching can be used for routing", func() {
 		t := f.T()
 
@@ -43,7 +44,7 @@ func testTLSRoutePassthrough(namespace string) {
 			Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 				CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
-						gatewayapi.GatewayParentRefV1Alpha2("", "tls-passthrough"), // TODO need a better way to inform the test case of the Gateway it should use
+						gatewayapi.GatewayParentRefV1Alpha2(gateway.Namespace, gateway.Name),
 					},
 				},
 				Hostnames: []gatewayapi_v1alpha2.Hostname{"passthrough.tlsroute.gatewayapi.projectcontour.io"},


### PR DESCRIPTION
Passes the Gateway namespace/name to
use to the test body functions, to address
the TODOs around the test bodies implicitly
knowing the Gateway to attach to.

Signed-off-by: Steve Kriss <krisss@vmware.com>