### PR TITLE
add ForwardJWT option

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -278,6 +278,12 @@ type JWTProvider struct {
 	// Remote JWKS to use for verifying JWT signatures.
 	// +kubebuilder:validation:Required
 	RemoteJWKS RemoteJWKS `json:"remoteJWKS"`
+
+	// Whether the JWT should be forwarded to the backend
+	// service after successful verification. By default,
+	// the JWT is not forwarded.
+	// +optional
+	ForwardJWT bool `json:"forwardJWT,omitempty"`
 }
 
 // RemoteJWKS defines how to fetch a JWKS from an HTTP endpoint.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -3779,6 +3779,11 @@ spec:
                             is marked as the default, individual routes must explicitly
                             identify the provider they require.
                           type: boolean
+                        forwardJWT:
+                          description: Whether the JWT should be forwarded to the
+                            backend service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
                         issuer:
                           description: Issuer that JWTs are required to have in the
                             "iss" field. If not provided, JWT issuers are not checked.

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -3988,6 +3988,11 @@ spec:
                             is marked as the default, individual routes must explicitly
                             identify the provider they require.
                           type: boolean
+                        forwardJWT:
+                          description: Whether the JWT should be forwarded to the
+                            backend service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
                         issuer:
                           description: Issuer that JWTs are required to have in the
                             "iss" field. If not provided, JWT issuers are not checked.

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -3793,6 +3793,11 @@ spec:
                             is marked as the default, individual routes must explicitly
                             identify the provider they require.
                           type: boolean
+                        forwardJWT:
+                          description: Whether the JWT should be forwarded to the
+                            backend service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
                         issuer:
                           description: Issuer that JWTs are required to have in the
                             "iss" field. If not provided, JWT issuers are not checked.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3994,6 +3994,11 @@ spec:
                             is marked as the default, individual routes must explicitly
                             identify the provider they require.
                           type: boolean
+                        forwardJWT:
+                          description: Whether the JWT should be forwarded to the
+                            backend service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
                         issuer:
                           description: Issuer that JWTs are required to have in the
                             "iss" field. If not provided, JWT issuers are not checked.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3988,6 +3988,11 @@ spec:
                             is marked as the default, individual routes must explicitly
                             identify the provider they require.
                           type: boolean
+                        forwardJWT:
+                          description: Whether the JWT should be forwarded to the
+                            backend service after successful verification. By default,
+                            the JWT is not forwarded.
+                          type: boolean
                         issuer:
                           description: Issuer that JWTs are required to have in the
                             "iss" field. If not provided, JWT issuers are not checked.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -655,6 +655,7 @@ type JWTProvider struct {
 	Issuer     string
 	Audiences  []string
 	RemoteJWKS RemoteJWKS
+	ForwardJWT bool
 }
 
 type RemoteJWKS struct {

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -479,6 +479,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 						},
 						CacheDuration: cacheDuration,
 					},
+					ForwardJWT: jwtProvider.ForwardJWT,
 				})
 			}
 		}

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -757,6 +757,7 @@ func FilterJWTAuth(jwtProviders []dag.JWTProvider) *http.HttpFilter {
 					CacheDuration: cacheDuration,
 				},
 			},
+			Forward: provider.ForwardJWT,
 		}
 
 		// Set up a requirement map so that per-route filter config can refer

--- a/internal/featuretests/v3/jwtverification_test.go
+++ b/internal/featuretests/v3/jwtverification_test.go
@@ -1044,6 +1044,150 @@ func TestJWTVerification(t *testing.T) {
 		),
 	})
 
