### PR TITLE
Remove usage of k8s utils package (including pointer* helpers)

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/leadership"
 	"github.com/projectcontour/contour/internal/metrics"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/projectcontour/contour/internal/xds"
 	contour_xds_v3 "github.com/projectcontour/contour/internal/xds/v3"
@@ -54,7 +55,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
 	ctrl_cache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -613,8 +613,8 @@ func (s *Server) setupRateLimitService(contourConfiguration contour_api_v1alpha1
 		SNI:                     sni,
 		Domain:                  contourConfiguration.RateLimitService.Domain,
 		Timeout:                 responseTimeout,
-		FailOpen:                pointer.BoolDeref(contourConfiguration.RateLimitService.FailOpen, false),
-		EnableXRateLimitHeaders: pointer.BoolDeref(contourConfiguration.RateLimitService.EnableXRateLimitHeaders, false),
+		FailOpen:                ref.Val(contourConfiguration.RateLimitService.FailOpen, false),
+		EnableXRateLimitHeaders: ref.Val(contourConfiguration.RateLimitService.EnableXRateLimitHeaders, false),
 	}, nil
 }
 

--- a/cmd/contour/serve_test.go
+++ b/cmd/contour/serve_test.go
@@ -17,13 +17,12 @@ import (
 	"testing"
 
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
-
 	"github.com/projectcontour/contour/internal/dag"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 )
 
 func TestGetDAGBuilder(t *testing.T) {
@@ -97,7 +96,7 @@ func TestGetDAGBuilder(t *testing.T) {
 				},
 				Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 			},
-			ApplyToIngress: pointer.Bool(false),
+			ApplyToIngress: ref.To(false),
 		}
 
 		serve := &Server{
@@ -136,7 +135,7 @@ func TestGetDAGBuilder(t *testing.T) {
 				},
 				Remove: []string{"res-remove-key-1", "res-remove-key-2"},
 			},
-			ApplyToIngress: pointer.Bool(true),
+			ApplyToIngress: ref.To(true),
 		}
 
 		serve := &Server{

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -26,6 +26,7 @@ import (
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/ref"
 	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
 	"github.com/projectcontour/contour/pkg/config"
 
@@ -33,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"k8s.io/utils/pointer"
 )
 
 type serveContext struct {
@@ -160,7 +160,7 @@ func grpcOptions(log logrus.FieldLogger, contourXDSConfig *contour_api_v1alpha1.
 		}),
 	}
 
-	if !pointer.BoolDeref(contourXDSConfig.Insecure, false) {
+	if !ref.Val(contourXDSConfig.Insecure, false) {
 		tlsconfig := tlsconfig(log, contourXDSConfig)
 		creds := credentials.NewTLS(tlsconfig)
 		opts = append(opts, grpc.Creds(creds))
@@ -329,25 +329,25 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 
 	timeoutParams := &contour_api_v1alpha1.TimeoutParameters{}
 	if len(ctx.Config.Timeouts.RequestTimeout) > 0 {
-		timeoutParams.RequestTimeout = pointer.StringPtr(ctx.Config.Timeouts.RequestTimeout)
+		timeoutParams.RequestTimeout = ref.To(ctx.Config.Timeouts.RequestTimeout)
 	}
 	if len(ctx.Config.Timeouts.ConnectionIdleTimeout) > 0 {
-		timeoutParams.ConnectionIdleTimeout = pointer.StringPtr(ctx.Config.Timeouts.ConnectionIdleTimeout)
+		timeoutParams.ConnectionIdleTimeout = ref.To(ctx.Config.Timeouts.ConnectionIdleTimeout)
 	}
 	if len(ctx.Config.Timeouts.StreamIdleTimeout) > 0 {
-		timeoutParams.StreamIdleTimeout = pointer.StringPtr(ctx.Config.Timeouts.StreamIdleTimeout)
+		timeoutParams.StreamIdleTimeout = ref.To(ctx.Config.Timeouts.StreamIdleTimeout)
 	}
 	if len(ctx.Config.Timeouts.MaxConnectionDuration) > 0 {
-		timeoutParams.MaxConnectionDuration = pointer.StringPtr(ctx.Config.Timeouts.MaxConnectionDuration)
+		timeoutParams.MaxConnectionDuration = ref.To(ctx.Config.Timeouts.MaxConnectionDuration)
 	}
 	if len(ctx.Config.Timeouts.DelayedCloseTimeout) > 0 {
-		timeoutParams.DelayedCloseTimeout = pointer.StringPtr(ctx.Config.Timeouts.DelayedCloseTimeout)
+		timeoutParams.DelayedCloseTimeout = ref.To(ctx.Config.Timeouts.DelayedCloseTimeout)
 	}
 	if len(ctx.Config.Timeouts.ConnectionShutdownGracePeriod) > 0 {
-		timeoutParams.ConnectionShutdownGracePeriod = pointer.StringPtr(ctx.Config.Timeouts.ConnectionShutdownGracePeriod)
+		timeoutParams.ConnectionShutdownGracePeriod = ref.To(ctx.Config.Timeouts.ConnectionShutdownGracePeriod)
 	}
 	if len(ctx.Config.Timeouts.ConnectTimeout) > 0 {
-		timeoutParams.ConnectTimeout = pointer.StringPtr(ctx.Config.Timeouts.ConnectTimeout)
+		timeoutParams.ConnectTimeout = ref.To(ctx.Config.Timeouts.ConnectTimeout)
 	}
 
 	var dnsLookupFamily contour_api_v1alpha1.ClusterDNSFamilyType
@@ -370,8 +370,8 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 				Namespace: nsedName.Namespace,
 			},
 			Domain:                  ctx.Config.RateLimitService.Domain,
-			FailOpen:                pointer.Bool(ctx.Config.RateLimitService.FailOpen),
-			EnableXRateLimitHeaders: pointer.Bool(ctx.Config.RateLimitService.EnableXRateLimitHeaders),
+			FailOpen:                ref.To(ctx.Config.RateLimitService.FailOpen),
+			EnableXRateLimitHeaders: ref.To(ctx.Config.RateLimitService.EnableXRateLimitHeaders),
 		}
 	}
 
@@ -384,7 +384,7 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 			Set:    ctx.Config.Policy.ResponseHeadersPolicy.Set,
 			Remove: ctx.Config.Policy.ResponseHeadersPolicy.Remove,
 		},
-		ApplyToIngress: pointer.Bool(ctx.Config.Policy.ApplyToIngress),
+		ApplyToIngress: ref.To(ctx.Config.Policy.ApplyToIngress),
 	}
 
 	var clientCertificate *contour_api_v1alpha1.NamespacedName

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -26,12 +26,12 @@ import (
 
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/tsaarni/certyaml"
-	"k8s.io/utils/pointer"
 
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/contourconfig"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
@@ -93,7 +93,7 @@ func TestServeContextTLSParams(t *testing.T) {
 				CAFile:   "cacert.pem",
 				CertFile: "contourcert.pem",
 				KeyFile:  "contourkey.pem",
-				Insecure: pointer.Bool(false),
+				Insecure: ref.To(false),
 			},
 			expectError: false,
 		},
@@ -101,7 +101,7 @@ func TestServeContextTLSParams(t *testing.T) {
 			tls: &contour_api_v1alpha1.TLS{
 				CertFile: "contourcert.pem",
 				KeyFile:  "contourkey.pem",
-				Insecure: pointer.Bool(false),
+				Insecure: ref.To(false),
 			},
 			expectError: true,
 		},
@@ -191,7 +191,7 @@ func TestServeContextCertificateHandling(t *testing.T) {
 		CAFile:   filepath.Join(configDir, "CAcert.pem"),
 		CertFile: filepath.Join(configDir, "contourcert.pem"),
 		KeyFile:  filepath.Join(configDir, "contourkey.pem"),
-		Insecure: pointer.Bool(false),
+		Insecure: ref.To(false),
 	}
 
 	// Initial set of credentials must be written into temp directory before
@@ -257,7 +257,7 @@ func TestTlsVersionDeprecation(t *testing.T) {
 		CAFile:   filepath.Join(configDir, "CAcert.pem"),
 		CertFile: filepath.Join(configDir, "contourcert.pem"),
 		KeyFile:  filepath.Join(configDir, "contourkey.pem"),
-		Insecure: pointer.Bool(false),
+		Insecure: ref.To(false),
 	}
 
 	err = caCert.WritePEM(contourTLS.CAFile, filepath.Join(configDir, "CAkey.pem"))
@@ -385,7 +385,7 @@ func TestConvertServeContext(t *testing.T) {
 					CAFile:   "/certs/ca.crt",
 					CertFile: "/certs/cert.crt",
 					KeyFile:  "/certs/cert.key",
-					Insecure: pointer.Bool(false),
+					Insecure: ref.To(false),
 				},
 			},
 			Ingress: &contour_api_v1alpha1.IngressConfig{
@@ -406,9 +406,9 @@ func TestConvertServeContext(t *testing.T) {
 					Namespace: "projectcontour",
 				},
 				Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
-					UseProxyProto:             pointer.Bool(false),
-					DisableAllowChunkedLength: pointer.Bool(false),
-					DisableMergeSlashes:       pointer.Bool(false),
+					UseProxyProto:             ref.To(false),
+					DisableAllowChunkedLength: ref.To(false),
+					DisableMergeSlashes:       ref.To(false),
 					TLS: &contour_api_v1alpha1.EnvoyTLS{
 						MinimumProtocolVersion: "",
 					},
@@ -463,28 +463,28 @@ func TestConvertServeContext(t *testing.T) {
 				},
 				DefaultHTTPVersions: nil,
 				Timeouts: &contour_api_v1alpha1.TimeoutParameters{
-					ConnectionIdleTimeout: pointer.StringPtr("60s"),
-					ConnectTimeout:        pointer.StringPtr("2s"),
+					ConnectionIdleTimeout: ref.To("60s"),
+					ConnectTimeout:        ref.To("2s"),
 				},
 				Cluster: &contour_api_v1alpha1.ClusterParameters{
 					DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
 				},
 				Network: &contour_api_v1alpha1.NetworkParameters{
-					EnvoyAdminPort:    pointer.Int(9001),
+					EnvoyAdminPort:    ref.To(9001),
 					XffNumTrustedHops: contourconfig.UInt32Ptr(0),
 				},
 			},
 			Gateway: nil,
 			HTTPProxy: &contour_api_v1alpha1.HTTPProxyConfig{
-				DisablePermitInsecure: pointer.Bool(false),
+				DisablePermitInsecure: ref.To(false),
 				FallbackCertificate:   nil,
 			},
