### PR TITLE
internal/dag: validate Secrets only when used

### DIFF
--- a/changelogs/unreleased/4788-skriss-minor.md
+++ b/changelogs/unreleased/4788-skriss-minor.md
@@ -1,0 +1,5 @@
+## Secrets not relevant to Contour no longer validated
+
+Contour no longer validates Secrets that are not used by an Ingress, HTTPProxy, Gateway, or Contour global config.
+Validation is now performed as needed when a Secret is referenced.
+This change also replaces misleading "Secret not found" error conditions with more specific errors when a Secret referenced by one of the above objects does exist, but is not valid.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -9675,7 +9675,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: &Secret{Object: cert1},
+								CACertificate: secret(cert1),
 							},
 						},
 					),
@@ -9703,7 +9703,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: &Secret{Object: cert1},
+								CACertificate: secret(cert1),
 							},
 						},
 					),
@@ -9766,7 +9766,7 @@ func TestDAGInsert(t *testing.T) {
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
 								SkipClientCertValidation: true,
-								CACertificate:            &Secret{Object: cert1},
+								CACertificate:            secret(cert1),
 							},
 						},
 					),
@@ -9797,8 +9797,8 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: &Secret{Object: cert1},
-								CRL:           &Secret{Object: crl},
+								CACertificate: secret(cert1),
+								CRL:           secret(crl),
 							},
 						},
 					),
@@ -9829,8 +9829,8 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate:         &Secret{Object: cert1},
-								CRL:                   &Secret{Object: crl},
+								CACertificate:         secret(cert1),
+								CRL:                   secret(crl),
 								OnlyVerifyLeafCertCrl: true,
 							},
 						},
@@ -13258,6 +13258,9 @@ func clustermap(services ...*v1.Service) []*Cluster {
 func secret(s *v1.Secret) *Secret {
 	return &Secret{
 		Object: s,
+		ValidationStatus: &SecretValidationStatus{
+			Valid: true,
+		},
 	}
 }
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -13257,10 +13257,10 @@ func clustermap(services ...*v1.Service) []*Cluster {
 
 func secret(s *v1.Secret) *Secret {
 	return &Secret{
-		Object: s,
-		ValidationStatus: &SecretValidationStatus{
-			Valid: true,
-		},
+		Object:         s,
+		ValidTLSSecret: &SecretValidationStatus{Valid: true},
+		ValidCASecret:  &SecretValidationStatus{Valid: true},
+		ValidCRLSecret: &SecretValidationStatus{Valid: true},
 	}
 }
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -4382,6 +4382,7 @@ func TestDAGInsert(t *testing.T) {
 			Name:      "ca",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			CACertificateKey: []byte(fixture.CERTIFICATE),
 		},
@@ -4392,6 +4393,7 @@ func TestDAGInsert(t *testing.T) {
 			Name:      "ca",
 			Namespace: "caCertOriginalNs",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			CACertificateKey: []byte(fixture.CERTIFICATE),
 		},
@@ -4402,6 +4404,7 @@ func TestDAGInsert(t *testing.T) {
 			Name:      "crl",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			CRLKey: []byte(fixture.CRL),
 		},
@@ -9535,7 +9538,7 @@ func TestDAGInsert(t *testing.T) {
 									},
 									Protocol: "tls",
 									UpstreamValidation: &PeerValidationContext{
-										CACertificate: secret(cert1),
+										CACertificate: caSecret(cert1),
 										SubjectName:   "example.com",
 									},
 								},
@@ -9567,7 +9570,7 @@ func TestDAGInsert(t *testing.T) {
 									},
 									Protocol: "h2",
 									UpstreamValidation: &PeerValidationContext{
-										CACertificate: secret(cert1),
+										CACertificate: caSecret(cert1),
 										SubjectName:   "example.com",
 									},
 								},
@@ -9641,7 +9644,7 @@ func TestDAGInsert(t *testing.T) {
 									},
 									Protocol: "tls",
 									UpstreamValidation: &PeerValidationContext{
-										CACertificate: secret(cert2),
+										CACertificate: caSecret(cert2),
 										SubjectName:   "example.com",
 									},
 								},