+	// JWT Provider with ForwardJWT specified.
+	proxy9 := fixture.NewProxy("simple").WithSpec(
+		contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "jwt.example.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: "secret",
+				},
+				JWTProviders: []contour_api_v1.JWTProvider{
+					{
+						Name:   "provider-1",
+						Issuer: "issuer.jwt.example.com",
+						RemoteJWKS: contour_api_v1.RemoteJWKS{
+							URI:           "https://jwt.example.com/jwks.json",
+							Timeout:       "7s",
+							CacheDuration: "30s",
+						},
+						ForwardJWT: true,
+					},
+				},
+			},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
+					Name: s1.Name,
+					Port: 80,
+				}},
+				JWTVerificationPolicy: &contour_api_v1.JWTVerificationPolicy{Require: "provider-1"},
+			}},
+		})
+
+	rh.OnUpdate(proxy8, proxy9)
+
+	// the JWT Provider should have Forward: true.
+	c.Request(listenerType, "ingress_https").Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			&envoy_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				FilterChains: appendFilterChains(
+					filterchaintls("jwt.example.com", sec1,
+						jwtAuthnFilterFor("jwt.example.com", &envoy_jwt_v3.JwtAuthentication{
+							Providers: map[string]*envoy_jwt_v3.JwtProvider{
+								"provider-1": {
+									Issuer: "issuer.jwt.example.com",
+									JwksSourceSpecifier: &envoy_jwt_v3.JwtProvider_RemoteJwks{
+										RemoteJwks: &envoy_jwt_v3.RemoteJwks{
+											HttpUri: &envoy_core_v3.HttpUri{
+												Uri: "https://jwt.example.com/jwks.json",
+												HttpUpstreamType: &envoy_core_v3.HttpUri_Cluster{
+													Cluster: "dnsname/https/jwt.example.com",
+												},
+												Timeout: protobuf.Duration(7 * time.Second),
+											},
+											CacheDuration: protobuf.Duration(30 * time.Second),
+										},
+									},
+									Forward: true,
+								},
+							},
+							RequirementMap: map[string]*envoy_jwt_v3.JwtRequirement{
+								"provider-1": {
+									RequiresType: &envoy_jwt_v3.JwtRequirement_ProviderName{
+										ProviderName: "provider-1",
+									},
+								},
+							},
+						}),
+						nil, "h2", "http/1.1"),
+				),
+				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+			},
+		),
+	}).Request(clusterType, "dnsname/https/jwt.example.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: clusterType,
+		Resources: resources(t,
+			&envoy_cluster_v3.Cluster{
+				Name: "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
+					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
+				},
+				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
+					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
+				},
+				ConnectTimeout: protobuf.Duration(2 * time.Second),
+				LoadAssignment: &envoy_endpoint_v3.ClusterLoadAssignment{
+					ClusterName: "dnsname/https/jwt.example.com",
+					Endpoints: []*envoy_endpoint_v3.LocalityLbEndpoints{
+						{
+							LbEndpoints: []*envoy_endpoint_v3.LbEndpoint{
+								{
+									HostIdentifier: &envoy_endpoint_v3.LbEndpoint_Endpoint{
+										Endpoint: &envoy_endpoint_v3.Endpoint{
+											Address: &envoy_core_v3.Address{
+												Address: &envoy_core_v3.Address_SocketAddress{
+													SocketAddress: &envoy_core_v3.SocketAddress{
+														Protocol: envoy_core_v3.SocketAddress_TCP,
+														Address:  "jwt.example.com",
+														PortSpecifier: &envoy_core_v3.SocketAddress_PortValue{
+															PortValue: uint32(443),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				TransportSocket: &envoy_core_v3.TransportSocket{
+					Name: "envoy.transport_sockets.tls",
+					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
+							Sni:              "jwt.example.com",
+						}),
+					},
+				},
+			},
+		),
+	}).Request(routeType, "https/jwt.example.com").Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: routeType,
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration(
+				"https/jwt.example.com",
+				envoy_v3.VirtualHost("jwt.example.com",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: routeCluster("default/s1/80/da39a3ee5e"),
+						TypedPerFilterConfig: map[string]*anypb.Any{
+							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
+							}),
+						},
+					},
+				),
+			),
+		),
+	})
 }
 
 func TestJWTVerification_Inclusion(t *testing.T) {

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -1956,6 +1956,21 @@ RemoteJWKS
 <p>Remote JWKS to use for verifying JWT signatures.</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>forwardJWT</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Whether the JWT should be forwarded to the backend
+service after successful verification. By default,
+the JWT is not forwarded.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1.JWTVerificationPolicy">JWTVerificationPolicy

--- a/site/content/docs/main/config/jwt-verification.md
+++ b/site/content/docs/main/config/jwt-verification.md
@@ -37,11 +37,13 @@ spec:
           uri: https://example.com/jwks.json
           timeout: 1s
           cacheDuration: 5m
+        forwardJWT: true
   routes:
     ...
 ```
 
 The provider above requires JWTs to have an issuer of example.com, an audience of either audience-1 or audience-2, and a signature that can be verified using the configured JWKS.
+It also forwards the JWT to the backend via the `Authorization` header after successful verification.
 
 To apply a JWT provider as a requirement to a given route, specify a `jwtVerificationPolicy` for the route:
 


### PR DESCRIPTION
Adds a ForwardJWT option to JWTProvider,
to enable forwarding JWTs to the backend
after successful verification.

Signed-off-by: Steve Kriss <krisss@vmware.com>