### PR TITLE
Added support for `ALL` DNS lookup family

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -314,7 +314,7 @@ type RemoteJWKS struct {
 	// for addresses in the IPv4 family. If "v6" is configured, the DNS resolver
 	// will only perform a lookup for addresses in the IPv6 family.
 	// If "all" is configured, the DNS resolver
-	// will only perform a lookup for addresses in both the IPv4 and IPv6 family.
+	// will perform a lookup for addresses in both the IPv4 and IPv6 family.
 	// If "auto" is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
 	// in the IPv4 family. If not specified, the Contour-wide setting defined

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -313,6 +313,8 @@ type RemoteJWKS struct {
 	// When configured as "v4", the DNS resolver will only perform a lookup
 	// for addresses in the IPv4 family. If "v6" is configured, the DNS resolver
 	// will only perform a lookup for addresses in the IPv6 family.
+	// If "all" is configured, the DNS resolver
+	// will only perform a lookup for addresses in both the IPv4 and IPv6 family.
 	// If "auto" is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
 	// in the IPv4 family. If not specified, the Contour-wide setting defined

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -528,6 +528,8 @@ const (
 	IPv4ClusterDNSFamily ClusterDNSFamilyType = "v4"
 	// DNS lookups will only attempt v6 queries.
 	IPv6ClusterDNSFamily ClusterDNSFamilyType = "v6"
+	// DNS lookups will attempt both v4 and v6 queries.
+	AllClusterDNSFamily ClusterDNSFamilyType = "all"
 )
 
 // ClusterParameters holds various configurable cluster values.
@@ -538,13 +540,16 @@ type ClusterParameters struct {
 	// will only perform a lookup for addresses in the IPv6 family.
 	// If AUTO is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
-	// in the IPv4 family.
+	// in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+	// both IPv4 and IPv6 families, and return all resolved addresses.
+	// When this is used, Happy Eyeballs will be enabled for upstream connections.
+	// Refer to Happy Eyeballs Support for more information.
 	// Note: This only applies to externalName clusters.
 	//
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
 	// for more information.
 	//
-	// Values: `auto` (default), `v4`, `v6`.
+	// Values: `auto` (default), `v4`, `v6`, `all`.
 	//
 	// Other values will produce an error.
 	// +optional

--- a/apis/projectcontour/v1alpha1/contourconfig_helpers.go
+++ b/apis/projectcontour/v1alpha1/contourconfig_helpers.go
@@ -59,7 +59,7 @@ func (x XDSServerType) Validate() error {
 
 func (d ClusterDNSFamilyType) Validate() error {
 	switch d {
-	case AutoClusterDNSFamily, IPv4ClusterDNSFamily, IPv6ClusterDNSFamily:
+	case AutoClusterDNSFamily, IPv4ClusterDNSFamily, IPv6ClusterDNSFamily, AllClusterDNSFamily:
 		return nil
 	default:
 		return fmt.Errorf("invalid cluster dns family type %q", d)

--- a/apis/projectcontour/v1alpha1/contourconfig_helpers_test.go
+++ b/apis/projectcontour/v1alpha1/contourconfig_helpers_test.go
@@ -96,6 +96,9 @@ func TestContourConfigurationSpecValidate(t *testing.T) {
 		c.Envoy.Cluster.DNSLookupFamily = v1alpha1.IPv6ClusterDNSFamily
 		require.NoError(t, c.Validate())
 
+		c.Envoy.Cluster.DNSLookupFamily = v1alpha1.AllClusterDNSFamily
+		require.NoError(t, c.Validate())
+
 		c.Envoy.Cluster.DNSLookupFamily = "foo"
 		require.Error(t, c.Validate())
 

--- a/changelogs/unreleased/4909-Vishal-Chdhry-minor.md
+++ b/changelogs/unreleased/4909-Vishal-Chdhry-minor.md
@@ -1,2 +1,2 @@
-Added support for `ALL` DNS lookup family If `ALL` is specified, the DNS resolver will perform a lookup for both IPv4 and IPv6 families, and return all resolved addresses. When this is used, Happy Eyeballs will be enabled for upstream connections.
+Added support for `ALL` DNS lookup family. If `ALL` is specified, the DNS resolver will perform a lookup for both IPv4 and IPv6 families, and return all resolved addresses. When this is used, Happy Eyeballs will be enabled for upstream connections.
 

--- a/changelogs/unreleased/4909-Vishal-Chdhry-minor.md
+++ b/changelogs/unreleased/4909-Vishal-Chdhry-minor.md
@@ -1,0 +1,2 @@
+Added support for `ALL` DNS lookup family If `ALL` is specified, the DNS resolver will perform a lookup for both IPv4 and IPv6 families, and return all resolved addresses. When this is used, Happy Eyeballs will be enabled for upstream connections.
+

--- a/cmd/contour/bootstrap.go
+++ b/cmd/contour/bootstrap.go
@@ -35,7 +35,7 @@ func registerBootstrap(app *kingpin.Application) (*kingpin.CmdClause, *envoy.Boo
 	bootstrap.Flag("envoy-key-file", "Client key filename for Envoy secure xDS gRPC communication.").Envar("ENVOY_KEY_FILE").StringVar(&config.GrpcClientKey)
 	bootstrap.Flag("namespace", "The namespace the Envoy container will run in.").Envar("CONTOUR_NAMESPACE").Default("projectcontour").StringVar(&config.Namespace)
 	bootstrap.Flag("xds-resource-version", "The versions of the xDS resources to request from Contour.").Default("v3").StringVar((*string)(&config.XDSResourceVersion))
-	bootstrap.Flag("dns-lookup-family", "Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6 or auto.").StringVar(&config.DNSLookupFamily)
+	bootstrap.Flag("dns-lookup-family", "Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6, auto, or all.").StringVar(&config.DNSLookupFamily)
 	bootstrap.Flag("overload-max-heap", "Defines the maximum heap size in bytes until overload manager stops accepting new connections.").Uint64Var(&config.MaximumHeapSizeBytes)
 	return bootstrap, &config
 }

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -358,6 +358,8 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 		dnsLookupFamily = contour_api_v1alpha1.IPv6ClusterDNSFamily
 	case config.IPv4ClusterDNSFamily:
 		dnsLookupFamily = contour_api_v1alpha1.IPv4ClusterDNSFamily
+	case config.AllClusterDNSFamily:
+		dnsLookupFamily = contour_api_v1alpha1.AllClusterDNSFamily
 	}
 
 	var rateLimitService *contour_api_v1alpha1.RateLimitServiceConfig

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5782,9 +5782,9 @@ spec:
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
                                 family. If \"all\" is configured, the DNS resolver
-                                will only perform a lookup for addresses in both the
-                                IPv4 and IPv6 family. If \"auto\" is configured, the
-                                DNS resolver will first perform a lookup for addresses
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
                                 in the IPv6 family and fallback to a lookup for addresses
                                 in the IPv4 family. If not specified, the Contour-wide
                                 setting defined in the config file or ContourConfiguration

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -87,10 +87,14 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. Note: This only applies to externalName
-                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                           for more information. \n Values: `auto` (default), `v4`,
-                          `v6`. \n Other values will produce an error."
+                          `v6`, `all`. \n Other values will produce an error."
                         type: string
                     type: object
                   defaultHTTPVersions:
@@ -3070,10 +3074,15 @@ spec:
                               perform a lookup for addresses in the IPv6 family. If
                               AUTO is configured, the DNS resolver will first perform
                               a lookup for addresses in the IPv6 family and fallback
-                              to a lookup for addresses in the IPv4 family. Note:
-                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                               for more information. \n Values: `auto` (default), `v4`,
-                              `v6`. \n Other values will produce an error."
+                              `v6`, `all`. \n Other values will produce an error."
                             type: string
                         type: object
                       defaultHTTPVersions:
@@ -5772,11 +5781,13 @@ spec:
                                 will only perform a lookup for addresses in the IPv4
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
-                                family. If \"auto\" is configured, the DNS resolver
-                                will first perform a lookup for addresses in the IPv6
-                                family and fallback to a lookup for addresses in the
-                                IPv4 family. If not specified, the Contour-wide setting
-                                defined in the config file or ContourConfiguration
+                                family. If \"all\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in both the
+                                IPv4 and IPv6 family. If \"auto\" is configured, the
+                                DNS resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
                                 applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                                 for more information."
                               enum:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -297,14 +297,14 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. If ALL is specified, the DNS resolver will 
-                          perform a lookup for both IPv4 and IPv6 families, and return all 
-                          resolved addresses. When this is used, Happy Eyeballs will be 
-                          enabled for upstream connections. Refer to Happy Eyeballs Support 
-                          for more information. Note: This only applies to externalName
-                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), all, `v4`,
-                          `v6`. \n Other values will produce an error."
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`, `all`. \n Other values will produce an error."
                         type: string
                     type: object
                   defaultHTTPVersions:
@@ -3277,21 +3277,22 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names are
-                              looked up When configured as V4, the DNS resolver will only
-                              perform a lookup for addresses in the IPv4 family. If V6
-                              is configured, the DNS resolver will only perform a lookup
-                              for addresses in the IPv6 family. If AUTO is configured,
-                              the DNS resolver will first perform a lookup for addresses
-                              in the IPv6 family and fallback to a lookup for addresses
-                              in the IPv4 family. If ALL is specified, the DNS resolver will 
-                              perform a lookup for both IPv4 and IPv6 families, and return all 
-                              resolved addresses. When this is used, Happy Eyeballs will be 
-                              enabled for upstream connections. Refer to Happy Eyeballs Support 
-                              for more information. Note: This only applies to externalName
-                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), all, `v4`,
-                              `v6`. \n Other values will produce an error."
+                            description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`, `all`. \n Other values will produce an error."
                             type: string
                         type: object
                       defaultHTTPVersions:
@@ -5990,11 +5991,13 @@ spec:
                                 will only perform a lookup for addresses in the IPv4
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
-                                family. If \"auto\" is configured, the DNS resolver
-                                will first perform a lookup for addresses in the IPv6
-                                family and fallback to a lookup for addresses in the
-                                IPv4 family. If not specified, the Contour-wide setting
-                                defined in the config file or ContourConfiguration
+                                family. If \"all\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in both the
+                                IPv4 and IPv6 family. If \"auto\" is configured, the
+                                DNS resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
                                 applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                                 for more information."
                               enum:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -297,9 +297,13 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. Note: This only applies to externalName
+                          in the IPv4 family. If ALL is specified, the DNS resolver will 
+                          perform a lookup for both IPv4 and IPv6 families, and return all 
+                          resolved addresses. When this is used, Happy Eyeballs will be 
+                          enabled for upstream connections. Refer to Happy Eyeballs Support 
+                          for more information. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), `v4`,
+                          for more information. \n Values: `auto` (default), all, `v4`,
                           `v6`. \n Other values will produce an error."
                         type: string
                     type: object
@@ -3273,16 +3277,20 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names
-                              are looked up When configured as V4, the DNS resolver
-                              will only perform a lookup for addresses in the IPv4
-                              family. If V6 is configured, the DNS resolver will only
-                              perform a lookup for addresses in the IPv6 family. If
-                              AUTO is configured, the DNS resolver will first perform
-                              a lookup for addresses in the IPv6 family and fallback
-                              to a lookup for addresses in the IPv4 family. Note:
-                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), `v4`,
+                            description: "DNSLookupFamily defines how external names are
+                              looked up When configured as V4, the DNS resolver will only
+                              perform a lookup for addresses in the IPv4 family. If V6
+                              is configured, the DNS resolver will only perform a lookup
+                              for addresses in the IPv6 family. If AUTO is configured,
+                              the DNS resolver will first perform a lookup for addresses
+                              in the IPv6 family and fallback to a lookup for addresses
+                              in the IPv4 family. If ALL is specified, the DNS resolver will 
+                              perform a lookup for both IPv4 and IPv6 families, and return all 
+                              resolved addresses. When this is used, Happy Eyeballs will be 
+                              enabled for upstream connections. Refer to Happy Eyeballs Support 
+                              for more information. Note: This only applies to externalName
+                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), all, `v4`,
                               `v6`. \n Other values will produce an error."
                             type: string
                         type: object

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5992,9 +5992,9 @@ spec:
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
                                 family. If \"all\" is configured, the DNS resolver
-                                will only perform a lookup for addresses in both the
-                                IPv4 and IPv6 family. If \"auto\" is configured, the
-                                DNS resolver will first perform a lookup for addresses
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
                                 in the IPv6 family and fallback to a lookup for addresses
                                 in the IPv4 family. If not specified, the Contour-wide
                                 setting defined in the config file or ContourConfiguration

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -101,14 +101,14 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. If ALL is specified, the DNS resolver will 
-                          perform a lookup for both IPv4 and IPv6 families, and return all 
-                          resolved addresses. When this is used, Happy Eyeballs will be 
-                          enabled for upstream connections. Refer to Happy Eyeballs Support 
-                          for more information. Note: This only applies to externalName
-                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), all, `v4`,
-                          `v6`. \n Other values will produce an error."
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`, `all`. \n Other values will produce an error."
                         type: string
                     type: object
                   defaultHTTPVersions:
@@ -3081,21 +3081,22 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names are
-                              looked up When configured as V4, the DNS resolver will only
-                              perform a lookup for addresses in the IPv4 family. If V6
-                              is configured, the DNS resolver will only perform a lookup
-                              for addresses in the IPv6 family. If AUTO is configured,
-                              the DNS resolver will first perform a lookup for addresses
-                              in the IPv6 family and fallback to a lookup for addresses
-                              in the IPv4 family. If ALL is specified, the DNS resolver will 
-                              perform a lookup for both IPv4 and IPv6 families, and return all 
-                              resolved addresses. When this is used, Happy Eyeballs will be 
-                              enabled for upstream connections. Refer to Happy Eyeballs Support 
-                              for more information. Note: This only applies to externalName
-                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), all, `v4`,
-                              `v6`. \n Other values will produce an error."
+                            description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`, `all`. \n Other values will produce an error."
                             type: string
                         type: object
                       defaultHTTPVersions:
@@ -5794,11 +5795,13 @@ spec:
                                 will only perform a lookup for addresses in the IPv4
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
-                                family. If \"auto\" is configured, the DNS resolver
-                                will first perform a lookup for addresses in the IPv6
-                                family and fallback to a lookup for addresses in the
-                                IPv4 family. If not specified, the Contour-wide setting
-                                defined in the config file or ContourConfiguration
+                                family. If \"all\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in both the
+                                IPv4 and IPv6 family. If \"auto\" is configured, the
+                                DNS resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
                                 applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                                 for more information."
                               enum:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -101,9 +101,13 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. Note: This only applies to externalName
+                          in the IPv4 family. If ALL is specified, the DNS resolver will 
+                          perform a lookup for both IPv4 and IPv6 families, and return all 
+                          resolved addresses. When this is used, Happy Eyeballs will be 
+                          enabled for upstream connections. Refer to Happy Eyeballs Support 
+                          for more information. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), `v4`,
+                          for more information. \n Values: `auto` (default), all, `v4`,
                           `v6`. \n Other values will produce an error."
                         type: string
                     type: object
