### PR TITLE
Fix: ExtensionServices are updated continuously by contour

### DIFF
--- a/changelogs/unreleased/4846-Vishal-Chdhry-minor.md
+++ b/changelogs/unreleased/4846-Vishal-Chdhry-minor.md
@@ -1,0 +1,1 @@
+ExtensionServices are updated continuously by contour

--- a/changelogs/unreleased/4846-Vishal-Chdhry-minor.md
+++ b/changelogs/unreleased/4846-Vishal-Chdhry-minor.md
@@ -1,1 +1,0 @@
-ExtensionServices are updated continuously by contour

--- a/changelogs/unreleased/4846-Vishal-Chdhry-small.md
+++ b/changelogs/unreleased/4846-Vishal-Chdhry-small.md
@@ -1,0 +1,1 @@
+Fixed bug where ExtensionServices were being updated continuously by Contour

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/sirupsen/logrus"
@@ -190,6 +191,7 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 	case opUpdate:
 		if cmp.Equal(op.oldObj, op.newObj,
 			cmpopts.IgnoreFields(contour_api_v1.HTTPProxy{}, "Status"),
+			cmpopts.IgnoreFields(contour_api_v1alpha1.ExtensionService{}, "Status"),
 			cmpopts.IgnoreFields(gatewayapi_v1beta1.GatewayClass{}, "Status"),
 			cmpopts.IgnoreFields(gatewayapi_v1beta1.Gateway{}, "Status"),
 			cmpopts.IgnoreFields(gatewayapi_v1beta1.HTTPRoute{}, "Status"),

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -39,6 +40,13 @@ func isStatusEqual(objA, objB interface{}) bool {
 			// updated on each DAG rebuild regardless if the status of object changed or not.
 			// Not ignoring this causes each status to be updated each time since the objects
 			// are always different for each DAG rebuild (Issue #2979).
+			if cmp.Equal(a.Status, b.Status,
+				cmpopts.IgnoreFields(contour_api_v1.Condition{}, "LastTransitionTime")) {
+				return true
+			}
+		}
+	case *contour_api_v1alpha1.ExtensionService:
+		if b, ok := objB.(*contour_api_v1alpha1.ExtensionService); ok {
 			if cmp.Equal(a.Status, b.Status,
 				cmpopts.IgnoreFields(contour_api_v1.Condition{}, "LastTransitionTime")) {
 				return true


### PR DESCRIPTION
Added case for ignoring transition time and status changes of extension service

Fixes: #4838 

Signed-off-by: Vishal Choudhary <contactvishaltech@gmail.com>
