### PR TITLE
Gateway API: support URLRewrite filter

### DIFF
--- a/changelogs/unreleased/4962-skriss-small.md
+++ b/changelogs/unreleased/4962-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: adds support for the [HTTPURLRewrite filter](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPURLRewriteFilter), which allows for rewriting the path or Host header as requests are being forwarded to the backend.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3556,6 +3556,259 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
+		"HTTPRoute rule with URLRewrite filter with ReplacePrefixMatch to another value": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
+								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+									Path: &gatewayapi_v1beta1.HTTPPathModifier{
+										Type:               gatewayapi_v1beta1.PrefixMatchHTTPPathModifier,
+										ReplacePrefixMatch: ref.To("/replacement"),
+									},
+								},
+							}},
+							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Name: HTTP_LISTENER_NAME,
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixSegment("/prefix"),
+							PathRewritePolicy: &PathRewritePolicy{
+								PrefixRewrite: "/replacement",
+							},
+							Clusters: clustersWeight(service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		"HTTPRoute rule with URLRewrite filter with ReplacePrefixMatch to \"/\"": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
+								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+									Path: &gatewayapi_v1beta1.HTTPPathModifier{
+										Type:               gatewayapi_v1beta1.PrefixMatchHTTPPathModifier,
+										ReplacePrefixMatch: ref.To("/"),
+									},
+								},
+							}},
+							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Name: HTTP_LISTENER_NAME,
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixSegment("/prefix"),
+							PathRewritePolicy: &PathRewritePolicy{
+								PrefixRegexRemove: "^/prefix/*",
+							},
+							Clusters: clustersWeight(service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		"HTTPRoute rule with URLRewrite filter with ReplaceFullPath": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
+								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+									Path: &gatewayapi_v1beta1.HTTPPathModifier{
+										Type:            gatewayapi_v1beta1.FullPathHTTPPathModifier,
+										ReplaceFullPath: ref.To("/replacement"),
+									},
+								},
+							}},
+							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Name: HTTP_LISTENER_NAME,
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixSegment("/prefix"),
+							PathRewritePolicy: &PathRewritePolicy{
+								FullPathRewrite: "/replacement",
+							},
+							Clusters: clustersWeight(service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		"HTTPRoute rule with URLRewrite filter with Hostname rewrite": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+								Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
+								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+									Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("rewritten.com")),
+								},
+							}},
+							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Name: HTTP_LISTENER_NAME,
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition:   prefixSegment("/prefix"),
+							RequestHeadersPolicy: &HeadersPolicy{HostRewrite: "rewritten.com"},
+							Clusters:             clustersWeight(service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		"HTTPRoute rule with RequestHeadersModifier and URLRewrite filter with Hostname rewrite": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []interface{}{
+				kuardService,
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "basic",
+						Namespace: "projectcontour",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+						},
+						Hostnames: []gatewayapi_v1beta1.Hostname{
+							"test.projectcontour.io",
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/prefix"),
+							Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{
+												Name:  "Host",
+												Value: "requestheader.rewritten.com",
+											},
+										},
+									},
+								},
+								{
+									Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
+									URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+										Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("url.rewritten.com")),
+									},
+								},
+							},
+							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						}},
+					},
+				},
+			},
+			want: listeners(
+				&Listener{
+					Name: HTTP_LISTENER_NAME,
+					Port: 80,
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixSegment("/prefix"),
+							RequestHeadersPolicy: &HeadersPolicy{
+								Add:         map[string]string{},
+								HostRewrite: "url.rewritten.com",
+							},
+							Clusters: clustersWeight(service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		// END
+
 		"different weights for multiple forwardTos": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -258,7 +258,7 @@ type Route struct {
 	RetryPolicy *RetryPolicy
 
 	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
-	PrefixRewrite string
+	PathRewritePolicy *PathRewritePolicy
 
 	// Mirror Policy defines the mirroring policy for this Route.
 	MirrorPolicy *MirrorPolicy
@@ -342,6 +342,13 @@ type RetryPolicy struct {
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if RetryOn is blank.
 	PerTryTimeout timeout.Setting
+}
+
+// PathRewritePolicy defines a policy for rewriting the path of
+// the request during forwarding. At most one field should be populated.
+type PathRewritePolicy struct {
+	PrefixRewrite   string
+	FullPathRewrite string
 }
 
 // MirrorPolicy defines the mirroring policy for a route.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -347,8 +347,16 @@ type RetryPolicy struct {
 // PathRewritePolicy defines a policy for rewriting the path of
 // the request during forwarding. At most one field should be populated.
 type PathRewritePolicy struct {
-	PrefixRewrite   string
+	// Replace the part of the path matched by a prefix match
+	// with this value.
+	PrefixRewrite string
+
+	// Replace the full path with this value.
 	FullPathRewrite string
+
+	// Replace the part of the path matched by the specified
+	// regex with "/" (intended for removing a prefix).
+	PrefixRegexRemove string
 }
 
 // MirrorPolicy defines the mirroring policy for a route.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -16,6 +16,7 @@ package dag
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1522,7 +1523,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			prefixMatch, ok := mc.path.(*PrefixMatchCondition)
 			if ok {
 				pathRewritePolicy.PrefixRewrite = ""
-				pathRewritePolicy.PrefixRegexRemove = "^" + prefixMatch.Prefix + "/*"
+				pathRewritePolicy.PrefixRegexRemove = "^" + regexp.QuoteMeta(prefixMatch.Prefix) + "/*"
 			}
 		}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1523,6 +1523,8 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			prefixMatch, ok := mc.path.(*PrefixMatchCondition)
 			if ok {
 				pathRewritePolicy.PrefixRewrite = ""
+				// The regex below will capture/remove all consecutive trailing slashes
+				// immediately after the prefix, to handle requests like /prefix///foo.
 				pathRewritePolicy.PrefixRegexRemove = "^" + regexp.QuoteMeta(prefixMatch.Prefix) + "/*"
 			}
 		}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -6620,7 +6620,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
 	})
 
