### PR TITLE
internal/sorter: Routes w/ query param matches are sorted based on query param name

### DIFF
--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -133,6 +133,8 @@ func longestRouteByHeaderAndQueryParamConditions(lhs, rhs *dag.Route) bool {
 	}
 
 	// QueryParamMatchConditions are equal length: compare name item by item.
+	// We can do this simple comparison since we only have one match type, will
+	// need to expand this with a sorter for query params if we introduce more.
 	for i := 0; i < len(lhs.QueryParamMatchConditions); i++ {
 		if lhs.QueryParamMatchConditions[i].Name != rhs.QueryParamMatchConditions[i].Name {
 			return lhs.QueryParamMatchConditions[i].Name < rhs.QueryParamMatchConditions[i].Name

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -118,7 +118,6 @@ func longestRouteByHeaderAndQueryParamConditions(lhs, rhs *dag.Route) bool {
 
 	// HeaderMatchConditions are equal length: compare item by item.
 	pair := make([]dag.HeaderMatchCondition, 2)
-
 	for i := 0; i < len(lhs.HeaderMatchConditions); i++ {
 		pair[0] = lhs.HeaderMatchConditions[i]
 		pair[1] = rhs.HeaderMatchConditions[i]
@@ -128,11 +127,19 @@ func longestRouteByHeaderAndQueryParamConditions(lhs, rhs *dag.Route) bool {
 		}
 	}
 
-	// If there is no difference in the header match conditions, compare the length
-	// of the query param match conditions. Note that this is sufficient for implementing
-	// the Gateway API spec, but this may need to be enhanced if we add query param
-	// match support to HTTPProxy.
-	return len(lhs.QueryParamMatchConditions) > len(rhs.QueryParamMatchConditions)
+	// One route has a longer QueryParamMatchConditions slice.
+	if len(lhs.QueryParamMatchConditions) != len(rhs.QueryParamMatchConditions) {
+		return len(lhs.QueryParamMatchConditions) > len(rhs.QueryParamMatchConditions)
+	}
+
+	// QueryParamMatchConditions are equal length: compare name item by item.
+	for i := 0; i < len(lhs.QueryParamMatchConditions); i++ {
+		if lhs.QueryParamMatchConditions[i].Name != rhs.QueryParamMatchConditions[i].Name {
+			return lhs.QueryParamMatchConditions[i].Name < rhs.QueryParamMatchConditions[i].Name
+		}
+	}
+
+	return false
 }
 
 // Sorts the given Route slice in place. Routes are ordered first by

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -283,7 +283,7 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 	assert.Equal(t, want, have)
 }
 
-func TestSortRoutesMostQueryParams(t *testing.T) {
+func TestSortRoutesQueryParams(t *testing.T) {
 	want := []*dag.Route{
 		{
 
@@ -292,6 +292,26 @@ func TestSortRoutesMostQueryParams(t *testing.T) {
 				{Name: "query-param-1", Value: "query-value-1"},
 				{Name: "query-param-2", Value: "query-value-2"},
 				{Name: "query-param-3", Value: "query-value-3"},
+			},
+		},
+		{
+
+			PathMatchCondition: matchExact("/"),
+			// If same number of matches, sort on element-by-element
+			// comparison of each query param name provided.
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				{Name: "aaa-query-param-1", Value: "query-value-1"},
+				{Name: "query-param-2", Value: "query-value-2"},
+			},
+		},
+		{
+
+			PathMatchCondition: matchExact("/"),
+			// If same number of matches, sort on element-by-element
+			// comparison of each query param name provided.
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				{Name: "query-param-1", Value: "query-value-1"},
+				{Name: "bbb-query-param-2", Value: "query-value-2"},
 			},
 		},
 		{


### PR DESCRIPTION
To ensure stable ordering of the xDS config sent to Envoy

Added test will fail sometimes w/o this change

Updates: #4715