### PR TITLE
use Docker cache mounts for go build & mod cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /contour
 
 ARG BUILD_GOPROXY
 ENV GOPROXY=${BUILD_GOPROXY}
-COPY go.mod go.sum /contour/
-RUN go mod download
 
+COPY go.mod go.mod
+COPY go.sum go.sum
 COPY cmd cmd
 COPY internal internal
 COPY pkg pkg
@@ -24,7 +24,7 @@ ARG BUILD_EXTRA_GO_LDFLAGS
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN make build \
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod make build \
 	    CGO_ENABLED=${BUILD_CGO_ENABLED} \
 		EXTRA_GO_LDFLAGS="${BUILD_EXTRA_GO_LDFLAGS}" \
 		GOOS=${TARGETOS} \


### PR DESCRIPTION
This significantly speeds up repeat builds
on the same host, and is more effective at
caching go modules than the Docker layer
caching technique that was being used
previously since a single module change
does not invalidate the entire cache.

Signed-off-by: Steve Kriss <krisss@vmware.com>

Note, this won't make CI builds any faster
since they run on a fresh host every time,
but makes repeat local dev builds way faster.

ref. https://docs.docker.com/engine/reference/builder/#run---mount