### PR TITLE
internal/xds/v3: Improve logging on connection close

### DIFF
--- a/changelogs/unreleased/4993-sunjayBhatia-small.md
+++ b/changelogs/unreleased/4993-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Improve xDS server logging on connection close to be less verbose by default. Previously all closed connections from Envoy xDS resource subscriptions were logged as errors.

--- a/internal/xds/v3/callbacks.go
+++ b/internal/xds/v3/callbacks.go
@@ -14,8 +14,10 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_server_v3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/sirupsen/logrus"
@@ -27,11 +29,35 @@ import (
 // OnStreamRequest is implemented.
 func NewRequestLoggingCallbacks(log logrus.FieldLogger) envoy_server_v3.Callbacks {
 	return &envoy_server_v3.CallbackFuncs{
+		StreamOpenFunc: func(ctx context.Context, streamID int64, typeURL string) error {
+			logStreamOpenDetails(log, streamID, typeURL)
+			return nil
+		},
+		StreamClosedFunc: func(streamID int64, node *envoy_config_core_v3.Node) {
+			logStreamClosedDetails(log, streamID, node)
+		},
 		StreamRequestFunc: func(streamID int64, req *envoy_service_discovery_v3.DiscoveryRequest) error {
 			logDiscoveryRequestDetails(log, req)
 			return nil
 		},
 	}
+}
+
+// Helper function for use in the Envoy xDS server callbacks to
+// log details of opened streams.
+func logStreamOpenDetails(l logrus.FieldLogger, streamID int64, typeURL string) {
+	l.WithField("type_url", typeURL).WithField("stream_id", streamID).Debug("stream opened")
+}
+
+// Helper function for use in the Envoy xDS server callbacks to
+// log details of closed streams.
+func logStreamClosedDetails(l logrus.FieldLogger, streamID int64, node *envoy_config_core_v3.Node) {
+	log := l.WithField("stream_id", streamID)
+	if node != nil {
+		log = log.WithField("node_id", node.Id)
+	}
+
+	log.Debug("stream closed")
 }
 
 // Helper function for use in the Envoy xDS server callbacks and the Contour


### PR DESCRIPTION
- contour xDS server does not log errors if connection was canceled by client, detected via gRPC code
- when connection is closed change to debug from info level to avoid log noise
- add stream open/close logging callbacks for go-control-plane implementation