-			EnableExternalNameService: pointer.Bool(false),
+			EnableExternalNameService: ref.To(false),
 			RateLimitService:          nil,
 			Policy: &contour_api_v1alpha1.PolicyConfig{
 				RequestHeadersPolicy:  &contour_api_v1alpha1.HeadersPolicy{},
 				ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{},
-				ApplyToIngress:        pointer.Bool(false),
+				ApplyToIngress:        ref.To(false),
 			},
 			Metrics: &contour_api_v1alpha1.MetricsConfig{
 				Address: "0.0.0.0",
@@ -530,7 +530,7 @@ func TestConvertServeContext(t *testing.T) {
 						Set:    map[string]string{"custom-response-header-set": "foo-bar", "Host": "response-bar.com"},
 						Remove: []string{"custom-response-header-remove"},
 					},
-					ApplyToIngress: pointer.Bool(true),
+					ApplyToIngress: ref.To(true),
 				}
 				return cfg
 			},
@@ -610,7 +610,7 @@ func TestConvertServeContext(t *testing.T) {
 			},
 			getContourConfiguration: func(cfg contour_api_v1alpha1.ContourConfigurationSpec) contour_api_v1alpha1.ContourConfigurationSpec {
 				cfg.HTTPProxy = &contour_api_v1alpha1.HTTPProxyConfig{
-					DisablePermitInsecure: pointer.Bool(true),
+					DisablePermitInsecure: ref.To(true),
 					FallbackCertificate: &contour_api_v1alpha1.NamespacedName{
 						Name:      "fallbackname",
 						Namespace: "fallbacknamespace",
@@ -636,8 +636,8 @@ func TestConvertServeContext(t *testing.T) {
 						Namespace: "ratens",
 					},
 					Domain:                  "contour",
-					FailOpen:                pointer.Bool(true),
-					EnableXRateLimitHeaders: pointer.Bool(true),
+					FailOpen:                ref.To(true),
+					EnableXRateLimitHeaders: ref.To(true),
 				}
 				return cfg
 			},
@@ -681,7 +681,7 @@ func TestConvertServeContext(t *testing.T) {
 				return ctx
 			},
 			getContourConfiguration: func(cfg contour_api_v1alpha1.ContourConfigurationSpec) contour_api_v1alpha1.ContourConfigurationSpec {
-				cfg.Envoy.Listener.DisableMergeSlashes = pointer.Bool(true)
+				cfg.Envoy.Listener.DisableMergeSlashes = ref.To(true)
 				return cfg
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 	k8s.io/klog/v2 v2.80.1
-	k8s.io/utils v0.0.0-20220922133306-665eaaec4324
 	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/controller-tools v0.10.0
 	sigs.k8s.io/gateway-api v0.6.0-rc1
@@ -135,6 +134,7 @@ require (
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803164354-a70c9af30aea // indirect
+	k8s.io/utils v0.0.0-20220922133306-665eaaec4324 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/internal/contourconfig/contourconfiguration.go
+++ b/internal/contourconfig/contourconfiguration.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/imdario/mergo"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/internal/timeout"
-	"k8s.io/utils/pointer"
 )
 
 // UIntPtr returns a pointer to a uint value.
@@ -57,7 +57,7 @@ func Defaults() contour_api_v1alpha1.ContourConfigurationSpec {
 				CAFile:   "/certs/ca.crt",
 				CertFile: "/certs/tls.crt",
 				KeyFile:  "/certs/tls.key",
-				Insecure: pointer.Bool(false),
+				Insecure: ref.To(false),
 			},
 		},
 		Ingress: &contour_api_v1alpha1.IngressConfig{
@@ -74,9 +74,9 @@ func Defaults() contour_api_v1alpha1.ContourConfigurationSpec {
 		},
 		Envoy: &contour_api_v1alpha1.EnvoyConfig{
 			Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
-				UseProxyProto:             pointer.Bool(false),
-				DisableAllowChunkedLength: pointer.Bool(false),
-				DisableMergeSlashes:       pointer.Bool(false),
+				UseProxyProto:             ref.To(false),
+				DisableAllowChunkedLength: ref.To(false),
+				DisableMergeSlashes:       ref.To(false),
 				ConnectionBalancer:        "",
 				TLS: &contour_api_v1alpha1.EnvoyTLS{
 					MinimumProtocolVersion: "1.2",
@@ -131,21 +131,21 @@ func Defaults() contour_api_v1alpha1.ContourConfigurationSpec {
 			},
 			Network: &contour_api_v1alpha1.NetworkParameters{
 				XffNumTrustedHops: UInt32Ptr(0),
-				EnvoyAdminPort:    pointer.Int(9001),
+				EnvoyAdminPort:    ref.To(9001),
 			},
 		},
 		Gateway: nil,
 		HTTPProxy: &contour_api_v1alpha1.HTTPProxyConfig{
-			DisablePermitInsecure: pointer.Bool(false),
+			DisablePermitInsecure: ref.To(false),
 			RootNamespaces:        nil,
 			FallbackCertificate:   nil,
 		},
-		EnableExternalNameService: pointer.Bool(false),
+		EnableExternalNameService: ref.To(false),
 		RateLimitService:          nil,
 		Policy: &contour_api_v1alpha1.PolicyConfig{
 			RequestHeadersPolicy:  &contour_api_v1alpha1.HeadersPolicy{},
 			ResponseHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{},
-			ApplyToIngress:        pointer.Bool(false),
+			ApplyToIngress:        ref.To(false),
 		},
 		Metrics: &contour_api_v1alpha1.MetricsConfig{
 			Address: "0.0.0.0",

--- a/internal/contourconfig/contourconfiguration_test.go
+++ b/internal/contourconfig/contourconfiguration_test.go
@@ -19,10 +19,10 @@ import (
 
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/contourconfig"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/pointer"
 )
 
 func TestOverlayOnDefaults(t *testing.T) {
@@ -35,7 +35,7 @@ func TestOverlayOnDefaults(t *testing.T) {
 				CAFile:   "/foo/ca.crt",
 				CertFile: "/foo/tls.crt",
 				KeyFile:  "/foo/tls.key",
-				Insecure: pointer.Bool(true),
+				Insecure: ref.To(true),
 			},
 		},
 		Ingress: &contour_api_v1alpha1.IngressConfig{
@@ -52,9 +52,9 @@ func TestOverlayOnDefaults(t *testing.T) {
 		},
 		Envoy: &contour_api_v1alpha1.EnvoyConfig{
 			Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
-				UseProxyProto:             pointer.Bool(true),
-				DisableAllowChunkedLength: pointer.Bool(true),
-				DisableMergeSlashes:       pointer.Bool(true),
+				UseProxyProto:             ref.To(true),
+				DisableAllowChunkedLength: ref.To(true),
+				DisableMergeSlashes:       ref.To(true),
 				ConnectionBalancer:        "yesplease",
 				TLS: &contour_api_v1alpha1.EnvoyTLS{
 					MinimumProtocolVersion: "1.7",
@@ -106,20 +106,20 @@ func TestOverlayOnDefaults(t *testing.T) {
 				"HTTP/3",
 			},
 			Timeouts: &contour_api_v1alpha1.TimeoutParameters{
-				RequestTimeout:                pointer.String("1s"),
-				ConnectionIdleTimeout:         pointer.String("2s"),
-				StreamIdleTimeout:             pointer.String("3s"),
-				MaxConnectionDuration:         pointer.String("4s"),
-				DelayedCloseTimeout:           pointer.String("5s"),
-				ConnectionShutdownGracePeriod: pointer.String("6s"),
-				ConnectTimeout:                pointer.String("7s"),
+				RequestTimeout:                ref.To("1s"),
+				ConnectionIdleTimeout:         ref.To("2s"),
+				StreamIdleTimeout:             ref.To("3s"),
+				MaxConnectionDuration:         ref.To("4s"),
+				DelayedCloseTimeout:           ref.To("5s"),
+				ConnectionShutdownGracePeriod: ref.To("6s"),
+				ConnectTimeout:                ref.To("7s"),
 			},
 			Cluster: &contour_api_v1alpha1.ClusterParameters{
 				DNSLookupFamily: contour_api_v1alpha1.IPv4ClusterDNSFamily,
 			},
 			Network: &contour_api_v1alpha1.NetworkParameters{
 				XffNumTrustedHops: contourconfig.UInt32Ptr(77),
-				EnvoyAdminPort:    pointer.Int(9997),
+				EnvoyAdminPort:    ref.To(9997),
 			},
 		},
 		Gateway: &contour_api_v1alpha1.GatewayConfig{
@@ -130,22 +130,22 @@ func TestOverlayOnDefaults(t *testing.T) {
 			},
 		},
 		HTTPProxy: &contour_api_v1alpha1.HTTPProxyConfig{
-			DisablePermitInsecure: pointer.Bool(true),
+			DisablePermitInsecure: ref.To(true),
 			RootNamespaces:        []string{"rootnamespace"},
 			FallbackCertificate: &contour_api_v1alpha1.NamespacedName{
 				Namespace: "fallbackcertificatenamespace",
 				Name:      "fallbackcertificatename",
 			},
 		},
-		EnableExternalNameService: pointer.Bool(true),
+		EnableExternalNameService: ref.To(true),
 		RateLimitService: &contour_api_v1alpha1.RateLimitServiceConfig{
 			ExtensionService: contour_api_v1alpha1.NamespacedName{
 				Namespace: "ratelimitservicenamespace",
 				Name:      "ratelimitservicename",
 			},
 			Domain:                  "ratelimitservicedomain",
-			FailOpen:                pointer.Bool(true),
-			EnableXRateLimitHeaders: pointer.Bool(true),
+			FailOpen:                ref.To(true),
+			EnableXRateLimitHeaders: ref.To(true),
 		},
 		Policy: &contour_api_v1alpha1.PolicyConfig{
 			RequestHeadersPolicy: &contour_api_v1alpha1.HeadersPolicy{
@@ -156,7 +156,7 @@ func TestOverlayOnDefaults(t *testing.T) {
 				Set:    map[string]string{"set": "val"},
 				Remove: []string{"remove"},
 			},
-			ApplyToIngress: pointer.Bool(true),
+			ApplyToIngress: ref.To(true),
 		},
 		Metrics: &contour_api_v1alpha1.MetricsConfig{
 			Address: "9.8.7.6",
@@ -238,13 +238,13 @@ func TestParseTimeoutPolicy(t *testing.T) {
 		},
 		"timeouts all set": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				RequestTimeout:                pointer.String("1s"),
-				ConnectionIdleTimeout:         pointer.String("2s"),
-				StreamIdleTimeout:             pointer.String("3s"),
-				MaxConnectionDuration:         pointer.String("infinity"),
-				DelayedCloseTimeout:           pointer.String("5s"),
-				ConnectionShutdownGracePeriod: pointer.String("6s"),
-				ConnectTimeout:                pointer.String("8s"),
+				RequestTimeout:                ref.To("1s"),
+				ConnectionIdleTimeout:         ref.To("2s"),
+				StreamIdleTimeout:             ref.To("3s"),
+				MaxConnectionDuration:         ref.To("infinity"),
+				DelayedCloseTimeout:           ref.To("5s"),
+				ConnectionShutdownGracePeriod: ref.To("6s"),
+				ConnectTimeout:                ref.To("8s"),
 			},
 			expected: contourconfig.Timeouts{
 				Request:                       timeout.DurationSetting(time.Second),
@@ -258,43 +258,43 @@ func TestParseTimeoutPolicy(t *testing.T) {
 		},
 		"request timeout invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				RequestTimeout: pointer.String("xxx"),
+				RequestTimeout: ref.To("xxx"),
 			},
 			errorMsg: "failed to parse request timeout",
 		},
 		"connection idle timeout invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				ConnectionIdleTimeout: pointer.String("a"),
+				ConnectionIdleTimeout: ref.To("a"),
 			},
 			errorMsg: "failed to parse connection idle timeout",
 		},
 		"stream idle timeout invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				StreamIdleTimeout: pointer.String("invalid"),
+				StreamIdleTimeout: ref.To("invalid"),
 			},
 			errorMsg: "failed to parse stream idle timeout",
 		},
 		"max connection duration invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				MaxConnectionDuration: pointer.String("xxx"),
+				MaxConnectionDuration: ref.To("xxx"),
 			},
 			errorMsg: "failed to parse max connection duration",
 		},
 		"delayed close timeout invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				DelayedCloseTimeout: pointer.String("xxx"),
