### PR TITLE
internal/dag: Add exact path match condition in HttpProxy

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -61,11 +61,15 @@ type Include struct {
 }
 
 // MatchCondition are a general holder for matching rules for HTTPProxies.
-// One of Prefix, Header or QueryParameter must be provided.
+// One of Prefix, Exact, Header or QueryParameter must be provided.
 type MatchCondition struct {
 	// Prefix defines a prefix match for a request.
 	// +optional
 	Prefix string `json:"prefix,omitempty"`
+
+	// Exact defines a exact match for a request.
+	// +optional
+	Exact string `json:"exact,omitempty"`
 
 	// Header specifies the header condition to match.
 	// +optional

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -68,6 +68,7 @@ type MatchCondition struct {
 	Prefix string `json:"prefix,omitempty"`
 
 	// Exact defines a exact match for a request.
+	// This field is not allowed in include match conditions.
 	// +optional
 	Exact string `json:"exact,omitempty"`
 

--- a/changelogs/unreleased/5000-arjunsalyan-minor.md
+++ b/changelogs/unreleased/5000-arjunsalyan-minor.md
@@ -1,0 +1,3 @@
+## HTTPProxy: Add support for exact path match condition
+
+HttpProxy conditions block now also supports exact path match condition.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -4592,9 +4592,6 @@ spec:
                             required:
                             - name
                             type: object
-                          exact:
-                            description: Exact defines a exact match for a request.
-                            type: string
                         type: object
                       type: array
                     name:
@@ -4695,7 +4692,6 @@ spec:
                           prefix:
                             description: Prefix defines a prefix match for a request.
                             type: string
-<<<<<<< HEAD
                           queryParameter:
                             description: QueryParameter specifies the query parameter
                               condition to match.
@@ -4740,11 +4736,9 @@ spec:
                             required:
                             - name
                             type: object
-=======
                           exact:
-                            description: Prefix defines a prefix match for a request.
+                            description: Exact defines a prefix match for a request.
                             type: string
->>>>>>> edd85080 (internal/dag: Add exact path match condition in HttpProxy)
                         type: object
                       type: array
                     cookieRewritePolicies:

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -4500,9 +4500,13 @@ spec:
                         include invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4644,9 +4648,13 @@ spec:
                         Conditions, will make the route invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4736,9 +4744,6 @@ spec:
                             required:
                             - name
                             type: object
-                          exact:
-                            description: Exact defines a prefix match for a request.
-                            type: string
                         type: object
                       type: array
                     cookieRewritePolicies:

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -4592,6 +4592,9 @@ spec:
                             required:
                             - name
                             type: object
+                          exact:
+                            description: Exact defines a exact match for a request.
+                            type: string
                         type: object
                       type: array
                     name:
@@ -4692,6 +4695,7 @@ spec:
                           prefix:
                             description: Prefix defines a prefix match for a request.
                             type: string
+<<<<<<< HEAD
                           queryParameter:
                             description: QueryParameter specifies the query parameter
                               condition to match.
@@ -4736,6 +4740,11 @@ spec:
                             required:
                             - name
                             type: object
+=======
+                          exact:
+                            description: Prefix defines a prefix match for a request.
+                            type: string
+>>>>>>> edd85080 (internal/dag: Add exact path match condition in HttpProxy)
                         type: object
                       type: array
                     cookieRewritePolicies:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -4713,9 +4713,13 @@ spec:
                         include invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4857,9 +4861,13 @@ spec:
                         Conditions, will make the route invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -4514,9 +4514,13 @@ spec:
                         include invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4658,9 +4662,13 @@ spec:
                         Conditions, will make the route invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4719,9 +4719,13 @@ spec:
                         include invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4863,9 +4867,13 @@ spec:
                         Conditions, will make the route invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4713,9 +4713,13 @@ spec:
                         include invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.
@@ -4857,9 +4861,13 @@ spec:
                         Conditions, will make the route invalid.'
                       items:
                         description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix, Header or QueryParameter
+                          rules for HTTPProxies. One of Prefix, Exact, Header or QueryParameter
                           must be provided.
                         properties:
+                          exact:
+                            description: Exact defines a exact match for a request.
+                              This field is not allowed in include match conditions.
+                            type: string
                           header:
                             description: Header specifies the header condition to
                               match.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -14863,9 +14863,9 @@ func routeCluster(prefix string, first *Cluster, rest ...*Cluster) *Route {
 	}
 }
 
-func routeClusterExact(exact string, first *Cluster, rest ...*Cluster) *Route {
+func routeClusterExact(path string, first *Cluster, rest ...*Cluster) *Route {
 	return &Route{
-		PathMatchCondition: exactString(exact),
+		PathMatchCondition: exact(path),
 		Clusters:           append([]*Cluster{first}, rest...),
 	}
 }
@@ -15089,9 +15089,6 @@ func listeners(ls ...*Listener) []*Listener {
 
 func prefixString(prefix string) MatchCondition {
 	return &PrefixMatchCondition{Prefix: prefix, PrefixMatchType: PrefixMatchString}
-}
-func exactString(exact string) MatchCondition {
-	return &ExactMatchCondition{Path: exact}
 }
 func prefixSegment(prefix string) MatchCondition {
 	return &PrefixMatchCondition{Prefix: prefix, PrefixMatchType: PrefixMatchSegment}

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -22,37 +22,66 @@ import (
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 )
 
-// mergePathMatchConditions merges the given slice of prefix MatchConditions into a single
-// prefix Condition.
+// mergePathMatchConditions merges the given slice of prefix or exact MatchConditions into a single
+// prefix/exact Condition.
+// If the root condition is prefix, and included condition is prefix then after merging we get one prefix condition.
+// If the root condition is prefix, and included condition is exact then after merging we get one exact condition.
+// If the root condition is exact, and included condition is exact then after merging we get one exact condition.
+// If the root condition is exact, and included condition is prefix then after merging we get one prefix condition.
+// Hence this can be concluded that the last rule in the delegation chain decides the path type
+//
 // pathMatchConditionsValid guarantees that if a prefix is present, it will start with a
 // / character, so we can simply concatenate.
-func mergePathMatchConditions(conds []contour_api_v1.MatchCondition) *PrefixMatchCondition {
-	prefix := ""
+func mergePathMatchConditions(conds []contour_api_v1.MatchCondition) MatchCondition {
+	mergedPath := ""
+
 	for _, cond := range conds {
-		prefix += cond.Prefix
+		switch {
+		case cond.Prefix != "":
+			mergedPath += cond.Prefix
+		case cond.Exact != "":
+			mergedPath += cond.Exact
+		}
 	}
 
 	re := regexp.MustCompile(`//+`)
-	prefix = re.ReplaceAllString(prefix, `/`)
+	mergedPath = re.ReplaceAllString(mergedPath, `/`)
 
 	// After the merge operation is done, if the string is still empty, then
 	// we need to set the prefix to /.
 	// Remember that this step is done AFTER all the includes have happened.
 	// Setting this to / allows us to pass this prefix to Envoy, as there must
 	// be at least one path, prefix, or regex set on each Envoy route.
-	if prefix == "" {
-		prefix = `/`
+	if mergedPath == "" || len(conds) == 0 {
+		mergedPath = `/`
+		return &PrefixMatchCondition{
+			Prefix: mergedPath,
+		}
 	}
 
-	return &PrefixMatchCondition{
-		Prefix: prefix,
+	// If mergedPath is not empty then choose match type using the last rule of the delegation chain
+	lastCondition := conds[len(conds)-1]
+	switch {
+	case lastCondition.Prefix != "":
+		return &PrefixMatchCondition{
+			Prefix: mergedPath,
+		}
+	case lastCondition.Exact != "":
+		return &ExactMatchCondition{
+			Path: mergedPath,
+		}
+	default:
+		return &PrefixMatchCondition{
+			Prefix: mergedPath,
+		}
 	}
 }
 
 // pathMatchConditionsValid validates a slice of MatchConditions can be correctly merged.
-// It encodes the business rules about what is allowed for prefix MatchConditions.
+// It encodes the business rules about what is allowed for MatchConditions.
 func pathMatchConditionsValid(conds []contour_api_v1.MatchCondition) error {
 	prefixCount := 0
+	exactCount := 0
 
 	for _, cond := range conds {
 		if cond.Prefix != "" {
@@ -61,8 +90,14 @@ func pathMatchConditionsValid(conds []contour_api_v1.MatchCondition) error {
 				return fmt.Errorf("prefix conditions must start with /, %s was supplied", cond.Prefix)
 			}
 		}
-		if prefixCount > 1 {
-			return errors.New("more than one prefix is not allowed in a condition block")
+		if cond.Exact != "" {
+			exactCount++
+			if cond.Exact[0] != '/' {
+				return fmt.Errorf("exact conditions must start with /, %s was supplied", cond.Exact)
+			}
+		}
+		if prefixCount > 1 || exactCount > 1 || prefixCount+exactCount > 1 {
+			return errors.New("more than one prefix or exact is not allowed in a condition block")
 		}
 	}
 

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -23,13 +23,8 @@ import (
 )
 
 // mergePathMatchConditions merges the given slice of prefix or exact MatchConditions into a single
-// prefix/exact Condition.
-// If the root condition is prefix, and included condition is prefix then after merging we get one prefix condition.
-// If the root condition is prefix, and included condition is exact then after merging we get one exact condition.
-// If the root condition is exact, and included condition is exact then after merging we get one exact condition.
-// If the root condition is exact, and included condition is prefix then after merging we get one prefix condition.
-// Hence this can be concluded that the last rule in the delegation chain decides the path type
-//
+// prefix/exact Condition. The leaf condition of the include tree decides whether the merged condition
+// will be prefix or exact
 // pathMatchConditionsValid guarantees that if a prefix is present, it will start with a
 // / character, so we can simply concatenate.
 func mergePathMatchConditions(conds []contour_api_v1.MatchCondition) MatchCondition {
@@ -98,6 +93,17 @@ func pathMatchConditionsValid(conds []contour_api_v1.MatchCondition) error {
 		}
 		if prefixCount > 1 || exactCount > 1 || prefixCount+exactCount > 1 {
 			return errors.New("more than one prefix or exact is not allowed in a condition block")
+		}
+	}
+
+	return nil
+}
+
+// includeMatchConditionsValid validates the MatchConditions supplied in the includes
+func includeMatchConditionsValid(conds []contour_api_v1.MatchCondition) error {
+	for _, cond := range conds {
+		if cond.Exact != "" {
+			return fmt.Errorf("exact conditions are not allowed in includes block")
 		}
 	}
 

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -29,15 +29,55 @@ func TestPathMatchCondition(t *testing.T) {
 			matchconditions: nil,
 			want:            &PrefixMatchCondition{Prefix: "/"},
 		},
-		"single slash": {
+		"single slash prefix": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/",
 			}},
 			want: &PrefixMatchCondition{Prefix: "/"},
 		},
+		"single slash exact": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/",
+			}},
+			want: &ExactMatchCondition{Path: "/"},
+		},
+		"empty exact": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "",
+			}},
+			want: &PrefixMatchCondition{Prefix: "/"},
+		},
+		"prefix match": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Prefix: "/a",
+			}},
+			want: &PrefixMatchCondition{Prefix: "/a"},
+		},
+		"exact match": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/a",
+			}},
+			want: &ExactMatchCondition{Path: "/a"},
+		},
 		"two slashes": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/",