@@ -9675,7 +9678,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: secret(cert1),
+								CACertificate: caSecret(cert1),
 							},
 						},
 					),
@@ -9703,7 +9706,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: secret(cert1),
+								CACertificate: caSecret(cert1),
 							},
 						},
 					),
@@ -9766,7 +9769,7 @@ func TestDAGInsert(t *testing.T) {
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
 								SkipClientCertValidation: true,
-								CACertificate:            secret(cert1),
+								CACertificate:            caSecret(cert1),
 							},
 						},
 					),
@@ -9797,8 +9800,8 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: secret(cert1),
-								CRL:           secret(crl),
+								CACertificate: caSecret(cert1),
+								CRL:           crlSecret(crl),
 							},
 						},
 					),
@@ -9829,8 +9832,8 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate:         secret(cert1),
-								CRL:                   secret(crl),
+								CACertificate:         caSecret(cert1),
+								CRL:                   crlSecret(crl),
 								OnlyVerifyLeafCertCrl: true,
 							},
 						},
@@ -13259,7 +13262,19 @@ func secret(s *v1.Secret) *Secret {
 	return &Secret{
 		Object:         s,
 		ValidTLSSecret: &SecretValidationStatus{Valid: true},
-		ValidCASecret:  &SecretValidationStatus{Valid: true},
+	}
+}
+
+func caSecret(s *v1.Secret) *Secret {
+	return &Secret{
+		Object:        s,
+		ValidCASecret: &SecretValidationStatus{Valid: true},
+	}
+}
+
+func crlSecret(s *v1.Secret) *Secret {
+	return &Secret{
+		Object:         s,
 		ValidCRLSecret: &SecretValidationStatus{Valid: true},
 	}
 }

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -9865,7 +9865,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate: &Secret{Object: cert1},
+								CACertificate: caSecret(cert1),
 								ForwardClientCertificate: &ClientCertificateDetails{
 									Subject: true,
 									Cert:    true,
@@ -9903,7 +9903,7 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate:             &Secret{Object: cert1},
+								CACertificate:             caSecret(cert1),
 								OptionalClientCertificate: true,
 							},
 						},

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -13261,21 +13261,21 @@ func clustermap(services ...*v1.Service) []*Cluster {
 func secret(s *v1.Secret) *Secret {
 	return &Secret{
 		Object:         s,
-		ValidTLSSecret: &SecretValidationStatus{Valid: true},
+		ValidTLSSecret: &SecretValidationStatus{},
 	}
 }
 
 func caSecret(s *v1.Secret) *Secret {
 	return &Secret{
 		Object:        s,
-		ValidCASecret: &SecretValidationStatus{Valid: true},
+		ValidCASecret: &SecretValidationStatus{},
 	}
 }
 
 func crlSecret(s *v1.Secret) *Secret {
 	return &Secret{
 		Object:         s,
-		ValidCRLSecret: &SecretValidationStatus{Valid: true},
+		ValidCRLSecret: &SecretValidationStatus{},
 	}
 }
 

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -43,7 +43,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		obj          interface{}
 		want         bool
 	}{
-		"insert secret": {
+		"insert TLS secret not referenced": {
 			obj: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret",
@@ -69,54 +69,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert CA secret w/ explanatory text": {
-			obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Type: v1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					CACertificateKey: []byte(fixture.CERTIFICATE_WITH_TEXT),
-				},
-			},
-			want: true,
-		},
-		"insert CA bundle secret w/ non-PEM data": {
-			obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Type: v1.SecretTypeOpaque,
-				Data: caBundleData(fixture.CERTIFICATE, fixture.CERTIFICATE, fixture.CERTIFICATE, fixture.CERTIFICATE),
-			},
-			want: true,
-		},
-		"insert CA bundle secret w/ no CN for CA": {
-			obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "caNoCN",
-					Namespace: "default",
-				},
-				Type: v1.SecretTypeOpaque,
-				Data: caBundleData(fixture.CA_CERT_NO_CN),
-			},
-			want: true,
-		},
-
-		"insert CA bundle secret w/ non-PEM data and no certificates": {
-			obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Type: v1.SecretTypeOpaque,
-				Data: caBundleData(),
-			},
-			want: false,
-		},
-
 		"insert secret referenced by ingress": {
 			pre: []interface{}{
 				&networking_v1.Ingress{
@@ -141,30 +93,6 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert secret referenced by ingress with multiple pem blocks": {
-			pre: []interface{}{
-				&networking_v1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "www",
-						Namespace: "default",
-					},
-					Spec: networking_v1.IngressSpec{
-						TLS: []networking_v1.IngressTLS{{
-							SecretName: "secret",
-						}},
-					},
-				},
-			},
-			obj: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Type: v1.SecretTypeTLS,
-				Data: secretdata(fixture.EC_CERTIFICATE, fixture.EC_PRIVATE_KEY),
-			},
-			want: true,
-		},
 		"insert secret w/ wrong type referenced by ingress": {
 			pre: []interface{}{
 				&networking_v1.Ingress{
@@ -186,7 +114,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				},
 				Type: "banana",
 			},
-			want: false,
+			want: true,
 		},
 		"insert secret referenced by ingress via tls delegation": {
 			pre: []interface{}{
@@ -371,7 +299,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
-		"insert certificate secret": {
+		"insert certificate secret not referenced": {
 			obj: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ca",

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -948,8 +948,10 @@ func (s *ServiceCluster) Rebalance() {
 // Secret represents a K8s Secret for TLS usage as a DAG Vertex. A Secret is
 // a leaf in the DAG.
 type Secret struct {
-	Object           *v1.Secret
-	ValidationStatus *SecretValidationStatus
+	Object         *v1.Secret
+	ValidTLSSecret *SecretValidationStatus
+	ValidCASecret  *SecretValidationStatus
+	ValidCRLSecret *SecretValidationStatus
 }
 
 func (s *Secret) Name() string      { return s.Object.Name }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -948,7 +948,8 @@ func (s *ServiceCluster) Rebalance() {
 // Secret represents a K8s Secret for TLS usage as a DAG Vertex. A Secret is
 // a leaf in the DAG.
 type Secret struct {
-	Object *v1.Secret
+	Object           *v1.Secret
+	ValidationStatus *SecretValidationStatus
 }
 
 func (s *Secret) Name() string      { return s.Object.Name }
@@ -967,6 +968,11 @@ func (s *Secret) Cert() []byte {
 // PrivateKey returns the secret's tls private key
 func (s *Secret) PrivateKey() []byte {
 	return s.Object.Data[v1.TLSPrivateKeyKey]
+}
+
+type SecretValidationStatus struct {
+	Valid bool
+	Error error
 }
 
 // HTTPHealthCheckPolicy http health check policy

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -973,7 +973,6 @@ func (s *Secret) PrivateKey() []byte {
 }
 
 type SecretValidationStatus struct {
-	Valid bool
 	Error error
 }
 

--- a/internal/dag/extension_processor.go
+++ b/internal/dag/extension_processor.go
@@ -92,7 +92,7 @@ func (p *ExtensionServiceProcessor) buildExtensionService(
 
 	var clientCertSecret *Secret
 	if p.ClientCertificate != nil {
-		clientCertSecret, err = cache.LookupSecret(*p.ClientCertificate, validTLSSecret)
+		clientCertSecret, err = cache.LookupTLSSecret(*p.ClientCertificate)
 		if err != nil {
 			validCondition.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 				"tls.envoy-client-certificate Secret %q is invalid: %s", p.ClientCertificate, err)

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -689,7 +689,7 @@ func (p *GatewayAPIProcessor) resolveListenerSecret(certificateRefs []gatewayapi
 		meta = types.NamespacedName{Name: string(certificateRef.Name), Namespace: p.source.gateway.Namespace}
 	}
 
-	listenerSecret, err := p.source.LookupSecret(meta, validTLSSecret)
+	listenerSecret, err := p.source.LookupTLSSecret(meta)
 	if err != nil {
 		gwAccessor.AddListenerCondition(
 			listenerName,

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -199,7 +199,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 		// Attach secrets to TLS enabled vhosts.
 		if !tls.Passthrough {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(proxy.Namespace))
-			sec, err := p.source.LookupSecret(secretName, validTLSSecret)
+			sec, err := p.source.LookupTLSSecret(secretName)
 			if err != nil {
 				validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 					"Spec.VirtualHost.TLS Secret %q is invalid: %s", tls.SecretName, err)
@@ -243,7 +243,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 					return
 				}
 
-				sec, err = p.source.LookupSecret(*p.FallbackCertificate, validTLSSecret)
+				sec, err = p.source.LookupTLSSecret(*p.FallbackCertificate)
 				if err != nil {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotValid",
 						"Spec.Virtualhost.TLS Secret %q fallback certificate is invalid: %s", p.FallbackCertificate, err)
@@ -276,7 +276,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				}
 				if tls.ClientValidation.CACertificate != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))
-					cacert, err := p.source.LookupSecret(secretName, validCA)
+					cacert, err := p.source.LookupCASecret(secretName)
 					if err != nil {
 						// PeerValidationContext is requested, but cert is missing or not configured.
 						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
@@ -290,7 +290,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				}
 				if tls.ClientValidation.CertificateRevocationList != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CertificateRevocationList, k8s.DefaultNamespace(proxy.Namespace))
-					crl, err := p.source.LookupSecret(secretName, validCRL)
+					crl, err := p.source.LookupCRLSecret(secretName)
 					if err != nil {
 						// CRL is missing or not configured.
 						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
@@ -887,7 +887,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 
 			var clientCertSecret *Secret
 			if p.ClientCertificate != nil {
-				clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validTLSSecret)
+				clientCertSecret, err = p.source.LookupTLSSecret(*p.ClientCertificate)
 				if err != nil {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 						"tls.envoy-client-certificate Secret %q is invalid: %s", p.ClientCertificate, err)

--- a/internal/dag/ingress_processor.go
+++ b/internal/dag/ingress_processor.go
@@ -80,7 +80,7 @@ func (p *IngressProcessor) computeSecureVirtualhosts() {
 	for _, ing := range p.source.ingresses {
 		for _, tls := range ing.Spec.TLS {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ing), k8s.DefaultNamespace(ing.GetNamespace()))
-			sec, err := p.source.LookupSecret(secretName, validTLSSecret)
+			sec, err := p.source.LookupTLSSecret(secretName)
 			if err != nil {
 				p.WithError(err).
 					WithField("name", ing.GetName()).
@@ -135,7 +135,7 @@ func (p *IngressProcessor) computeIngressRule(ing *networking_v1.Ingress, rule n
 	var clientCertSecret *Secret
 	var err error
 	if p.ClientCertificate != nil {
-		clientCertSecret, err = p.source.LookupSecret(*p.ClientCertificate, validTLSSecret)
+		clientCertSecret, err = p.source.LookupTLSSecret(*p.ClientCertificate)
 		if err != nil {
 			p.WithError(err).
 				WithField("name", ing.GetName()).

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -345,6 +345,20 @@ func TestValidSecrets(t *testing.T) {
 			caSecretError:  errors.New(`empty "ca.crt" key`),
 			crlSecretError: errors.New(`empty "crl.pem" key`),
 		},
+		"kubernetes.io/dockercfg Secret, with TLS cert, CA cert and CRL": {
+			secret: &v1.Secret{
+				Type: v1.SecretTypeDockercfg,
+				Data: map[string][]byte{
+					v1.TLSCertKey:       []byte(fixture.CERTIFICATE),
+					v1.TLSPrivateKeyKey: []byte(fixture.RSA_PRIVATE_KEY),
+					CACertificateKey:    []byte(fixture.CA_CERT),
+					CRLKey:              []byte(fixture.CRL),
+				},
+			},
+			tlsSecretError: errors.New(`secret type is not "kubernetes.io/tls"`),
+			caSecretError:  errors.New(`secret type is not "kubernetes.io/tls" or "Opaque"`),
+			crlSecretError: errors.New(`secret type is not "kubernetes.io/tls" or "Opaque"`),
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/secret_test.go
+++ b/internal/dag/secret_test.go
@@ -349,11 +349,9 @@ func TestValidSecrets(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			s := &Secret{Object: tc.secret}
-
-			assert.Equal(t, tc.tlsSecretError, validTLSSecret(s))
-			assert.Equal(t, tc.caSecretError, validCA(s))
-			assert.Equal(t, tc.crlSecretError, validCRL(s))
+			assert.Equal(t, tc.tlsSecretError, validTLSSecret(tc.secret))
+			assert.Equal(t, tc.caSecretError, validCASecret(tc.secret))
+			assert.Equal(t, tc.crlSecretError, validCRLSecret(tc.secret))
 		})
 	}
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3524,6 +3524,7 @@ func TestDAGStatus(t *testing.T) {
 
 	jwksInvalidCACert := &v1.Secret{
 		ObjectMeta: fixture.ObjectMeta("roots/cacert"),
+		Type:       v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"wrong-key": []byte(fixture.CERTIFICATE),
 		},
@@ -3582,7 +3583,7 @@ func TestDAGStatus(t *testing.T) {
 				WithError(
 					contour_api_v1.ConditionTypeJWTVerificationError,
 					"RemoteJWKSUpstreamValidationInvalid",
-					"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: invalid CA Secret \"roots/cacert\": Secret not valid in a way that doesn't throw an error",
+					"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: invalid CA Secret \"roots/cacert\": empty \"ca.crt\" key",
 				),
 		},
 	})

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3582,7 +3582,7 @@ func TestDAGStatus(t *testing.T) {
 				WithError(
 					contour_api_v1.ConditionTypeJWTVerificationError,
 					"RemoteJWKSUpstreamValidationInvalid",
-					"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: invalid CA Secret \"roots/cacert\": Secret not found",
+					"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: invalid CA Secret \"roots/cacert\": Secret not valid in a way that doesn't throw an error",
 				),
 		},
 	})

--- a/internal/featuretests/v3/backendcavalidation_test.go
+++ b/internal/featuretests/v3/backendcavalidation_test.go
@@ -35,6 +35,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 			Name:      "foo",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -65,7 +65,7 @@ func clientSecret() *v1.Secret {
 			Name:      "envoyclientsecret",
 			Namespace: "default",
 		},
-		Type: "kubernetes.io/tls",
+		Type: v1.SecretTypeTLS,
 		Data: featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
 	}
 }
@@ -76,6 +76,7 @@ func caSecret() *v1.Secret {
 			Name:      "backendcacert",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -47,6 +47,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			Name:      "clientCASecret",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},
@@ -211,6 +212,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			Name:      "crl",
 			Namespace: "default",
 		},
+		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CRLKey: []byte(featuretests.CRL),
 		},

--- a/internal/featuretests/v3/extensionservice_test.go
+++ b/internal/featuretests/v3/extensionservice_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
 )
@@ -175,6 +176,7 @@ func extUpstreamValidation(t *testing.T, rh cache.ResourceEventHandler, c *Conto
 	// Create a secret for the CA certificate that can be delegated
 	rh.OnAdd(&corev1.Secret{
 		ObjectMeta: fixture.ObjectMeta("otherNs/cacert"),
+		Type:       v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},
@@ -431,6 +433,7 @@ func TestExtensionService(t *testing.T) {
 
 			rh.OnAdd(&corev1.Secret{
 				ObjectMeta: fixture.ObjectMeta("ns/cacert"),
+				Type:       v1.SecretTypeOpaque,
 				Data: map[string][]byte{
 					dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 				},

--- a/internal/featuretests/v3/jwtverification_test.go
+++ b/internal/featuretests/v3/jwtverification_test.go
@@ -729,6 +729,7 @@ func TestJWTVerification(t *testing.T) {
 
 	rh.OnAdd(&corev1.Secret{
 		ObjectMeta: fixture.ObjectMeta("default/cacert"),
+		Type:       v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			dag.CACertificateKey: []byte(featuretests.CERTIFICATE),
 		},


### PR DESCRIPTION
Changes Secret validation to happen when Secrets
are used by processors, rather than as they are added
to the DAG cache. Also caches the validation results
on the DAG objects for efficiency.

This eliminates the need for Contour to inspect Secrets
that are not used by an Ingress/HTTPProxy/Gateway. It
also replaces the confusing "Secret not found" errors
with specific validation errors when a Secret does exist,
but is not valid.

This also allows Secret validation logic to be more
precise, since we know what the processors are trying
to use them for.

Fixes #2616.
Fixes #2908.