+				DelayedCloseTimeout: ref.To("xxx"),
 			},
 			errorMsg: "failed to parse delayed close timeout",
 		},
 		"connection shutdown grace period invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				ConnectionShutdownGracePeriod: pointer.String("xxx"),
+				ConnectionShutdownGracePeriod: ref.To("xxx"),
 			},
 			errorMsg: "failed to parse connection shutdown grace period",
 		},
 		"connect timeout invalid": {
 			config: &contour_api_v1alpha1.TimeoutParameters{
-				ConnectTimeout: pointer.String("infinite"),
+				ConnectTimeout: ref.To("infinite"),
 			},
 			errorMsg: "failed to parse connect timeout",
 		},

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -1451,7 +1450,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1490,7 +1489,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1543,7 +1542,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1597,7 +1596,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1652,7 +1651,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1707,7 +1706,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1762,7 +1761,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							}},
 						}},
@@ -1851,17 +1850,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 							}, {
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/blog"),
+									Value: ref.To("/blog"),
 								},
 							}, {
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/tech"),
+									Value: ref.To("/tech"),
 								},
 							}},
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -2502,7 +2501,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1beta1.HeaderMatchExact, "foo", "bar"),
 							}},
@@ -2550,12 +2549,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									{
 										Path: &gatewayapi_v1beta1.HTTPPathMatch{
 											Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-											Value: pointer.StringPtr("/blog"),
+											Value: ref.To("/blog"),
 										},
 									}, {
 										Path: &gatewayapi_v1beta1.HTTPPathMatch{
 											Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-											Value: pointer.StringPtr("/tech"),
+											Value: ref.To("/tech"),
 										},
 										Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1beta1.HeaderMatchExact, "foo", "bar"),
 									},
@@ -2696,7 +2695,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 								Method: ref.To(gatewayapi_v1beta1.HTTPMethodGet),
 							}},
@@ -2742,7 +2741,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
@@ -2793,7 +2792,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
@@ -2845,7 +2844,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 									{
@@ -3068,7 +3067,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								{
 									BackendRef: gatewayapi_v1beta1.BackendRef{
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-										Weight:                 pointer.Int32(1),
+										Weight:                 ref.To(int32(1)),
 									},
 									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 										{
@@ -3141,7 +3140,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								{
 									BackendRef: gatewayapi_v1beta1.BackendRef{
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-										Weight:                 pointer.Int32(1),
+										Weight:                 ref.To(int32(1)),
 									},
 									Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
 										{
@@ -3270,7 +3269,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									{
 										BackendRef: gatewayapi_v1beta1.BackendRef{
 											BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-											Weight:                 pointer.Int32(1),
+											Weight:                 ref.To(int32(1)),
 										},
 										Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
 											Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
@@ -3327,7 +3326,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									{
 										BackendRef: gatewayapi_v1beta1.BackendRef{
 											BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-											Weight:                 pointer.Int32(1),
+											Weight:                 ref.To(int32(1)),
 										},
 										Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
 											Type: gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier,
@@ -3382,10 +3381,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
 								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
 								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Scheme:     pointer.String("https"),
+									Scheme:     ref.To("https"),
 									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
 									Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
-									StatusCode: pointer.Int(301),
+									StatusCode: ref.To(301),
 								},
 							}},
 						}},
@@ -3435,10 +3434,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
 								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
 								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Scheme:     pointer.String("https"),
+									Scheme:     ref.To("https"),
 									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
 									Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
-									StatusCode: pointer.Int(301),
+									StatusCode: ref.To(301),
 								},
 							}},
 						}},
@@ -3813,7 +3812,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -3877,7 +3876,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -3942,7 +3941,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -3991,7 +3990,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -4040,7 +4039,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -4089,7 +4088,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						}},
@@ -4328,9 +4327,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
 							BackendRefs: gatewayapi.TLSRouteBackendRefs(
-								gatewayapi.TLSRouteBackendRef("kuard", 8080, pointer.Int32Ptr(1)),
-								gatewayapi.TLSRouteBackendRef("kuard2", 8080, pointer.Int32Ptr(2)),
-								gatewayapi.TLSRouteBackendRef("kuard3", 8080, pointer.Int32Ptr(3)),
+								gatewayapi.TLSRouteBackendRef("kuard", 8080, ref.To(int32(1))),
+								gatewayapi.TLSRouteBackendRef("kuard2", 8080, ref.To(int32(2))),
+								gatewayapi.TLSRouteBackendRef("kuard3", 8080, ref.To(int32(3))),
 							),
 						}},
 					},
@@ -4377,9 +4376,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						Hostnames: []gatewayapi_v1alpha2.Hostname{"tcp.projectcontour.io"},
 						Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
 							BackendRefs: gatewayapi.TLSRouteBackendRefs(
-								gatewayapi.TLSRouteBackendRef("kuard", 8080, pointer.Int32Ptr(1)),
-								gatewayapi.TLSRouteBackendRef("kuard2", 8080, pointer.Int32Ptr(0)),
-								gatewayapi.TLSRouteBackendRef("kuard3", 8080, pointer.Int32Ptr(3)),
+								gatewayapi.TLSRouteBackendRef("kuard", 8080, ref.To(int32(1))),
+								gatewayapi.TLSRouteBackendRef("kuard2", 8080, ref.To(int32(0))),
+								gatewayapi.TLSRouteBackendRef("kuard3", 8080, ref.To(int32(3))),
 							),
 						}},
 					},
@@ -5327,37 +5326,37 @@ func TestDAGInsert(t *testing.T) {
 					HTTP: &networking_v1.HTTPIngressRuleValue{
 						Paths: []networking_v1.HTTPIngressPath{
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("Exact")),
+								PathType: (*networking_v1.PathType)(ref.To("Exact")),
 								Path:     "/exact",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("Exact")),
+								PathType: (*networking_v1.PathType)(ref.To("Exact")),
 								Path:     "/exact_with_regex/.*",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("Prefix")),
+								PathType: (*networking_v1.PathType)(ref.To("Prefix")),
 								Path:     "/prefix",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("Prefix")),
+								PathType: (*networking_v1.PathType)(ref.To("Prefix")),
 								Path:     "/prefix_trailing_slash/",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("Prefix")),
+								PathType: (*networking_v1.PathType)(ref.To("Prefix")),
 								Path:     "/prefix_with_regex/.*",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("ImplementationSpecific")),
+								PathType: (*networking_v1.PathType)(ref.To("ImplementationSpecific")),
 								Path:     "/implementation_specific",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
 							{
-								PathType: (*networking_v1.PathType)(pointer.StringPtr("ImplementationSpecific")),
+								PathType: (*networking_v1.PathType)(ref.To("ImplementationSpecific")),
 								Path:     "/implementation_specific_with_regex/.*",
 								Backend:  *backendv1("kuard", intstr.FromString("http")),
 							},
@@ -7975,13 +7974,13 @@ func TestDAGInsert(t *testing.T) {
 						DomainRewrite: &contour_api_v1.CookieDomainRewrite{
 							Value: "example.com",
 						},
-						Secure:   pointer.Bool(true),
-						SameSite: pointer.String("Strict"),
+						Secure:   ref.To(true),
+						SameSite: ref.To("Strict"),
 					},
 					{
 						Name:     "some-other-cookie",
-						SameSite: pointer.String("Lax"),
-						Secure:   pointer.Bool(false),
+						SameSite: ref.To("Lax"),
+						Secure:   ref.To(false),
 					},
 				},
 				Services: []contour_api_v1.Service{{
@@ -8017,12 +8016,12 @@ func TestDAGInsert(t *testing.T) {
 							DomainRewrite: &contour_api_v1.CookieDomainRewrite{
 								Value: "example.com",
 							},
-							Secure:   pointer.Bool(true),
-							SameSite: pointer.String("Strict"),
+							Secure:   ref.To(true),
+							SameSite: ref.To("Strict"),
 						},
 						{
 							Name:     "some-other-cookie",
-							SameSite: pointer.String("Lax"),
+							SameSite: ref.To("Lax"),
 						},
 					},
 				}},