+			}, {
+				Prefix: "/",
+			}},
+			want: &PrefixMatchCondition{Prefix: "/"},
+		},
+		"prefix-exact mixed two slashes": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Prefix: "/",
+			}, {
+				Exact: "/",
+			}},
+			want: &ExactMatchCondition{Path: "/"},
+		},
+		"exact-prefix mixed two slashes": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/",
 			}, {
 				Prefix: "/",
 			}},
@@ -51,11 +91,33 @@ func TestPathMatchCondition(t *testing.T) {
 			}},
 			want: &PrefixMatchCondition{Prefix: "/a/b"},
 		},
-		"trailing slash": {
+		"prefix-exact mixed matchconditions": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Prefix: "/a/",
+			}, {
+				Exact: "/b",
+			}},
+			want: &ExactMatchCondition{Path: "/a/b"},
+		},
+		"exact-prefix mixed matchconditions": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/a/",
+			}, {
+				Prefix: "/b",
+			}},
+			want: &PrefixMatchCondition{Prefix: "/a/b"},
+		},
+		"trailing slash prefix": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/a/",
 			}},
 			want: &PrefixMatchCondition{Prefix: "/a/"},
+		},
+		"trailing slash exact": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/a/",
+			}},
+			want: &ExactMatchCondition{Path: "/a/"},
 		},
 		"trailing slash on second prefix condition": {
 			matchconditions: []contour_api_v1.MatchCondition{{
@@ -66,10 +128,46 @@ func TestPathMatchCondition(t *testing.T) {
 				}},
 			want: &PrefixMatchCondition{Prefix: "/a/b/"},
 		},
-		"nothing but slashes": {
+		"trailing slash on second exact condition": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/a",
+			},
+				{
+					Exact: "/b/",
+				}},
+			want: &ExactMatchCondition{Path: "/a/b/"},
+		},
+		"nothing but slashes prefix": {
 			matchconditions: []contour_api_v1.MatchCondition{
 				{
 					Prefix: "///",
+				},
+				{
+					Prefix: "/",
+				}},
+			want: &PrefixMatchCondition{Prefix: "/"},
+		},
+		"nothing but slashes one exact": {
+			matchconditions: []contour_api_v1.MatchCondition{
+				{
+					Exact: "///",
+				}},
+			want: &ExactMatchCondition{Path: "/"},
+		},
+		"nothing but slashes two exacts": {
+			matchconditions: []contour_api_v1.MatchCondition{
+				{
+					Exact: "///",
+				},
+				{
+					Exact: "/",
+				}},
+			want: &ExactMatchCondition{Path: "/"},
+		},
+		"nothing but slashes mixed": {
+			matchconditions: []contour_api_v1.MatchCondition{
+				{
+					Exact: "///",
 				},
 				{
 					Prefix: "/",
@@ -81,6 +179,13 @@ func TestPathMatchCondition(t *testing.T) {
 				Header: new(contour_api_v1.HeaderMatchCondition),
 			}},
 			want: &PrefixMatchCondition{Prefix: "/"},
+		},
+		"header condition with exact": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Header: new(contour_api_v1.HeaderMatchCondition),
+				Exact:  "/a",
+			}},
+			want: &ExactMatchCondition{Path: "/a"},
 		},
 	}
 
