### PR TITLE
update the staled controller name to projectcontour.io/gateway-controller

### DIFF
--- a/changelogs/unreleased/4966-izturn-docs.md
+++ b/changelogs/unreleased/4966-izturn-docs.md
@@ -1,0 +1,1 @@
+Change the default controller name from `projectcontour.io/projectcontour/contour` to `projectcontour.io/gateway-controller`

--- a/changelogs/unreleased/4966-izturn-docs.md
+++ b/changelogs/unreleased/4966-izturn-docs.md
@@ -1,1 +1,1 @@
-Change the default controller name from `projectcontour.io/projectcontour/contour` to `projectcontour.io/gateway-controller`
+Gateway API: change the default controller name from `projectcontour.io/projectcontour/contour` to `projectcontour.io/gateway-controller` for static provisioning.

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -553,13 +553,13 @@ func TestConvertServeContext(t *testing.T) {
 		"gatewayapi - controller": {
 			getServeContext: func(ctx *serveContext) *serveContext {
 				ctx.Config.GatewayConfig = &config.GatewayParameters{
-					ControllerName: "projectcontour.io/projectcontour/contour",
+					ControllerName: "projectcontour.io/gateway-controller",
 				}
 				return ctx
 			},
 			getContourConfiguration: func(cfg contour_api_v1alpha1.ContourConfigurationSpec) contour_api_v1alpha1.ContourConfigurationSpec {
 				cfg.Gateway = &contour_api_v1alpha1.GatewayConfig{
-					ControllerName: "projectcontour.io/projectcontour/contour",
+					ControllerName: "projectcontour.io/gateway-controller",
 				}
 				return cfg
 			},

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -107,7 +107,7 @@ spec:
     cluster:
       dnsLookupFamily: auto
   gateway:
-      controllerName: projectcontour.io/projectcontour/contour
+      controllerName: projectcontour.io/gateway-controller
   httpproxy:
     disablePermitInsecure: false
     rootNamespaces: 

--- a/design/configuration-crd.md
+++ b/design/configuration-crd.md
@@ -107,7 +107,7 @@ spec:
     cluster:
       dnsLookupFamily: auto
   gateway:
-      controllerName: projectcontour.io/gateway-controller
+      controllerName: projectcontour.io/projectcontour/contour
   httpproxy:
     disablePermitInsecure: false
     rootNamespaces: 

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -13,7 +13,7 @@ data:
     #
     # Specify the Gateway API configuration.
     # gateway:
-    #   controllerName: projectcontour.io/projectcontour/contour
+    #   controllerName: projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/gateway/03-gatewayclass.yaml
+++ b/examples/gateway/03-gatewayclass.yaml
@@ -4,4 +4,4 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: example
 spec:
-  controllerName: projectcontour.io/projectcontour/contour
+  controllerName: projectcontour.io/gateway-controller

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -46,7 +46,7 @@ data:
     #
     # Specify the Gateway API configuration.
     # gateway:
-    #   controllerName: projectcontour.io/projectcontour/contour
+    #   controllerName: projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -52,7 +52,7 @@ data:
     #
     # Specify the Gateway API configuration.
     gateway:
-      controllerName: projectcontour.io/projectcontour/contour
+      controllerName: projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -16706,7 +16706,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: example
 spec:
-  controllerName: projectcontour.io/projectcontour/contour
+  controllerName: projectcontour.io/gateway-controller
 
 ---
 kind: Gateway

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -46,7 +46,7 @@ data:
     #
     # Specify the Gateway API configuration.
     # gateway:
-    #   controllerName: projectcontour.io/projectcontour/contour
+    #   controllerName: projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/hack/generate-gateway-deployment.sh
+++ b/hack/generate-gateway-deployment.sh
@@ -38,7 +38,7 @@ for y in "${REPO}/examples/contour/"*.yaml ; do
         # skip
         ;;
     */01-contour-config.yaml)
-        sed 's|# gateway:|gateway:|g ; s|#   controllerName: projectcontour.io/projectcontour/contour|  controllerName: projectcontour.io/projectcontour/contour|g' < "$y"
+        sed 's|# gateway:|gateway:|g ; s|#   controllerName: projectcontour.io/gateway-controller|  controllerName: projectcontour.io/projectcontour/contour|g' < "$y"
         ;;
     *)
         cat $y

--- a/hack/generate-gateway-deployment.sh
+++ b/hack/generate-gateway-deployment.sh
@@ -38,7 +38,7 @@ for y in "${REPO}/examples/contour/"*.yaml ; do
         # skip
         ;;
     */01-contour-config.yaml)
