### PR TITLE
Enable HTTPRouteQueryParamMatching and HTTPRouteMethodMatching in main conformance tests

### DIFF
--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -58,5 +58,5 @@ else
   git clone https://github.com/kubernetes-sigs/gateway-api
   cd gateway-api
   git checkout "${GATEWAY_API_VERSION}"
-  go test ./conformance -gateway-class=contour
+  go test ./conformance -gateway-class=contour -supported-features=HTTPRouteQueryParamMatching,HTTPRouteMethodMatching
 fi


### PR DESCRIPTION
Uses new -supported-features flag from main of gateway-api

feature flag for ReferenceGrants is now an exemption rather than an opt-in

Fixes: #4779
