### PR TITLE
Implement support for ResponseHeaderModifier

### DIFF
--- a/changelogs/unreleased/4908-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4908-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Implement support for Gateway API HTTPRoute ResponseHeaderModifier filter.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -2913,18 +2913,35 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
-								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-									Set: []gatewayapi_v1beta1.HTTPHeader{
-										{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-										{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
-									},
-									Add: []gatewayapi_v1beta1.HTTPHeader{
-										{Name: "custom-header-add", Value: "foo-bar"},
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "foo-bar"},
+										},
+										Remove: []string{"x-remove"},
 									},
 								},
-							}},
+								{
+									// Second instance of filter should be ignored.
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "ignored"},
+										},
+										Remove: []string{"x-remove-ignored"},
+									},
+								},
+							},
 						}},
 					},
 				},
@@ -2944,6 +2961,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								Add: map[string]string{
 									"Custom-Header-Add": "foo-bar", // Verify the header key is canonicalized.
 								},
+								Remove:      []string{"X-Remove"}, // Verify the header key is canonicalized.
 								HostRewrite: "bar.com",
 							},
 						},
@@ -2971,18 +2989,35 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
-								Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
-								ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-									Set: []gatewayapi_v1beta1.HTTPHeader{
-										{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-										{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
-									},
-									Add: []gatewayapi_v1beta1.HTTPHeader{
-										{Name: "custom-header-add", Value: "foo-bar"},
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
+									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "foo-bar"},
+										},
+										Remove: []string{"x-remove"},
 									},
 								},
-							}},
+								{
+									// Second instance of filter should be ignored.
+									Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
+									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+											{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "ignored"},
+										},
+										Remove: []string{"x-remove-ignored"},
+									},
+								},
+							},
 						}},
 					},
 				},
@@ -3003,6 +3038,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								Add: map[string]string{
 									"Custom-Header-Add": "foo-bar", // Verify the header key is canonicalized.
 								},
+								Remove: []string{"X-Remove"}, // Verify the header key is canonicalized.
 							},
 						},
 					)),
@@ -3034,18 +3070,35 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 										Weight:                 pointer.Int32(1),
 									},
-									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
-										Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Set: []gatewayapi_v1beta1.HTTPHeader{
-												{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-												{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
-											},
-											Add: []gatewayapi_v1beta1.HTTPHeader{
-												{Name: "custom-header-add", Value: "foo-bar"},
+									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+										{
+											Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+												Set: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
+												},
+												Add: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: "custom-header-add", Value: "foo-bar"},
+												},
+												Remove: []string{"x-remove"},
 											},
 										},
-									}},
+										{
+											// Second instance of filter should be ignored.
+											Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+												Set: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+												},
+												Add: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: "custom-header-add", Value: "ignored"},
+												},
+												Remove: []string{"x-remove-ignored"},
+											},
+										},
+									},
 								},
 							},
 						}},
@@ -3059,7 +3112,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clusterHeaders(map[string]string{"Custom-Header-Set": "foo-bar"}, map[string]string{"Custom-Header-Add": "foo-bar"}, nil, "bar.com", nil, nil, nil, service(kuardService)),
+							Clusters:           clusterHeaders(map[string]string{"Custom-Header-Set": "foo-bar"}, map[string]string{"Custom-Header-Add": "foo-bar"}, []string{"X-Remove"}, "bar.com", nil, nil, nil, service(kuardService)),
 						},
 					)),
 				},
@@ -3090,18 +3143,35 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 										Weight:                 pointer.Int32(1),
 									},
-									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
-										Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
-										ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Set: []gatewayapi_v1beta1.HTTPHeader{
-												{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-												{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
-											},
-											Add: []gatewayapi_v1beta1.HTTPHeader{
-												{Name: "custom-header-add", Value: "foo-bar"},
+									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+										{
+											Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
+											ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+												Set: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar.com"},
+												},
+												Add: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: "custom-header-add", Value: "foo-bar"},
+												},
+												Remove: []string{"x-remove"},
 											},
 										},
-									}},
+										{
+											// Second instance of filter should be ignored.
+											Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
+											ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+												Set: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+													{Name: gatewayapi_v1beta1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+												},
+												Add: []gatewayapi_v1beta1.HTTPHeader{
+													{Name: "custom-header-add", Value: "ignored"},
+												},
+												Remove: []string{"x-remove-ignored"},
+											},
+										},
+									},
 								},
 							},
 						}},
