### PR TITLE
fix target port in AWS NLB TLS guide

### DIFF
--- a/site/content/guides/deploy-aws-tls-nlb.md
+++ b/site/content/guides/deploy-aws-tls-nlb.md
@@ -85,7 +85,7 @@ spec:
   externalTrafficPolicy: Local
   ports:
   - port: 443
-    targetPort: 80
+    targetPort: 8080
     name: http
     protocol: TCP
   selector:


### PR DESCRIPTION
Envoy now listens on port 8080 within the pod
for HTTP requests.

Signed-off-by: Steve Kriss <krisss@vmware.com>