### PR TITLE
provisioner: move LogLevel validation to controller

### DIFF
--- a/apis/projectcontour/v1alpha1/contourdeployment.go
+++ b/apis/projectcontour/v1alpha1/contourdeployment.go
@@ -14,8 +14,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,24 +38,6 @@ const (
 	// OffLog disable logging for Envoy.
 	OffLog LogLevel = "off"
 )
-
-func (l LogLevel) EnvoyValidate() error {
-	switch l {
-	case TraceLog, DebugLog, InfoLog, WarnLog, ErrorLog, CriticalLog, OffLog:
-		return nil
-	default:
-		return fmt.Errorf("invalid log level %q for envoy", l)
-	}
-}
-
-func (l LogLevel) ContourValidate() error {
-	switch l {
-	case DebugLog, InfoLog:
-		return nil
-	default:
-		return fmt.Errorf("invalid log level %q for contour", l)
-	}
-}
 
 // ContourDeploymentSpec specifies options for how a Contour
 // instance should be provisioned.

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -195,7 +196,11 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				}
 			}
 
-			if params.Spec.Envoy.LogLevel != "" && params.Spec.Envoy.LogLevel.EnvoyValidate() != nil {
+			switch params.Spec.Envoy.LogLevel {
+			// valid values, nothing to do.
+			case "", v1alpha1.TraceLog, v1alpha1.DebugLog, v1alpha1.InfoLog, v1alpha1.WarnLog, v1alpha1.ErrorLog, v1alpha1.CriticalLog, v1alpha1.OffLog:
+			// invalid value, set message.
+			default:
 				msg := fmt.Sprintf("invalid ContourDeployment spec.envoy.logLevel %q, must be trace, debug, info, warn, error, critical or off",
 					params.Spec.Envoy.LogLevel)
 				invalidParamsMessages = append(invalidParamsMessages, msg)


### PR DESCRIPTION
Moves Envoy log level validation from
the API package to the GatewayClass
controller to be consistent with other
validations.

Signed-off-by: Steve Kriss <krisss@vmware.com>