@@ -8046,11 +8045,11 @@ func TestDAGInsert(t *testing.T) {
 				CookieRewritePolicies: []contour_api_v1.CookieRewritePolicy{
 					{
 						Name:   "some-cookie",
-						Secure: pointer.Bool(true),
+						Secure: ref.To(true),
 					},
 					{
 						Name:     "some-cookie",
-						SameSite: pointer.String("Lax"),
+						SameSite: ref.To("Lax"),
 					},
 				},
 				Services: []contour_api_v1.Service{{
@@ -8080,11 +8079,11 @@ func TestDAGInsert(t *testing.T) {
 					CookieRewritePolicies: []contour_api_v1.CookieRewritePolicy{
 						{
 							Name:   "some-cookie",
-							Secure: pointer.Bool(true),
+							Secure: ref.To(true),
 						},
 						{
 							Name:     "some-cookie",
-							SameSite: pointer.String("Lax"),
+							SameSite: ref.To("Lax"),
 						},
 					},
 				}},
@@ -8223,7 +8222,7 @@ func TestDAGInsert(t *testing.T) {
 				Services: []contour_api_v1.Service{{
 					Name:     s14.GetName(),
 					Port:     80,
-					Protocol: pointer.StringPtr("tls"),
+					Protocol: ref.To("tls"),
 				}},
 			},
 		},
@@ -10988,10 +10987,10 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 							}},
 							RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-								Scheme:     pointer.StringPtr("https"),
-								Hostname:   pointer.StringPtr("envoyproxy.io"),
-								Port:       pointer.Int32Ptr(443),
-								StatusCode: pointer.Int(301),
+								Scheme:     ref.To("https"),
+								Hostname:   ref.To("envoyproxy.io"),
+								Port:       ref.To(int32(443)),
+								StatusCode: ref.To(301),
 							},
 						}},
 					},
@@ -11031,10 +11030,10 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/",
 							}},
 							RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-								Scheme:     pointer.StringPtr("https"),
-								Hostname:   pointer.StringPtr("envoyproxy.io"),
-								Port:       pointer.Int32Ptr(443),
-								StatusCode: pointer.Int(301),
+								Scheme:     ref.To("https"),
+								Hostname:   ref.To("envoyproxy.io"),
+								Port:       ref.To(int32(443)),
+								StatusCode: ref.To(301),
 							},
 						}},
 					},
@@ -11083,10 +11082,10 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/blog",
 							}},
 							RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-								Scheme:     pointer.StringPtr("https"),
-								Hostname:   pointer.StringPtr("envoyproxy.io"),
-								Port:       pointer.Int32Ptr(443),
-								StatusCode: pointer.Int(301),
+								Scheme:     ref.To("https"),
+								Hostname:   ref.To("envoyproxy.io"),
+								Port:       ref.To(int32(443)),
+								StatusCode: ref.To(301),
 							},
 						}},
 					},
@@ -11235,10 +11234,10 @@ func TestDAGInsert(t *testing.T) {
 								Prefix: "/redirect",
 							}},
 							RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-								Scheme:     pointer.StringPtr("https"),
-								Hostname:   pointer.StringPtr("envoyproxy.io"),
-								Port:       pointer.Int32Ptr(443),
-								StatusCode: pointer.Int(301),
+								Scheme:     ref.To("https"),
+								Hostname:   ref.To("envoyproxy.io"),
+								Port:       ref.To(int32(443)),
+								StatusCode: ref.To(301),
 							},
 						},
 						},
@@ -11637,14 +11636,14 @@ func TestDAGInsert(t *testing.T) {
 							CookieRewritePolicies: []CookieRewritePolicy{
 								{
 									Name:     "some-cookie",
-									Path:     pointer.String("/foo"),
-									Domain:   pointer.String("example.com"),
+									Path:     ref.To("/foo"),
+									Domain:   ref.To("example.com"),
 									Secure:   2,
-									SameSite: pointer.String("Strict"),
+									SameSite: ref.To("Strict"),
 								},
 								{
 									Name:     "some-other-cookie",
-									SameSite: pointer.String("Lax"),
+									SameSite: ref.To("Lax"),
 									Secure:   1,
 								},
 							},
@@ -11671,14 +11670,14 @@ func TestDAGInsert(t *testing.T) {
 									CookieRewritePolicies: []CookieRewritePolicy{
 										{
 											Name:     "some-cookie",
-											Path:     pointer.String("/foo"),
-											Domain:   pointer.String("example.com"),
+											Path:     ref.To("/foo"),
+											Domain:   ref.To("example.com"),
 											Secure:   2,
-											SameSite: pointer.String("Strict"),
+											SameSite: ref.To("Strict"),
 										},
 										{
 											Name:     "some-other-cookie",
-											SameSite: pointer.String("Lax"),
+											SameSite: ref.To("Lax"),
 										},
 									},
 								},

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectcontour/contour/internal/annotation"
 	"github.com/projectcontour/contour/internal/ingressclass"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -118,7 +118,7 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 					WithField("namespace", obj.GetNamespace()).
 					WithField("kind", k8s.KindOf(obj)).
 					WithField("ingress-class-annotation", annotation.IngressClass(obj)).
-					WithField("ingress-class-name", pointer.StringPtrDerefOr(obj.Spec.IngressClassName, "")).
+					WithField("ingress-class-name", ref.Val(obj.Spec.IngressClassName, "")).
 					WithField("target-ingress-classes", kc.IngressClassNames).
 					Debug("ignoring Ingress with unmatched ingress class")
 				return false

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ingressclass"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -30,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -371,7 +371,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: networking_v1.IngressSpec{
-					IngressClassName: pointer.StringPtr("nginx"),
+					IngressClassName: ref.To("nginx"),
 				},
 			},
 			want: false,
@@ -383,7 +383,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: networking_v1.IngressSpec{
-					IngressClassName: pointer.StringPtr("contour"),
+					IngressClassName: ref.To("contour"),
 				},
 			},
 			want: true,
@@ -472,7 +472,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					},
 				},
 				Spec: networking_v1.IngressSpec{
-					IngressClassName: pointer.StringPtr("contour"),
+					IngressClassName: ref.To("contour"),
 				},
 			},
 			want: false,
@@ -487,7 +487,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 					},
 				},
 				Spec: networking_v1.IngressSpec{
-					IngressClassName: pointer.StringPtr("nginx"),
+					IngressClassName: ref.To("nginx"),
 				},
 			},
 			want: true,

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/internal/status"
 
 	"github.com/sirupsen/logrus"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -1246,7 +1246,7 @@ func gatewayPathMatchCondition(match *gatewayapi_v1beta1.HTTPPathMatch, routeAcc
 		return &PrefixMatchCondition{Prefix: "/"}, true
 	}
 
-	path := pointer.StringDeref(match.Value, "/")
+	path := ref.Val(match.Value, "/")
 
 	// If path match type is not defined, default to 'PathPrefix'.
 	if match.Type == nil || *match.Type == gatewayapi_v1beta1.PathMatchPathPrefix {

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/internal/timeout"
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -332,12 +332,12 @@ func cookieRewritePolicies(policies []contour_api_v1.CookieRewritePolicy) ([]Coo
 		var path *string
 		if p.PathRewrite != nil {
 			policiesSet++
-			path = pointer.String(p.PathRewrite.Value)
+			path = ref.To(p.PathRewrite.Value)
 		}
 		var domain *string
 		if p.DomainRewrite != nil {
 			policiesSet++
-			domain = pointer.String(p.DomainRewrite.Value)
+			domain = ref.To(p.DomainRewrite.Value)
 		}
 		// We use a uint here since a pointer to bool cannot be
 		// distingiuished when unset or false in golang text templates.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -2334,11 +2333,11 @@ func TestDAGStatus(t *testing.T) {
 				CookieRewritePolicies: []contour_api_v1.CookieRewritePolicy{
 					{
 						Name:   "a-cookie",
-						Secure: pointer.Bool(true),
+						Secure: ref.To(true),
 					},
 					{
 						Name:     "a-cookie",
-						SameSite: pointer.String("Lax"),
+						SameSite: ref.To("Lax"),
 					},
 				},
 			}},
@@ -2370,11 +2369,11 @@ func TestDAGStatus(t *testing.T) {
 						CookieRewritePolicies: []contour_api_v1.CookieRewritePolicy{
 							{
 								Name:   "a-cookie",
-								Secure: pointer.Bool(true),
+								Secure: ref.To(true),
 							},
 							{
 								Name:     "a-cookie",
-								SameSite: pointer.String("Lax"),
+								SameSite: ref.To("Lax"),
 							},
 						},
 					},
@@ -4036,7 +4035,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
 										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 									},
-									Weight: pointer.Int32(1),
+									Weight: ref.To(int32(1)),
 								},
 							},
 						},
