### PR TITLE
test/e2e/httpproxy: Remove gRPC test flake attempts

### DIFF
--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -41,8 +41,7 @@ import (
 )
 
 func testGRPCServicePlaintext(namespace string) {
-	// Flake tracking issue: https://github.com/projectcontour/contour/issues/4707
-	Specify("requests to a gRPC service configured with plaintext work as expected", FlakeAttempts(3), func() {
+	Specify("requests to a gRPC service configured with plaintext work as expected", func() {
 		t := f.T()
 
 		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")


### PR DESCRIPTION
Test has been stable for a while with retries, removing to ensure it is fully fixed

Updates: #4707 