### PR TITLE
Use dependabot to keep github actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,13 @@ updates:
   - release-note/none-required
   reviewers:
   - projectcontour/maintainers
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  labels:
+  - area/tooling
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
   


### PR DESCRIPTION
Should help with action deprecation by being proactive about updating them

