### PR TITLE
trivy: Only perform vulnerability scanning

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aquasecurity/trivy-action@0.8.0
         with:
+          security-checks: vuln
           scan-type: 'fs'
           format: 'sarif'
           output: 'trivy-results.sarif'


### PR DESCRIPTION
github should already be checking repo for secrets etc. and trivy is finding test fixtures as issues.

An alternative to this would be to skip directories containing secrets/fixtures using the skip-dirs option.