@@ -310,6 +415,81 @@ func TestPrefixMatchConditionsValid(t *testing.T) {
 		"invalid prefix condition with headers": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "api",
+				Header: &contour_api_v1.HeaderMatchCondition{
+					Name:     "x-header",
+					Contains: "abc",
+				},
+			}},
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := pathMatchConditionsValid(tc.matchconditions)
+			assert.Equal(t, tc.want, err == nil)
+		})
+	}
+}
+
+func TestExactMatchConditionsValid(t *testing.T) {
+	tests := map[string]struct {
+		matchconditions []contour_api_v1.MatchCondition
+		want            bool
+	}{
+		"valid exact condition only": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/api",
+			}},
+			want: true,
+		},
+		"valid exact condition with headers": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/api",
+				Header: &contour_api_v1.HeaderMatchCondition{
+					Name:     "x-header",
+					Contains: "abc",
+				},
+			}},
+			want: true,
+		},
+		"two exact matchconditions": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/api",
+			}, {
+				Exact: "/v1",
+			}},
+			want: false,
+		},
+		"exact-prefix two matchconditions": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/api",
+			}, {
+				Prefix: "/v1",
+			}},
+			want: false,
+		},
+		"two exact matchconditions with headers": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "/api",
+				Header: &contour_api_v1.HeaderMatchCondition{
+					Name:     "x-header",
+					Contains: "abc",
+				},
+			}, {
+				Exact: "/v1",
+			}},
+			want: false,
+		},
+		"invalid exact condition": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "api",
+			}},
+			want: false,
+		},
+		"invalid exact condition with headers": {
+			matchconditions: []contour_api_v1.MatchCondition{{
+				Exact: "api",
 				Header: &contour_api_v1.HeaderMatchCondition{
 					Name:     "x-header",
 					Contains: "abc",

--- a/internal/dag/conditions_test.go
+++ b/internal/dag/conditions_test.go
@@ -75,14 +75,6 @@ func TestPathMatchCondition(t *testing.T) {
 			}},
 			want: &ExactMatchCondition{Path: "/"},
 		},
-		"exact-prefix mixed two slashes": {
-			matchconditions: []contour_api_v1.MatchCondition{{
-				Exact: "/",
-			}, {
-				Prefix: "/",
-			}},
-			want: &PrefixMatchCondition{Prefix: "/"},
-		},
 		"mixed matchconditions": {
 			matchconditions: []contour_api_v1.MatchCondition{{
 				Prefix: "/a/",
@@ -98,14 +90,6 @@ func TestPathMatchCondition(t *testing.T) {
 				Exact: "/b",
 			}},
 			want: &ExactMatchCondition{Path: "/a/b"},
-		},
-		"exact-prefix mixed matchconditions": {
-			matchconditions: []contour_api_v1.MatchCondition{{
-				Exact: "/a/",
-			}, {
-				Prefix: "/b",
-			}},
-			want: &PrefixMatchCondition{Prefix: "/a/b"},
 		},
 		"trailing slash prefix": {
 			matchconditions: []contour_api_v1.MatchCondition{{
@@ -128,15 +112,6 @@ func TestPathMatchCondition(t *testing.T) {
 				}},
 			want: &PrefixMatchCondition{Prefix: "/a/b/"},
 		},
-		"trailing slash on second exact condition": {
-			matchconditions: []contour_api_v1.MatchCondition{{
-				Exact: "/a",
-			},
-				{
-					Exact: "/b/",
-				}},
-			want: &ExactMatchCondition{Path: "/a/b/"},
-		},
 		"nothing but slashes prefix": {
 			matchconditions: []contour_api_v1.MatchCondition{
 				{
@@ -154,25 +129,15 @@ func TestPathMatchCondition(t *testing.T) {
 				}},
 			want: &ExactMatchCondition{Path: "/"},
 		},
-		"nothing but slashes two exacts": {
+		"nothing but slashes mixed": {
 			matchconditions: []contour_api_v1.MatchCondition{
 				{
-					Exact: "///",
+					Prefix: "///",
 				},
 				{
 					Exact: "/",
 				}},
 			want: &ExactMatchCondition{Path: "/"},
-		},
-		"nothing but slashes mixed": {
-			matchconditions: []contour_api_v1.MatchCondition{
-				{
-					Exact: "///",
-				},
-				{
-					Prefix: "/",
-				}},
-			want: &PrefixMatchCondition{Prefix: "/"},
 		},
 		"header condition": {
 			matchconditions: []contour_api_v1.MatchCondition{{

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -359,6 +359,12 @@ func (r *Route) HasPathPrefix() bool {
 	return ok
 }
 
+// HasPathExact returns whether this route has a ExactPathCondition.
+func (r *Route) HasPathExact() bool {
+	_, ok := r.PathMatchCondition.(*ExactMatchCondition)
+	return ok
+}
+
 // HasPathRegex returns whether this route has a RegexPathCondition.
 func (r *Route) HasPathRegex() bool {
 	_, ok := r.PathMatchCondition.(*RegexMatchCondition)

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -599,6 +599,12 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			namespace = proxy.Namespace
 		}
 
+		if err := includeMatchConditionsValid(include.Conditions); err != nil {
+			validCond.AddErrorf(contour_api_v1.ConditionTypeIncludeError, "PathMatchConditionsNotValid",
+				"include: %s", err)
+			continue
+		}
+
 		if err := pathMatchConditionsValid(include.Conditions); err != nil {
 			validCond.AddErrorf(contour_api_v1.ConditionTypeIncludeError, "PathMatchConditionsNotValid",
 				"include: %s", err)

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -1292,7 +1292,7 @@ func TestDAGStatus(t *testing.T) {
 		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
 			{Name: proxyInvalidMultiplePrefixes.Name, Namespace: proxyInvalidMultiplePrefixes.Namespace}: fixture.NewValidCondition().
 				WithGeneration(proxyInvalidMultiplePrefixes.Generation).
-				WithError(contour_api_v1.ConditionTypeRouteError, "PathMatchConditionsNotValid", "route: more than one prefix is not allowed in a condition block"),
+				WithError(contour_api_v1.ConditionTypeRouteError, "PathMatchConditionsNotValid", "route: more than one prefix or exact is not allowed in a condition block"),
 		},
 	})
 
@@ -1345,7 +1345,7 @@ func TestDAGStatus(t *testing.T) {
 		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
 			{Name: proxyInvalidTwoPrefixesWithInclude.Name, Namespace: proxyInvalidTwoPrefixesWithInclude.Namespace}: fixture.NewValidCondition().
 				WithGeneration(proxyInvalidTwoPrefixesWithInclude.Generation).
-				WithError(contour_api_v1.ConditionTypeIncludeError, "PathMatchConditionsNotValid", "include: more than one prefix is not allowed in a condition block"),
+				WithError(contour_api_v1.ConditionTypeIncludeError, "PathMatchConditionsNotValid", "include: more than one prefix or exact is not allowed in a condition block"),
 			{Name: proxyValidChildTeamA.Name, Namespace: proxyValidChildTeamA.Namespace}: fixture.NewValidCondition().
 				WithGeneration(proxyValidChildTeamA.Generation).
 				Orphaned(),

--- a/internal/fixture/service_fixtures.go
+++ b/internal/fixture/service_fixtures.go
@@ -41,6 +41,17 @@ var ServiceRootsHome = &v1.Service{
 	},
 }
 
+var ServiceRootsFoo1 = &v1.Service{
+	ObjectMeta: ObjectMeta("roots/foo1"),
+	Spec: v1.ServiceSpec{
+		Ports: []v1.ServicePort{{
+			Name:     "http",
+			Protocol: "TCP",
+			Port:     8080,
+		}},
+	},
+}
+
 var ServiceRootsFoo2 = &v1.Service{
 	ObjectMeta: ObjectMeta("roots/foo2"),
 	Spec: v1.ServiceSpec{

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2425,7 +2425,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Exact defines a exact path match for a request.</p>
+<p>Exact defines a exact path match for a request. Not allowed with inclusion.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2425,7 +2425,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Exact defines a exact path match for a request. Not allowed with inclusion.</p>
+<p>Exact defines a exact match for a request.
+This field is not allowed in include match conditions.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -2392,7 +2392,7 @@ set when a request is rate-limited.</p>
 </p>
 <p>
 <p>MatchCondition are a general holder for matching rules for HTTPProxies.
-One of Prefix, Header or QueryParameter must be provided.</p>
+One of Prefix, Exact, Header or QueryParameter must be provided.</p>
 </p>
 <table>
 <thead>
@@ -2413,6 +2413,19 @@ string
 <td>
 <em>(Optional)</em>
 <p>Prefix defines a prefix match for a request.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
+<code>exact</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Exact defines a exact path match for a request.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/inclusion-delegation.md
+++ b/site/content/docs/main/config/inclusion-delegation.md
@@ -26,7 +26,7 @@ This may result in duplicates, for example two `prefix:` conditions, mix of both
 To resolve this Contour applies the following logic.
 
 - `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
-- `exact:` conditions are also concatenated just like `prefix:` conditions, but `exact:` conditions are not allowed in the root httpproxy or in the inlcusion block. If the child httpproxy has `exact:` condition then after concatenation, it becomes a single `exact:` condition. For example, `prefix: /static` and `exact: /main.js` become a single `exact: /static/main.js` condition.
+- `exact:` conditions are also concatenated just like `prefix:` conditions, but `exact:` conditions are not allowed in include match conditions. If the child httpproxy has `exact:` condition then after concatenation, it becomes a single `exact:` condition. For example, `prefix: /static` and `exact: /main.js` become a single `exact: /static/main.js` condition.
 - Proxies with repeated identical `header:` conditions of type "exact match" (the same header keys exactly) are marked as "Invalid" since they create an un-routable configuration.
 
 ## Configuring Inclusion

--- a/site/content/docs/main/config/inclusion-delegation.md
+++ b/site/content/docs/main/config/inclusion-delegation.md
@@ -22,10 +22,12 @@ This process is recursive.
 
 Conditions are sets of individual condition statements, for example `prefix: /blog` is the condition that the matching request's path must start with `/blog`.
 When conditions are combined through inclusion Contour merges the conditions inherited via inclusion with any conditions specified on the route.
-This may result in duplicates, for example two `prefix:` conditions, or two header match conditions with the same name and value.
+This may result in duplicates, for example two `prefix:` conditions, two `exact:` conditions, mix of both `exact:` and `prefix`, or two header match conditions with the same name and value.
 To resolve this Contour applies the following logic.
 
 - `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
+- `exact` conditions are also concatenated just like `prefix` conditions, but the condition in the child httpproxy
+decides the resulting merged path condition. For example, if root condition is `prefix: /api` and child httpproxy has `exact: /health` condition then it becomes a single `exact: /api/health` condition. Similarly, `exact: /api` + `prefix: /v1` becomes one `prefix: /api/v1` condition.
 - Proxies with repeated identical `header:` conditions of type "exact match" (the same header keys exactly) are marked as "Invalid" since they create an un-routable configuration.
 
 ## Configuring Inclusion

--- a/site/content/docs/main/config/inclusion-delegation.md
+++ b/site/content/docs/main/config/inclusion-delegation.md
@@ -22,12 +22,11 @@ This process is recursive.
 
 Conditions are sets of individual condition statements, for example `prefix: /blog` is the condition that the matching request's path must start with `/blog`.
 When conditions are combined through inclusion Contour merges the conditions inherited via inclusion with any conditions specified on the route.
-This may result in duplicates, for example two `prefix:` conditions, two `exact:` conditions, mix of both `exact:` and `prefix`, or two header match conditions with the same name and value.
+This may result in duplicates, for example two `prefix:` conditions, mix of both `prefix:` and `exact` conditions, or two header match conditions with the same name and value.
 To resolve this Contour applies the following logic.
 
 - `prefix:` conditions are concatenated together in the order they were applied from the root object. For example the conditions, `prefix: /api`, `prefix: /v1` becomes a single `prefix: /api/v1` conditions. Note: Multiple prefixes cannot be supplied on a single set of Route conditions.
-- `exact` conditions are also concatenated just like `prefix` conditions, but the condition in the child httpproxy
-decides the resulting merged path condition. For example, if root condition is `prefix: /api` and child httpproxy has `exact: /health` condition then it becomes a single `exact: /api/health` condition. Similarly, `exact: /api` + `prefix: /v1` becomes one `prefix: /api/v1` condition.
+- `exact:` conditions are also concatenated just like `prefix:` conditions, but `exact:` conditions are not allowed in the root httpproxy or in the inlcusion block. If the child httpproxy has `exact:` condition then after concatenation, it becomes a single `exact:` condition. For example, `prefix: /static` and `exact: /main.js` become a single `exact: /static/main.js` condition.
 - Proxies with repeated identical `header:` conditions of type "exact match" (the same header keys exactly) are marked as "Invalid" since they create an un-routable configuration.
 
 ## Configuring Inclusion

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -90,7 +90,8 @@ Prefix conditions **must** start with a `/` if they are present.
 
 Paths defined are matched using exact conditions.
 Up to one exact condition may be present in any condition block. Any condition block can
-either have an exact condition or prefix condition, but not both together.
+either have an exact condition or prefix condition, but not both together. Exact conditions are
+not allowed in root httpproxies or in includes blocks.
 
 Exact conditions **must** start with a `/` if they are present.
 

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -91,7 +91,7 @@ Prefix conditions **must** start with a `/` if they are present.
 Paths defined are matched using exact conditions.
 Up to one exact condition may be present in any condition block. Any condition block can
 either have an exact condition or prefix condition, but not both together. Exact conditions are
-not allowed in root httpproxies or in includes blocks.
+only allowed in route match conditions and not in include match conditions.
 
 Exact conditions **must** start with a `/` if they are present.
 

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -1,7 +1,7 @@
 # Request Routing
 
 A HTTPProxy object must have at least one route or include defined.
-In this example, any requests to `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*` will be routed to the Service `s2`.
+In this example, any requests to `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*` will be routed to the Service `s2` using the prefix conditions. Requests to `multi-path.bar.com/feed` will be routed to Service `s2` using exact match condition.
 All other requests to the host `multi-path.bar.com` will be routed to the Service `s1`.
 
 ```yaml
@@ -22,6 +22,11 @@ spec:
           port: 80
     - conditions:
       - prefix: /blog # matches `multi-path.bar.com/blog` or `multi-path.bar.com/blog/*`
+      services:
+        - name: s2
+          port: 80
+    - conditions:
+      - exact: /feed # matches `multi-path.bar.com/feed` only
       services:
         - name: s2
           port: 80
@@ -71,7 +76,8 @@ spec:
 
 Each Route entry in a HTTPProxy **may** contain one or more conditions.
 These conditions are combined with an AND operator on the route passed to Envoy.
-Conditions can be either a `prefix`, `header` or a `queryParameter` condition.
+Conditions can be either a `prefix`, `exact`, `header` or a `queryParameter` condition. `prefix` and `exact`
+conditions cannot be used together in one condition block.
 
 #### Prefix conditions
 
@@ -79,6 +85,14 @@ Paths defined are matched using prefix conditions.
 Up to one prefix condition may be present in any condition block.
 
 Prefix conditions **must** start with a `/` if they are present.
+
+#### Exact conditions
+
+Paths defined are matched using exact conditions.
+Up to one exact condition may be present in any condition block. Any condition block can
+either have an exact condition or prefix condition, but not both together.
+
+Exact conditions **must** start with a `/` if they are present.
 
 #### Header conditions
 

--- a/test/e2e/httpproxy/exact_path_condition_match_test.go
+++ b/test/e2e/httpproxy/exact_path_condition_match_test.go
@@ -1,0 +1,158 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package httpproxy
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testExactPathCondition(namespace string) {
+	Specify("Exact path match routing works and has precedence over prefix match", func() {
+		var (
+			t                = f.T()
+			serviceNamespace = namespace
+		)
+
+		f.Fixtures.Echo.Deploy(serviceNamespace, "echo-blue")
+		f.Fixtures.Echo.Deploy(serviceNamespace, "echo-green")
+		f.Fixtures.Echo.Deploy(serviceNamespace, "echo-default")
+
+		serviceProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: serviceNamespace,
+				Name:      "echo-exact",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "exactpathcondition.projectcontour.io",
+				},
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-blue",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/blue",
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-blue",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/common/exact-blue",
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-green",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/common/exact-blue/",
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-green",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/blue-exact-green",
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-green",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/blue/exact-green",
+							},
+						},
+					},
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-default",
+								Port: 80,
+							},
+						},
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
+
+		cases := map[string]string{
+			"/":                        "echo-default",
+			"/blue":                    "echo-blue",
+			"/blue/exact-green":        "echo-green",
+			"/common/exact-blue":       "echo-blue",
+			"/common/exact-blue/green": "echo-green",
+			"/blue-exact-green":        "echo-green",
+			"/blue-exact-green/extra":  "echo-blue",
+			"/app":                     "echo-default",
+		}
+
+		for path, expectedService := range cases {
+			t.Logf("Querying %q, expecting service %q", path, expectedService)
+
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host:      serviceProxy.Spec.VirtualHost.Fqdn,
+				Path:      path,
+				Condition: e2e.HasStatusCode(200),
+			})
+			if !assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode) {
+				continue
+			}
+
+			assert.Equal(t, expectedService, f.GetEchoResponseBody(res.Body).Service)
+		}
+	})
+}

--- a/test/e2e/httpproxy/exact_path_condition_match_test.go
+++ b/test/e2e/httpproxy/exact_path_condition_match_test.go
@@ -130,14 +130,14 @@ func testExactPathCondition(namespace string) {
 		f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
 
 		cases := map[string]string{
-			"/":                        "echo-default",
-			"/blue":                    "echo-blue",
-			"/blue/exact-green":        "echo-green",
-			"/common/exact-blue":       "echo-blue",
-			"/common/exact-blue/green": "echo-green",
-			"/blue-exact-green":        "echo-green",
-			"/blue-exact-green/extra":  "echo-blue",
-			"/app":                     "echo-default",
+			"/":                        "echo-default", // Condition matched: "Prefix: /"
+			"/blue":                    "echo-blue",    // Condition matched: "Prefix: /blue"
+			"/blue/exact-green":        "echo-green",   // Condition matched: "Exact:  /blue/exact" (exact takes precedence over "Prefix: /blue")
+			"/common/exact-blue":       "echo-blue",    // Condition matched: "Exact:  /common/exact-blue"
+			"/common/exact-blue/green": "echo-green",   // Condition matched: "Prefix: /common/exact-blue/"
+			"/blue-exact-green":        "echo-green",   // Condition matched: "Exact:  /blue-exact-green"
+			"/blue-exact-green/extra":  "echo-blue",    // Condition matched: "Prefix: /blue"
+			"/app":                     "echo-default", // Condition matched: "Prefix: /"
 		}
 
 		for path, expectedService := range cases {

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -157,6 +157,10 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-include-prefix-condition", testIncludePrefixCondition)
 
+	f.NamespacedTest("httpproxy-include-exact-condition", testIncludeExactCondition)
+
+	f.NamespacedTest("httpproxy-exact-path-condition-app", testExactPathCondition)
+
 	f.NamespacedTest("httpproxy-retry-policy-validation", testRetryPolicyValidation)
 
 	f.NamespacedTest("httpproxy-wildcard-subdomain-fqdn", testWildcardSubdomainFQDN)

--- a/test/e2e/httpproxy/include_exact_condition_test.go
+++ b/test/e2e/httpproxy/include_exact_condition_test.go
@@ -1,0 +1,187 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package httpproxy
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testIncludeExactCondition(namespace string) {
+	Specify("HTTPProxy include exacts can cross namespaces", func() {
+		var (
+			t              = f.T()
+			appNamespace   = "httpproxy-include-exact-condition-app"
+			adminNamespace = "httpproxy-include-exact-condition-admin"
+		)
+
+		for _, ns := range []string{appNamespace, adminNamespace} {
+			f.CreateNamespace(ns)
+			defer f.DeleteNamespace(ns, false)
+		}
+
+		f.Fixtures.Echo.Deploy(appNamespace, "echo-app")
+		f.Fixtures.Echo.Deploy(adminNamespace, "echo-admin")
+
+		appProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: appNamespace,
+				Name:      "echo-app",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-app",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		// appProxy will be orphaned when created so can't wait for
+		// it to be valid.
+		require.NoError(t, f.Client.Create(context.TODO(), appProxy))
+
+		adminProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: adminNamespace,
+				Name:      "echo-admin",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: "echo-admin",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		// adminProxy will be orphaned when created so can't wait for
+		// it to be valid.
+		require.NoError(t, f.Client.Create(context.TODO(), adminProxy))
+
+		baseProxy := &contourv1.HTTPProxy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "echo",
+			},
+			Spec: contourv1.HTTPProxySpec{
+				VirtualHost: &contourv1.VirtualHost{
+					Fqdn: "includeexactcondition.projectcontour.io",
+				},
+				Includes: []contourv1.Include{
+					{
+						Name:      appProxy.Name,
+						Namespace: appProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/app",
+							},
+						},
+					},
+					{
+						Name:      adminProxy.Name,
+						Namespace: adminProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/app/admin",
+							},
+						},
+					},
+					{
+						Name:      adminProxy.Name,
+						Namespace: adminProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/admin",
+							},
+						},
+					},
+					{
+						Name:      appProxy.Name,
+						Namespace: appProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/admin/app",
+							},
+						},
+					},
+					{
+						Name:      appProxy.Name,
+						Namespace: appProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Exact: "/admin-app",
+							},
+						},
+					},
+					{
+						Name:      appProxy.Name,
+						Namespace: appProxy.Namespace,
+						Conditions: []contourv1.MatchCondition{
+							{
+								Prefix: "/",
+							},
+						},
+					},
+				},
+			},
+		}
+		f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
+
+		cases := map[string]string{
+			"/":              "echo-app",
+			"/app":           "echo-app",
+			"/app/admin":     "echo-admin",
+			"/app/adminfoo":  "echo-app",
+			"/app/admin/foo": "echo-app",
+			"/admin":         "echo-admin",
+			"/admin/":        "echo-admin",
+			"/admin-app":     "echo-app",
+			"/admin/app":     "echo-app",
+			"/random":        "echo-app",
+		}
+
+		for path, expectedService := range cases {
+			t.Logf("Querying %q, expecting service %q", path, expectedService)
+
+			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+				Host:      baseProxy.Spec.VirtualHost.Fqdn,
+				Path:      path,
+				Condition: e2e.HasStatusCode(200),
+			})
+			if !assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode) {
+				continue
+			}
+
+			assert.Equal(t, expectedService, f.GetEchoResponseBody(res.Body).Service)
+		}
+	})
+}

--- a/test/e2e/httpproxy/include_exact_condition_test.go
+++ b/test/e2e/httpproxy/include_exact_condition_test.go
@@ -189,12 +189,12 @@ func testIncludeExactCondition(namespace string) {
 		f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
 
 		cases := map[string]string{
-			"/app/foo":      "echo-app",
-			"/app/admin":    "echo-admin",
-			"/app/bar":      "echo-admin",
-			"/app/v1":       "echo-app",
-			"/app/v1/page":  "echo-app",
-			"/admin/portal": "echo-admin",
+			"/app/foo":      "echo-app",   // Condition matched: "Prefix: /app"   +  "Exact:  /foo"    = "Exact:  /app/foo"
+			"/app/admin":    "echo-admin", // Condition matched: "Prefix: /app/"  +  "Prefix: /"       = "Prefix: /app"
+			"/app/bar":      "echo-admin", // Condition matched: "Prefix: /app/"  +  "Prefix: /"       = "Prefix: /app"
+			"/app/v1":       "echo-app",   // Condition matched: "Prefix: /app"   +  "Prefix: /v1"     = "Prefix: /app/v1"
+			"/app/v1/page":  "echo-app",   // Condition matched: "Prefix: /app"   +  "Prefix: /v1"     = "Prefix: /app/v1"
+			"/admin/portal": "echo-admin", // Condition matched: "Prefix: /admin" +  "Exact:  /portal" = "Exact:  /app/v1"
 		}
 
 		for path, expectedService := range cases {


### PR DESCRIPTION
This adds support for exact path matching in the HttpProxy along side prefix matching

fixes #4069
Signed-off-by: Arjun Salyan <iarjunsalyan@gmail.com>