### PR TITLE
Ignore prbuild workflow for dependabot branches on push

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -3,6 +3,8 @@ name: Build and Test Pull Request
 # Trigger the workflow on push or pull request
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
To reduce the number of workflow runs that clutter our actions and dependabot PR workflow result reporting
