### PR TITLE
Add trivy scan workflow

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@v0.8.0
         with:
           scan-type: 'fs'
           format: 'sarif'

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -25,7 +25,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           ignore-unfixed: true
-          severity: 'HIGH'
+          severity: 'HIGH,CRITICAL'
       - uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,31 @@
+name: Trivy Scan
+
+on:
+  push:
+    # Run on main and supported release branches
+    branches:
+      - main
+      - release-1.23
+      - release-1.22
+      - release-1.21
+  # Run weekly
+  schedule:
+    - cron: '0 12 * * 1'
+  # Allow manual runs
+  workflow_dispatch:
+
+jobs:
+  trivy-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'HIGH'
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/site/content/resources/release-process.md
+++ b/site/content/resources/release-process.md
@@ -53,7 +53,8 @@ export CONTOUR_OPERATOR_UPSTREAM_REMOTE_NAME=upstream
     ```
 1. Proofread the release notes and do any reordering, rewording, reformatting necessary, including editing or deleting the "Deprecation and Removal Notices" section.
 1. Add the new release to the compatibility matrix (`site/content/resources/compatibility-matrix.md`).
-1. Add the new release to the compatibility YAML (`/versions.yaml`).
+1. Add the new release to the compatibility YAML (`/versions.yaml`). Be sure to mark this new version as supported and mark oldest currently supported version as no longer supported.
+1. Update `.github/workflows/trivy-scan.yaml` to add new release branch and remove oldest listed (should always be 3 latest branches listed).
 1. Document upgrade instructions for the new release (`site/content/resources/upgrading.md`).
 1. Commit all changes, push the branch, and PR it into `main`.
 


### PR DESCRIPTION
Runs on push to main and release branches, weekly, and can be triggered manually

Uploads a code scan result similar to CodeQL
