### PR TITLE
test/scripts: upgrade metallb to v0.13.5

### DIFF
--- a/test/scripts/make-kind-cluster.sh
+++ b/test/scripts/make-kind-cluster.sh
@@ -81,11 +81,9 @@ for image in ${images}; do
 done
 
 # Install metallb.
-${KUBECTL} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/namespace.yaml
-if ! kubectl get secret -n metallb-system memberlist; then
-    ${KUBECTL} create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-fi
-${KUBECTL} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/metallb.yaml
+${KUBECTL} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
+${KUBECTL} wait --timeout="${WAITTIME}" -n metallb-system deployment/controller --for=condition=Available
+
 # Apply config with addresses based on docker network IPAM
 if [[ "${IPV6_CLUSTER}" == "true" ]]; then
     subnet=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":"))')
@@ -98,19 +96,25 @@ else
     address_first_octets=$(echo ${subnet} | awk -F. '{printf "%s.%s",$1,$2}')
     address_range="${address_first_octets}.255.200-${address_first_octets}.255.250"
 fi
+
 ${KUBECTL} apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
 metadata:
   namespace: metallb-system
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - ${address_range}
+  name: pool
+spec:
+  addresses:
+  - ${address_range}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: pool-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - pool
 EOF
 
 


### PR DESCRIPTION
Addresses warnings for PodSecurityPolicy
deprecation/upcoming removal in k8s 1.25.

Signed-off-by: Steve Kriss <krisss@vmware.com>