-	run(t, "HTTPRouteFilterURLRewrite with ReplaceFullPath HTTPPathModifierType is not yet supported for httproute rule", testcase{
+	run(t, "HTTPRouteFilterURLRewrite with custom HTTPPathModifierType is not supported", testcase{
 		objs: []interface{}{
 			kuardService,
 			&gatewayapi_v1beta1.HTTPRoute{
@@ -6645,7 +6645,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type: gatewayapi_v1beta1.HTTPRouteFilterURLRewrite,
 							URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
 								Path: &gatewayapi_v1beta1.HTTPPathModifier{
-									Type: gatewayapi_v1beta1.FullPathHTTPPathModifier,
+									Type: "custom",
 								},
 							},
 						}},
@@ -6659,16 +6659,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []metav1.Condition{
 						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonHTTPRouteFilterType),
-							Message: "HTTPRoute.Spec.Rules.Filters.URLRewrite.Path.Type: invalid type \"ReplaceFullPath\": only ReplacePrefixMatch is supported.",
-						},
-						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted HTTPRoute",
+							Status:  metav1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
+							Message: "HTTPRoute.Spec.Rules.Filters.URLRewrite.Path.Type: invalid type \"custom\": only ReplacePrefixMatch and ReplaceFullPath are supported.",
 						},
 					},
 				},
@@ -6915,6 +6909,53 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Status:  contour_api_v1.ConditionTrue,
 							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 							Message: "Accepted HTTPRoute",
+						},
+					},
+				},
+			},
+		}},
+		// Invalid filters still result in an attached route.
+		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "HTTPRoute", 1),
+	})
+
+	run(t, "custom filter type is not supported", testcase{
+		objs: []interface{}{
+			kuardService,
+			&gatewayapi_v1beta1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "basic",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "contour",
+					},
+				},
+				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					},
+					Hostnames: []gatewayapi_v1beta1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1beta1.PathMatchPathPrefix, "/"),
+						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{{
+							Type: "custom-filter",
+						}},
+					}},
+				},
+			}},
+		wantRouteConditions: []*status.RouteStatusUpdate{{
+			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
+			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				{
+					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
+							Status:  metav1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
+							Message: "HTTPRoute.Spec.Rules.Filters: invalid type \"custom-filter\": only RequestHeaderModifier, ResponseHeaderModifier, RequestRedirect, RequestMirror and URLRewrite are supported.",
 						},
 					},
 				},

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -294,15 +294,24 @@ func routeRoute(r *dag.Route) *envoy_route_v3.Route_Route {
 	}
 
 	if r.PathRewritePolicy != nil {
-		if len(r.PathRewritePolicy.PrefixRewrite) > 0 {
+		switch {
+		case len(r.PathRewritePolicy.PrefixRewrite) > 0:
 			ra.PrefixRewrite = r.PathRewritePolicy.PrefixRewrite
-		} else if len(r.PathRewritePolicy.FullPathRewrite) > 0 {
+		case len(r.PathRewritePolicy.FullPathRewrite) > 0:
 			ra.RegexRewrite = &matcher.RegexMatchAndSubstitute{
 				Pattern: &matcher.RegexMatcher{
 					EngineType: &matcher.RegexMatcher_GoogleRe2{},
 					Regex:      "^/.*$", // match the entire path
 				},
 				Substitution: r.PathRewritePolicy.FullPathRewrite,
+			}
+		case len(r.PathRewritePolicy.PrefixRegexRemove) > 0:
+			ra.RegexRewrite = &matcher.RegexMatchAndSubstitute{
+				Pattern: &matcher.RegexMatcher{
+					EngineType: &matcher.RegexMatcher_GoogleRe2{},
+					Regex:      r.PathRewritePolicy.PrefixRegexRemove,
+				},
+				Substitution: "/",
 			}
 		}
 	}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -299,18 +299,12 @@ func routeRoute(r *dag.Route) *envoy_route_v3.Route_Route {
 			ra.PrefixRewrite = r.PathRewritePolicy.PrefixRewrite
 		case len(r.PathRewritePolicy.FullPathRewrite) > 0:
 			ra.RegexRewrite = &matcher.RegexMatchAndSubstitute{
-				Pattern: &matcher.RegexMatcher{
-					EngineType: &matcher.RegexMatcher_GoogleRe2{},
-					Regex:      "^/.*$", // match the entire path
-				},
+				Pattern:      SafeRegexMatch("^/.*$"), // match the entire path
 				Substitution: r.PathRewritePolicy.FullPathRewrite,
 			}
 		case len(r.PathRewritePolicy.PrefixRegexRemove) > 0:
 			ra.RegexRewrite = &matcher.RegexMatchAndSubstitute{
-				Pattern: &matcher.RegexMatcher{
-					EngineType: &matcher.RegexMatcher_GoogleRe2{},
-					Regex:      r.PathRewritePolicy.PrefixRegexRemove,
-				},
+				Pattern:      SafeRegexMatch(r.PathRewritePolicy.PrefixRegexRemove),
 				Substitution: "/",
 			}
 		}

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -651,6 +651,26 @@ func TestRouteRoute(t *testing.T) {
 				},
 			},
 		},