@@ -4158,7 +4157,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("doesnt-start-with-slash"),
+								Value: ref.To("doesnt-start-with-slash"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -4212,7 +4211,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchExact),
-								Value: pointer.StringPtr("doesnt-start-with-slash"),
+								Value: ref.To("doesnt-start-with-slash"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -4266,7 +4265,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/foo///bar"),
+								Value: ref.To("/foo///bar"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -4320,7 +4319,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchExact),
-								Value: pointer.StringPtr("//foo/bar"),
+								Value: ref.To("//foo/bar"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -4374,7 +4373,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchType("UNKNOWN")), // <---- unknown type to break the test
-								Value: pointer.StringPtr("/"),
+								Value: ref.To("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -4477,7 +4476,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/"),
+								Value: ref.To("/"),
 							},
 							Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
 								{
@@ -4535,7 +4534,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/"),
+								Value: ref.To("/"),
 							},
 							QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
 								{
@@ -4654,7 +4653,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/"),
+								Value: ref.To("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("invalid-one", 8080, 1),
@@ -4662,7 +4661,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/blog"),
+								Value: ref.To("/blog"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("invalid-two", 8080, 1),
@@ -6102,7 +6101,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/"),
+								Value: ref.To("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -6117,7 +6116,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
 							Path: &gatewayapi_v1beta1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-								Value: pointer.StringPtr("/blog"),
+								Value: ref.To("/blog"),
 							},
 						}},
 						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
@@ -7898,7 +7897,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 					Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 					Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
-						BackendRefs: gatewayapi.TLSRouteBackendRef(kuardService.Name, 8080, pointer.Int32(0)),
+						BackendRefs: gatewayapi.TLSRouteBackendRef(kuardService.Name, 8080, ref.To(int32(0))),
 					}},
 				},
 			}},

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -24,12 +24,12 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 )
 
 func proxyClientCertificateOpt(t *testing.T) func(*dag.Builder) {
@@ -109,7 +109,7 @@ func TestBackendClientAuthenticationWithHTTPProxy(t *testing.T) {
 				Services: []projcontour.Service{{
 					Name:     svc.Name,
 					Port:     443,
-					Protocol: pointer.StringPtr("tls"),
+					Protocol: ref.To("tls"),
 					UpstreamValidation: &projcontour.UpstreamValidation{
 						CACertificate: sec2.Name,
 						SubjectName:   "subjname",

--- a/internal/featuretests/v3/extensionservice_test.go
+++ b/internal/featuretests/v3/extensionservice_test.go
@@ -29,10 +29,10 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/ref"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
 )
 
 func extBasic(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
@@ -81,7 +81,7 @@ func extCleartext(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
 	rh.OnAdd(&v1alpha1.ExtensionService{
 		ObjectMeta: fixture.ObjectMeta("ns/ext"),
 		Spec: v1alpha1.ExtensionServiceSpec{
-			Protocol: pointer.StringPtr("h2c"),
+			Protocol: ref.To("h2c"),
 			Services: []v1alpha1.ExtensionServiceTarget{
 				{Name: "svc1", Port: 8081},
 				{Name: "svc2", Port: 8082},
@@ -325,7 +325,7 @@ func extInconsistentProto(_ *testing.T, rh cache.ResourceEventHandler, c *Contou
 			Services: []v1alpha1.ExtensionServiceTarget{
 				{Name: "svc1", Port: 8081},
 			},
-			Protocol: pointer.StringPtr("h2c"),
+			Protocol: ref.To("h2c"),
 			UpstreamValidation: &contour_api_v1.UpstreamValidation{
 				CACertificate: "cacert",
 				SubjectName:   "ext.projectcontour.io",

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/featuretests"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/sirupsen/logrus"
 
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -33,7 +34,6 @@ import (
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 // Assert that services of type v1.ServiceTypeExternalName can be
@@ -172,7 +172,7 @@ func TestExternalNameService(t *testing.T) {
 		WithSpec(contour_api_v1.HTTPProxySpec{
 			Routes: []contour_api_v1.Route{{
 				Services: []contour_api_v1.Service{{
-					Protocol: pointer.StringPtr("h2"),
+					Protocol: ref.To("h2"),
 					Name:     s1.Name,
 					Port:     80,
 				}},
@@ -236,7 +236,7 @@ func TestExternalNameService(t *testing.T) {
 		WithSpec(contour_api_v1.HTTPProxySpec{
 			Routes: []contour_api_v1.Route{{
 				Services: []contour_api_v1.Service{{
-					Protocol: pointer.StringPtr("tls"),
+					Protocol: ref.To("tls"),
 					Name:     s1.Name,
 					Port:     80,
 				}},
@@ -297,7 +297,7 @@ func TestExternalNameService(t *testing.T) {
 		WithSpec(contour_api_v1.HTTPProxySpec{
 			TCPProxy: &contour_api_v1.TCPProxy{
 				Services: []contour_api_v1.Service{{
-					Protocol: pointer.StringPtr("tls"),
+					Protocol: ref.To("tls"),
 					Name:     s1.Name,
 					Port:     80,
 				}},

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -24,11 +24,11 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/ref"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -595,7 +595,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: networking_v1.IngressSpec{
-				IngressClassName: pointer.StringPtr("testingressclass"),
+				IngressClassName: ref.To("testingressclass"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
 			},
 		}
@@ -623,7 +623,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: networking_v1.IngressSpec{
-				IngressClassName: pointer.StringPtr("wrongingressclass"),
+				IngressClassName: ref.To("wrongingressclass"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
 			},
 		}
@@ -853,7 +853,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: networking_v1.IngressSpec{
-				IngressClassName: pointer.StringPtr("contour"),
+				IngressClassName: ref.To("contour"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
 			},
 		}
@@ -881,7 +881,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 				Namespace: Namespace,
 			},
 			Spec: networking_v1.IngressSpec{
-				IngressClassName: pointer.StringPtr("notcontour"),
+				IngressClassName: ref.To("notcontour"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
 			},
 		}

--- a/internal/featuretests/v3/redirectroutepolicy_test.go
+++ b/internal/featuretests/v3/redirectroutepolicy_test.go
@@ -16,13 +16,12 @@ package v3
 import (
 	"testing"
 
-	"k8s.io/utils/pointer"
-
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/ref"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -40,11 +39,11 @@ func TestRedirectResponsePolicy_HTTProxy(t *testing.T) {
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
 			Routes: []contour_api_v1.Route{{
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Scheme:     pointer.StringPtr("https"),
-					Hostname:   pointer.StringPtr("envoyproxy.io"),
-					Port:       pointer.Int32Ptr(443),
-					StatusCode: pointer.IntPtr(301),
-					Path:       pointer.StringPtr("/blog"),
+					Scheme:     ref.To("https"),
+					Hostname:   ref.To("envoyproxy.io"),
+					Port:       ref.To(int32(443)),
+					StatusCode: ref.To(301),
+					Path:       ref.To("/blog"),
 				},
 			}},
 		})
@@ -84,11 +83,11 @@ func TestRedirectResponsePolicy_HTTProxy(t *testing.T) {
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "hello.world"},
 			Routes: []contour_api_v1.Route{{
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Scheme:     pointer.StringPtr("https"),
-					Hostname:   pointer.StringPtr("envoyproxy.io"),
-					Port:       pointer.Int32Ptr(443),
-					StatusCode: pointer.IntPtr(301),
-					Prefix:     pointer.StringPtr("/blogprefix"),
+					Scheme:     ref.To("https"),
+					Hostname:   ref.To("envoyproxy.io"),
+					Port:       ref.To(int32(443)),
+					StatusCode: ref.To(301),
+					Prefix:     ref.To("/blogprefix"),
 				},
 			}},
 		})
@@ -132,12 +131,12 @@ func TestRedirectResponsePolicy_HTTProxy(t *testing.T) {
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Scheme:     pointer.StringPtr("https"),
-					Hostname:   pointer.StringPtr("envoyproxy.io"),
-					Port:       pointer.Int32Ptr(443),
-					StatusCode: pointer.IntPtr(301),
-					Prefix:     pointer.StringPtr("/blogprefix"),
-					Path:       pointer.StringPtr("/blogprefix"),
+					Scheme:     ref.To("https"),
+					Hostname:   ref.To("envoyproxy.io"),
+					Port:       ref.To(int32(443)),
+					StatusCode: ref.To(301),
+					Prefix:     ref.To("/blogprefix"),
+					Path:       ref.To("/blogprefix"),
 				},
 			}},
 		})

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -540,7 +539,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 			},
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
-				BackendRefs: gatewayapi.TLSRouteBackendRef("svc1", 443, pointer.Int32(1)),
+				BackendRefs: gatewayapi.TLSRouteBackendRef("svc1", 443, ref.To(int32(1))),
 			}},
 		},
 	}
@@ -597,8 +596,8 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 			Hostnames: []gatewayapi_v1alpha2.Hostname{"test.projectcontour.io"},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
 				BackendRefs: gatewayapi.TLSRouteBackendRefs(
-					gatewayapi.TLSRouteBackendRef("svc1", 443, pointer.Int32(1)),
-					gatewayapi.TLSRouteBackendRef("svc2", 443, pointer.Int32(7)),
+					gatewayapi.TLSRouteBackendRef("svc1", 443, ref.To(int32(1))),
+					gatewayapi.TLSRouteBackendRef("svc2", 443, ref.To(int32(7))),
 				),
 			}},
 		},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -16,7 +16,6 @@ package gatewayapi
 import (
 	"github.com/projectcontour/contour/internal/ref"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -73,7 +72,7 @@ func HTTPRouteMatch(pathType gatewayapi_v1beta1.PathMatchType, value string) []g
 		{
 			Path: &gatewayapi_v1beta1.HTTPPathMatch{
 				Type:  ref.To(pathType),
-				Value: pointer.StringPtr(value),
+				Value: ref.To(value),
 			},
 		},
 	}

--- a/internal/ingressclass/ingressclass.go
+++ b/internal/ingressclass/ingressclass.go
@@ -16,8 +16,8 @@ package ingressclass
 import (
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
+	"github.com/projectcontour/contour/internal/ref"
 	networking_v1 "k8s.io/api/networking/v1"
-	"k8s.io/utils/pointer"
 )
 
 // DefaultClassName is the default IngressClass name that Contour will match
@@ -33,7 +33,7 @@ func MatchesIngress(obj *networking_v1.Ingress, ingressClassNames []string) bool
 		return matches(annotationClass, ingressClassNames)
 	}
 
-	return matches(pointer.StringPtrDerefOr(obj.Spec.IngressClassName, ""), ingressClassNames)
+	return matches(ref.Val(obj.Spec.IngressClassName, ""), ingressClassNames)
 }
 
 // MatchesHTTPProxy returns true if the passed in HTTPProxy annotations

--- a/internal/ingressclass/ingressclass_test.go
+++ b/internal/ingressclass/ingressclass_test.go
@@ -17,10 +17,10 @@ import (
 	"testing"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/stretchr/testify/assert"
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestMatchesIngress(t *testing.T) {
@@ -37,7 +37,7 @@ func TestMatchesIngress(t *testing.T) {
 	// No annotation set, spec field set to default, class not configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("contour"),
+			IngressClassName: ref.To("contour"),
 		},
 	}, nil))
 	// Annotation set, no spec field set, class not configured
@@ -51,7 +51,7 @@ func TestMatchesIngress(t *testing.T) {
 	// No annotation set, spec field set, class not configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("aclass"),
+			IngressClassName: ref.To("aclass"),
 		},
 	}, nil))
 	// No annotation, no spec field set, class configured
@@ -67,7 +67,7 @@ func TestMatchesIngress(t *testing.T) {
 	// No annotation set, spec field set, class configured
 	assert.True(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("something"),
+			IngressClassName: ref.To("something"),
 		},
 	}, []string{"something"}))
 	// Annotation set, no spec field set, class configured
