### PR TITLE
Fix workgroup AddContext bug

### DIFF
--- a/internal/workgroup/group_test.go
+++ b/internal/workgroup/group_test.go
@@ -52,7 +52,7 @@ func TestGroupFirstReturnValueIsReturnedToRunsCaller(t *testing.T) {
 func TestGroupAddContext(t *testing.T) {
 	var g Group
 	wait := make(chan int)
-	g.Add(func(<-chan struct{}) error {
+	g.AddContext(func(ctx context.Context) error {
 		<-wait
 		return io.EOF
 	})


### PR DESCRIPTION
In case functions are added to workgroup using AddContext method, the AddContext method doesn't exit if the corresponding function exits. This change makes sure the Run flow exits in case the function running has exited.