### PR TITLE
Do not trigger DAG rebuild for irrelevant HTTProutes/TLSroutes

### DIFF
--- a/changelogs/unreleased/4912-fangfpeng-small.md
+++ b/changelogs/unreleased/4912-fangfpeng-small.md
@@ -1,0 +1,1 @@
+For HTTProute/TLSRoute, only if it references the relevant Gateway, it will trigger DAG rebuild.

--- a/changelogs/unreleased/4912-fangfpeng-small.md
+++ b/changelogs/unreleased/4912-fangfpeng-small.md
@@ -1,1 +1,1 @@
-For HTTProute/TLSRoute, only if it references the relevant Gateway, it will trigger DAG rebuild.
+Don't trigger DAG rebuilds/xDS configuration updates for irrelevant HTTPRoutes and TLSRoutes.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -505,13 +505,16 @@ func isRefToSecret(ref gatewayapi_v1beta1.SecretObjectReference, secret *v1.Secr
 
 // routesTriggersRebuild returns true if this route references gateway in this cache.
 func (kc *KubernetesCache) routeTriggersRebuild(parentRefs []gatewayapi_v1beta1.ParentReference) bool {
-	if kc.gateway != nil {
-		for _, parentRef := range parentRefs {
-			if gatewayapi.IsRefToGateway(parentRef, k8s.NamespacedNameOf(kc.gateway)) {
-				return true
-			}
+	if kc.gateway == nil {
+		return false
+	}
+
+	for _, parentRef := range parentRefs {
+		if gatewayapi.IsRefToGateway(parentRef, k8s.NamespacedNameOf(kc.gateway)) {
+			return true
 		}
 	}
+
 	return false
 }
 

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -190,17 +190,15 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 			if kc.routeTriggersRebuild(obj) {
 				kc.httproutes[k8s.NamespacedNameOf(obj)] = obj
 				return true
-			} else {
-				return false
 			}
+			return false
 		case *gatewayapi_v1alpha2.TLSRoute:
 			// No need to add route to cache if it is irrelevant
 			if kc.routeTriggersRebuild(obj) {
 				kc.tlsroutes[k8s.NamespacedNameOf(obj)] = obj
 				return true
-			} else {
-				return false
 			}
+			return false
 		case *gatewayapi_v1beta1.ReferenceGrant:
 			kc.referencegrants[k8s.NamespacedNameOf(obj)] = obj
 			return true

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -1619,30 +1619,16 @@ func TestServiceTriggersRebuild(t *testing.T) {
 		}
 	}
 
-	httpRoute := func(namespace, name, parentRefNamespace, parentRefName string) *gatewayapi_v1beta1.HTTPRoute {
+	httpRoute := func(namespace, name string) *gatewayapi_v1beta1.HTTPRoute {
 		return &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
 			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
-						gatewayapi.GatewayParentRef(parentRefNamespace, parentRefName),
-					},
-				},
 				Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
 					BackendRefs: gatewayapi.HTTPBackendRef(name, 80, 1),
 				}},
-			},
-		}
-	}
-
-	gateway := func(namespace, name string) *gatewayapi_v1beta1.Gateway {
-		return &gatewayapi_v1beta1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
 			},
 		}
 	}
@@ -1723,18 +1709,16 @@ func TestServiceTriggersRebuild(t *testing.T) {
 		},
 		"httproute exists in same namespace as service": {
 			cache: cache(
-				gateway("default", "gateway"),
 				service("default", "service-1"),
-				httpRoute("default", "service-1", "default", "gateway"),
+				httpRoute("default", "service-1"),
 			),
 			svc:  service("default", "service-1"),
 			want: true,
 		},
 		"httproute does not exist in same namespace as service": {
 			cache: cache(
-				gateway("default", "gateway"),
 				service("default", "service-1"),
-				httpRoute("user", "service-1", "default", "gateway"),
+				httpRoute("user", "service-1"),
 			),
 			svc:  service("default", "service-1"),
 			want: false,
@@ -2180,10 +2164,10 @@ func TestRouteTriggersRebuild(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tc.httproute != nil {
-				assert.Equal(t, tc.want, tc.cache.routeTriggersRebuild(tc.httproute))
+				assert.Equal(t, tc.want, tc.cache.routeTriggersRebuild(tc.httproute.Spec.ParentRefs))
 			}
 			if tc.tlsroute != nil {
-				assert.Equal(t, tc.want, tc.cache.routeTriggersRebuild(tc.tlsroute))
+				assert.Equal(t, tc.want, tc.cache.routeTriggersRebuild(tc.tlsroute.Spec.ParentRefs))
 			}
 		})
 	}


### PR DESCRIPTION
For HTTProute/TLSRoute, only if it references the relevant Gateway, it will trigger DAG rebuild.

Closes #4800.

Signed-off-by: fpeng <fpeng@vmware.com>