### PR TITLE
feat: Add HTTP support for External Auth

### DIFF
--- a/apis/projectcontour/v1/helpers.go
+++ b/apis/projectcontour/v1/helpers.go
@@ -20,7 +20,7 @@ import (
 // AuthorizationConfigured returns whether authorization  is
 // configured on this virtual host.
 func (v *VirtualHost) AuthorizationConfigured() bool {
-	return v.TLS != nil && v.Authorization != nil
+	return v.Authorization != nil
 }
 
 // DisableAuthorization returns true if this virtual host disables

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -194,8 +194,8 @@ type ExtensionServiceReference struct {
 type AuthorizationServer struct {
 	// ExtensionServiceRef specifies the extension resource that will authorize client requests.
 	//
-	// +required
-	ExtensionServiceRef ExtensionServiceReference `json:"extensionRef"`
+	// +optional
+	ExtensionServiceRef ExtensionServiceReference `json:"extensionRef,omitempty"`
 
 	// AuthPolicy sets a default authorization policy for client requests.
 	// This policy will be used unless overridden by individual routes.

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -62,6 +62,11 @@ type ContourConfigurationSpec struct {
 	// +optional
 	EnableExternalNameService *bool `json:"enableExternalNameService,omitempty"`
 
+	// GlobalExternalAuthorization allows envoys external authorization filter
+	// to be enabled for all virtual hosts.
+	// +optional
+	GlobalExternalAuthorization *contour_api_v1.AuthorizationServer `json:"globalExtAuth,omitempty"`
+
 	// RateLimitService optionally holds properties of the Rate Limit Service
 	// to be used for global rate limiting.
 	// +optional

--- a/apis/projectcontour/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/projectcontour/v1alpha1/zz_generated.deepcopy.go
@@ -165,6 +165,11 @@ func (in *ContourConfigurationSpec) DeepCopyInto(out *ContourConfigurationSpec) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.GlobalExternalAuthorization != nil {
+		in, out := &in.GlobalExternalAuthorization, &out.GlobalExternalAuthorization
+		*out = new(v1.AuthorizationServer)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.RateLimitService != nil {
 		in, out := &in.RateLimitService, &out.RateLimitService
 		*out = new(RateLimitServiceConfig)

--- a/changelogs/unreleased/4994-clayton-gonsalves-minor.md
+++ b/changelogs/unreleased/4994-clayton-gonsalves-minor.md
@@ -1,0 +1,17 @@
+## Add support for Global External Authorization for HTTPProxy.
+
+Contour now supports external authorization for all hosts by setting the config as part of the `contourConfig` like so: 
+
+```yaml
+globalExtAuth:
+  extensionService: projectcontour-auth/htpasswd
+  failOpen: false
+  authPolicy:
+    context:
+      header1: value1
+      header2: value2
+  responseTimeout: 1s
+```
+
+Individual hosts can also override or opt out of this global configuration. 
+You can read more about this feature in detail in the [guide](https://projectcontour.io/docs/v1.25.0/guides/external-authorization/#global-external-authorization). 

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -695,7 +695,6 @@ func (s *Server) setupGlobalExternalAuthentication(contourConfiguration contour_
 		Timeout:          responseTimeout,
 		FailOpen:         contourConfiguration.GlobalExternalAuthorization.FailOpen,
 		Context:          context,
-		WithRequestBody:  &dag.AuthorizationServerBufferSettings{},
 	}
 
 	if contourConfiguration.GlobalExternalAuthorization.WithRequestBody != nil {

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -372,6 +372,10 @@ func (s *Server) doServe() error {
 		return err
 	}
 
+	if listenerConfig.GlobalExternalAuthConfig, err = s.setupGlobalExternalAuthentication(contourConfiguration); err != nil {
+		return err
+	}
+
 	contourMetrics := metrics.NewMetrics(s.registry)
 
 	// Endpoints updates are handled directly by the EndpointsTranslator
@@ -435,19 +439,20 @@ func (s *Server) doServe() error {
 	}
 
 	builder := s.getDAGBuilder(dagBuilderConfig{
-		ingressClassNames:         ingressClassNames,
-		rootNamespaces:            contourConfiguration.HTTPProxy.RootNamespaces,
-		gatewayControllerName:     gatewayControllerName,
-		gatewayRef:                gatewayRef,
-		disablePermitInsecure:     *contourConfiguration.HTTPProxy.DisablePermitInsecure,
-		enableExternalNameService: *contourConfiguration.EnableExternalNameService,
-		dnsLookupFamily:           contourConfiguration.Envoy.Cluster.DNSLookupFamily,
-		headersPolicy:             contourConfiguration.Policy,
-		clientCert:                clientCert,
-		fallbackCert:              fallbackCert,
-		connectTimeout:            timeouts.ConnectTimeout,
-		client:                    s.mgr.GetClient(),
-		metrics:                   contourMetrics,
+		ingressClassNames:                  ingressClassNames,
+		rootNamespaces:                     contourConfiguration.HTTPProxy.RootNamespaces,
+		gatewayControllerName:              gatewayControllerName,
+		gatewayRef:                         gatewayRef,
+		disablePermitInsecure:              *contourConfiguration.HTTPProxy.DisablePermitInsecure,
+		enableExternalNameService:          *contourConfiguration.EnableExternalNameService,
+		dnsLookupFamily:                    contourConfiguration.Envoy.Cluster.DNSLookupFamily,
+		headersPolicy:                      contourConfiguration.Policy,
+		clientCert:                         clientCert,
+		fallbackCert:                       fallbackCert,
+		connectTimeout:                     timeouts.ConnectTimeout,
+		client:                             s.mgr.GetClient(),
+		metrics:                            contourMetrics,
+		globalExternalAuthorizationService: contourConfiguration.GlobalExternalAuthorization,
 	})
 
 	// Build the core Kubernetes event handler.
@@ -641,6 +646,55 @@ func (s *Server) setupRateLimitService(contourConfiguration contour_api_v1alpha1
 		FailOpen:                    ref.Val(contourConfiguration.RateLimitService.FailOpen, false),
 		EnableXRateLimitHeaders:     ref.Val(contourConfiguration.RateLimitService.EnableXRateLimitHeaders, false),
 		EnableResourceExhaustedCode: ref.Val(contourConfiguration.RateLimitService.EnableResourceExhaustedCode, false),
+	}, nil
+}
+
+func (s *Server) setupGlobalExternalAuthentication(contourConfiguration contour_api_v1alpha1.ContourConfigurationSpec) (*xdscache_v3.GlobalExternalAuthConfig, error) {
+	if contourConfiguration.GlobalExternalAuthorization == nil {
+		return nil, nil
+	}
+
+	// ensure the specified ExtensionService exists
+	extensionSvc := &contour_api_v1alpha1.ExtensionService{}
+
+	key := client.ObjectKey{
+		Namespace: contourConfiguration.GlobalExternalAuthorization.ExtensionServiceRef.Namespace,
+		Name:      contourConfiguration.GlobalExternalAuthorization.ExtensionServiceRef.Name,
+	}
+
+	// Using GetAPIReader() here because the manager's caches won't be started yet,
+	// so reads from the manager's client (which uses the caches for reads) will fail.
+	if err := s.mgr.GetAPIReader().Get(context.Background(), key, extensionSvc); err != nil {
+		return nil, fmt.Errorf("error getting global external authorization extension service %s: %v", key, err)
+	}
+
+	// get the response timeout from the ExtensionService
+	var responseTimeout timeout.Setting
+	var err error
+
+	if tp := extensionSvc.Spec.TimeoutPolicy; tp != nil {
+		responseTimeout, err = timeout.Parse(tp.Response)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing global http ext auth extension service %s response timeout: %v", key, err)
+		}
+	}
+
+	var sni string
+	if extensionSvc.Spec.UpstreamValidation != nil {
+		sni = extensionSvc.Spec.UpstreamValidation.SubjectName
+	}
+
+	var context map[string]string
+	if contourConfiguration.GlobalExternalAuthorization.AuthPolicy.Context != nil {
+		context = contourConfiguration.GlobalExternalAuthorization.AuthPolicy.Context
+	}
+
+	return &xdscache_v3.GlobalExternalAuthConfig{
+		ExtensionService: key,
+		SNI:              sni,
+		Timeout:          responseTimeout,
+		FailOpen:         contourConfiguration.GlobalExternalAuthorization.FailOpen,
+		Context:          context,
 	}, nil
 }
 
@@ -849,19 +903,20 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 }
 
 type dagBuilderConfig struct {
-	ingressClassNames         []string
-	rootNamespaces            []string
-	gatewayControllerName     string
-	gatewayRef                *types.NamespacedName
-	disablePermitInsecure     bool
-	enableExternalNameService bool
-	dnsLookupFamily           contour_api_v1alpha1.ClusterDNSFamilyType
-	headersPolicy             *contour_api_v1alpha1.PolicyConfig
-	clientCert                *types.NamespacedName
-	fallbackCert              *types.NamespacedName
-	connectTimeout            time.Duration
-	client                    client.Client
-	metrics                   *metrics.Metrics
+	ingressClassNames                  []string
+	rootNamespaces                     []string
+	gatewayControllerName              string
+	gatewayRef                         *types.NamespacedName
+	disablePermitInsecure              bool
+	enableExternalNameService          bool
+	dnsLookupFamily                    contour_api_v1alpha1.ClusterDNSFamilyType
+	headersPolicy                      *contour_api_v1alpha1.PolicyConfig
+	clientCert                         *types.NamespacedName
+	fallbackCert                       *types.NamespacedName
+	connectTimeout                     time.Duration
+	client                             client.Client
+	metrics                            *metrics.Metrics
+	globalExternalAuthorizationService *contour_api_v1.AuthorizationServer
 }
 
 func (s *Server) getDAGBuilder(dbc dagBuilderConfig) *dag.Builder {
@@ -930,14 +985,15 @@ func (s *Server) getDAGBuilder(dbc dagBuilderConfig) *dag.Builder {
 			ConnectTimeout:    dbc.connectTimeout,
 		},
 		&dag.HTTPProxyProcessor{
-			EnableExternalNameService: dbc.enableExternalNameService,
-			DisablePermitInsecure:     dbc.disablePermitInsecure,
-			FallbackCertificate:       dbc.fallbackCert,
-			DNSLookupFamily:           dbc.dnsLookupFamily,
-			ClientCertificate:         dbc.clientCert,
-			RequestHeadersPolicy:      &requestHeadersPolicy,
-			ResponseHeadersPolicy:     &responseHeadersPolicy,
-			ConnectTimeout:            dbc.connectTimeout,
+			EnableExternalNameService:   dbc.enableExternalNameService,
+			DisablePermitInsecure:       dbc.disablePermitInsecure,
+			FallbackCertificate:         dbc.fallbackCert,
+			DNSLookupFamily:             dbc.dnsLookupFamily,
+			ClientCertificate:           dbc.clientCert,
+			RequestHeadersPolicy:        &requestHeadersPolicy,
+			ResponseHeadersPolicy:       &responseHeadersPolicy,
+			ConnectTimeout:              dbc.connectTimeout,
+			GlobalExternalAuthorization: dbc.globalExternalAuthorizationService,
 		},
 	}
 

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -689,13 +689,23 @@ func (s *Server) setupGlobalExternalAuthentication(contourConfiguration contour_
 		context = contourConfiguration.GlobalExternalAuthorization.AuthPolicy.Context
 	}
 
-	return &xdscache_v3.GlobalExternalAuthConfig{
+	globalExternalAuthConfig := &xdscache_v3.GlobalExternalAuthConfig{
 		ExtensionService: key,
 		SNI:              sni,
 		Timeout:          responseTimeout,
 		FailOpen:         contourConfiguration.GlobalExternalAuthorization.FailOpen,
 		Context:          context,
-	}, nil
+		WithRequestBody:  &dag.AuthorizationServerBufferSettings{},
+	}
+
+	if contourConfiguration.GlobalExternalAuthorization.WithRequestBody != nil {
+		globalExternalAuthConfig.WithRequestBody = &dag.AuthorizationServerBufferSettings{
+			PackAsBytes:         contourConfiguration.GlobalExternalAuthorization.WithRequestBody.PackAsBytes,
+			AllowPartialMessage: contourConfiguration.GlobalExternalAuthorization.WithRequestBody.AllowPartialMessage,
+			MaxRequestBytes:     contourConfiguration.GlobalExternalAuthorization.WithRequestBody.MaxRequestBytes,
+		}
+	}
+	return globalExternalAuthConfig, nil
 }
 
 func (s *Server) setupDebugService(debugConfig contour_api_v1alpha1.DebugConfig, builder *dag.Builder) error {

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -411,6 +411,87 @@ spec:
                     - namespace
                     type: object
                 type: object
+              globalExtAuth:
+                description: GlobalExternalAuthorization allows envoys external authorization
+                  filter to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: AuthPolicy sets a default authorization policy for
+                      client requests. This policy will be used unless overridden
+                      by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: Context is a set of key/value pairs that are
+                          sent to the authentication server in the check request.
+                          If a context is provided at an enclosing scope, the entries
+                          are merged such that the inner scope overrides matching
+                          keys from the outer scope.
+                        type: object
+                      disabled:
+                        description: When true, this field disables client request
+                          authentication for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent. If this field is
+                          not specified, the default "projectcontour.io/v1alpha1"
+                          will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: If FailOpen is true, the client request is forwarded
+                      to the upstream service even if the authorization server fails
+                      to respond. This field should not be set in most cases. It is
+                      intended for use only while migrating applications from internal
+                      authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: ResponseTimeout configures maximum time to wait for
+                      a check response from the authorization server. Timeout durations
+                      are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no
+                      timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
               health:
                 description: "Health defines the endpoints Contour uses to serve health
                   checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
@@ -3433,6 +3514,87 @@ spec:
                         - namespace
                         type: object
                     type: object
+                  globalExtAuth:
+                    description: GlobalExternalAuthorization allows envoys external
+                      authorization filter to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
                   health:
                     description: "Health defines the endpoints Contour uses to serve
                       health checks. \n Contour's default is { address: \"0.0.0.0\",
@@ -5793,8 +5955,6 @@ spec:
                               Authorization Server is in raw bytes.
                             type: boolean
                         type: object
-                    required:
-                    - extensionRef
                     type: object
                   corsPolicy:
                     description: Specifies the cross-origin policy to apply to the

--- a/examples/global-external-auth/01-authserver.yaml
+++ b/examples/global-external-auth/01-authserver.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testserver
+  namespace: projectcontour
+  labels:
+    app.kubernetes.io/name: testserver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: testserver
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: testserver
+    spec:
+      containers:
+      - name: testserver
+        image: docker.io/projectcontour/contour-authserver:v2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /contour-authserver
+        args:
+        - testserver
+        - --address=:9443
+        ports:
+        - name: auth
+          containerPort: 9443
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: testserver
+  namespace: projectcontour
+  labels:
+    app.kubernetes.io/name: testserver
+spec:
+  ports:
+  - name: auth
+    protocol: TCP
+    port: 9443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: testserver
+  type: ClusterIP

--- a/examples/global-external-auth/02-globalextauth-extsvc.yaml
+++ b/examples/global-external-auth/02-globalextauth-extsvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: projectcontour.io/v1alpha1
+kind: ExtensionService
+metadata:
+  namespace: projectcontour
+  name: testserver
+spec:
+  protocol: h2c
+  services:
+    - name: testserver
+      port: 9443
+  timeoutPolicy:
+    response: 100ms

--- a/examples/global-external-auth/03-contour-config.yaml
+++ b/examples/global-external-auth/03-contour-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contour
+  namespace: projectcontour
+data:
+  contour.yaml: |
+    globalExtAuth:
+      extensionService: projectcontour/testserver
+      failOpen: false
+      authPolicy:
+        context:
+          header1: value1
+          header2: value2
+      responseTimeout: 1s

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -624,6 +624,87 @@ spec:
                     - namespace
                     type: object
                 type: object
+              globalExtAuth:
+                description: GlobalExternalAuthorization allows envoys external authorization
+                  filter to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: AuthPolicy sets a default authorization policy for
+                      client requests. This policy will be used unless overridden
+                      by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: Context is a set of key/value pairs that are
+                          sent to the authentication server in the check request.
+                          If a context is provided at an enclosing scope, the entries
+                          are merged such that the inner scope overrides matching
+                          keys from the outer scope.
+                        type: object
+                      disabled:
+                        description: When true, this field disables client request
+                          authentication for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent. If this field is
+                          not specified, the default "projectcontour.io/v1alpha1"
+                          will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: If FailOpen is true, the client request is forwarded
+                      to the upstream service even if the authorization server fails
+                      to respond. This field should not be set in most cases. It is
+                      intended for use only while migrating applications from internal
+                      authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: ResponseTimeout configures maximum time to wait for
+                      a check response from the authorization server. Timeout durations
+                      are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no
+                      timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
               health:
                 description: "Health defines the endpoints Contour uses to serve health
                   checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
@@ -3646,6 +3727,87 @@ spec:
                         - namespace
                         type: object
                     type: object
+                  globalExtAuth:
+                    description: GlobalExternalAuthorization allows envoys external
+                      authorization filter to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
                   health:
                     description: "Health defines the endpoints Contour uses to serve
                       health checks. \n Contour's default is { address: \"0.0.0.0\",
@@ -6006,8 +6168,6 @@ spec:
                               Authorization Server is in raw bytes.
                             type: boolean
                         type: object
-                    required:
-                    - extensionRef
                     type: object
                   corsPolicy:
                     description: Specifies the cross-origin policy to apply to the

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -425,6 +425,87 @@ spec:
                     - namespace
                     type: object
                 type: object
+              globalExtAuth:
+                description: GlobalExternalAuthorization allows envoys external authorization
+                  filter to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: AuthPolicy sets a default authorization policy for
+                      client requests. This policy will be used unless overridden
+                      by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: Context is a set of key/value pairs that are
+                          sent to the authentication server in the check request.
+                          If a context is provided at an enclosing scope, the entries
+                          are merged such that the inner scope overrides matching
+                          keys from the outer scope.
+                        type: object
+                      disabled:
+                        description: When true, this field disables client request
+                          authentication for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent. If this field is
+                          not specified, the default "projectcontour.io/v1alpha1"
+                          will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: If FailOpen is true, the client request is forwarded
+                      to the upstream service even if the authorization server fails
+                      to respond. This field should not be set in most cases. It is
+                      intended for use only while migrating applications from internal
+                      authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: ResponseTimeout configures maximum time to wait for
+                      a check response from the authorization server. Timeout durations
+                      are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no
+                      timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
               health:
                 description: "Health defines the endpoints Contour uses to serve health
                   checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
@@ -3447,6 +3528,87 @@ spec:
                         - namespace
                         type: object
                     type: object
+                  globalExtAuth:
+                    description: GlobalExternalAuthorization allows envoys external
+                      authorization filter to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
                   health:
                     description: "Health defines the endpoints Contour uses to serve
                       health checks. \n Contour's default is { address: \"0.0.0.0\",
@@ -5807,8 +5969,6 @@ spec:
                               Authorization Server is in raw bytes.
                             type: boolean
                         type: object
-                    required:
-                    - extensionRef
                     type: object
                   corsPolicy:
                     description: Specifies the cross-origin policy to apply to the

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -630,6 +630,87 @@ spec:
                     - namespace
                     type: object
                 type: object
+              globalExtAuth:
+                description: GlobalExternalAuthorization allows envoys external authorization
+                  filter to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: AuthPolicy sets a default authorization policy for
+                      client requests. This policy will be used unless overridden
+                      by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: Context is a set of key/value pairs that are
+                          sent to the authentication server in the check request.
+                          If a context is provided at an enclosing scope, the entries
+                          are merged such that the inner scope overrides matching
+                          keys from the outer scope.
+                        type: object
+                      disabled:
+                        description: When true, this field disables client request
+                          authentication for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent. If this field is
+                          not specified, the default "projectcontour.io/v1alpha1"
+                          will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: If FailOpen is true, the client request is forwarded
+                      to the upstream service even if the authorization server fails
+                      to respond. This field should not be set in most cases. It is
+                      intended for use only while migrating applications from internal
+                      authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: ResponseTimeout configures maximum time to wait for
+                      a check response from the authorization server. Timeout durations
+                      are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no
+                      timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
               health:
                 description: "Health defines the endpoints Contour uses to serve health
                   checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
@@ -3652,6 +3733,87 @@ spec:
                         - namespace
                         type: object
                     type: object
+                  globalExtAuth:
+                    description: GlobalExternalAuthorization allows envoys external
+                      authorization filter to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
                   health:
                     description: "Health defines the endpoints Contour uses to serve
                       health checks. \n Contour's default is { address: \"0.0.0.0\",
@@ -6012,8 +6174,6 @@ spec:
                               Authorization Server is in raw bytes.
                             type: boolean
                         type: object
-                    required:
-                    - extensionRef
                     type: object
                   corsPolicy:
                     description: Specifies the cross-origin policy to apply to the

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -624,6 +624,87 @@ spec:
                     - namespace
                     type: object
                 type: object
+              globalExtAuth:
+                description: GlobalExternalAuthorization allows envoys external authorization
+                  filter to be enabled for all virtual hosts.
+                properties:
+                  authPolicy:
+                    description: AuthPolicy sets a default authorization policy for
+                      client requests. This policy will be used unless overridden
+                      by individual routes.
+                    properties:
+                      context:
+                        additionalProperties:
+                          type: string
+                        description: Context is a set of key/value pairs that are
+                          sent to the authentication server in the check request.
+                          If a context is provided at an enclosing scope, the entries
+                          are merged such that the inner scope overrides matching
+                          keys from the outer scope.
+                        type: object
+                      disabled:
+                        description: When true, this field disables client request
+                          authentication for the scope of the policy.
+                        type: boolean
+                    type: object
+                  extensionRef:
+                    description: ExtensionServiceRef specifies the extension resource
+                      that will authorize client requests.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent. If this field is
+                          not specified, the default "projectcontour.io/v1alpha1"
+                          will be used
+                        minLength: 1
+                        type: string
+                      name:
+                        description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace of the referent. If this field is
+                          not specifies, the namespace of the resource that targets
+                          the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                        minLength: 1
+                        type: string
+                    type: object
+                  failOpen:
+                    description: If FailOpen is true, the client request is forwarded
+                      to the upstream service even if the authorization server fails
+                      to respond. This field should not be set in most cases. It is
+                      intended for use only while migrating applications from internal
+                      authorization to Contour external authorization.
+                    type: boolean
+                  responseTimeout:
+                    description: ResponseTimeout configures maximum time to wait for
+                      a check response from the authorization server. Timeout durations
+                      are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                      Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                      The string "infinity" is also a valid input and specifies no
+                      timeout.
+                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                    type: string
+                  withRequestBody:
+                    description: WithRequestBody specifies configuration for sending
+                      the client request's body to authorization server.
+                    properties:
+                      allowPartialMessage:
+                        description: If AllowPartialMessage is true, then Envoy will
+                          buffer the body until MaxRequestBytes are reached.
+                        type: boolean
+                      maxRequestBytes:
+                        default: 1024
+                        description: MaxRequestBytes sets the maximum size of message
+                          body ExtAuthz filter will hold in-memory.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      packAsBytes:
+                        description: If PackAsBytes is true, the body sent to Authorization
+                          Server is in raw bytes.
+                        type: boolean
+                    type: object
+                type: object
               health:
                 description: "Health defines the endpoints Contour uses to serve health
                   checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
@@ -3646,6 +3727,87 @@ spec:
                         - namespace
                         type: object
                     type: object
+                  globalExtAuth:
+                    description: GlobalExternalAuthorization allows envoys external
+                      authorization filter to be enabled for all virtual hosts.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy sets a default authorization policy
+                          for client requests. This policy will be used unless overridden
+                          by individual routes.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that
+                              are sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the
+                              entries are merged such that the inner scope overrides
+                              matching keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      extensionRef:
+                        description: ExtensionServiceRef specifies the extension resource
+                          that will authorize client requests.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent. If this field
+                              is not specified, the default "projectcontour.io/v1alpha1"
+                              will be used
+                            minLength: 1
+                            type: string
+                          name:
+                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace of the referent. If this field
+                              is not specifies, the namespace of the resource that
+                              targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                            minLength: 1
+                            type: string
+                        type: object
+                      failOpen:
+                        description: If FailOpen is true, the client request is forwarded
+                          to the upstream service even if the authorization server
+                          fails to respond. This field should not be set in most cases.
+                          It is intended for use only while migrating applications
+                          from internal authorization to Contour external authorization.
+                        type: boolean
+                      responseTimeout:
+                        description: ResponseTimeout configures maximum time to wait
+                          for a check response from the authorization server. Timeout
+                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                          "h". The string "infinity" is also a valid input and specifies
+                          no timeout.
+                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
+                    type: object
                   health:
                     description: "Health defines the endpoints Contour uses to serve
                       health checks. \n Contour's default is { address: \"0.0.0.0\",
@@ -6006,8 +6168,6 @@ spec:
                               Authorization Server is in raw bytes.
                             type: boolean
                         type: object
-                    required:
-                    - extensionRef
                     type: object
                   corsPolicy:
                     description: Specifies the cross-origin policy to apply to the

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -680,24 +680,9 @@ type SecureVirtualHost struct {
 	// DownstreamValidation defines how to verify the client's certificate.
 	DownstreamValidation *PeerValidationContext
 
-	// AuthorizationService points to the extension that client
-	// requests are forwarded to for authorization. If nil, no
-	// authorization is enabled for this host.
-	AuthorizationService *ExtensionCluster
-
-	// AuthorizationResponseTimeout sets how long the proxy should wait
-	// for authorization server responses.
-	AuthorizationResponseTimeout timeout.Setting
-
-	// AuthorizationFailOpen sets whether authorization server
-	// failures should cause the client request to also fail. The
-	// only reason to set this to `true` is when you are migrating
-	// from internal to external authorization.
-	AuthorizationFailOpen bool
-
-	// AuthorizationServerWithRequestBody specifies configuration
-	// for buffering request data sent to AuthorizationServer
-	AuthorizationServerWithRequestBody *AuthorizationServerBufferSettings
+	// ExternalAuthorization contains the configuration for enabling
+	// the ExtAuthz filter.
+	ExternalAuthorization *ExternalAuthorization
 
 	// JWTProviders specify how to verify JWTs.
 	JWTProviders []JWTProvider
@@ -732,6 +717,29 @@ type JWTRule struct {
 	PathMatchCondition    MatchCondition
 	HeaderMatchConditions []HeaderMatchCondition
 	ProviderName          string
+}
+
+// ExternalAuthorization contains the configuration for enabling
+// the ExtAuthz filter.
+type ExternalAuthorization struct {
+	// AuthorizationService points to the extension that client
+	// requests are forwarded to for authorization. If nil, no
+	// authorization is enabled for this host.
+	AuthorizationService *ExtensionCluster
+
+	// AuthorizationResponseTimeout sets how long the proxy should wait
+	// for authorization server responses.
+	AuthorizationResponseTimeout timeout.Setting
+
+	// AuthorizationFailOpen sets whether authorization server
+	// failures should cause the client request to also fail. The
+	// only reason to set this to `true` is when you are migrating
+	// from internal to external authorization.
+	AuthorizationFailOpen bool
+
+	// AuthorizationServerWithRequestBody specifies configuration
+	// for buffering request data sent to AuthorizationServer
+	AuthorizationServerWithRequestBody *AuthorizationServerBufferSettings
 }
 
 // AuthorizationServerBufferSettings enables ExtAuthz filter to buffer client

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -1710,7 +1710,15 @@ func TestAddFilter(t *testing.T) {
 		},
 		"Add to the default filters": {
 			builder: HTTPConnectionManagerBuilder().DefaultFilters(),
-			add:     FilterExternalAuthz("test", "", false, timeout.Setting{}, nil),
+			add: FilterExternalAuthz(&dag.ExternalAuthorization{
+				AuthorizationService: &dag.ExtensionCluster{
+					Name: "test",
+					SNI:  "",
+				},
+				AuthorizationFailOpen:              false,
+				AuthorizationResponseTimeout:       timeout.Setting{},
+				AuthorizationServerWithRequestBody: nil,
+			}),
 			want: []*http.HttpFilter{
 				{
 					Name: "compressor",
@@ -1775,7 +1783,15 @@ func TestAddFilter(t *testing.T) {
 						}),
 					},
 				},
-				FilterExternalAuthz("test", "", false, timeout.Setting{}, nil),
+				FilterExternalAuthz(&dag.ExternalAuthorization{
+					AuthorizationService: &dag.ExtensionCluster{
+						Name: "test",
+						SNI:  "",
+					},
+					AuthorizationFailOpen:              false,
+					AuthorizationResponseTimeout:       timeout.Setting{},
+					AuthorizationServerWithRequestBody: nil,
+				}),
 				{
 					Name: "router",
 					ConfigType: &http.HttpFilter_TypedConfig{
@@ -1786,12 +1802,19 @@ func TestAddFilter(t *testing.T) {
 		},
 		"Add to the default filters with AuthorizationServerBufferSettings": {
 			builder: HTTPConnectionManagerBuilder().DefaultFilters(),
-			add: FilterExternalAuthz(
-				"test", "ext-auth-server.com", false, timeout.Setting{}, &dag.AuthorizationServerBufferSettings{
+			add: FilterExternalAuthz(&dag.ExternalAuthorization{
+				AuthorizationService: &dag.ExtensionCluster{
+					Name: "test",
+					SNI:  "ext-auth-server.com",
+				},
+				AuthorizationFailOpen:        false,
+				AuthorizationResponseTimeout: timeout.Setting{},
+				AuthorizationServerWithRequestBody: &dag.AuthorizationServerBufferSettings{
 					MaxRequestBytes:     10,
 					AllowPartialMessage: true,
 					PackAsBytes:         true,
-				}),
+				},
+			}),
 			want: []*http.HttpFilter{
 				{
 					Name: "compressor",

--- a/internal/featuretests/v3/global_authorization_test.go
+++ b/internal/featuretests/v3/global_authorization_test.go
@@ -1,0 +1,710 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"testing"
+
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_config_filter_http_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/projectcontour/contour/internal/dag"
+	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
+	"github.com/projectcontour/contour/internal/featuretests"
+	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/projectcontour/contour/internal/protobuf"
+	"github.com/projectcontour/contour/internal/timeout"
+	xdscache_v3 "github.com/projectcontour/contour/internal/xdscache/v3"
+	"google.golang.org/protobuf/types/known/anypb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func globalExternalAuthorizationFilterExists(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := &contour_api_v1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "proxy1",
+		},
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			statsListener()),
+	}).Status(p).IsValid()
+}
+
+func globalExternalAuthorizationFilterExistsTLS(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := fixture.NewProxy("TLSProxy").
+		WithFQDN("foo.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: "certificate",
+				},
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+				},
+			},
+		})
+
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	httpsListener := &envoy_listener_v3.Listener{
+		Name:    "ingress_https",
+		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v3.ListenerFilters(
+			envoy_v3.TLSInspector(),
+		),
+		FilterChains: []*envoy_listener_v3.FilterChain{
+			filterchaintls("foo.com",
+				&corev1.Secret{
+					ObjectMeta: fixture.ObjectMeta("certificate"),
+					Type:       "kubernetes.io/tls",
+					Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+				},
+				authzFilterFor(
+					"foo.com",
+					&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+						Services:               grpcCluster("extension/auth/extension"),
+						ClearRouteCache:        true,
+						IncludePeerCertificate: true,
+						StatusOnError: &envoy_type.HttpStatus{
+							Code: envoy_type.StatusCode_Forbidden,
+						},
+						TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+					},
+				),
+				nil, "h2", "http/1.1"),
+		},
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			httpsListener,
+			statsListener()),
+	}).Status(p).IsValid()
+}
+
+func globalExternalAuthorizationWithTLSGlobalAuthDisabled(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := fixture.NewProxy("TLSProxy").
+		WithFQDN("foo.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: "certificate",
+				},
+				Authorization: &contour_api_v1.AuthorizationServer{
+					AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+						Disabled: true,
+					},
+				},
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+				},
+			},
+		})
+
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	httpsListener := &envoy_listener_v3.Listener{
+		Name:    "ingress_https",
+		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v3.ListenerFilters(
+			envoy_v3.TLSInspector(),
+		),
+		FilterChains: []*envoy_listener_v3.FilterChain{
+			filterchaintls("foo.com",
+				&corev1.Secret{
+					ObjectMeta: fixture.ObjectMeta("certificate"),
+					Type:       "kubernetes.io/tls",
+					Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+				},
+				httpsFilterFor("foo.com"),
+				nil, "h2", "http/1.1"),
+		},
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			httpsListener,
+			statsListener()),
+	}).Status(p).IsValid()
+}
+
+func globalExternalAuthorizationWithMergedAuthPolicy(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := &contour_api_v1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "proxy1",
+		},
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+					AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+						Context: map[string]string{
+							"header_type": "proxy_config",
+							"header_2":    "message_2",
+						},
+					},
+				},
+			},
+		},
+	}
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			statsListener()),
+	}).Status(p).IsValid()
+
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: routeType,
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration(
+				"ingress_http",
+				envoy_v3.VirtualHost("foo.com",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: routeCluster("default/s1/80/da39a3ee5e"),
+						TypedPerFilterConfig: map[string]*anypb.Any{
+							"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(
+								&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
+									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
+										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{
+											ContextExtensions: map[string]string{
+												"header_type": "proxy_config",
+												"header_1":    "message_1",
+												"header_2":    "message_2",
+											},
+										},
+									},
+								},
+							),
+						},
+					},
+				),
+			),
+		),
+	})
+}
+
+func globalExternalAuthorizationWithMergedAuthPolicyTLS(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := fixture.NewProxy("TLSProxy").
+		WithFQDN("foo.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: "certificate",
+				},
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+					AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+						Context: map[string]string{
+							"header_type": "proxy_config",
+							"header_2":    "message_2",
+						},
+					},
+				},
+			},
+		})
+
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	httpsListener := &envoy_listener_v3.Listener{
+		Name:    "ingress_https",
+		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v3.ListenerFilters(
+			envoy_v3.TLSInspector(),
+		),
+		FilterChains: []*envoy_listener_v3.FilterChain{
+			filterchaintls("foo.com",
+				&corev1.Secret{
+					ObjectMeta: fixture.ObjectMeta("certificate"),
+					Type:       "kubernetes.io/tls",
+					Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+				},
+				authzFilterFor(
+					"foo.com",
+					&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+						Services:               grpcCluster("extension/auth/extension"),
+						ClearRouteCache:        true,
+						IncludePeerCertificate: true,
+						StatusOnError: &envoy_type.HttpStatus{
+							Code: envoy_type.StatusCode_Forbidden,
+						},
+						TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+					},
+				),
+				nil, "h2", "http/1.1"),
+		},
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			httpsListener,
+			statsListener()),
+	}).Status(p).IsValid()
+
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: routeType,
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration(
+				"https/foo.com",
+				envoy_v3.VirtualHost("foo.com",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: routeCluster("default/s1/80/da39a3ee5e"),
+						TypedPerFilterConfig: map[string]*anypb.Any{
+							"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(
+								&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
+									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
+										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{
+											ContextExtensions: map[string]string{
+												"header_type": "proxy_config",
+												"header_1":    "message_1",
+												"header_2":    "message_2",
+											},
+										},
+									},
+								},
+							),
+						},
+					},
+				),
+			),
+			envoy_v3.RouteConfiguration(
+				"ingress_http",
+				envoy_v3.VirtualHost("foo.com",
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: withRedirect(),
+					},
+				),
+			),
+		),
+	})
+}
+
+func globalExternalAuthorizationWithTLSAuthOverride(t *testing.T, rh cache.ResourceEventHandler, c *Contour) {
+	p := fixture.NewProxy("TLSProxy").
+		WithFQDN("foo.com").
+		WithSpec(contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{
+				Fqdn: "foo.com",
+				TLS: &contour_api_v1.TLS{
+					SecretName: "certificate",
+				},
+				Authorization: &contour_api_v1.AuthorizationServer{
+					ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
+						Namespace: "auth",
+						Name:      "extension",
+					},
+					ResponseTimeout: defaultResponseTimeout.String(),
+					FailOpen:        true,
+					WithRequestBody: &contour_api_v1.AuthorizationServerBufferSettings{
+						MaxRequestBytes:     512,
+						PackAsBytes:         true,
+						AllowPartialMessage: true,
+					},
+				},
+			},
+			Routes: []contour_api_v1.Route{
+				{
+					Services: []contour_api_v1.Service{
+						{
+							Name: "s1",
+							Port: 80,
+						},
+					},
+				},
+			},
+		})
+
+	rh.OnAdd(p)
+
+	var httpListener = defaultHTTPListener()
+
+	// replace the default filter chains with an HCM that includes the global
+	// extAuthz filter.
+	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
+
+	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+
+	httpsListener := &envoy_listener_v3.Listener{
+		Name:    "ingress_https",
+		Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+		ListenerFilters: envoy_v3.ListenerFilters(
+			envoy_v3.TLSInspector(),
+		),
+		FilterChains: []*envoy_listener_v3.FilterChain{
+			filterchaintls("foo.com",
+				&corev1.Secret{
+					ObjectMeta: fixture.ObjectMeta("certificate"),
+					Type:       "kubernetes.io/tls",
+					Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+				},
+				authzFilterFor(
+					"foo.com",
+					&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+						Services:               grpcCluster("extension/auth/extension"),
+						ClearRouteCache:        true,
+						IncludePeerCertificate: true,
+						FailureModeAllow:       true,
+						StatusOnError: &envoy_type.HttpStatus{
+							Code: envoy_type.StatusCode_Forbidden,
+						},
+						WithRequestBody: &envoy_config_filter_http_ext_authz_v3.BufferSettings{
+							MaxRequestBytes:     512,
+							PackAsBytes:         true,
+							AllowPartialMessage: true,
+						},
+						TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+					},
+				),
+				nil, "h2", "http/1.1"),
+		},
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
+
+	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			httpListener,
+			httpsListener,
+			statsListener()),
+	}).Status(p).IsValid()
+}
+
+func TestGlobalAuthorization(t *testing.T) {
+	subtests := map[string]func(*testing.T, cache.ResourceEventHandler, *Contour){
+		// Default extAuthz on non TLS host.
+		"GlobalExternalAuthorizationFilterExists": globalExternalAuthorizationFilterExists,
+		// Default extAuthz on non TLS and TLS hosts.
+		"GlobalExternalAuthorizationFilterExistsTLS": globalExternalAuthorizationFilterExistsTLS,
+		// extAuthz disabled on TLS host.
+		"GlobalExternalAuthorizationWithTLSGlobalAuthDisabled": globalExternalAuthorizationWithTLSGlobalAuthDisabled,
+		// extAuthz override on TLS host.
+		"GlobalExternalAuthorizationWithTLSAuthOverride": globalExternalAuthorizationWithTLSAuthOverride,
+		// extAuthz authpolicy merge for non TLS hosts.
+		"GlobalExternalAuthorizationWithMergedAuthPolicy": globalExternalAuthorizationWithMergedAuthPolicy,
+		// extAuthz authpolicy merge for TLS hosts.
+		"GlobalExternalAuthorizationWithMergedAuthPolicyTLS": globalExternalAuthorizationWithMergedAuthPolicyTLS,
+	}
+
+	for n, f := range subtests {
+		f := f
+		t.Run(n, func(t *testing.T) {
+			rh, c, done := setup(t,
+				func(cfg *xdscache_v3.ListenerConfig) {
+					cfg.GlobalExternalAuthConfig = &xdscache_v3.GlobalExternalAuthConfig{
+						ExtensionService: k8s.NamespacedNameFrom("auth/extension"),
+						FailOpen:         false,
+						Context: map[string]string{
+							"header_type": "root_config",
+							"header_1":    "message_1",
+						},
+						Timeout: timeout.DurationSetting(defaultResponseTimeout),
+					}
+				},
+				func(b *dag.Builder) {
+					b.Processors = []dag.Processor{
+						&dag.ExtensionServiceProcessor{},
+						&dag.HTTPProxyProcessor{
+							GlobalExternalAuthorization: &contour_api_v1.AuthorizationServer{
+								ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
+									Name:      "extension",
+									Namespace: "auth",
+								},
+								FailOpen:        false,
+								ResponseTimeout: defaultResponseTimeout.String(),
+								AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+									Context: map[string]string{
+										"header_type": "root_config",
+										"header_1":    "message_1",
+									},
+								},
+							},
+						},
+						&dag.ListenerProcessor{},
+					}
+				})
+			defer done()
+
+			// Add common test fixtures.
+			rh.OnAdd(fixture.NewService("s1").WithPorts(corev1.ServicePort{Port: 80}))
+			rh.OnAdd(fixture.NewService("auth/oidc-server").
+				WithPorts(corev1.ServicePort{Port: 8081}))
+
+			rh.OnAdd(featuretests.Endpoints("auth", "oidc-server", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.21"),
+				Ports:     featuretests.Ports(featuretests.Port("", 8081)),
+			}))
+
+			rh.OnAdd(&v1alpha1.ExtensionService{
+				ObjectMeta: fixture.ObjectMeta("auth/extension"),
+				Spec: v1alpha1.ExtensionServiceSpec{
+					Services: []v1alpha1.ExtensionServiceTarget{
+						{Name: "oidc-server", Port: 8081},
+					},
+					TimeoutPolicy: &contour_api_v1.TimeoutPolicy{
+						Response: defaultResponseTimeout.String(),
+					},
+				},
+			})
+
+			rh.OnAdd(fixture.NewService("app-server").
+				WithPorts(corev1.ServicePort{Port: 80}))
+
+			rh.OnAdd(featuretests.Endpoints("auth", "app-server", corev1.EndpointSubset{
+				Addresses: featuretests.Addresses("192.168.183.21"),
+				Ports:     featuretests.Ports(featuretests.Port("", 80)),
+			}))
+
+			rh.OnAdd(&corev1.Secret{
+				ObjectMeta: fixture.ObjectMeta("certificate"),
+				Type:       "kubernetes.io/tls",
+				Data:       featuretests.Secretdata(featuretests.CERTIFICATE, featuretests.RSA_PRIVATE_KEY),
+			})
+
+			f(t, rh, c)
+		})
+	}
+}

