### PR TITLE
Bump Go to 1.19.3

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -10,7 +10,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.19.2
+  GO_VERSION: 1.19.3
 jobs:
   e2e-envoy-xds:
     runs-on: ubuntu-latest

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -9,7 +9,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.19.2
+  GO_VERSION: 1.19.3
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.19.2
+BUILD_BASE_IMAGE ?= golang:1.19.3
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/4856-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4856-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates Go to 1.19.3, see [release notes here](https://go.dev/doc/devel/release#go1.19.minor).


### PR DESCRIPTION
See release notes: https://go.dev/doc/devel/release#go1.19.minor
