### PR TITLE
Add support for optional certificate validation

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1131,6 +1131,14 @@ type DownstreamValidation struct {
 	// certificate chain will be subject to validation by CRL.
 	// +optional
 	OnlyVerifyLeafCertCrl bool `json:"crlOnlyVerifyLeafCert"`
+
+	// OnlyRequestClientCert when set to true will request a client certificate
+	// but allow the connection to continue if the client does not provide one.
+	// If a client certificate is sent, it will be verified according to the
+	// other properties, which includes disabling validation if
+	// SkipClientCertValidation is set. Defaults to false.
+	// +optional
+	OnlyRequestClientCert bool `json:"onlyRequestClientCert"`
 }
 
 // HTTPProxyStatus reports the current state of the HTTPProxy.

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1132,13 +1132,13 @@ type DownstreamValidation struct {
 	// +optional
 	OnlyVerifyLeafCertCrl bool `json:"crlOnlyVerifyLeafCert"`
 
-	// OnlyRequestClientCert when set to true will request a client certificate
+	// OptionalClientCertificate when set to true will request a client certificate
 	// but allow the connection to continue if the client does not provide one.
 	// If a client certificate is sent, it will be verified according to the
 	// other properties, which includes disabling validation if
 	// SkipClientCertValidation is set. Defaults to false.
 	// +optional
-	OnlyRequestClientCert bool `json:"onlyRequestClientCert"`
+	OptionalClientCertificate bool `json:"optionalClientCertificate"`
 }
 
 // HTTPProxyStatus reports the current state of the HTTPProxy.

--- a/changelogs/unreleased/4796-gautierdelorme-minor.md
+++ b/changelogs/unreleased/4796-gautierdelorme-minor.md
@@ -1,5 +1,5 @@
 ## Optional Client Certificate Validation
 
 By default, client certificates are required but some applications might support different authentication schemes.
-You can now set the `httpproxy.spec.virtualhost.tls.clientValidation.onlyRequestClientCert` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one.
+You can now set the `httpproxy.spec.virtualhost.tls.clientValidation.optionalClientCertificate` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one.
 If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `httpproxy.spec.virtualhost.tls.clientValidation.skipClientCertValidation` is set.

--- a/changelogs/unreleased/4796-gautierdelorme-minor.md
+++ b/changelogs/unreleased/4796-gautierdelorme-minor.md
@@ -1,0 +1,5 @@
+## Optional Client Certificate Validation
+
+By default, client certificates are required but some applications might support different authentication schemes.
+You can now set the `httpproxy.spec.virtualhost.tls.clientValidation.onlyRequestClientCert` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one.
+If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `httpproxy.spec.virtualhost.tls.clientValidation.skipClientCertValidation` is set.

--- a/changelogs/unreleased/4796-gautierdelorme-minor.md
+++ b/changelogs/unreleased/4796-gautierdelorme-minor.md
@@ -1,5 +1,6 @@
 ## Optional Client Certificate Validation
 
-By default, client certificates are required but some applications might support different authentication schemes.
+By default, when client certificate validation is configured, client certificates are required.
+However, some applications might support different authentication schemes.
 You can now set the `httpproxy.spec.virtualhost.tls.clientValidation.optionalClientCertificate` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one.
 If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `httpproxy.spec.virtualhost.tls.clientValidation.skipClientCertValidation` is set.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5766,9 +5766,9 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