@@ -81,7 +81,7 @@ func TestMatchesIngress(t *testing.T) {
 	// No annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("aclass"),
+			IngressClassName: ref.To("aclass"),
 		},
 	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
@@ -92,7 +92,7 @@ func TestMatchesIngress(t *testing.T) {
 			},
 		},
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("aclass"),
+			IngressClassName: ref.To("aclass"),
 		},
 	}, []string{"something"}))
 	// Annotation set, spec field set, class configured
@@ -103,7 +103,7 @@ func TestMatchesIngress(t *testing.T) {
 			},
 		},
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("something"),
+			IngressClassName: ref.To("something"),
 		},
 	}, []string{"something"}))
 	// Multiple classes: Annotation set, no spec field set, class configured
@@ -117,7 +117,7 @@ func TestMatchesIngress(t *testing.T) {
 	// Multiple classes: No annotation set, spec field set, class configured
 	assert.False(t, MatchesIngress(&networking_v1.Ingress{
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("aclass"),
+			IngressClassName: ref.To("aclass"),
 		},
 	}, []string{"something", "somethingelse"}))
 	// Multiple classes: Annotation set, spec field set, class configured
@@ -128,7 +128,7 @@ func TestMatchesIngress(t *testing.T) {
 			},
 		},
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("aclass"),
+			IngressClassName: ref.To("aclass"),
 		},
 	}, []string{"somethingelse", "something"}))
 	// Multiple classes: Annotation set, spec field set, class configured
@@ -139,7 +139,7 @@ func TestMatchesIngress(t *testing.T) {
 			},
 		},
 		Spec: networking_v1.IngressSpec{
-			IngressClassName: pointer.StringPtr("something"),
+			IngressClassName: ref.To("something"),
 		},
 	}, []string{"something", "somethingelse"}))
 }

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -27,7 +27,6 @@ import (
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -86,7 +85,7 @@ func (s *StatusAddressUpdater) OnAdd(obj interface{}) {
 	switch o := obj.(type) {
 	case *networking_v1.Ingress:
 		if !ingressclass.MatchesIngress(o, s.IngressClassNames) {
-			logNoMatch(s.Logger.WithField("ingress-class-name", pointer.StringPtrDerefOr(o.Spec.IngressClassName, "")), o)
+			logNoMatch(s.Logger.WithField("ingress-class-name", ref.Val(o.Spec.IngressClassName, "")), o)
 			return
 		}
 

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -28,7 +28,6 @@ import (
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -660,7 +659,7 @@ func simpleIngressGenerator(name, ingressClassAnnotation, ingressClassSpec strin
 	}
 	var ingressClassName *string
 	if ingressClassSpec != "" {
-		ingressClassName = pointer.StringPtr(ingressClassSpec)
+		ingressClassName = ref.To(ingressClassSpec)
 	}
 	return &networking_v1.Ingress{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -351,10 +350,10 @@ func TestGatewayReconcile(t *testing.T) {
 				},
 				Spec: contourv1alpha1.ContourDeploymentSpec{
 					RuntimeSettings: &contourv1alpha1.ContourConfigurationSpec{
-						EnableExternalNameService: pointer.Bool(true),
+						EnableExternalNameService: ref.To(true),
 						Envoy: &contourv1alpha1.EnvoyConfig{
 							Listener: &contourv1alpha1.EnvoyListenerConfig{
-								DisableMergeSlashes: pointer.Bool(true),
+								DisableMergeSlashes: ref.To(true),
 							},
 						},
 					},
@@ -388,7 +387,7 @@ func TestGatewayReconcile(t *testing.T) {
 				require.NoError(t, r.client.Get(context.Background(), keyFor(contourConfig), contourConfig))
 
 				want := contourv1alpha1.ContourConfigurationSpec{
-					EnableExternalNameService: pointer.Bool(true),
+					EnableExternalNameService: ref.To(true),
 					Gateway: &contourv1alpha1.GatewayConfig{
 						GatewayRef: &contourv1alpha1.NamespacedName{
 							Namespace: gw.Name,
@@ -397,7 +396,7 @@ func TestGatewayReconcile(t *testing.T) {
 					},
 					Envoy: &contourv1alpha1.EnvoyConfig{
 						Listener: &contourv1alpha1.EnvoyListenerConfig{
-							DisableMergeSlashes: pointer.Bool(true),
+							DisableMergeSlashes: ref.To(true),
 						},
 						Service: &contourv1alpha1.NamespacedName{
 							Namespace: gw.Namespace,
@@ -488,10 +487,10 @@ func TestGatewayReconcile(t *testing.T) {
 				},
 				Spec: contourv1alpha1.ContourDeploymentSpec{
 					RuntimeSettings: &contourv1alpha1.ContourConfigurationSpec{
-						EnableExternalNameService: pointer.Bool(true),
+						EnableExternalNameService: ref.To(true),
 						Envoy: &contourv1alpha1.EnvoyConfig{
 							Listener: &contourv1alpha1.EnvoyListenerConfig{
-								DisableMergeSlashes: pointer.Bool(true),
+								DisableMergeSlashes: ref.To(true),
 							},
 						},
 					},

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -16,12 +16,12 @@ package model
 import (
 	contourv1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	opintstr "github.com/projectcontour/contour/internal/provisioner/intstr"
+	"github.com/projectcontour/contour/internal/ref"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -649,7 +649,7 @@ func MakeNodePorts(ports map[string]int) []NodePort {
 	for k, v := range ports {
 		p := NodePort{
 			Name:       k,
-			PortNumber: pointer.Int32Ptr(int32(v)),
+			PortNumber: ref.To(int32(v)),
 		}
 		nodePorts = append(nodePorts, p)
 	}

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -22,12 +22,12 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/labels"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects"
+	"github.com/projectcontour/contour/internal/ref"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -324,7 +324,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 			Labels:    contour.AppLabels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
-			RevisionHistoryLimit: pointer.Int32Ptr(int32(10)),
+			RevisionHistoryLimit: ref.To(int32(10)),
 			// Ensure the deamonset adopts only its own pods.
 			Selector:       EnvoyPodSelector(contour),
 			UpdateStrategy: contour.Spec.EnvoyDaemonSetUpdateStrategy,
@@ -343,7 +343,7 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 							Name: envoyCertsVolName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									DefaultMode: pointer.Int32Ptr(int32(420)),
+									DefaultMode: ref.To(int32(420)),
 									SecretName:  contour.EnvoyCertsSecretName(),
 								},
 							},
@@ -362,8 +362,8 @@ func DesiredDaemonSet(contour *model.Contour, contourImage, envoyImage string) *
 						},
 					},
 					ServiceAccountName:            contour.EnvoyRBACNames().ServiceAccount,
-					AutomountServiceAccountToken:  pointer.BoolPtr(false),
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(300)),
+					AutomountServiceAccountToken:  ref.To(false),
+					TerminationGracePeriodSeconds: ref.To(int64(300)),
 					SecurityContext:               objects.NewUnprivilegedPodSecurity(),
 					DNSPolicy:                     corev1.DNSClusterFirst,
 					RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -396,8 +396,8 @@ func desiredDeployment(contour *model.Contour, contourImage, envoyImage string) 
 			Labels:    contour.AppLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:             pointer.Int32(contour.Spec.EnvoyReplicas),
-			RevisionHistoryLimit: pointer.Int32Ptr(int32(10)),
+			Replicas:             ref.To(contour.Spec.EnvoyReplicas),
+			RevisionHistoryLimit: ref.To(int32(10)),
 			// Ensure the deamonset adopts only its own pods.
 			Selector: EnvoyPodSelector(contour),
 			Strategy: contour.Spec.EnvoyDeploymentStrategy,
@@ -418,7 +418,7 @@ func desiredDeployment(contour *model.Contour, contourImage, envoyImage string) 
 							Name: envoyCertsVolName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									DefaultMode: pointer.Int32Ptr(int32(420)),
+									DefaultMode: ref.To(int32(420)),
 									SecretName:  contour.EnvoyCertsSecretName(),
 								},
 							},
@@ -437,8 +437,8 @@ func desiredDeployment(contour *model.Contour, contourImage, envoyImage string) 
 						},
 					},
 					ServiceAccountName:            contour.EnvoyRBACNames().ServiceAccount,
-					AutomountServiceAccountToken:  pointer.BoolPtr(false),
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(300)),
+					AutomountServiceAccountToken:  ref.To(false),
+					TerminationGracePeriodSeconds: ref.To(int64(300)),
 					SecurityContext:               objects.NewUnprivilegedPodSecurity(),
 					DNSPolicy:                     corev1.DNSClusterFirst,
 					RestartPolicy:                 corev1.RestartPolicyAlways,

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -23,12 +23,12 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/labels"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects"
+	"github.com/projectcontour/contour/internal/ref"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -200,9 +200,9 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 			Labels:    contour.AppLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
-			ProgressDeadlineSeconds: pointer.Int32(600),
-			Replicas:                pointer.Int32(contour.Spec.ContourReplicas),
-			RevisionHistoryLimit:    pointer.Int32(10),
+			ProgressDeadlineSeconds: ref.To(int32(600)),
+			Replicas:                ref.To(contour.Spec.ContourReplicas),
+			RevisionHistoryLimit:    ref.To(int32(10)),
 			// Ensure the deployment adopts only its own pods.
 			Selector: ContourDeploymentPodSelector(contour),
 			Strategy: contour.Spec.ContourDeploymentStrategy,
@@ -240,7 +240,7 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 							Name: contourCertsVolName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									DefaultMode: pointer.Int32Ptr(int32(420)),
+									DefaultMode: ref.To(int32(420)),
 									SecretName:  contour.ContourCertsSecretName(),
 								},
 							},
@@ -251,7 +251,7 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 "default-scheduler",
 					SecurityContext:               objects.NewUnprivilegedPodSecurity(),
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(30)),
+					TerminationGracePeriodSeconds: ref.To(int64(30)),
 				},
 			},
 		},

