### PR TITLE
fixes to enable development on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-ARG BUILDPLATFORM=linux/amd64
 ARG BUILD_BASE_IMAGE
 
+# The build image uses the os/arch of the host (i.e. $BUILDPLATFORM),
+# and golang handles the cross-compilation to $TARGETOS/$TARGETARCH.
 FROM --platform=$BUILDPLATFORM $BUILD_BASE_IMAGE AS build
 WORKDIR /contour
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -38,10 +38,6 @@ import (
 )
 
 const (
-	// Note that these image references MUST use a tag, not a digest, in order for
-	// the pre-loading into kind to work, since loading + referencing
-	// an image by digest is not supported (see https://github.com/kubernetes-sigs/kind/issues/2394).
-
 	// EchoServerImage is the image to use as a backend fixture.
 	EchoServerImage = "gcr.io/k8s-staging-ingressconformance/echoserver:v20210922-cec7cf2"
 

--- a/test/scripts/make-kind-cluster.sh
+++ b/test/scripts/make-kind-cluster.sh
@@ -71,15 +71,6 @@ if ! kind::cluster::exists "$CLUSTERNAME" ; then
   ${KUBECTL} version
 fi
 
-# Push test images into the cluster. Do this up-front
-# so that the first test does not incur the cost of 
-# pulling them. Helps avoid flakes.
-images=$(grep "Image = " $(find "$REPO/test/e2e" -name "fixtures.go") | awk '{print $3}' | tr -d '"')
-for image in ${images}; do
-  docker pull "${image}"
-  kind::cluster::load "${image}"
-done
-
 # Install metallb.
 ${KUBECTL} apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
 ${KUBECTL} wait --timeout="${WAITTIME}" -n metallb-system deployment/controller --for=condition=Available


### PR DESCRIPTION
- remove default build platform of `linux/amd64` (current versions of Docker should automatically populate this based on the host)
- remove pre-loading of E2E test fixture images into kind (probably not necessary anymore given we're no longer using httpbin, which was huge; the current images are small #'s of MB -- hitting what looks like https://github.com/kubernetes-sigs/kind/issues/2549 which is actually a containerd issue, but things work fine if the images are just pulled normally)