-                          onlyRequestClientCert:
-                            description: OnlyRequestClientCert when set to true will
-                              request a client certificate but allow the connection
+                          optionalClientCertificate:
+                            description: OptionalClientCertificate when set to true
+                              will request a client certificate but allow the connection
                               to continue if the client does not provide one. If a
                               client certificate is sent, it will be verified according
                               to the other properties, which includes disabling validation

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5766,6 +5766,14 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
+                          onlyRequestClientCert:
+                            description: OnlyRequestClientCert when set to true will
+                              request a client certificate but allow the connection
+                              to continue if the client does not provide one. If a
+                              client certificate is sent, it will be verified according
+                              to the other properties, which includes disabling validation
+                              if SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
                           skipClientCertValidation:
                             description: SkipClientCertValidation disables downstream
                               client certificate validation. Defaults to false. This

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5975,9 +5975,9 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
-                          onlyRequestClientCert:
-                            description: OnlyRequestClientCert when set to true will
-                              request a client certificate but allow the connection
+                          optionalClientCertificate:
+                            description: OptionalClientCertificate when set to true
+                              will request a client certificate but allow the connection
                               to continue if the client does not provide one. If a
                               client certificate is sent, it will be verified according
                               to the other properties, which includes disabling validation

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5975,6 +5975,14 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
+                          onlyRequestClientCert:
+                            description: OnlyRequestClientCert when set to true will
+                              request a client certificate but allow the connection
+                              to continue if the client does not provide one. If a
+                              client certificate is sent, it will be verified according
+                              to the other properties, which includes disabling validation
+                              if SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
                           skipClientCertValidation:
                             description: SkipClientCertValidation disables downstream
                               client certificate validation. Defaults to false. This

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -5780,9 +5780,9 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
-                          onlyRequestClientCert:
-                            description: OnlyRequestClientCert when set to true will
-                              request a client certificate but allow the connection
+                          optionalClientCertificate:
+                            description: OptionalClientCertificate when set to true
+                              will request a client certificate but allow the connection
                               to continue if the client does not provide one. If a
                               client certificate is sent, it will be verified according
                               to the other properties, which includes disabling validation

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -5780,6 +5780,14 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
+                          onlyRequestClientCert:
+                            description: OnlyRequestClientCert when set to true will
+                              request a client certificate but allow the connection
+                              to continue if the client does not provide one. If a
+                              client certificate is sent, it will be verified according
+                              to the other properties, which includes disabling validation
+                              if SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
                           skipClientCertValidation:
                             description: SkipClientCertValidation disables downstream
                               client certificate validation. Defaults to false. This

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5981,9 +5981,9 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
-                          onlyRequestClientCert:
-                            description: OnlyRequestClientCert when set to true will
-                              request a client certificate but allow the connection
+                          optionalClientCertificate:
+                            description: OptionalClientCertificate when set to true
+                              will request a client certificate but allow the connection
                               to continue if the client does not provide one. If a
                               client certificate is sent, it will be verified according
                               to the other properties, which includes disabling validation

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5981,6 +5981,14 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
+                          onlyRequestClientCert:
+                            description: OnlyRequestClientCert when set to true will
+                              request a client certificate but allow the connection
+                              to continue if the client does not provide one. If a
+                              client certificate is sent, it will be verified according
+                              to the other properties, which includes disabling validation
+                              if SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
                           skipClientCertValidation:
                             description: SkipClientCertValidation disables downstream
                               client certificate validation. Defaults to false. This

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5975,9 +5975,9 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
-                          onlyRequestClientCert:
-                            description: OnlyRequestClientCert when set to true will
-                              request a client certificate but allow the connection
+                          optionalClientCertificate:
+                            description: OptionalClientCertificate when set to true
+                              will request a client certificate but allow the connection
                               to continue if the client does not provide one. If a
                               client certificate is sent, it will be verified according
                               to the other properties, which includes disabling validation

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5975,6 +5975,14 @@ spec:
                               secrets are limited to 1MiB in size.
                             minLength: 1
                             type: string
+                          onlyRequestClientCert:
+                            description: OnlyRequestClientCert when set to true will
+                              request a client certificate but allow the connection
+                              to continue if the client does not provide one. If a
+                              client certificate is sent, it will be verified according
+                              to the other properties, which includes disabling validation
+                              if SkipClientCertValidation is set. Defaults to false.
+                            type: boolean
                           skipClientCertValidation:
                             description: SkipClientCertValidation disables downstream
                               client certificate validation. Defaults to false. This

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -6533,8 +6533,8 @@ func TestDAGInsert(t *testing.T) {
 				TLS: &contour_api_v1.TLS{
 					SecretName: sec1.Name,
 					ClientValidation: &contour_api_v1.DownstreamValidation{
-						CACertificate:         cert1.Name,
-						OnlyRequestClientCert: true,
+						CACertificate:             cert1.Name,
+						OptionalClientCertificate: true,
 					},
 				},
 			},
