### PR TITLE
Secret updates/deletes only trigger DAG rebuilds if referenced

### DIFF
--- a/changelogs/unreleased/4792-skriss-small.md
+++ b/changelogs/unreleased/4792-skriss-small.md
@@ -1,0 +1,1 @@
+Don't trigger DAG rebuilds for updates/deletes of unrelated Secrets.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -258,9 +258,8 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 	switch obj := obj.(type) {
 	case *v1.Secret:
 		m := k8s.NamespacedNameOf(obj)
-		_, ok := kc.secrets[m]
 		delete(kc.secrets, m)
-		return ok
+		return kc.secretTriggersRebuild(obj)
 	case *v1.Service:
 		m := k8s.NamespacedNameOf(obj)
 		_, ok := kc.services[m]

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -985,7 +985,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 				},
 				Type: v1.SecretTypeTLS,
 			},
-			want: true,
+			want: false,
 		},
 		"remove service": {
 			cache: cache(&v1.Service{

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -56,6 +56,10 @@ func proxyClientCertificateOpt(t *testing.T) func(*dag.Builder) {
 			},
 			&dag.ListenerProcessor{},
 		}
+
+		b.Source.ConfiguredSecretRefs = []*types.NamespacedName{
+			{Namespace: secret.Namespace, Name: secret.Name},
+		}
 	}
 }
 

--- a/internal/featuretests/v3/fallbackcert_test.go
+++ b/internal/featuretests/v3/fallbackcert_test.go
@@ -42,6 +42,10 @@ func TestFallbackCertificate(t *testing.T) {
 			},
 			&dag.ListenerProcessor{},
 		}
+
+		b.Source.ConfiguredSecretRefs = []*types.NamespacedName{
+			{Namespace: "admin", Name: "fallbacksecret"},
+		}
 	})
 	defer done()
 


### PR DESCRIPTION
On Secret updates and deletes, only
trigger DAG rebuilds if the Secret
is referenced by an Ingress, HTTPProxy,
Gateway or global config.

Closes #4386.

Signed-off-by: Steve Kriss <krisss@vmware.com>