--- a/internal/featuretests/v3/global_authorization_test.go
+++ b/internal/featuretests/v3/global_authorization_test.go
@@ -69,28 +69,7 @@ func globalExternalAuthorizationFilterExists(t *testing.T, rh cache.ResourceEven
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: listenerType,
@@ -128,28 +107,7 @@ func globalExternalAuthorizationFilterExistsTLS(t *testing.T, rh cache.ResourceE
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -223,28 +181,7 @@ func globalExternalAuthorizationWithTLSGlobalAuthDisabled(t *testing.T, rh cache
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -308,28 +245,7 @@ func globalExternalAuthorizationWithMergedAuthPolicy(t *testing.T, rh cache.Reso
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: listenerType,
@@ -403,28 +319,7 @@ func globalExternalAuthorizationWithMergedAuthPolicyTLS(t *testing.T, rh cache.R
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -545,28 +440,7 @@ func globalExternalAuthorizationWithTLSAuthOverride(t *testing.T, rh cache.Resou
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	var hcm = envoy_v3.HTTPConnectionManagerBuilder().
-		RouteConfigName("ingress_http").
-		MetricsPrefix("ingress_http").
-		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
-		DefaultFilters().
-		AddFilter(&http.HttpFilter{
-			Name: wellknown.HTTPExternalAuthorization,
-			ConfigType: &http.HttpFilter_TypedConfig{
-				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
-					Services:               grpcCluster("extension/auth/extension"),
-					ClearRouteCache:        true,
-					IncludePeerCertificate: true,
-					StatusOnError: &envoy_type.HttpStatus{
-						Code: envoy_type.StatusCode_Forbidden,
-					},
-					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				}),
-			},
-		}).
-		Get()
-
-	httpListener.FilterChains = envoy_v3.FilterChains(hcm)
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -707,4 +581,28 @@ func TestGlobalAuthorization(t *testing.T) {
 			f(t, rh, c)
 		})
 	}
+}
+
+// getGlobalExtAuthHCM returns a HTTP Connection Manager with Global External Authorization configured.
+func getGlobalExtAuthHCM() *envoy_listener_v3.Filter {
+	return envoy_v3.HTTPConnectionManagerBuilder().
+		RouteConfigName("ingress_http").
+		MetricsPrefix("ingress_http").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		AddFilter(&http.HttpFilter{
+			Name: wellknown.HTTPExternalAuthorization,
+			ConfigType: &http.HttpFilter_TypedConfig{
+				TypedConfig: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthz{
+					Services:               grpcCluster("extension/auth/extension"),
+					ClearRouteCache:        true,
+					IncludePeerCertificate: true,
+					StatusOnError: &envoy_type.HttpStatus{
+						Code: envoy_type.StatusCode_Forbidden,
+					},
+					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				}),
+			},
+		}).
+		Get()
 }

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -98,7 +98,7 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 	for vhost, routes := range root.GetVirtualHostRoutes() {
 		sortRoutes(routes)
 		routeConfigs[ENVOY_HTTP_LISTENER].VirtualHosts = append(routeConfigs[ENVOY_HTTP_LISTENER].VirtualHosts,
-			envoy_v3.VirtualHostAndRoutes(vhost, routes, false, nil))
+			envoy_v3.VirtualHostAndRoutes(vhost, routes, false))
 	}
 
 	for vhost, routes := range root.GetSecureVirtualHostRoutes() {
@@ -110,7 +110,7 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 
 		sortRoutes(routes)
 		routeConfigs[name].VirtualHosts = append(routeConfigs[name].VirtualHosts,
-			envoy_v3.VirtualHostAndRoutes(&vhost.VirtualHost, routes, true, vhost.AuthorizationService))
+			envoy_v3.VirtualHostAndRoutes(&vhost.VirtualHost, routes, true))
 
 		// A fallback route configuration contains routes for all the vhosts that have the fallback certificate enabled.
 		// When a request is received, the default TLS filterchain will accept the connection,