@@ -9827,8 +9827,8 @@ func TestDAGInsert(t *testing.T) {
 							MinTLSVersion: "1.2",
 							Secret:        secret(sec1),
 							DownstreamValidation: &PeerValidationContext{
-								CACertificate:         &Secret{Object: cert1},
-								OnlyRequestClientCert: true,
+								CACertificate:             &Secret{Object: cert1},
+								OptionalClientCertificate: true,
 							},
 						},
 					),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -540,6 +540,9 @@ type PeerValidationContext struct {
 	// OnlyVerifyLeafCertCrl when set to true, only the certificate at the end of the
 	// certificate chain will be subject to validation by CRL.
 	OnlyVerifyLeafCertCrl bool
+	// OnlyRequestClientCert when set to true will ensure Envoy does not require
+	// that the client sends a certificate but if one is sent it will process it.
+	OnlyRequestClientCert bool
 }
 
 // GetCACertificate returns the CA certificate from PeerValidationContext.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -540,9 +540,9 @@ type PeerValidationContext struct {
 	// OnlyVerifyLeafCertCrl when set to true, only the certificate at the end of the
 	// certificate chain will be subject to validation by CRL.
 	OnlyVerifyLeafCertCrl bool
-	// OnlyRequestClientCert when set to true will ensure Envoy does not require
+	// OptionalClientCertificate when set to true will ensure Envoy does not require
 	// that the client sends a certificate but if one is sent it will process it.
-	OnlyRequestClientCert bool
+	OptionalClientCertificate bool
 }
 
 // GetCACertificate returns the CA certificate from PeerValidationContext.

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -263,6 +263,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 			if tls.ClientValidation != nil {
 				dv := &PeerValidationContext{
 					SkipClientCertValidation: tls.ClientValidation.SkipClientCertValidation,
+					OnlyRequestClientCert:    tls.ClientValidation.OnlyRequestClientCert,
 				}
 				if tls.ClientValidation.CACertificate != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -262,8 +262,8 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 			// Fill in DownstreamValidation when external client validation is enabled.
 			if tls.ClientValidation != nil {
 				dv := &PeerValidationContext{
-					SkipClientCertValidation: tls.ClientValidation.SkipClientCertValidation,
-					OnlyRequestClientCert:    tls.ClientValidation.OnlyRequestClientCert,
+					SkipClientCertValidation:  tls.ClientValidation.SkipClientCertValidation,
+					OptionalClientCertificate: tls.ClientValidation.OptionalClientCertificate,
 				}
 				if tls.ClientValidation.CACertificate != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))

--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -125,7 +125,7 @@ func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_
 			peerValidationContext.GetCRL(), peerValidationContext.OnlyVerifyLeafCertCrl)
 		if vc != nil {
 			context.CommonTlsContext.ValidationContextType = vc
-			context.RequireClientCertificate = protobuf.Bool(true)
+			context.RequireClientCertificate = protobuf.Bool(!peerValidationContext.OnlyRequestClientCert)
 		}
 	}
 

--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -125,7 +125,7 @@ func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_
 			peerValidationContext.GetCRL(), peerValidationContext.OnlyVerifyLeafCertCrl)
 		if vc != nil {
 			context.CommonTlsContext.ValidationContextType = vc
-			context.RequireClientCertificate = protobuf.Bool(!peerValidationContext.OnlyRequestClientCert)
+			context.RequireClientCertificate = protobuf.Bool(!peerValidationContext.OptionalClientCertificate)
 		}
 	}
 

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -323,6 +323,20 @@ func TestDownstreamTLSContext(t *testing.T) {
 			},
 		},
 	}
+	peerValidationContextOptionalClientCertValidationWithCA := &dag.PeerValidationContext{
+		CACertificate: &dag.Secret{
+			Object: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					dag.CACertificateKey: ca,
+				},
+			},
+		},
+		OnlyRequestClientCert: true,
+	}
 	peerValidationContextWithCRLCheck := &dag.PeerValidationContext{
 		CACertificate: &dag.Secret{
 			Object: &v1.Secret{
@@ -463,6 +477,18 @@ func TestDownstreamTLSContext(t *testing.T) {
 					ValidationContextType:          validationContextSkipVerifyWithCA,
 				},
 				RequireClientCertificate: protobuf.Bool(true),
+			},
+		},
+		"optional client cert validation with ca": {
+			DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, cipherSuites, peerValidationContextOptionalClientCertValidationWithCA, "h2", "http/1.1"),
+			&envoy_tls_v3.DownstreamTlsContext{
+				CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+					TlsParams:                      tlsParams,
+					TlsCertificateSdsSecretConfigs: tlsCertificateSdsSecretConfigs,
+					AlpnProtocols:                  alpnProtocols,
+					ValidationContextType:          validationContext,
+				},
+				RequireClientCertificate: protobuf.Bool(false),
 			},
 		},
 		"Downstream validation with CRL check": {

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -335,7 +335,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 				},
 			},
 		},