@@ -3077,16 +3081,20 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names
-                              are looked up When configured as V4, the DNS resolver
-                              will only perform a lookup for addresses in the IPv4
-                              family. If V6 is configured, the DNS resolver will only
-                              perform a lookup for addresses in the IPv6 family. If
-                              AUTO is configured, the DNS resolver will first perform
-                              a lookup for addresses in the IPv6 family and fallback
-                              to a lookup for addresses in the IPv4 family. Note:
-                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), `v4`,
+                            description: "DNSLookupFamily defines how external names are
+                              looked up When configured as V4, the DNS resolver will only
+                              perform a lookup for addresses in the IPv4 family. If V6
+                              is configured, the DNS resolver will only perform a lookup
+                              for addresses in the IPv6 family. If AUTO is configured,
+                              the DNS resolver will first perform a lookup for addresses
+                              in the IPv6 family and fallback to a lookup for addresses
+                              in the IPv4 family. If ALL is specified, the DNS resolver will 
+                              perform a lookup for both IPv4 and IPv6 families, and return all 
+                              resolved addresses. When this is used, Happy Eyeballs will be 
+                              enabled for upstream connections. Refer to Happy Eyeballs Support 
+                              for more information. Note: This only applies to externalName
+                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), all, `v4`,
                               `v6`. \n Other values will produce an error."
                             type: string
                         type: object

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -5796,9 +5796,9 @@ spec:
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
                                 family. If \"all\" is configured, the DNS resolver