-        sed 's|# gateway:|gateway:|g ; s|#   controllerName: projectcontour.io/gateway-controller|  controllerName: projectcontour.io/projectcontour/contour|g' < "$y"
+        sed 's|# gateway:|gateway:|g ; s|#   controllerName: projectcontour.io/gateway-controller|  controllerName: projectcontour.io/gateway-controller|g' < "$y"
         ;;
     *)
         cat $y

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -196,7 +196,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 
 | Field Name     | Type           | Default | Description                                                                    |
 | -------------- | -------------- | ------- | ------------------------------------------------------------------------------ |
-| controllerName | string         |         | Gateway Class controller name (i.e. projectcontour.io/projectcontour/contour). If set, Contour will reconcile the oldest GatewayClass, and its oldest Gateway, with this controller string. Only one of `controllerName` or `gatewayRef` must be set. |
+| controllerName | string         |         | Gateway Class controller name (i.e.projectcontour.io/gateway-controller). If set, Contour will reconcile the oldest GatewayClass, and its oldest Gateway, with this controller string. Only one of `controllerName` or `gatewayRef` must be set. |
 | gatewayRef     | NamespacedName |         | [Gateway namespace and name](#gateway-ref). If set, Contour will reconcile this specific Gateway. Only one of `controllerName` or `gatewayRef` must be set. |
 
 ### Gateway Ref
@@ -285,7 +285,7 @@ data:
     #
     # specify the gateway-api Gateway Contour should configure
     # gateway:
-    #   controllerName: projectcontour.io/projectcontour/contour
+    #   controllerName:projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -196,7 +196,7 @@ The gateway configuration block is used to configure which gateway-api Gateway C
 
 | Field Name     | Type           | Default | Description                                                                    |
 | -------------- | -------------- | ------- | ------------------------------------------------------------------------------ |
-| controllerName | string         |         | Gateway Class controller name (i.e.projectcontour.io/gateway-controller). If set, Contour will reconcile the oldest GatewayClass, and its oldest Gateway, with this controller string. Only one of `controllerName` or `gatewayRef` must be set. |
+| controllerName | string         |         | Gateway Class controller name (i.e. projectcontour.io/gateway-controller). If set, Contour will reconcile the oldest GatewayClass, and its oldest Gateway, with this controller string. Only one of `controllerName` or `gatewayRef` must be set. |
 | gatewayRef     | NamespacedName |         | [Gateway namespace and name](#gateway-ref). If set, Contour will reconcile this specific Gateway. Only one of `controllerName` or `gatewayRef` must be set. |
 
 ### Gateway Ref
@@ -285,7 +285,7 @@ data:
     #
     # specify the gateway-api Gateway Contour should configure
     # gateway:
-    #   controllerName:projectcontour.io/gateway-controller
+    #   controllerName: projectcontour.io/gateway-controller
     #
     # should contour expect to be running inside a k8s cluster
     # incluster: true

--- a/site/content/guides/gateway-api.md
+++ b/site/content/guides/gateway-api.md
@@ -67,7 +67,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: contour
 spec:
-  controllerName:projectcontour.io/gateway-controller
+  controllerName: projectcontour.io/gateway-controller
 EOF
 ```
 

--- a/site/content/guides/gateway-api.md
+++ b/site/content/guides/gateway-api.md
@@ -121,7 +121,7 @@ metadata:
 data:
   contour.yaml: |
     gateway:
-      controllerName:projectcontour.io/gateway-controller
+      controllerName: projectcontour.io/gateway-controller
 EOF
 
 kubectl -n projectcontour rollout restart deployment/contour

--- a/site/content/guides/gateway-api.md
+++ b/site/content/guides/gateway-api.md
@@ -67,7 +67,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
   name: contour
 spec:
-  controllerName: projectcontour.io/projectcontour/contour
+  controllerName:projectcontour.io/gateway-controller
 EOF
 ```
 
@@ -121,7 +121,7 @@ metadata:
 data:
   contour.yaml: |
     gateway:
-      controllerName: projectcontour.io/projectcontour/contour
+      controllerName:projectcontour.io/gateway-controller
 EOF
 
 kubectl -n projectcontour rollout restart deployment/contour

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -46,7 +46,7 @@ var _ = Describe("GatewayClass/Gateway admission tests", func() {
 	)
 
 	BeforeEach(func() {
-		controllerName = fmt.Sprintf("projectcontour.io/projectcontour/contour-%d", getRandomNumber())
+		controllerName = fmt.Sprintf("projectcontour.io/gateway-controller-%d", getRandomNumber())
 
 		// Contour config file contents, can be modified in nested
 		// BeforeEach.


### PR DESCRIPTION

Signed-off-by: Gang Liu [gang.liu@daocloud.io](mailto:gang.liu@daocloud.io)

Update the staled controller name to `projectcontour.io/gateway-controller` to fix `examples/gateway` and more