### PR TITLE
release-1.22: Bump Envoy to 1.23.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.3
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/4897-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/4897-sunjayBhatia-minor.md
@@ -1,0 +1,4 @@
+## Bump Envoy to v1.23.3
+
+Bumps Envoy to security patch version 1.23.3.
+See Envoy release notes [here](https://www.envoyproxy.io/docs/envoy/v1.23.3/version_history/v1.23/v1.23.3).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -33,7 +33,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	config := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.22.1",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.3",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.1
+        image: docker.io/envoyproxy/envoy:v1.23.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5161,7 +5161,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.1
+        image: docker.io/envoyproxy/envoy:v1.23.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5156,7 +5156,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.1
+        image: docker.io/envoyproxy/envoy:v1.23.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -366,20 +366,6 @@ func (d *Deployment) EnsureEnvoyDeployment() error {
 	return d.ensureResource(d.EnvoyDeployment, new(apps_v1.Deployment))
 }
 
-// Wait for Envoy daemonset update to go out of date due to the
-// update propagating. Possibly needed before calling WaitForEnvoyDaemonSetUpdated
-// to ensure that does not pass without waiting for update to propagate.
-func (d *Deployment) WaitForEnvoyDaemonSetOutOfDate() error {
-	daemonSetUpdated := func() (bool, error) {
-		tempDS := new(apps_v1.DaemonSet)
-		if err := d.client.Get(context.TODO(), client.ObjectKeyFromObject(d.EnvoyDaemonSet), tempDS); err != nil {
-			return false, err
-		}
-		return tempDS.Status.UpdatedNumberScheduled < tempDS.Status.DesiredNumberScheduled, nil
-	}
-	return wait.PollImmediate(time.Millisecond*50, time.Minute*3, daemonSetUpdated)
-}
-
 func (d *Deployment) WaitForEnvoyUpdated() error {
 	if d.EnvoyDeploymentMode == DaemonsetMode {
 		return d.waitForEnvoyDaemonSetUpdated()
@@ -393,7 +379,8 @@ func (d *Deployment) waitForEnvoyDaemonSetUpdated() error {
 		if err := d.client.Get(context.TODO(), client.ObjectKeyFromObject(d.EnvoyDaemonSet), tempDS); err != nil {
 			return false, err
 		}
-		return tempDS.Status.NumberAvailable > 0 &&
+		return tempDS.Status.ObservedGeneration == tempDS.Generation &&
+			tempDS.Status.NumberAvailable > 0 &&
 			tempDS.Status.NumberAvailable == tempDS.Status.DesiredNumberScheduled &&
 			tempDS.Status.UpdatedNumberScheduled == tempDS.Status.DesiredNumberScheduled, nil
 	}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -107,7 +107,6 @@ var _ = Describe("upgrading Contour", func() {
 			require.NoError(f.T(), f.Deployment.WaitForContourDeploymentUpdated())
 
 			By("waiting for envoy daemonset to be updated")
-			require.NoError(f.T(), f.Deployment.WaitForEnvoyDaemonSetOutOfDate())
 			require.NoError(f.T(), f.Deployment.WaitForEnvoyUpdated())
 
 			By("ensuring app is still routable")


### PR DESCRIPTION
See release notes:
https://www.envoyproxy.io/docs/envoy/v1.23.3/version_history/v1.23/v1.23.3
