### PR TITLE
update golangci-lint version and action version

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -14,6 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.50.1
           args: --build-tags=e2e,conformance,gcp,oidc,tools,none
       - uses: act10ns/slack@v1
         with:

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -290,6 +290,8 @@ func doShutdownManager(config *shutdownmanagerContext) {
 	http.HandleFunc("/healthz", config.healthzHandler)
 	http.HandleFunc("/shutdown", config.shutdownReadyHandler)
 
+	// Fails gosec G114: Use of net/http serve function that has no support for setting timeouts
+	// nolint:gosec
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", config.httpServePort), nil); err != http.ErrServerClosed {
 		log.Fatal(err)
 	}

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -12,7 +12,7 @@ if command -v docker >/dev/null; then
 		--rm \
 		--volume $(pwd):/app \
 		--workdir /app \
-		golangci/golangci-lint:v1.48.0 ${PROGNAME} "$@"
+		golangci/golangci-lint:v1.50.1 ${PROGNAME} "$@"
 fi
 
 cat <<EOF


### PR DESCRIPTION
Updates #4814.

I'll create a separate issue for possibly addressing the issue reported by gosec for the shutdown manager.