-                                will only perform a lookup for addresses in both the
-                                IPv4 and IPv6 family. If \"auto\" is configured, the
-                                DNS resolver will first perform a lookup for addresses
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
                                 in the IPv6 family and fallback to a lookup for addresses
                                 in the IPv4 family. If not specified, the Contour-wide
                                 setting defined in the config file or ContourConfiguration

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5998,9 +5998,9 @@ spec:
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
                                 family. If \"all\" is configured, the DNS resolver
-                                will only perform a lookup for addresses in both the
-                                IPv4 and IPv6 family. If \"auto\" is configured, the
-                                DNS resolver will first perform a lookup for addresses
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
                                 in the IPv6 family and fallback to a lookup for addresses
                                 in the IPv4 family. If not specified, the Contour-wide
                                 setting defined in the config file or ContourConfiguration

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -303,9 +303,13 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. Note: This only applies to externalName
+                          in the IPv4 family. If ALL is specified, the DNS resolver will 
+                          perform a lookup for both IPv4 and IPv6 families, and return all 
+                          resolved addresses. When this is used, Happy Eyeballs will be 
+                          enabled for upstream connections. Refer to Happy Eyeballs Support 
+                          for more information. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), `v4`,
+                          for more information. \n Values: `auto` (default), all, `v4`,
                           `v6`. \n Other values will produce an error."
                         type: string
                     type: object