-		OnlyRequestClientCert: true,
+		OptionalClientCertificate: true,
 	}
 	peerValidationContextWithCRLCheck := &dag.PeerValidationContext{
 		CACertificate: &dag.Secret{

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -320,4 +320,53 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			statsListener(),
 		),
 	}).Status(proxy5).IsValid()
+
+	proxy6 := fixture.NewProxy("example.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "example.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: serverTLSSecret.Name,
+					ClientValidation: &contour_api_v1.DownstreamValidation{
+						CACertificate:         clientCASecret.Name,
+						OnlyRequestClientCert: true,
+					},
+				},
+			},
+			Routes: []contour_api_v1.Route{{
+				Services: []contour_api_v1.Service{{
+					Name: "kuard",
+					Port: 8080,
+				}},
+			}},
+		})
+	rh.OnUpdate(proxy5, proxy6)
+
+	ingressHTTPSOptionalVerify := &envoy_listener_v3.Listener{
+		Name:    "ingress_https",
+		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v3.ListenerFilters(
+			envoy_v3.TLSInspector(),
+		),
+		FilterChains: appendFilterChains(
+			filterchaintls("example.com", serverTLSSecret,
+				httpsFilterFor("example.com"),
+				&dag.PeerValidationContext{
+					CACertificate: &dag.Secret{
+						Object: clientCASecret,
+					},
+					OnlyRequestClientCert: true,
+				},
+				"h2", "http/1.1",
+			),
+		),
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			defaultHTTPListener(),
+			ingressHTTPSOptionalVerify,
+			statsListener(),
+		),
+	}).Status(proxy6).IsValid()
 }

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -328,8 +328,8 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 				TLS: &contour_api_v1.TLS{
 					SecretName: serverTLSSecret.Name,
 					ClientValidation: &contour_api_v1.DownstreamValidation{
-						CACertificate:         clientCASecret.Name,
-						OnlyRequestClientCert: true,
+						CACertificate:             clientCASecret.Name,
+						OptionalClientCertificate: true,
 					},
 				},
 			},
@@ -355,7 +355,7 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 					CACertificate: &dag.Secret{
 						Object: clientCASecret,
 					},
-					OnlyRequestClientCert: true,
+					OptionalClientCertificate: true,
 				},
 				"h2", "http/1.1",
 			),

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -977,6 +977,23 @@ bool
 certificate chain will be subject to validation by CRL.</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>onlyRequestClientCert</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OnlyRequestClientCert when set to true will request a client certificate
+but allow the connection to continue if the client does not provide one.
+If a client certificate is sent, it will be verified according to the
+other properties, which includes disabling validation if
+SkipClientCertValidation is set. Defaults to false.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1.ExtensionServiceReference">ExtensionServiceReference

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -979,7 +979,7 @@ certificate chain will be subject to validation by CRL.</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
-<code>onlyRequestClientCert</code>
+<code>optionalClientCertificate</code>
 <br>
 <em>
 bool
@@ -987,7 +987,7 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>OnlyRequestClientCert when set to true will request a client certificate
+<p>OptionalClientCertificate when set to true will request a client certificate
 but allow the connection to continue if the client does not provide one.
 If a client certificate is sent, it will be verified according to the
 other properties, which includes disabling validation if

--- a/site/content/docs/main/config/tls-termination.md
+++ b/site/content/docs/main/config/tls-termination.md
@@ -166,7 +166,7 @@ Its mandatory attribute `caSecret` contains a name of an existing Kubernetes Sec
 The data value of the key `ca.crt` must be a PEM-encoded certificate bundle and it must contain all the trusted CA certificates that are to be used for validating the client certificate.
 If the Opaque Secret also contains one of either `tls.crt` or `tls.key` keys, it will be ignored.
 