@@ -122,7 +122,7 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 			}
 
 			routeConfigs[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts = append(routeConfigs[ENVOY_FALLBACK_ROUTECONFIG].VirtualHosts,
-				envoy_v3.VirtualHostAndRoutes(&vhost.VirtualHost, routes, true, vhost.AuthorizationService))
+				envoy_v3.VirtualHostAndRoutes(&vhost.VirtualHost, routes, true))
 		}
 	}
 

--- a/internal/xdscache/v3/secret_test.go
+++ b/internal/xdscache/v3/secret_test.go
@@ -519,45 +519,6 @@ func buildDAGFallback(t *testing.T, fallbackCertificate *types.NamespacedName, o
 	return builder.Build()
 }
 
-// buildDAGGlobalExtAuth produces a dag.DAG from the supplied objects with global external authorization configured.
-func buildDAGGlobalExtAuth(t *testing.T, fallbackCertificate *types.NamespacedName, objs ...interface{}) *dag.DAG {
-	builder := dag.Builder{
-		Source: dag.KubernetesCache{
-			FieldLogger: fixture.NewTestLogger(t),
-		},
-		Processors: []dag.Processor{
-			&dag.ExtensionServiceProcessor{},
-			&dag.IngressProcessor{
-				FieldLogger: fixture.NewTestLogger(t),
-			},
-			&dag.HTTPProxyProcessor{
-				FallbackCertificate: fallbackCertificate,
-				GlobalExternalAuthorization: &contour_api_v1.AuthorizationServer{
-					ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
-						Name:      "test",
-						Namespace: "ns",
-					},
-					FailOpen: false,
-					AuthPolicy: &contour_api_v1.AuthorizationPolicy{
-						Context: map[string]string{
-							"header_1": "message_1",
-							"header_2": "message_2",
-						},
-					},
-					ResponseTimeout: "10s",
-				},
-			},
-			&dag.ListenerProcessor{},
-		},
-	}
-
-	for _, o := range objs {
-		builder.Source.Insert(o)
-	}
-
-	return builder.Build()
-}
-
 func secretmap(secrets ...*envoy_tls_v3.Secret) map[string]*envoy_tls_v3.Secret {
 	m := make(map[string]*envoy_tls_v3.Secret)
 	for _, s := range secrets {

--- a/internal/xdscache/v3/secret_test.go
+++ b/internal/xdscache/v3/secret_test.go
@@ -519,6 +519,45 @@ func buildDAGFallback(t *testing.T, fallbackCertificate *types.NamespacedName, o
 	return builder.Build()
 }
 
+// buildDAGGlobalExtAuth produces a dag.DAG from the supplied objects with global external authorization configured.
+func buildDAGGlobalExtAuth(t *testing.T, fallbackCertificate *types.NamespacedName, objs ...interface{}) *dag.DAG {
+	builder := dag.Builder{
+		Source: dag.KubernetesCache{
+			FieldLogger: fixture.NewTestLogger(t),
+		},
+		Processors: []dag.Processor{
+			&dag.ExtensionServiceProcessor{},
+			&dag.IngressProcessor{
+				FieldLogger: fixture.NewTestLogger(t),
+			},
+			&dag.HTTPProxyProcessor{
+				FallbackCertificate: fallbackCertificate,
+				GlobalExternalAuthorization: &contour_api_v1.AuthorizationServer{
+					ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
+						Name:      "test",
+						Namespace: "ns",
+					},
+					FailOpen: false,
+					AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+						Context: map[string]string{
+							"header_1": "message_1",
+							"header_2": "message_2",
+						},
+					},
+					ResponseTimeout: "10s",
+				},
+			},
+			&dag.ListenerProcessor{},
+		},
+	}
+
+	for _, o := range objs {
+		builder.Source.Insert(o)
+	}
+
+	return builder.Build()
+}
+
 func secretmap(secrets ...*envoy_tls_v3.Secret) map[string]*envoy_tls_v3.Secret {
 	m := make(map[string]*envoy_tls_v3.Secret)
 	for _, s := range secrets {

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -328,7 +328,8 @@ outer scope.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#projectcontour.io/v1.VirtualHost">VirtualHost</a>)
+<a href="#projectcontour.io/v1.VirtualHost">VirtualHost</a>, 
+<a href="#projectcontour.io/v1alpha1.ContourConfigurationSpec">ContourConfigurationSpec</a>)
 </p>
 <p>
 <p>AuthorizationServer configures an external server to authenticate
@@ -354,6 +355,7 @@ ExtensionServiceReference
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ExtensionServiceRef specifies the extension resource that will authorize client requests.</p>
 </td>
 </tr>
@@ -4625,6 +4627,22 @@ bool
 </tr>
 <tr>
 <td style="white-space:nowrap">
+<code>globalExtAuth</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.AuthorizationServer">
+AuthorizationServer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GlobalExternalAuthorization allows envoys external authorization filter
+to be enabled for all virtual hosts.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>rateLimitService</code>
 <br>
 <em>
@@ -5299,6 +5317,22 @@ bool
 <em>(Optional)</em>
 <p>EnableExternalNameService allows processing of ExternalNameServices</p>
 <p>Contour&rsquo;s default is false for security reasons.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>globalExtAuth</code>
+<br>
+<em>
+<a href="#projectcontour.io/v1.AuthorizationServer">
+AuthorizationServer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>GlobalExternalAuthorization allows envoys external authorization filter
+to be enabled for all virtual hosts.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/guides/external-authorization.md
+++ b/site/content/docs/main/guides/external-authorization.md
@@ -481,9 +481,9 @@ $ curl -k https://local.projectcontour.io/test/$((RANDOM))
 {"TestId":"","Path":"/test/51","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["18716e12-dcce-45ba-a3bb-bc26af3775d2"],"X-Request-Start":["t=1676901847.802"]}}
 ```
 
-### Overriding global external authorization for a virtual host
+### Overriding global external authorization for a HTTPS virtual host
 
-Sometimes you may want a different configuration than what is defined globally. To override the global external authorization, add the `authorization` block to your HTTPProxy as shown below
+You may want a different configuration than what is defined globally. To override the global external authorization, add the `authorization` block to your TLS enabled HTTPProxy as shown below
 
 ```yaml
 apiVersion: projectcontour.io/v1
@@ -516,6 +516,8 @@ You can verify that the endpoint has applied the overridden external authorizati
 $ curl -k --user user1:password1 https://local.projectcontour.io/test/$((RANDOM))
 {"TestId":"","Path":"/test/4514","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"Auth-Context-Overriden_message":["overriden_value"],"Auth-Handler":["htpasswd"],"Auth-Realm":["default"],"Auth-Username":["user1"],"Authorization":["Basic dXNlcjE6cGFzc3dvcmQx"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["8a02d6ce-8be0-4e87-8ed8-cca7e239e986"],"X-Request-Start":["t=1676902237.111"]}}
 ```
+
+NOTE: You can only override the global external configuration on a HTTPS virtual host.
 
 ## Caveats
 

--- a/site/content/docs/main/guides/external-authorization.md
+++ b/site/content/docs/main/guides/external-authorization.md
@@ -360,13 +360,170 @@ $ curl -k --user user1:password1 https://local.projectcontour.io/test/$((RANDOM)
 {"TestId":"","Path":"/test/27132","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"Auth-Handler":["htpasswd"],"Auth-Realm":["default"],"Auth-Username":["user1"],"Authorization":["Basic dXNlcjE6cGFzc3dvcmQx"],"Content-Length":["0"],"User-Agent":["curl/7.64.1"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["2c0ae102-4cf6-400e-a38f-5f0b844364cc"],"X-Request-Start":["t=1601601826.102"]}}
 ```
 
+## Global External Authorization
+
+Starting from version 1.25, Contour supports global external authorization. This allows you to setup a single external authorization configuration for all your virtual hosts (HTTP and HTTPS).
+
+To get started, ensure you have `contour-authserver` and the `ExtensionService` deployed as described above. 
+
+### Global Configuration
+
+Define the global external authorization configuration in your contour config. 
+
+```yaml
+globalExtAuth:
+  extensionService: projectcontour-auth/htpasswd
+  failOpen: false
+  authPolicy:
+    context:
+      header1: value1
+      header2: value2
+  responseTimeout: 1s
+```
+
+Setup a HTTPProxy without TLS
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: local.projectcontour.io
+  routes:
+  - services:
+    - name: ingress-conformance-echo
+      port: 80
+```
+
+```
+$ kubectl apply -f echo-proxy.yaml 
+httpproxy.projectcontour.io/echo created
+```
+
+When we make a HTTP request without authentication details, we can see that the endpoint is secured and returns a 401. 
+
+```
+$ curl -k -I http://local.projectcontour.io/test/$((RANDOM))
+HTTP/1.1 401 Unauthorized
+www-authenticate: Basic realm="default", charset="UTF-8"
+vary: Accept-Encoding
+date: Mon, 20 Feb 2023 13:45:31 GMT
+```
+
+If you add the username and password to the same request you can verify that the request succeeds. 
+```
+$ curl -k --user user1:password1 http://local.projectcontour.io/test/$((RANDOM))
+{"TestId":"","Path":"/test/27748","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"Auth-Context-Header1":["value1"],"Auth-Context-Header2":["value2"],"Auth-Context-Routq":["global"],"Auth-Handler":["htpasswd"],"Auth-Realm":["default"],"Auth-Username":["user1"],"Authorization":["Basic dXNlcjE6cGFzc3dvcmQx"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["http"],"X-Request-Id":["b6bb7036-8408-4b03-9ce5-7011d89799b4"],"X-Request-Start":["t=1676900780.118"]}}
+```
+
+Global external authorization can also be configured with TLS virtual hosts. Update your HTTPProxy by adding `tls` and `secretName` to it. 
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: local.projectcontour.io
+    tls:
+      secretName: ingress-conformance-echo
+  routes:
+  - services:
+    - name: ingress-conformance-echo
+      port: 80
+```
+
+```
+$ kubectl apply -f echo-proxy.yaml
+httpproxy.projectcontour.io/echo configured
+```
+
+you can verify the HTTPS requests succeeds
+```
+$ curl -k --user user1:password1 https://local.projectcontour.io/test/$((RANDOM))
+{"TestId":"","Path":"/test/13499","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"Auth-Context-Header1":["value1"],"Auth-Context-Header2":["value2"],"Auth-Context-Routq":["global"],"Auth-Handler":["htpasswd"],"Auth-Realm":["default"],"Auth-Username":["user1"],"Authorization":["Basic dXNlcjE6cGFzc3dvcmQx"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["2b3edbed-3c68-44ef-a659-2e1245d7fe13"],"X-Request-Start":["t=1676901557.918"]}}
+```
+
+### Excluding a virtual host from global external authorization
+
+You can exclude a virtual host from the global external authorization policy by setting the `disabled` flag to true under `authPolicy`. 
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: local.projectcontour.io
+    tls:
+      secretName: ingress-conformance-echo
+    authorization:
+      authPolicy:
+        disabled: true
+  routes:
+  - services:
+    - name: ingress-conformance-echo
+      port: 80
+```
+
+```
+$ kubectl apply -f echo-proxy.yaml
+httpproxy.projectcontour.io/echo configured
+```
+
+You can verify that an insecure request succeeds without being authorized. 
+
+```
+$ curl -k https://local.projectcontour.io/test/$((RANDOM))
+{"TestId":"","Path":"/test/51","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["18716e12-dcce-45ba-a3bb-bc26af3775d2"],"X-Request-Start":["t=1676901847.802"]}}
+```
+
+### Overriding global external authorization for a virtual host
+
+Sometimes you may want a different configuration than what is defined globally. To override the global external authorization, add the `authorization` block to your HTTPProxy as shown below
+
+```yaml
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: echo
+spec:
+  virtualhost:
+    fqdn: local.projectcontour.io
+    tls:
+      secretName: ingress-conformance-echo
+    authorization:
+      extensionRef:
+        name: htpasswd
+        namespace: projectcontour-auth
+  routes:
+  - services:
+    - name: ingress-conformance-echo
+      port: 80
+```
+
+```
+$ kubectl apply -f echo-proxy.yaml
+httpproxy.projectcontour.io/echo configured
+```
+
+You can verify that the endpoint has applied the overridden external authorization configuration.
+
+```
+$ curl -k --user user1:password1 https://local.projectcontour.io/test/$((RANDOM))
+{"TestId":"","Path":"/test/4514","Host":"local.projectcontour.io","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"Auth-Context-Overriden_message":["overriden_value"],"Auth-Handler":["htpasswd"],"Auth-Realm":["default"],"Auth-Username":["user1"],"Authorization":["Basic dXNlcjE6cGFzc3dvcmQx"],"User-Agent":["curl/7.86.0"],"X-Envoy-Expected-Rq-Timeout-Ms":["15000"],"X-Envoy-Internal":["true"],"X-Forwarded-For":["172.18.0.1"],"X-Forwarded-Proto":["https"],"X-Request-Id":["8a02d6ce-8be0-4e87-8ed8-cca7e239e986"],"X-Request-Start":["t=1676902237.111"]}}
+```
+
 ## Caveats
 
 There are a few caveats to consider when deploying external
 authorization:
 
 1. Only one external authorization server can be configured on a virtual host
-1. Only HTTPS virtual hosts are supported
+1. HTTP hosts are only supported with global external authorization.
 1. External authorization cannot be used with the TLS fallback certificate (i.e. client SNI support is required)
 
 [1]: https://github.com/projectcontour/contour-authserver

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -107,6 +107,11 @@ type Deployment struct {
 	RateLimitDeployment       *apps_v1.Deployment
 	RateLimitService          *v1.Service
 	RateLimitExtensionService *contour_api_v1alpha1.ExtensionService
+
+	// // Global External Authorization deployment.
+	GlobalExtAuthDeployment       *apps_v1.Deployment
+	GlobalExtAuthService          *v1.Service
+	GlobalExtAuthExtensionService *contour_api_v1alpha1.ExtensionService
 }
 
 // UnmarshalResources unmarshals resources from rendered Contour manifest in
@@ -196,6 +201,7 @@ func (d *Deployment) UnmarshalResources() error {
 		}
 	}
 
+	// ratelimit
 	rateLimitExamplePath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "ratelimit")
 	rateLimitDeploymentFile := filepath.Join(rateLimitExamplePath, "02-ratelimit.yaml")
 	rateLimitExtSvcFile := filepath.Join(rateLimitExamplePath, "03-ratelimit-extsvc.yaml")
@@ -223,7 +229,39 @@ func (d *Deployment) UnmarshalResources() error {
 	decoder = apimachinery_util_yaml.NewYAMLToJSONDecoder(rLESFile)
 	d.RateLimitExtensionService = new(contour_api_v1alpha1.ExtensionService)
 
-	return decoder.Decode(d.RateLimitExtensionService)
+	if err := decoder.Decode(d.RateLimitExtensionService); err != nil {
+		return err
+	}
+
+	// // Global external auth
+	globalExtAuthExamplePath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "global-external-auth")
+	globalExtAuthServerDeploymentFile := filepath.Join(globalExtAuthExamplePath, "01-authserver.yaml")
+	globalExtAuthExtSvcFile := filepath.Join(globalExtAuthExamplePath, "02-globalextauth-extsvc.yaml")
+
+	rGlobalExtAuthDeploymentFile, err := os.Open(globalExtAuthServerDeploymentFile)
+	if err != nil {
+		return err
+	}
+	defer rGlobalExtAuthDeploymentFile.Close()
+	decoder = apimachinery_util_yaml.NewYAMLToJSONDecoder(rGlobalExtAuthDeploymentFile)
+	d.GlobalExtAuthDeployment = new(apps_v1.Deployment)
+	if err := decoder.Decode(d.GlobalExtAuthDeployment); err != nil {
+		return err
+	}
+	d.GlobalExtAuthService = new(v1.Service)
+	if err := decoder.Decode(d.GlobalExtAuthService); err != nil {
+		return err
+	}
+
+	rGlobalExtAuthExtSvcFile, err := os.Open(globalExtAuthExtSvcFile)
+	if err != nil {
+		return err
+	}
+	defer rGlobalExtAuthExtSvcFile.Close()
+	decoder = apimachinery_util_yaml.NewYAMLToJSONDecoder(rGlobalExtAuthExtSvcFile)
+	d.GlobalExtAuthExtensionService = new(contour_api_v1alpha1.ExtensionService)
+
+	return decoder.Decode(d.GlobalExtAuthExtensionService)
 }
 
 // Common case of updating object if exists, create otherwise.
@@ -463,6 +501,30 @@ func (d *Deployment) EnsureRateLimitResources(namespace string, configContents s
 
 	extSvc := d.RateLimitExtensionService.DeepCopy()
 	extSvc.Namespace = setNamespace
+	return d.ensureResource(extSvc, new(contour_api_v1alpha1.ExtensionService))
+}
+
+func (d *Deployment) EnsureGlobalExternalAuthResources(namespace string) error {
+	setNamespace := d.Namespace.Name
+	if len(namespace) > 0 {
+		setNamespace = namespace
+	}
+
+	deployment := d.GlobalExtAuthDeployment.DeepCopy()
+	deployment.Namespace = setNamespace
+	if err := d.ensureResource(deployment, new(apps_v1.Deployment)); err != nil {
+		return err
+	}
+
+	service := d.GlobalExtAuthService.DeepCopy()
+	service.Namespace = setNamespace
+	if err := d.ensureResource(service, new(v1.Service)); err != nil {
+		return err
+	}
+
+	extSvc := d.GlobalExtAuthExtensionService.DeepCopy()
+	extSvc.Namespace = setNamespace
+
 	return d.ensureResource(extSvc, new(contour_api_v1alpha1.ExtensionService))
 }
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -108,7 +108,7 @@ type Deployment struct {
 	RateLimitService          *v1.Service
 	RateLimitExtensionService *contour_api_v1alpha1.ExtensionService
 
-	// // Global External Authorization deployment.
+	// Global External Authorization deployment.
 	GlobalExtAuthDeployment       *apps_v1.Deployment
 	GlobalExtAuthService          *v1.Service
 	GlobalExtAuthExtensionService *contour_api_v1alpha1.ExtensionService
@@ -233,7 +233,7 @@ func (d *Deployment) UnmarshalResources() error {
 		return err
 	}
 
-	// // Global external auth
+	// Global external auth
 	globalExtAuthExamplePath := filepath.Join(filepath.Dir(thisFile), "..", "..", "examples", "global-external-auth")
 	globalExtAuthServerDeploymentFile := filepath.Join(globalExtAuthExamplePath, "01-authserver.yaml")
 	globalExtAuthExtSvcFile := filepath.Join(globalExtAuthExamplePath, "02-globalextauth-extsvc.yaml")

--- a/test/e2e/httpproxy/global_external_auth_test.go
+++ b/test/e2e/httpproxy/global_external_auth_test.go
@@ -1,0 +1,397 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package httpproxy
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testGlobalExternalAuthVirtualHostNonTLS(namespace string) {
+	Specify("global external auth can be configured on a non TLS HTTPProxy", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "external-auth",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "http.globalexternalauth.projectcontour.io",
+				},
+				Routes: []contourv1.Route{
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/first",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/second",
+							},
+						},
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Disabled: true,
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Context: map[string]string{
+								"target": "default",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+
+		// By default requests to /first should not be authorized.
+		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/first",
+			Condition: e2e.HasStatusCode(401),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
+
+		// THe /second route disables authorization so this request should succeed.
+		res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/second",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		// The default route should not authorize by default.
+		res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/matches-default-route",
+			Condition: e2e.HasStatusCode(401),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
+	})
+}
+
+func testGlobalExternalAuthTLS(namespace string) {
+	Specify("global external auth can be configured on a TLS HTTPProxy", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "https.globalexternalauth.projectcontour.io")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "external-auth",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "https.globalexternalauth.projectcontour.io",
+					TLS: &contourv1.TLS{
+						SecretName: "echo",
+					},
+				},
+				Routes: []contourv1.Route{
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/first",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/second",
+							},
+						},
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Disabled: true,
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Context: map[string]string{
+								"target": "default",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+
+		// By default requests to /first should not be authorized.
+		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/first",
+			Condition: e2e.HasStatusCode(401),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
+
+		// THe /second route disables authorization so this request should succeed.
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/second",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		// The default route should not authorize by default.
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/matches-default-route",
+			Condition: e2e.HasStatusCode(401),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
+	})
+}
+
+func testGlobalExternalAuthNonTLSAuthDisabled(namespace string) {
+	Specify("global external auth can be disabled on a non TLS HTTPProxy", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "external-auth",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "disabled.http.globalexternalauth.projectcontour.io",
+					Authorization: &contourv1.AuthorizationServer{
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Disabled: true,
+						},
+					},
+				},
+				Routes: []contourv1.Route{
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/first",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/second",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+
+		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/first",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/second",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		res, ok = f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/matches-default-route",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	})
+}
+
+func testGlobalExternalAuthTLSAuthDisabled(namespace string) {
+	Specify("global external auth can be disabled on a TLS HTTPProxy", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "disabled.https.globalexternalauth.projectcontour.io")
+
+		p := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "external-auth",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "disabled.https.globalexternalauth.projectcontour.io",
+					TLS: &contourv1.TLS{
+						SecretName: "echo",
+					},
+					Authorization: &contourv1.AuthorizationServer{
+						AuthPolicy: &contourv1.AuthorizationPolicy{
+							Disabled: true,
+						},
+					},
+				},
+				Routes: []contourv1.Route{
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/first",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/second",
+							},
+						},
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+
+		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/first",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/second",
+			Condition: e2e.HasStatusCode(200),
+		})
+
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/matches-default-route",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+	})
+}

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/pkg/config"
@@ -483,4 +484,53 @@ descriptors:
 
 		f.NamespacedTest("grpc-web", testGRPCWeb)
 	})
+
+	Context("global external auth", func() {
+		withGlobalExtAuth := func(body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
+			return func(namespace string) {
+				Context("with global external auth service", func() {
+					BeforeEach(func() {
+						contourConfig.GlobalExternalAuthorization = config.GlobalExternalAuthorization{
+							ExtensionService: fmt.Sprintf("%s/%s", namespace, "testserver"),
+							FailOpen:         false,
+							AuthPolicy: &config.GlobalAuthorizationPolicy{
+								Context: map[string]string{
+									"location": "global_config",
+									"header_2": "message_2",
+								},
+							},
+							ResponseTimeout: "10s",
+						}
+						contourConfiguration.Spec.GlobalExternalAuthorization = &contour_api_v1.AuthorizationServer{
+							ExtensionServiceRef: contour_api_v1.ExtensionServiceReference{
+								Namespace: namespace,
+								Name:      "testserver",
+							},
+							FailOpen: false,
+							AuthPolicy: &contour_api_v1.AuthorizationPolicy{
+								Disabled: false,
+								Context: map[string]string{
+									"location": "global_config",
+									"header_2": "message_2",
+								},
+							},
+							ResponseTimeout: "10s",
+						}
+						require.NoError(f.T(),
+							f.Deployment.EnsureGlobalExternalAuthResources(namespace))
+					})
+					body(namespace)
+				})
+			}
+		}
+
+		f.NamespacedTest("httpproxy-global-ext-auth-non-tls", withGlobalExtAuth(testGlobalExternalAuthVirtualHostNonTLS))
+
+		f.NamespacedTest("httpproxy-global-ext-auth-tls", withGlobalExtAuth(testGlobalExternalAuthTLS))
+
+		f.NamespacedTest("httpproxy-global-ext-auth-non-tls-disabled", withGlobalExtAuth(testGlobalExternalAuthNonTLSAuthDisabled))
+
+		f.NamespacedTest("httpproxy-global-ext-auth-tls-disabled", withGlobalExtAuth(testGlobalExternalAuthTLSAuthDisabled))
+	})
+
 })


### PR DESCRIPTION
This change adds external authorization support for HTTP upstreams.
Fixes: #4954 

Signed-off-by: Clayton Gonsalves <claytonivorgonsalves@gmail.com>