@@ -3279,16 +3283,20 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names
-                              are looked up When configured as V4, the DNS resolver
-                              will only perform a lookup for addresses in the IPv4
-                              family. If V6 is configured, the DNS resolver will only
-                              perform a lookup for addresses in the IPv6 family. If
-                              AUTO is configured, the DNS resolver will first perform
-                              a lookup for addresses in the IPv6 family and fallback
-                              to a lookup for addresses in the IPv4 family. Note:
-                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), `v4`,
+                            description: "DNSLookupFamily defines how external names are
+                              looked up When configured as V4, the DNS resolver will only
+                              perform a lookup for addresses in the IPv4 family. If V6
+                              is configured, the DNS resolver will only perform a lookup
+                              for addresses in the IPv6 family. If AUTO is configured,
+                              the DNS resolver will first perform a lookup for addresses
+                              in the IPv6 family and fallback to a lookup for addresses
+                              in the IPv4 family. If ALL is specified, the DNS resolver will 
+                              perform a lookup for both IPv4 and IPv6 families, and return all 
+                              resolved addresses. When this is used, Happy Eyeballs will be 
+                              enabled for upstream connections. Refer to Happy Eyeballs Support 
+                              for more information. Note: This only applies to externalName
+                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), all, `v4`,
                               `v6`. \n Other values will produce an error."
                             type: string
                         type: object

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -303,14 +303,14 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. If ALL is specified, the DNS resolver will 
-                          perform a lookup for both IPv4 and IPv6 families, and return all 
-                          resolved addresses. When this is used, Happy Eyeballs will be 
-                          enabled for upstream connections. Refer to Happy Eyeballs Support 
-                          for more information. Note: This only applies to externalName
-                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), all, `v4`,
-                          `v6`. \n Other values will produce an error."
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`, `all`. \n Other values will produce an error."
                         type: string
                     type: object
                   defaultHTTPVersions:
@@ -3283,21 +3283,22 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names are
-                              looked up When configured as V4, the DNS resolver will only
-                              perform a lookup for addresses in the IPv4 family. If V6
-                              is configured, the DNS resolver will only perform a lookup
-                              for addresses in the IPv6 family. If AUTO is configured,
-                              the DNS resolver will first perform a lookup for addresses
-                              in the IPv6 family and fallback to a lookup for addresses
-                              in the IPv4 family. If ALL is specified, the DNS resolver will 
-                              perform a lookup for both IPv4 and IPv6 families, and return all 
-                              resolved addresses. When this is used, Happy Eyeballs will be 
-                              enabled for upstream connections. Refer to Happy Eyeballs Support 
-                              for more information. Note: This only applies to externalName
-                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), all, `v4`,
-                              `v6`. \n Other values will produce an error."
+                            description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`, `all`. \n Other values will produce an error."
                             type: string
                         type: object
                       defaultHTTPVersions:
@@ -5996,11 +5997,13 @@ spec:
                                 will only perform a lookup for addresses in the IPv4
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
-                                family. If \"auto\" is configured, the DNS resolver
-                                will first perform a lookup for addresses in the IPv6
-                                family and fallback to a lookup for addresses in the
-                                IPv4 family. If not specified, the Contour-wide setting
-                                defined in the config file or ContourConfiguration
+                                family. If \"all\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in both the
+                                IPv4 and IPv6 family. If \"auto\" is configured, the
+                                DNS resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
                                 applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                                 for more information."
                               enum:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -297,14 +297,14 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. If ALL is specified, the DNS resolver will 
-                          perform a lookup for both IPv4 and IPv6 families, and return all 
-                          resolved addresses. When this is used, Happy Eyeballs will be 
-                          enabled for upstream connections. Refer to Happy Eyeballs Support 
-                          for more information. Note: This only applies to externalName
-                          clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), all, `v4`,
-                          `v6`. \n Other values will produce an error."
+                          in the IPv4 family. If ALL is specified, the DNS resolver
+                          will perform a lookup for both IPv4 and IPv6 families, and
+                          return all resolved addresses. When this is used, Happy
+                          Eyeballs will be enabled for upstream connections. Refer
+                          to Happy Eyeballs Support for more information. Note: This
+                          only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`, `all`. \n Other values will produce an error."
                         type: string
                     type: object
                   defaultHTTPVersions:
@@ -3277,21 +3277,22 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names are
-                              looked up When configured as V4, the DNS resolver will only
-                              perform a lookup for addresses in the IPv4 family. If V6
-                              is configured, the DNS resolver will only perform a lookup
-                              for addresses in the IPv6 family. If AUTO is configured,
-                              the DNS resolver will first perform a lookup for addresses
-                              in the IPv6 family and fallback to a lookup for addresses
-                              in the IPv4 family. If ALL is specified, the DNS resolver will 
-                              perform a lookup for both IPv4 and IPv6 families, and return all 
-                              resolved addresses. When this is used, Happy Eyeballs will be 
-                              enabled for upstream connections. Refer to Happy Eyeballs Support 
-                              for more information. Note: This only applies to externalName
-                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), all, `v4`,
-                              `v6`. \n Other values will produce an error."
+                            description: "DNSLookupFamily defines how external names
+                              are looked up When configured as V4, the DNS resolver
+                              will only perform a lookup for addresses in the IPv4
+                              family. If V6 is configured, the DNS resolver will only
+                              perform a lookup for addresses in the IPv6 family. If
+                              AUTO is configured, the DNS resolver will first perform
+                              a lookup for addresses in the IPv6 family and fallback
+                              to a lookup for addresses in the IPv4 family. If ALL
+                              is specified, the DNS resolver will perform a lookup
+                              for both IPv4 and IPv6 families, and return all resolved
+                              addresses. When this is used, Happy Eyeballs will be
+                              enabled for upstream connections. Refer to Happy Eyeballs
+                              Support for more information. Note: This only applies
+                              to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`, `all`. \n Other values will produce an error."
                             type: string
                         type: object
                       defaultHTTPVersions:
@@ -5990,11 +5991,13 @@ spec:
                                 will only perform a lookup for addresses in the IPv4
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
-                                family. If \"auto\" is configured, the DNS resolver
-                                will first perform a lookup for addresses in the IPv6
-                                family and fallback to a lookup for addresses in the
-                                IPv4 family. If not specified, the Contour-wide setting
-                                defined in the config file or ContourConfiguration
+                                family. If \"all\" is configured, the DNS resolver
+                                will only perform a lookup for addresses in both the
+                                IPv4 and IPv6 family. If \"auto\" is configured, the
+                                DNS resolver will first perform a lookup for addresses
+                                in the IPv6 family and fallback to a lookup for addresses
+                                in the IPv4 family. If not specified, the Contour-wide
+                                setting defined in the config file or ContourConfiguration
                                 applies (defaults to \"auto\"). \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                                 for more information."
                               enum:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -297,9 +297,13 @@ spec:
                           for addresses in the IPv6 family. If AUTO is configured,
                           the DNS resolver will first perform a lookup for addresses
                           in the IPv6 family and fallback to a lookup for addresses
-                          in the IPv4 family. Note: This only applies to externalName
+                          in the IPv4 family. If ALL is specified, the DNS resolver will 
+                          perform a lookup for both IPv4 and IPv6 families, and return all 
+                          resolved addresses. When this is used, Happy Eyeballs will be 
+                          enabled for upstream connections. Refer to Happy Eyeballs Support 
+                          for more information. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information. \n Values: `auto` (default), `v4`,
+                          for more information. \n Values: `auto` (default), all, `v4`,
                           `v6`. \n Other values will produce an error."
                         type: string
                     type: object
@@ -3273,16 +3277,20 @@ spec:
                           values that can be set in the config file.
                         properties:
                           dnsLookupFamily:
-                            description: "DNSLookupFamily defines how external names
-                              are looked up When configured as V4, the DNS resolver
-                              will only perform a lookup for addresses in the IPv4
-                              family. If V6 is configured, the DNS resolver will only
-                              perform a lookup for addresses in the IPv6 family. If
-                              AUTO is configured, the DNS resolver will first perform
-                              a lookup for addresses in the IPv6 family and fallback
-                              to a lookup for addresses in the IPv4 family. Note:
-                              This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information. \n Values: `auto` (default), `v4`,
+                            description: "DNSLookupFamily defines how external names are
+                              looked up When configured as V4, the DNS resolver will only
+                              perform a lookup for addresses in the IPv4 family. If V6
+                              is configured, the DNS resolver will only perform a lookup
+                              for addresses in the IPv6 family. If AUTO is configured,
+                              the DNS resolver will first perform a lookup for addresses
+                              in the IPv6 family and fallback to a lookup for addresses
+                              in the IPv4 family. If ALL is specified, the DNS resolver will 
+                              perform a lookup for both IPv4 and IPv6 families, and return all 
+                              resolved addresses. When this is used, Happy Eyeballs will be 
+                              enabled for upstream connections. Refer to Happy Eyeballs Support 
+                              for more information. Note: This only applies to externalName
+                              clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
+                              for more information. \n Values: `auto` (default), all, `v4`,
                               `v6`. \n Other values will produce an error."
                             type: string
                         type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5992,9 +5992,9 @@ spec:
                                 family. If \"v6\" is configured, the DNS resolver
                                 will only perform a lookup for addresses in the IPv6
                                 family. If \"all\" is configured, the DNS resolver
-                                will only perform a lookup for addresses in both the
-                                IPv4 and IPv6 family. If \"auto\" is configured, the
-                                DNS resolver will first perform a lookup for addresses
+                                will perform a lookup for addresses in both the IPv4
+                                and IPv6 family. If \"auto\" is configured, the DNS
+                                resolver will first perform a lookup for addresses
                                 in the IPv6 family and fallback to a lookup for addresses
                                 in the IPv4 family. If not specified, the Contour-wide
                                 setting defined in the config file or ContourConfiguration

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -832,7 +832,10 @@ type Cluster struct {
 	// will only perform a lookup for addresses in the IPv6 family.
 	// If AUTO is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
-	// in the IPv4 family.
+	// in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+	// both IPv4 and IPv6 families, and return all resolved addresses.
+	// When this is used, Happy Eyeballs will be enabled for upstream connections.
+	// Refer to Happy Eyeballs Support for more information.
 	// Note: This only applies to externalName clusters.
 	DNSLookupFamily string
 

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -76,7 +76,10 @@ type HTTPProxyProcessor struct {
 	// will only perform a lookup for addresses in the IPv6 family.
 	// If AUTO is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
-	// in the IPv4 family.
+	// in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+	// both IPv4 and IPv6 families, and return all resolved addresses.
+	// When this is used, Happy Eyeballs will be enabled for upstream connections.
+	// Refer to Happy Eyeballs Support for more information.
 	// Note: This only applies to externalName clusters.
 	DNSLookupFamily contour_api_v1alpha1.ClusterDNSFamilyType
 
@@ -463,13 +466,13 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				// default to to the Contour-wide setting.
 				dnsLookupFamily := ""
 				switch jwtProvider.RemoteJWKS.DNSLookupFamily {
-				case "auto", "v4", "v6":
+				case "auto", "v4", "v6", "all":
 					dnsLookupFamily = jwtProvider.RemoteJWKS.DNSLookupFamily
 				case "":
 					dnsLookupFamily = string(p.DNSLookupFamily)
 				default:
 					validCond.AddErrorf(contour_api_v1.ConditionTypeJWTVerificationError, "RemoteJWKSDNSLookupFamilyInvalid",
-						"Spec.VirtualHost.JWTProviders.RemoteJWKS.DNSLookupFamily has an invalid value %q, must be auto, v4 or v6", jwtProvider.RemoteJWKS.DNSLookupFamily)
+						"Spec.VirtualHost.JWTProviders.RemoteJWKS.DNSLookupFamily has an invalid value %q, must be auto, all, v4 or v6", jwtProvider.RemoteJWKS.DNSLookupFamily)
 					return
 				}
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3108,7 +3108,7 @@ func TestDAGStatus(t *testing.T) {
 				WithError(
 					contour_api_v1.ConditionTypeJWTVerificationError,
 					"RemoteJWKSDNSLookupFamilyInvalid",
-					"Spec.VirtualHost.JWTProviders.RemoteJWKS.DNSLookupFamily has an invalid value \"v7\", must be auto, v4 or v6",
+					"Spec.VirtualHost.JWTProviders.RemoteJWKS.DNSLookupFamily has an invalid value \"v7\", must be auto, all, v4 or v6",
 				),
 		},
 	})