-By default, client certificates are required but some applications might support different authentication schemes. In that case you can set the `onlyRequestClientCert` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one. If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `skipClientCertValidation` is set.
+By default, client certificates are required but some applications might support different authentication schemes. In that case you can set the `optionalClientCertificate` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one. If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `skipClientCertValidation` is set.
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -180,7 +180,7 @@ spec:
       secretName: secret
       clientValidation:
         caSecret: client-root-ca
-        onlyRequestClientCert: true
+        optionalClientCertificate: true
   routes:
     - services:
         - name: s1

--- a/site/content/docs/main/config/tls-termination.md
+++ b/site/content/docs/main/config/tls-termination.md
@@ -166,6 +166,27 @@ Its mandatory attribute `caSecret` contains a name of an existing Kubernetes Sec
 The data value of the key `ca.crt` must be a PEM-encoded certificate bundle and it must contain all the trusted CA certificates that are to be used for validating the client certificate.
 If the Opaque Secret also contains one of either `tls.crt` or `tls.key` keys, it will be ignored.
 
+By default, client certificates are required but some applications might support different authentication schemes. In that case you can set the `onlyRequestClientCert` field to `true`. A client certificate will be requested, but the connection is allowed to continue if the client does not provide one. If a client certificate is sent, it will be verified according to the other properties, which includes disabling validations if `skipClientCertValidation` is set.
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: with-optional-client-auth
+spec:
+  virtualhost:
+    fqdn: www.example.com
+    tls:
+      secretName: secret
+      clientValidation:
+        caSecret: client-root-ca
+        onlyRequestClientCert: true
+  routes:
+    - services:
+        - name: s1
+          port: 80
+```
+
 When using external authorization, it may be desirable to use an external authorization server to validate client certificates on requests, rather than the Envoy proxy.
 
 ```yaml

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -228,6 +228,50 @@ func testClientCertAuth(namespace string) {
 		}
 		require.NoError(t, f.Client.Create(context.TODO(), echoWithAuthSkipVerifyWithCACert))
 
+		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth")
+
+		// Get a server certificate for echo-with-optional-auth.
+		echoWithOptionalAuth := &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo-with-optional-auth-cert",
+			},
+			Spec: certmanagerv1.CertificateSpec{
+
+				Usages: []certmanagerv1.KeyUsage{
+					certmanagerv1.UsageServerAuth,
+				},
+				DNSNames:   []string{"echo-with-optional-auth.projectcontour.io"},
+				SecretName: "echo-with-optional-auth",
+				IssuerRef: certmanagermetav1.ObjectReference{
+					Name: "ca-projectcontour-io",
+				},
+			},
+		}
+		require.NoError(t, f.Client.Create(context.TODO(), echoWithOptionalAuth))
+
+		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth-no-ca")
+
+		// Get a server certificate for echo-with-optional-auth-no-ca.
+		echoWithOptionalAuthNoCA := &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo-with-optional-auth-no-ca-cert",
+			},
+			Spec: certmanagerv1.CertificateSpec{
+
+				Usages: []certmanagerv1.KeyUsage{
+					certmanagerv1.UsageServerAuth,
+				},
+				DNSNames:   []string{"echo-with-optional-auth-no-ca.projectcontour.io"},
+				SecretName: "echo-with-optional-auth-no-ca",
+				IssuerRef: certmanagermetav1.ObjectReference{
+					Name: "ca-projectcontour-io",
+				},
+			},
+		}
+		require.NoError(t, f.Client.Create(context.TODO(), echoWithOptionalAuthNoCA))
+
 		// Get a client certificate.
 		clientCert := &certmanagerv1.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
@@ -394,6 +438,68 @@ func testClientCertAuth(namespace string) {
 		}
 		f.CreateHTTPProxyAndWaitFor(authSkipVerifyWithCAProxy, e2e.HTTPProxyValid)
 