--- a/internal/ref/ref.go
+++ b/internal/ref/ref.go
@@ -16,3 +16,10 @@ package ref
 func To[T any](v T) *T {
 	return &v
 }
+
+func Val[T any](v *T, def T) T {
+	if v != nil {
+		return *v
+	}
+	return def
+}

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -175,7 +175,7 @@ func (c *Cache) GatewayStatusAccessor(nsName types.NamespacedName, generation in
 		Conditions:         make(map[gatewayapi_v1beta1.GatewayConditionType]metav1.Condition),
 		ExistingConditions: getGatewayConditions(gs),
 		Generation:         generation,
-		TransitionTime:     metav1.NewTime(clock.Now()),
+		TransitionTime:     metav1.NewTime(time.Now()),
 	}
 
 	return gu, func() {
@@ -231,7 +231,7 @@ func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation 
 		GatewayRef:        c.gatewayRef,
 		GatewayController: c.gatewayController,
 		Generation:        generation,
-		TransitionTime:    metav1.NewTime(clock.Now()),
+		TransitionTime:    metav1.NewTime(time.Now()),
 		Resource:          resource,
 	}
 

--- a/internal/status/gatewayclassconditions_test.go
+++ b/internal/status/gatewayclassconditions_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	realclock "k8s.io/utils/clock"
-	fakeclock "k8s.io/utils/clock/testing"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -133,14 +131,7 @@ func TestConditionChanged(t *testing.T) {
 }
 
 func TestMergeConditions(t *testing.T) {
-	// Inject a fake clock and don't forget to reset it
-	fakeClock := fakeclock.NewFakeClock(time.Time{})
-	clock = fakeClock
-	defer func() {
-		clock = realclock.RealClock{}
-	}()
-
-	start := fakeClock.Now()
+	start := time.Now()
 	middle := start.Add(1 * time.Minute)
 	later := start.Add(2 * time.Minute)
 
@@ -187,10 +178,6 @@ func TestMergeConditions(t *testing.T) {
 			},
 		},
 	}
-
-	// Simulate the passage of time between original condition creation
-	// and update processing
-	fakeClock.SetTime(later)
 
 	for _, tc := range testCases {
 		got := mergeConditions(tc.current, tc.updates...)

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -15,6 +15,7 @@ package status
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/projectcontour/contour/internal/ref"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +54,7 @@ func (gatewayUpdate *GatewayStatusUpdate) AddCondition(
 		Status:             status,
 		Type:               string(cond),
 		Message:            message,
-		LastTransitionTime: metav1.NewTime(clock.Now()),
+		LastTransitionTime: metav1.NewTime(time.Now()),
 		ObservedGeneration: gatewayUpdate.Generation,
 	}
 	gatewayUpdate.Conditions[cond] = newCond
@@ -126,7 +127,7 @@ func (gatewayUpdate *GatewayStatusUpdate) AddListenerCondition(
 		Status:             status,
 		Type:               string(cond),
 		Message:            message,
-		LastTransitionTime: metav1.NewTime(clock.Now()),
+		LastTransitionTime: metav1.NewTime(time.Now()),
 		ObservedGeneration: gatewayUpdate.Generation,
 	}
 

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -15,11 +15,11 @@ package status
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilclock "k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -44,9 +44,6 @@ const (
 	ReasonInvalidGateway                gatewayapi_v1beta1.RouteConditionReason = "InvalidGateway"
 	ReasonListenersNotReady             gatewayapi_v1beta1.RouteConditionReason = "ListenersNotReady"
 )
-
-// clock is used to set lastTransitionTime on status conditions.
-var clock utilclock.Clock = utilclock.RealClock{}
 
 // RouteStatusUpdate represents an atomic update to a
 // Route's status.
@@ -113,7 +110,7 @@ func (r *RouteParentStatusUpdate) AddCondition(conditionType gatewayapi_v1beta1.
 		Status:             status,
 		Type:               string(conditionType),
 		Message:            message,
-		LastTransitionTime: metav1.NewTime(clock.Now()),
+		LastTransitionTime: metav1.NewTime(time.Now()),
 		ObservedGeneration: r.Generation,
 	}
 

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcontour/contour/internal/dag"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -35,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func TestRouteCacheContents(t *testing.T) {
@@ -811,32 +811,32 @@ func TestRouteVisit(t *testing.T) {
 									Paths: []networking_v1.HTTPIngressPath{
 										{
 											Path:     "/",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("Prefix")),
+											PathType: (*networking_v1.PathType)(ref.To("Prefix")),
 											Backend:  *backend("kuard", 8080),
 										},
 										{
 											Path:     "/foo",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("Prefix")),
+											PathType: (*networking_v1.PathType)(ref.To("Prefix")),
 											Backend:  *backend("kuard", 8080),
 										},
 										{
 											Path:     "/foo",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("ImplementationSpecific")),
+											PathType: (*networking_v1.PathType)(ref.To("ImplementationSpecific")),
 											Backend:  *backend("kuard", 8080),
 										},
 										{
 											Path:     "/foo2",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("ImplementationSpecific")),
+											PathType: (*networking_v1.PathType)(ref.To("ImplementationSpecific")),
 											Backend:  *backend("kuard", 8080),
 										},
 										{
 											Path:     "/foo3[a|b]?",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("ImplementationSpecific")),
+											PathType: (*networking_v1.PathType)(ref.To("ImplementationSpecific")),
 											Backend:  *backend("kuard", 8080),
 										},
 										{
 											Path:     "/foo4",
-											PathType: (*networking_v1.PathType)(pointer.StringPtr("Exact")),
+											PathType: (*networking_v1.PathType)(ref.To("Exact")),
 											Backend:  *backend("kuard", 8080),
 										},
 									},

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/onsi/gomega/gexec"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/pkg/config"
 	"gopkg.in/yaml.v3"
 	apps_v1 "k8s.io/api/apps/v1"