--- a/internal/envoy/bootstrap.go
+++ b/internal/envoy/bootstrap.go
@@ -88,7 +88,7 @@ type BootstrapConfig struct {
 	SkipFilePathCheck bool
 
 	// DNSLookupFamily specifies DNS Resolution Policy to use for Envoy -> Contour cluster name lookup.
-	// Either v4, v6 or auto.
+	// Either v4, v6, all or auto.
 	DNSLookupFamily string
 
 	// MaximumHeapSizeBytes specifies the number of bytes that overload manager allows heap to grow to.

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -61,7 +61,7 @@ func Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 		// external name set to LOGICAL_DNS when user selects the ALL loookup family
 		clusterDiscoveryType := ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS)
 		if cluster.DnsLookupFamily == envoy_cluster_v3.Cluster_ALL {
-			cluster.ClusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_LOGICAL_DNS)
+			clusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_LOGICAL_DNS)
 		}
 
 		cluster.ClusterDiscoveryType = clusterDiscoveryType

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -81,7 +81,7 @@ type ClusterDNSFamilyType string
 
 func (c ClusterDNSFamilyType) Validate() error {
 	switch c {
-	case AutoClusterDNSFamily, IPv4ClusterDNSFamily, IPv6ClusterDNSFamily:
+	case AutoClusterDNSFamily, IPv4ClusterDNSFamily, IPv6ClusterDNSFamily, AllClusterDNSFamily:
 		return nil
 	default:
 		return fmt.Errorf("invalid cluster DNS lookup family %q", c)
@@ -91,6 +91,7 @@ func (c ClusterDNSFamilyType) Validate() error {
 const AutoClusterDNSFamily ClusterDNSFamilyType = "auto"
 const IPv4ClusterDNSFamily ClusterDNSFamilyType = "v4"
 const IPv6ClusterDNSFamily ClusterDNSFamilyType = "v6"
+const AllClusterDNSFamily ClusterDNSFamilyType = "all"
 
 // AccessLogType is the name of a supported access logging mechanism.
 type AccessLogType string
@@ -387,7 +388,10 @@ type ClusterParameters struct {
 	// will only perform a lookup for addresses in the IPv6 family.
 	// If AUTO is configured, the DNS resolver will first perform a lookup
 	// for addresses in the IPv6 family and fallback to a lookup for addresses
-	// in the IPv4 family.
+	// in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+	// both IPv4 and IPv6 families, and return all resolved addresses.
+	// When this is used, Happy Eyeballs will be enabled for upstream connections.
+	// Refer to Happy Eyeballs Support for more information.
 	// Note: This only applies to externalName clusters.
 	//
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -126,6 +126,7 @@ func TestValidateClusterDNSFamilyType(t *testing.T) {
 	assert.NoError(t, AutoClusterDNSFamily.Validate())
 	assert.NoError(t, IPv4ClusterDNSFamily.Validate())
 	assert.NoError(t, IPv6ClusterDNSFamily.Validate())
+	assert.NoError(t, AllClusterDNSFamily.Validate())
 }
 
 func TestValidateHeadersPolicy(t *testing.T) {

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2680,7 +2680,7 @@ When configured as &ldquo;v4&rdquo;, the DNS resolver will only perform a lookup
 for addresses in the IPv4 family. If &ldquo;v6&rdquo; is configured, the DNS resolver
 will only perform a lookup for addresses in the IPv6 family.
 If &ldquo;all&rdquo; is configured, the DNS resolver
-will only perform a lookup for addresses in both the IPv4 and IPv6 family.
+will perform a lookup for addresses in both the IPv4 and IPv6 family.
 If &ldquo;auto&rdquo; is configured, the DNS resolver will first perform a lookup
 for addresses in the IPv6 family and fallback to a lookup for addresses
 in the IPv4 family. If not specified, the Contour-wide setting defined

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2679,6 +2679,8 @@ string
 When configured as &ldquo;v4&rdquo;, the DNS resolver will only perform a lookup
 for addresses in the IPv4 family. If &ldquo;v6&rdquo; is configured, the DNS resolver
 will only perform a lookup for addresses in the IPv6 family.
+If &ldquo;all&rdquo; is configured, the DNS resolver
+will only perform a lookup for addresses in both the IPv4 and IPv6 family.
 If &ldquo;auto&rdquo; is configured, the DNS resolver will first perform a lookup
 for addresses in the IPv6 family and fallback to a lookup for addresses
 in the IPv4 family. If not specified, the Contour-wide setting defined
@@ -4934,7 +4936,10 @@ names in an Envoy cluster config.</p>
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;auto&#34;</p></td>
+<tbody><tr><td><p>&#34;all&#34;</p></td>
+<td><p>DNS lookups will attempt both v4 and v6 queries.</p>
+</td>
+</tr><tr><td><p>&#34;auto&#34;</p></td>
 <td><p>DNS lookups will do a v6 lookup first, followed by a v4 if that fails.</p>
 </td>
 </tr><tr><td><p>&#34;v4&#34;</p></td>
@@ -4983,12 +4988,11 @@ for addresses in the IPv6 family and fallback to a lookup for addresses
 in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
 both IPv4 and IPv6 families, and return all resolved addresses.
 When this is used, Happy Eyeballs will be enabled for upstream connections.
-Refer to <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling#arch-overview-happy-eyeballs">Happy Eyeballs Support</a> 
-for more information.
+Refer to Happy Eyeballs Support for more information.
 Note: This only applies to externalName clusters.</p>
 <p>See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily">https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily</a>
 for more information.</p>
-<p>Values: <code>auto</code> (default), <code>v4</code>, <code>v6</code>.</p>
+<p>Values: <code>auto</code> (default), <code>v4</code>, <code>v6</code>, <code>all</code>.</p>
 <p>Other values will produce an error.</p>
 </td>
 </tr>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -4980,7 +4980,11 @@ for addresses in the IPv4 family. If V6 is configured, the DNS resolver
 will only perform a lookup for addresses in the IPv6 family.
 If AUTO is configured, the DNS resolver will first perform a lookup
 for addresses in the IPv6 family and fallback to a lookup for addresses
-in the IPv4 family.
+in the IPv4 family. If ALL is specified, the DNS resolver will perform a lookup for
+both IPv4 and IPv6 families, and return all resolved addresses.
+When this is used, Happy Eyeballs will be enabled for upstream connections.
+Refer to <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling#arch-overview-happy-eyeballs">Happy Eyeballs Support</a> 
+for more information.
 Note: This only applies to externalName clusters.</p>
 <p>See <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily">https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily</a>
 for more information.</p>

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -163,7 +163,7 @@ The cluster configuration block can be used to configure various parameters for 
 
 | Field Name        | Type   | Default | Description                                                                                                                                                             |
 | ----------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dns-lookup-family | string | auto    | This field specifies the dns-lookup-family to use for upstream requests to externalName type Kubernetes services from an HTTPProxy route. Values are: `auto`, `v4, `v6` |
+| dns-lookup-family | string | auto    | This field specifies the dns-lookup-family to use for upstream requests to externalName type Kubernetes services from an HTTPProxy route. Values are: `auto`, `v4`, `v6`, `all` |
 
 ### Network Configuration
 
@@ -367,7 +367,7 @@ data:
     # Envoy cluster settings.
     # cluster:
     #   configure the cluster dns lookup family
-    #   valid options are: auto (default), v4, v6
+    #   valid options are: auto (default), v4, v6, all
     #   dns-lookup-family: auto
     #
     # network:
@@ -469,7 +469,7 @@ connects to Contour:
 | <nobr>--envoy-key-file</nobr>          | ""                | Client key filename for Envoy secure xDS gRPC communication.                                                                                                                                                 |
 | <nobr>--namespace</nobr>               | projectcontour    | Namespace the Envoy container will run, also configured via ENV variable "CONTOUR_NAMESPACE". Namespace is used as part of the metric names on static resources defined in the bootstrap configuration file. |
 | <nobr>--xds-resource-version</nobr>    | v3                | Currently, the only valid xDS API resource version is `v3`.                                                                                                                                                  |
-| <nobr>--dns-lookup-family</nobr>       | auto              | Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6 or auto.                                                                                                   |
+| <nobr>--dns-lookup-family</nobr>       | auto              | Defines what DNS Resolution Policy to use for Envoy -> Contour cluster name lookup. Either v4, v6, auto or all.                                                                                                   |
 | <nobr>--log-format                     | text              | Log output format for Contour. Either text or json. |
 | <nobr>--overload-max-heap              | ""                | Defines the maximum heap size in bytes until Envoy overload manager stops accepting new connections. |
 


### PR DESCRIPTION
Added an `ALL` option which when selected, the DNS resolver returns both IPv4 and IPv6 addresses (if they exist),

Closes #4778 

Signed-off-by: Vishal Choudhary <contactvishaltech@gmail.com>