### PR TITLE
remove daily Gateway API conformance run

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -148,38 +148,3 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#contour-ci-notifications'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  gateway-conformance:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: add deps to path
-        run: |
-          ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-      - name: Gateway API conformance tests (latest)
-        env:
-          CONTOUR_E2E_IMAGE: ghcr.io/projectcontour/contour:main
-          GATEWAY_API_VERSION: "main"
-        run: |
-          # Skip the `load-contour-image-kind` target, pull the `main` image instead.
-          make setup-kind-cluster run-gateway-conformance cleanup-kind
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#contour-ci-notifications'
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-


### PR DESCRIPTION
Going forward, the latest Gateway API conformance
tests will be run in PRs against Contour feature
branches that track the latest Gateway API changes.

Closes #4837.

Signed-off-by: Steve Kriss <krisss@vmware.com>