+		"prefix regex removal": {
+			route: &dag.Route{
+				Clusters:          []*dag.Cluster{c1},
+				PathRewritePolicy: &dag.PathRewritePolicy{PrefixRegexRemove: "^/prefix/*"},
+			},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RegexRewrite: &matcher.RegexMatchAndSubstitute{
+						Pattern: &matcher.RegexMatcher{
+							EngineType: &matcher.RegexMatcher_GoogleRe2{},
+							Regex:      "^/prefix/*",
+						},
+						Substitution: "/",
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -617,6 +617,40 @@ func TestRouteRoute(t *testing.T) {
 				},
 			},
 		},
+		"prefix rewrite": {
+			route: &dag.Route{
+				Clusters:          []*dag.Cluster{c1},
+				PathRewritePolicy: &dag.PathRewritePolicy{PrefixRewrite: "/rewrite"},
+			},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					PrefixRewrite: "/rewrite",
+				},
+			},
+		},
+		"full path rewrite": {
+			route: &dag.Route{
+				Clusters:          []*dag.Cluster{c1},
+				PathRewritePolicy: &dag.PathRewritePolicy{FullPathRewrite: "/rewrite"},
+			},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RegexRewrite: &matcher.RegexMatchAndSubstitute{
+						Pattern: &matcher.RegexMatcher{
+							EngineType: &matcher.RegexMatcher_GoogleRe2{},
+							Regex:      "^/.*$",
+						},
+						Substitution: "/rewrite",
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -643,8 +643,7 @@ func TestRouteRoute(t *testing.T) {
 					},
 					RegexRewrite: &matcher.RegexMatchAndSubstitute{
 						Pattern: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{},
-							Regex:      "^/.*$",
+							Regex: "^/.*$",
 						},
 						Substitution: "/rewrite",
 					},
@@ -663,8 +662,7 @@ func TestRouteRoute(t *testing.T) {
 					},
 					RegexRewrite: &matcher.RegexMatchAndSubstitute{
 						Pattern: &matcher.RegexMatcher{
-							EngineType: &matcher.RegexMatcher_GoogleRe2{},
-							Regex:      "^/prefix/*",
+							Regex: "^/prefix/*",
 						},
 						Substitution: "/",
 					},

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -54,6 +54,10 @@ func TestGatewayConformance(t *testing.T) {
 			suite.SupportHTTPResponseHeaderModification:     true,
 			suite.SupportRouteDestinationPortMatching:       true,
 			suite.SupportGatewayClassObservedGenerationBump: true,
+
+			// TODO uncomment the below once they are included in a Gateway API release
+			// suite.HTTPRoutePathRewrite: true,
+			// suite.HTTPRouteHostRewrite: true,
 		},
 	})
 	cSuite.Setup(t)

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -60,5 +60,5 @@ else
   git checkout "${GATEWAY_API_VERSION}"
   # Keep the list of supported features in sync with
   # test/conformance/gatewayapi/gateway_conformance_test.go.
-  go test ./conformance -gateway-class=contour -supported-features=ReferenceGrant,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPResponseHeaderModification,RouteDestinationPortMatching,GatewayClassObservedGenerationBump
+  go test ./conformance -gateway-class=contour -supported-features=ReferenceGrant,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,HTTPResponseHeaderModification,RouteDestinationPortMatching,GatewayClassObservedGenerationBump,HTTPRoutePathRewrite,HTTPRouteHostRewrite
 fi


### PR DESCRIPTION
Closes #4300.

~~Implements prefix and full path rewriting; doesn't do host rewriting (will do that in a separate PR).~~

~~This currently passes the conformance test (with a fix for https://github.com/kubernetes-sigs/gateway-api/pull/1622/files#r1062855963 in place), but it is not working properly for the case where you want to remove the prefix entirely (e.g. `/prefix/foo` -> `/foo`). The issue is described in https://github.com/envoyproxy/envoy/issues/23130; looks like we might need to generate multiple Envoy routes to properly handle that case. Putting this up as a draft for now while I think about how to best handle that case.~~