@@ -3115,7 +3185,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
 						&Route{
 							PathMatchCondition: prefixString("/"),
-							Clusters:           clusterHeaders(nil, nil, nil, "", map[string]string{"Custom-Header-Set": "foo-bar", "Host": "bar.com"}, map[string]string{"Custom-Header-Add": "foo-bar"}, nil, service(kuardService)),
+							Clusters:           clusterHeaders(nil, nil, nil, "", map[string]string{"Custom-Header-Set": "foo-bar", "Host": "bar.com"}, map[string]string{"Custom-Header-Add": "foo-bar"}, []string{"X-Remove"}, service(kuardService)),
 						},
 					)),
 				},

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1060,10 +1060,10 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 
 		// Process rule-level filters.
 		var (
-			headerPolicy       *HeadersPolicy
-			headerModifierSeen bool
-			redirect           *gatewayapi_v1beta1.HTTPRequestRedirectFilter
-			mirrorPolicy       *MirrorPolicy
+			requestHeaderPolicy, responseHeaderPolicy             *HeadersPolicy
+			requestHeaderModifierSeen, responseHeaderModifierSeen bool
+			redirect                                              *gatewayapi_v1beta1.HTTPRequestRedirectFilter
+			mirrorPolicy                                          *MirrorPolicy
 		)
 
 		for _, filter := range rule.Filters {
@@ -1072,16 +1072,31 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				// Per Gateway API docs, "specifying a core filter multiple times has
 				// unspecified or custom conformance.", here we choose to just process
 				// the first one.
-				if headerModifierSeen {
+				if requestHeaderModifierSeen {
 					continue
 				}
 
-				headerModifierSeen = true
+				requestHeaderModifierSeen = true
 
 				var err error
-				headerPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier)
+				requestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, filter.Type)
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
+				}
+			case gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier:
+				// Per Gateway API docs, "specifying a core filter multiple times has
+				// unspecified or custom conformance.", here we choose to just process
+				// the first one.
+				if responseHeaderModifierSeen {
+					continue
+				}
+
+				responseHeaderModifierSeen = true
+
+				var err error
+				responseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, filter.Type)
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect:
 				// Get the redirect filter if there is one. Note that per Gateway API
@@ -1114,7 +1129,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 
 			default:
 				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType,
-					fmt.Sprintf("HTTPRoute.Spec.Rules.Filters: invalid type %q: only RequestHeaderModifier, RequestRedirect and RequestMirror are supported.", filter.Type))
+					fmt.Sprintf("HTTPRoute.Spec.Rules.Filters: invalid type %q: only RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect and RequestMirror are supported.", filter.Type))
 			}
 		}
 
@@ -1133,9 +1148,9 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 		var routes []*Route
 
 		if redirect != nil {
-			routes = p.redirectRoutes(matchconditions, headerPolicy, redirect, priority)
+			routes = p.redirectRoutes(matchconditions, requestHeaderPolicy, responseHeaderPolicy, redirect, priority)
 		} else {
-			routes = p.clusterRoutes(route.Namespace, matchconditions, headerPolicy, mirrorPolicy, rule.BackendRefs, routeAccessor, priority)
+			routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, rule.BackendRefs, routeAccessor, priority)
 		}
 
 		// Add each route to the relevant vhost(s)/svhosts(s).
@@ -1332,8 +1347,8 @@ func gatewayQueryParamMatchConditions(matches []gatewayapi_v1beta1.HTTPQueryPara
 	return dagMatchConditions, nil
 }
 
-// clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicy and backendRefs.
-func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, headerPolicy *HeadersPolicy, mirrorPolicy *MirrorPolicy, backendRefs []gatewayapi_v1beta1.HTTPBackendRef, routeAccessor *status.RouteParentStatusUpdate, priority uint8) []*Route {
+// clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and backendRefs.
+func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy, mirrorPolicy *MirrorPolicy, backendRefs []gatewayapi_v1beta1.HTTPBackendRef, routeAccessor *status.RouteParentStatusUpdate, priority uint8) []*Route {
 	if len(backendRefs) == 0 {
 		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
 		return nil
@@ -1350,17 +1365,23 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			continue
 		}
 
-		var headerPolicy *HeadersPolicy
+		var clusterRequestHeaderPolicy, clusterResponseHeaderPolicy *HeadersPolicy
 		for _, filter := range backendRef.Filters {
 			switch filter.Type {
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier:
 				var err error
-				headerPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier)
+				clusterRequestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, filter.Type)
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
+			case gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier:
+				var err error
+				clusterResponseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, filter.Type)
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
+				}
 			default:
-				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier type is supported.")
+				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.")
 			}
 		}
 
@@ -1377,11 +1398,12 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 		// https://github.com/projectcontour/contour/issues/3593
 		service.Weighted.Weight = routeWeight
 		clusters = append(clusters, &Cluster{
-			Upstream:             service,
-			Weight:               routeWeight,
-			Protocol:             service.Protocol,
-			RequestHeadersPolicy: headerPolicy,
-			TimeoutPolicy:        ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+			Upstream:              service,
+			Weight:                routeWeight,
+			Protocol:              service.Protocol,
+			RequestHeadersPolicy:  clusterRequestHeaderPolicy,
+			ResponseHeadersPolicy: clusterResponseHeaderPolicy,
+			TimeoutPolicy:         ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		})
 	}
 
@@ -1397,7 +1419,8 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			PathMatchCondition:        mc.path,
 			HeaderMatchConditions:     mc.headers,
 			QueryParamMatchConditions: mc.queryParams,
-			RequestHeadersPolicy:      headerPolicy,
+			RequestHeadersPolicy:      requestHeaderPolicy,
+			ResponseHeadersPolicy:     responseHeaderPolicy,
 			MirrorPolicy:              mirrorPolicy,
 			Priority:                  priority,
 		})
@@ -1419,8 +1442,8 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 	return routes
 }
 
-// redirectRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicy and redirect.
-func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions, headerPolicy *HeadersPolicy, redirect *gatewayapi_v1beta1.HTTPRequestRedirectFilter, priority uint8) []*Route {
+// redirectRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and redirect.
+func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy, redirect *gatewayapi_v1beta1.HTTPRequestRedirectFilter, priority uint8) []*Route {
 	var hostname string
 	if redirect.Hostname != nil {
 		hostname = string(*redirect.Hostname)
@@ -1458,7 +1481,8 @@ func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions,
 			},
 			PathMatchCondition:    mc.path,
 			HeaderMatchConditions: mc.headers,
-			RequestHeadersPolicy:  headerPolicy,
+			RequestHeadersPolicy:  requestHeaderPolicy,
+			ResponseHeadersPolicy: responseHeaderPolicy,
 		})
 	}
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -204,7 +204,7 @@ func headersPolicyRoute(policy *contour_api_v1.HeadersPolicy, allowHostRewrite b
 
 // headersPolicyGatewayAPI builds a *HeaderPolicy for the supplied HTTPHeaderFilter.
 // TODO: Take care about the order of operators once https://github.com/kubernetes-sigs/gateway-api/issues/480 was solved.
-func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter) (*HeadersPolicy, error) {
+func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPolicyType gatewayapi_v1beta1.HTTPRouteFilterType) (*HeadersPolicy, error) {
 	var (
 		set         = make(map[string]string, len(hf.Set))
 		add         = make(map[string]string, len(hf.Add))
@@ -219,7 +219,7 @@ func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter) (*HeadersP
 			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
 			continue
 		}
-		if key == "Host" {
+		if key == "Host" && headerPolicyType == gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier {
 			hostRewrite = setHeader.Value
 			continue
 		}
@@ -235,7 +235,7 @@ func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter) (*HeadersP
 			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
 			continue
 		}
-		if key == "Host" {
+		if key == "Host" && headerPolicyType == gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier {
 			hostRewrite = addHeader.Value
 			continue
 		}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -100,7 +100,7 @@ func buildRoute(dagRoute *dag.Route, vhostName string, secure bool, authService 
 			rt.RequestHeadersToRemove = dagRoute.RequestHeadersPolicy.Remove
 		}
 		if dagRoute.ResponseHeadersPolicy != nil {
-			rt.ResponseHeadersToAdd = headerValueList(dagRoute.ResponseHeadersPolicy.Set, false)
+			rt.ResponseHeadersToAdd = append(headerValueList(dagRoute.ResponseHeadersPolicy.Set, false), headerValueList(dagRoute.ResponseHeadersPolicy.Add, true)...)
 			rt.ResponseHeadersToRemove = dagRoute.ResponseHeadersPolicy.Remove
 		}
 		if dagRoute.RateLimitPolicy != nil && dagRoute.RateLimitPolicy.Local != nil {
@@ -457,7 +457,7 @@ func weightedClusters(route *dag.Route) *envoy_route_v3.WeightedCluster {
 			c.RequestHeadersToRemove = cluster.RequestHeadersPolicy.Remove
 		}
 		if cluster.ResponseHeadersPolicy != nil {
-			c.ResponseHeadersToAdd = headerValueList(cluster.ResponseHeadersPolicy.Set, false)
+			c.ResponseHeadersToAdd = append(headerValueList(cluster.ResponseHeadersPolicy.Set, false), headerValueList(cluster.ResponseHeadersPolicy.Add, true)...)
 			c.ResponseHeadersToRemove = cluster.ResponseHeadersPolicy.Remove
 		}
 		if len(route.CookieRewritePolicies) > 0 || len(cluster.CookieRewritePolicies) > 0 {

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -47,10 +47,11 @@ func TestGatewayConformance(t *testing.T) {
 		// Keep the list of supported features in sync with
 		// test/scripts/run-gateway-conformance.sh.
 		SupportedFeatures: map[suite.SupportedFeature]bool{
-			suite.SupportReferenceGrant:              true,
-			suite.SupportTLSRoute:                    true,
-			suite.SupportHTTPRouteQueryParamMatching: true,
-			suite.SupportHTTPRouteMethodMatching:     true,
+			suite.SupportReferenceGrant:                 true,
+			suite.SupportTLSRoute:                       true,
+			suite.SupportHTTPRouteQueryParamMatching:    true,
+			suite.SupportHTTPRouteMethodMatching:        true,
+			suite.SupportHTTPResponseHeaderModification: true,
 		},
 	})
 	cSuite.Setup(t)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// EchoServerImage is the image to use as a backend fixture.
-	EchoServerImage = "gcr.io/k8s-staging-ingressconformance/echoserver:v20210922-cec7cf2"
+	EchoServerImage = "gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e"
 
 	// GRPCServerImage is the image to use for tests that require a gRPC server.
 	GRPCServerImage = "ghcr.io/projectcontour/yages:v0.1.0"

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -203,7 +203,9 @@ var _ = Describe("Gateway API", func() {
 
 		f.NamespacedTest("gateway-query-param-match", testWithHTTPGateway(testGatewayMultipleQueryParamMatch))
 
-		f.NamespacedTest("gateway-request-header-modifier-forward-to", testWithHTTPGateway(testRequestHeaderModifierForwardTo))
+		f.NamespacedTest("gateway-request-header-modifier-backendref-filter", testWithHTTPGateway(testRequestHeaderModifierBackendRef))
+
+		f.NamespacedTest("gateway-response-header-modifier-backendref-filter", testWithHTTPGateway(testResponseHeaderModifierBackendRef))
 
 		f.NamespacedTest("gateway-host-rewrite", testWithHTTPGateway(testHostRewrite))
 

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -60,5 +60,5 @@ else
   git checkout "${GATEWAY_API_VERSION}"
   # Keep the list of supported features in sync with
   # test/conformance/gatewayapi/gateway_conformance_test.go.
-  go test ./conformance -gateway-class=contour -supported-features=ReferenceGrant,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching
+  go test ./conformance -gateway-class=contour -supported-features=ReferenceGrant,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPResponseHeaderModification
 fi


### PR DESCRIPTION
One note: Host header is allowed in response modifier filter since it is not significant in a response

Enables Gateway API conformance test for response header modifier, bumps echoserver image in e2e tests, and adds tests for filter per-backend since this is missing from upstream tests (should add this soon).

Fixes #4819