@@ -47,7 +48,6 @@ import (
 	apimachinery_util_yaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -521,7 +521,7 @@ func (d *Deployment) EnsureResourcesForLocalContour() error {
 	// The envoy deployment uses host ports, so can have at most
 	// one replica per node, and our cluster only has one worker
 	// node, so scale the deployment to 1.
-	d.EnvoyDeployment.Spec.Replicas = pointer.Int32(1)
+	d.EnvoyDeployment.Spec.Replicas = ref.To(int32(1))
 
 	return d.EnsureEnvoyDeployment()
 }
@@ -622,7 +622,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 		contourConfiguration.Spec.XDSServer.Port = port
 		contourConfiguration.Spec.XDSServer.Address = listenAllAddress()
 		contourConfiguration.Spec.XDSServer.TLS = &contour_api_v1alpha1.TLS{
-			Insecure: pointer.Bool(true),
+			Insecure: ref.To(true),
 		}
 
 		if err := d.client.Create(context.TODO(), contourConfiguration); err != nil {
@@ -821,7 +821,7 @@ func (d *Deployment) EnsureResourcesForInclusterContour(startContourDeployment b
 		// The envoy deployment uses host ports, so can have at most
 		// one replica per node, and our cluster only has one worker
 		// node, so scale the deployment to 1.
-		d.EnvoyDeployment.Spec.Replicas = pointer.Int32(1)
+		d.EnvoyDeployment.Spec.Replicas = ref.To(int32(1))
 
 		return d.EnsureEnvoyDeployment()
 	}

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,7 +88,7 @@ func (e *Echo) DeployN(ns, name string, replicas int32) func() {
 			Name:      name,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ref.To(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
 			},
@@ -397,7 +397,7 @@ func (g *GRPC) Deploy(ns, name string) func() {
 			Name:      name,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas: ref.To(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
 			},
@@ -519,7 +519,7 @@ func DefaultContourConfiguration() *contour_api_v1alpha1.ContourConfiguration {
 					CAFile:   "/certs/ca.crt",
 					CertFile: "/certs/tls.crt",
 					KeyFile:  "/certs/tls.key",
-					Insecure: pointer.Bool(false),
+					Insecure: ref.To(false),
 				},
 			},
 			Debug: &contour_api_v1alpha1.DebugConfig{
@@ -535,8 +535,8 @@ func DefaultContourConfiguration() *contour_api_v1alpha1.ContourConfiguration {
 					"HTTP/1.1", "HTTP/2",
 				},
 				Listener: &contour_api_v1alpha1.EnvoyListenerConfig{
-					UseProxyProto:             pointer.Bool(false),
-					DisableAllowChunkedLength: pointer.Bool(false),
+					UseProxyProto:             ref.To(false),
+					DisableAllowChunkedLength: ref.To(false),
 					ConnectionBalancer:        "",
 					TLS: &contour_api_v1alpha1.EnvoyTLS{
 						MinimumProtocolVersion: "1.2",
@@ -577,13 +577,13 @@ func DefaultContourConfiguration() *contour_api_v1alpha1.ContourConfiguration {
 					DNSLookupFamily: contour_api_v1alpha1.AutoClusterDNSFamily,
 				},
 				Network: &contour_api_v1alpha1.NetworkParameters{
-					EnvoyAdminPort: pointer.Int(9001),
+					EnvoyAdminPort: ref.To(9001),
 				},
 			},
 			HTTPProxy: &contour_api_v1alpha1.HTTPProxyConfig{
-				DisablePermitInsecure: pointer.Bool(false),
+				DisablePermitInsecure: ref.To(false),
 			},
-			EnableExternalNameService: pointer.Bool(false),
+			EnableExternalNameService: ref.To(false),
 			Metrics: &contour_api_v1alpha1.MetricsConfig{
 				Address: listenAllAddress(),
 				Port:    8000,

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -53,7 +52,7 @@ func testHostRewrite(namespace string, gateway types.NamespacedName) {
 							{
 								Path: &gatewayapi_v1beta1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1beta1.PathMatchPathPrefix),
-									Value: pointer.StringPtr("/"),
+									Value: ref.To("/"),
 								},
 							},
 						},

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -69,8 +68,8 @@ func testRequestRedirectRule(namespace string, gateway types.NamespacedName) {
 								Type: gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect,
 								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
 									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
-									StatusCode: pointer.Int(301),
-									Scheme:     pointer.String("https"),
+									StatusCode: ref.To(301),
+									Scheme:     ref.To("https"),
 									Port:       ref.To(gatewayapi_v1beta1.PortNumber(8080)),
 								},
 							},

--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -162,7 +162,7 @@ func testInvalidCookieRewriteFields(namespace string) {
 						CookieRewritePolicies: []contourv1.CookieRewritePolicy{
 							{
 								Name:     "invalid-samesite",
-								SameSite: pointer.String("Invalid"),
+								SameSite: ref.To("Invalid"),
 							},
 						},
 						Services: []contourv1.Service{
@@ -214,8 +214,8 @@ func testAppCookieRewrite(namespace string) {
 								Name:          "no-attributes",
 								PathRewrite:   &contourv1.CookiePathRewrite{Value: "/foo"},
 								DomainRewrite: &contourv1.CookieDomainRewrite{Value: "foo.com"},
-								Secure:        pointer.Bool(true),
-								SameSite:      pointer.String("Strict"),
+								Secure:        ref.To(true),
+								SameSite:      ref.To("Strict"),
 							},
 						},
 						Services: []contourv1.Service{
@@ -234,8 +234,8 @@ func testAppCookieRewrite(namespace string) {
 								Name:          "rewrite-all",
 								PathRewrite:   &contourv1.CookiePathRewrite{Value: "/ra"},
 								DomainRewrite: &contourv1.CookieDomainRewrite{Value: "ra.com"},
-								Secure:        pointer.Bool(false),
-								SameSite:      pointer.String("Lax"),
+								Secure:        ref.To(false),
+								SameSite:      ref.To("Lax"),
 							},
 						},
 						Services: []contourv1.Service{
@@ -333,8 +333,8 @@ func testAppCookieRewrite(namespace string) {
 									{
 										Name:        "route-service",
 										PathRewrite: &contourv1.CookiePathRewrite{Value: "/service"},
-										Secure:      pointer.Bool(true),
-										SameSite:    pointer.String("Lax"),
+										Secure:      ref.To(true),
+										SameSite:    ref.To("Lax"),
 									},
 									{
 										Name:        "service",
@@ -506,8 +506,8 @@ func testHeaderRewriteCookieRewrite(namespace string) {
 						CookieRewritePolicies: []contourv1.CookieRewritePolicy{
 							{
 								Name:     "X-Contour-Session-Affinity",
-								Secure:   pointer.Bool(true),
-								SameSite: pointer.String("Strict"),
+								Secure:   ref.To(true),
+								SameSite: ref.To("Strict"),
 							},
 						},
 						Services: []contourv1.Service{
@@ -681,8 +681,8 @@ func testCookieRewriteTLS(namespace string) {
 								Name:          "a-cookie",
 								PathRewrite:   &contourv1.CookiePathRewrite{Value: "/"},
 								DomainRewrite: &contourv1.CookieDomainRewrite{Value: "cookie-rewrite-tls.projectcontour.io"},
-								Secure:        pointer.Bool(true),
-								SameSite:      pointer.String("Strict"),
+								Secure:        ref.To(true),
+								SameSite:      ref.To("Strict"),
 							},
 						},
 						Services: []contourv1.Service{

--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -27,6 +27,7 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	. "github.com/onsi/ginkgo/v2"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/projectcontour/yages/yages"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func testGRPCServicePlaintext(namespace string) {
@@ -67,7 +67,7 @@ func testGRPCServicePlaintext(namespace string) {
 							{
 								Name:     "grpc-echo",
 								Port:     9000,
-								Protocol: pointer.String("h2c"),
+								Protocol: ref.To("h2c"),
 							},
 						},
 						Conditions: []contourv1.MatchCondition{
@@ -149,7 +149,7 @@ func testGRPCWeb(namespace string) {
 							{
 								Name:     "grpc-echo",
 								Port:     9000,
-								Protocol: pointer.String("h2c"),
+								Protocol: ref.To("h2c"),
 							},
 						},
 					},

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -28,11 +28,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/pkg/config"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var f = e2e.NewFramework(false)
@@ -127,7 +127,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("set to true", func() {
 			BeforeEach(func() {
 				contourConfig.DisableMergeSlashes = true
-				contourConfiguration.Spec.Envoy.Listener.DisableMergeSlashes = pointer.Bool(true)
+				contourConfiguration.Spec.Envoy.Listener.DisableMergeSlashes = ref.To(true)
 			})
 
 			f.NamespacedTest("httpproxy-disable-merge-slashes", testDisableMergeSlashes(true))
@@ -298,7 +298,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
-				contourConfiguration.Spec.EnableExternalNameService = pointer.Bool(true)
+				contourConfiguration.Spec.EnableExternalNameService = ref.To(true)
 			})
 			testExternalNameServiceInsecure(namespace)
 		})
@@ -308,7 +308,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
-				contourConfiguration.Spec.EnableExternalNameService = pointer.Bool(true)
+				contourConfiguration.Spec.EnableExternalNameService = ref.To(true)
 			})
 			testExternalNameServiceTLS(namespace)
 		})
@@ -318,7 +318,7 @@ var _ = Describe("HTTPProxy", func() {
 		Context("with ExternalName Services enabled", func() {
 			BeforeEach(func() {
 				contourConfig.EnableExternalNameService = true
-				contourConfiguration.Spec.EnableExternalNameService = pointer.Bool(true)
+				contourConfiguration.Spec.EnableExternalNameService = ref.To(true)
 			})
 			testExternalNameServiceLocalhostInvalid(namespace)
 		})
@@ -343,8 +343,8 @@ var _ = Describe("HTTPProxy", func() {
 								Namespace: namespace,
 							},
 							Domain:                  "contour",
-							FailOpen:                pointer.Bool(false),
-							EnableXRateLimitHeaders: pointer.Bool(false),
+							FailOpen:                ref.To(false),
+							EnableXRateLimitHeaders: ref.To(false),
 						}
 						require.NoError(f.T(),
 							f.Deployment.EnsureRateLimitResources(

--- a/test/e2e/httpproxy/request_redirect_test.go
+++ b/test/e2e/httpproxy/request_redirect_test.go
@@ -20,13 +20,13 @@ import (
 	"net/http"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/ref"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func testRequestRedirectRuleNoService(namespace string) {
@@ -114,7 +114,7 @@ func getRedirectHTTPProxy(namespace string, removeServices bool) *contour_api_v1
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Hostname: pointer.StringPtr("projectcontour.io"),
+					Hostname: ref.To("projectcontour.io"),
 				},
 			}, {
 				Conditions: []contour_api_v1.MatchCondition{{
@@ -125,10 +125,10 @@ func getRedirectHTTPProxy(namespace string, removeServices bool) *contour_api_v1
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Scheme:     pointer.StringPtr("https"),
-					Hostname:   pointer.StringPtr("envoyproxy.io"),
-					Port:       pointer.Int32Ptr(8080),
-					StatusCode: pointer.Int(301),
+					Scheme:     ref.To("https"),
+					Hostname:   ref.To("envoyproxy.io"),
+					Port:       ref.To(int32(8080)),
+					StatusCode: ref.To(301),
 				},
 			}, {
 				Conditions: []contour_api_v1.MatchCondition{{
@@ -139,7 +139,7 @@ func getRedirectHTTPProxy(namespace string, removeServices bool) *contour_api_v1
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Path: pointer.StringPtr("/path"),
+					Path: ref.To("/path"),
 				},
 			}, {
 				Conditions: []contour_api_v1.MatchCondition{{
@@ -150,7 +150,7 @@ func getRedirectHTTPProxy(namespace string, removeServices bool) *contour_api_v1
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Prefix: pointer.StringPtr("/v2"),
+					Prefix: ref.To("/v2"),
 				},
 			}, {
 				Conditions: []contour_api_v1.MatchCondition{{
@@ -161,7 +161,7 @@ func getRedirectHTTPProxy(namespace string, removeServices bool) *contour_api_v1
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Prefix: pointer.StringPtr("/v2"),
+					Prefix: ref.To("/v2"),
 				},
 			}},
 		},
@@ -197,8 +197,8 @@ func getRedirectHTTPProxyInvalid(namespace string) *contour_api_v1.HTTPProxy {
 					Port: 80,
 				}},
 				RequestRedirectPolicy: &contour_api_v1.HTTPRequestRedirectPolicy{
-					Path:   pointer.StringPtr("/path"),
-					Prefix: pointer.StringPtr("/path"),
+					Path:   ref.To("/path"),
+					Prefix: ref.To("/path"),
 				},
 			}},
 		},

--- a/test/e2e/incluster/leaderelection_test.go
+++ b/test/e2e/incluster/leaderelection_test.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/projectcontour/contour/internal/ref"
 	"github.com/stretchr/testify/require"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,7 +50,7 @@ func testLeaderElection(namespace string) {
 				return "", err
 			}
 
-			leaseHolder := pointer.StringDeref(leaderElectionLease.Spec.HolderIdentity, "")
+			leaseHolder := ref.Val(leaderElectionLease.Spec.HolderIdentity, "")
 			if !strings.HasPrefix(leaseHolder, "contour-") {
 				return "", fmt.Errorf("invalid leader name: %q", leaseHolder)
 			}

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/ref"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -31,7 +32,6 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var f = e2e.NewFramework(false)
@@ -238,7 +238,7 @@ var _ = Describe("Ingress", func() {
 		Context("when ApplyToIngress is false", func() {
 			BeforeEach(func() {
 				contourConfig.Policy.ApplyToIngress = false
-				contourConfiguration.Spec.Policy.ApplyToIngress = pointer.Bool(false)
+				contourConfiguration.Spec.Policy.ApplyToIngress = ref.To(false)
 			})
 
 			f.NamespacedTest("global-headers-policy-apply-to-ingress-false", testGlobalHeadersPolicy(false))
@@ -247,7 +247,7 @@ var _ = Describe("Ingress", func() {
 		Context("when ApplyToIngress is true", func() {
 			BeforeEach(func() {
 				contourConfig.Policy.ApplyToIngress = true
-				contourConfiguration.Spec.Policy.ApplyToIngress = pointer.Bool(true)
+				contourConfiguration.Spec.Policy.ApplyToIngress = ref.To(true)
 			})
 
 			f.NamespacedTest("global-headers-policy-apply-to-ingress-true", testGlobalHeadersPolicy(true))


### PR DESCRIPTION
Replaces all usage with our own generic based helpers

Also removes usage of clock/fake clock interface since it was not being used with any effect in testing