### PR TITLE
Fix upgrade from version tag finding

### DIFF
--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -7,11 +7,22 @@ set -o pipefail
 if CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
   # We are on a tag, so find previous tag to this one.
   git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | grep -A1 -x $CURRENT_TAG | tail -1
-elif git branch --show-current | grep -q release; then
-  # We are on a release branch, so find tag.
-  git describe --tags --abbrev=0
+elif git describe --tags --abbrev=0 | grep -q -v v1.2.0; then
+  # Note: Contour v1.2.0 was improperly tagged on main so we
+  # ignore it to ensure we dont hit that case here.
+
+  # We should be on a release branch with an existing tag.
+  # Check the branch name and error if it does not contain release.
+  # Tags should not be added to non-release branches.
+  if git branch --show-current | grep -q release; then
+    git describe --tags --abbrev=0
+  else
+    echo 'Error: invalid tag on branch'
+    exit 1
+  fi
 else
-  # We are likely on main or some other checkout, just use latest tag.
+  # We are on a release branch with no tag created yet, main, or some
+  # other checkout, so just use the latest tag.
   # If needed, user can override this version with environment variables.
   git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | head -1
 fi


### PR DESCRIPTION
- logic for when we're checked out on a tag remains the same
- Contour v1.2.0 was improperly tagged on main, so next case is when we're checked out on a release branch with a previous tag, we ignore v1.2.0 and use the existing tag
  - no branches other than release branches should have tags
- remaining cases are for release branches w/ tags, main, etc. so find the latest tag

Fixes #4809