### PR TITLE
test/e2e/gateway: Remove redundant tests

### DIFF
--- a/test/e2e/gateway/path_condition_match_test.go
+++ b/test/e2e/gateway/path_condition_match_test.go
@@ -51,12 +51,6 @@ func testGatewayPathConditionMatch(namespace string, gateway types.NamespacedNam
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/path/prefix"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-prefix", 80, 1),
 					},
-
-					{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchExact, "/path/exact"),
-						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-exact", 80, 1),
-					},
-
 					{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-slash-default", 80, 1),
@@ -67,20 +61,8 @@ func testGatewayPathConditionMatch(namespace string, gateway types.NamespacedNam
 		f.CreateHTTPRouteAndWaitFor(route, httpRouteAccepted)
 
 		cases := map[string]string{
-			"/":    "echo-slash-default",
-			"/foo": "echo-slash-default",
-
-			"/path/prefix":         "echo-slash-prefix",
-			"/path/prefix/":        "echo-slash-prefix",
-			"/path/prefix/foo":     "echo-slash-prefix",
-			"/path/prefix/foo/bar": "echo-slash-prefix",
-			"/path/prefixfoo":      "echo-slash-default", // not a segment prefix match
-			"/foo/path/prefix":     "echo-slash-default",
-
-			"/path/exact":     "echo-slash-exact",
-			"/path/exactfoo":  "echo-slash-default",
-			"/path/exact/":    "echo-slash-default",
-			"/path/exact/foo": "echo-slash-default",
+			"/path/prefix/":   "echo-slash-prefix",
+			"/path/prefixfoo": "echo-slash-default", // not a segment prefix match
 		}
 
 		for path, expectedService := range cases {


### PR DESCRIPTION
Changes:
- Remove test cases for path matching
  - Covered by conformance tests for exact path matching and prefix path matching
  - Still need to contribute a couple prefix match cases back upstream before we can delete this test completely
- Remove basic path redirect test
  - Covered in Gateway API v0.6.0
  - More advanced features are not covered in the latest release but are on main, so we cannot remove those cases yet.

Updates #4579