+		// This proxy requests a client certificate but only verifies it if sent.
+		optionalAuthProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo-with-optional-auth",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "echo-with-optional-auth.projectcontour.io",
+					TLS: &contourv1.TLS{
+						SecretName: "echo-with-optional-auth",
+						ClientValidation: &contourv1.DownstreamValidation{
+							OnlyRequestClientCert: true,
+							CACertificate:         "echo-with-auth",
+						},
+					},
+				},
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-with-optional-auth",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(optionalAuthProxy, e2e.HTTPProxyValid)
+
+		// This proxy requests a client certificate but doesn't verify it if sent.
+		optionalAuthNoCAProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo-with-optional-auth-no-ca",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "echo-with-optional-auth-no-ca.projectcontour.io",
+					TLS: &contourv1.TLS{
+						SecretName: "echo-with-optional-auth-no-ca",
+						ClientValidation: &contourv1.DownstreamValidation{
+							OnlyRequestClientCert:    true,
+							SkipClientCertValidation: true,
+						},
+					},
+				},
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-with-optional-auth-no-ca",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid)
+
 		// get the valid & invalid client certs
 		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.Spec.SecretName)
 		invalidClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCertInvalid.Spec.SecretName)
@@ -463,6 +569,37 @@ func testClientCertAuth(namespace string) {
 			},
 			"echo-with-auth-skip-verify-with-ca with echo-client-cert-invalid should succeed": {
 				host:       authSkipVerifyWithCAProxy.Spec.VirtualHost.Fqdn,
+				clientCert: &invalidClientCert,
+				wantErr:    "",
+			},
+
+			"echo-with-optional-auth without a client cert should succeed": {
+				host:       optionalAuthProxy.Spec.VirtualHost.Fqdn,
+				clientCert: nil,
+				wantErr:    "",
+			},
+			"echo-with-optional-auth with echo-client-cert should succeed": {
+				host:       optionalAuthProxy.Spec.VirtualHost.Fqdn,
+				clientCert: &validClientCert,
+				wantErr:    "",
+			},
+			"echo-with-optional-auth with echo-client-cert-invalid should error": {
+				host:       optionalAuthProxy.Spec.VirtualHost.Fqdn,
+				clientCert: &invalidClientCert,
+				wantErr:    "tls: unknown certificate authority",
+			},
+			"echo-with-optional-auth-no-ca without a client cert should succeed": {
+				host:       optionalAuthNoCAProxy.Spec.VirtualHost.Fqdn,
+				clientCert: nil,
+				wantErr:    "",
+			},
+			"echo-with-optional-auth-no-ca with echo-client-cert should succeed": {
+				host:       optionalAuthNoCAProxy.Spec.VirtualHost.Fqdn,
+				clientCert: &validClientCert,
+				wantErr:    "",
+			},
+			"echo-with-optional-auth-no-ca with echo-client-cert-invalid should succeed": {
+				host:       optionalAuthNoCAProxy.Spec.VirtualHost.Fqdn,
 				clientCert: &invalidClientCert,
 				wantErr:    "",
 			},

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -450,8 +450,8 @@ func testClientCertAuth(namespace string) {
 					TLS: &contourv1.TLS{
 						SecretName: "echo-with-optional-auth",
 						ClientValidation: &contourv1.DownstreamValidation{
-							OnlyRequestClientCert: true,
-							CACertificate:         "echo-with-auth",
+							OptionalClientCertificate: true,
+							CACertificate:             "echo-with-auth",
 						},
 					},
 				},
@@ -481,8 +481,8 @@ func testClientCertAuth(namespace string) {
 					TLS: &contourv1.TLS{
 						SecretName: "echo-with-optional-auth-no-ca",
 						ClientValidation: &contourv1.DownstreamValidation{
-							OnlyRequestClientCert:    true,
-							SkipClientCertValidation: true,
+							OptionalClientCertificate: true,
+							SkipClientCertValidation:  true,
 						},
 					},
 				},


### PR DESCRIPTION
This is required to support optional mTLS so that apps can use different authentication schemes (e.g. mTLS, cookies, tokens, etc...).
I initially named the new option `OnlyVerifyClientCertIfGiven` but this was confusing when `SkipClientCertValidation` is also enabled. I decided to go with `OnlyRequestClientCert` (and not `RequireClientCert` for example) since all the other option are opt-in by setting them to true so I would like to avoid changing this assumption with this new option. The other problem was at the Go API level `DownstreamValidation.RequireClientCert` default value would be `false` since that's the null value for booleans which would change the current behavior and I wanted to avoid implementing it as a pointer.

Signed-off-by: Gautier Delorme <gautier.delorme@gmail.com>