### PR TITLE
Allow limiting K8s watches on specific namespaces.

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -62,6 +62,9 @@ type serveContext struct {
 	// httpproxy root namespaces
 	rootNamespaces string
 
+	// Watch only these namespaces to allow running with limited RBAC permissions.
+	watchNamespaces string
+
 	// ingress class
 	ingressClassName string
 
@@ -241,6 +244,17 @@ func (ctx *serveContext) proxyRootNamespaces() []string {
 	}
 	var ns []string
 	for _, s := range strings.Split(ctx.rootNamespaces, ",") {
+		ns = append(ns, strings.TrimSpace(s))
+	}
+	return ns
+}
+
+func (ctx *serveContext) watchedNamespaces() []string {
+	if strings.TrimSpace(ctx.watchNamespaces) == "" {
+		return nil
+	}
+	var ns []string
+	for _, s := range strings.Split(ctx.watchNamespaces, ",") {
 		ns = append(ns, strings.TrimSpace(s))
 	}
 	return ns

--- a/examples/namespaced/kustomization.yaml
+++ b/examples/namespaced/kustomization.yaml
@@ -1,0 +1,54 @@
+resources:
+- ../render/
+
+patchesJson6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: contour
+  # This patch changes the ClusterRoleBinding to a RoleBinding,
+  # and renames the object to contour-resources to avoid conflict with existing RoleBinding.
+  patch: |-
+    - op: replace
+      path: /kind
+      value: RoleBinding
+    - op: replace
+      path: /metadata/name
+      value: contour-resources
+    - op: replace
+      path: /roleRef/kind
+      value: Role
+    - op: replace
+      path: /roleRef/name
+      value: contour-resources
+    - op: add
+      path: /metadata/namespace
+      value: projectcontour
+# This patch changes the ClusterRole to a Role,
+# and renames the object to contour-resources to avoid conflict with existing Role.
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: contour
+  patch: |-
+    - op: replace
+      path: /kind
+      value: Role
+    - op: replace
+      path: /metadata/name
+      value: contour-resources
+    - op: add
+      path: /metadata/namespace
+      value: projectcontour
+# Append argument to Contour serve command
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: contour
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --watch-namespaces=projectcontour


### PR DESCRIPTION
This PR adds an option for users to limit which namespaces `contour serve` will attempt to access. Following use cases could benefit from this feature:

* Allows Contour to be used in a restricted environment where it is not acceptable to grant `ClusterRole` and `ClusterRoleBinding` to Contour.
* It could be used to limit the number of resources processed by Contour.

An example of the first use case: Users want to install their own dedicated instances of Contour together with their application into their own namespace in a soft-multitenant cluster. Cluster administrator might be willing to installing the CRDs for users, but due to security reasons it is unacceptable to grant `ClusterRoles` that give users access to resources in other namespaces, most importantly it would allow the user to read *all* `Secrets` in the cluster. 

The implementation uses the controller-runtime feature to set the watched `Namespace` option when only single namespace needs to be watched, or alternatively it uses `MultiNamespacedCacheBuilder` when more than one namespace needs to be watched. With some preliminary testing, it seems to work. To test the feature, kustomize file is added to the examples. It simply changes the existing `ClusterRole` and `ClusterRoleBinding` to namespaced `Role` and `RoleBinding`.

The same feature seems to be supported by NGINX with `-watch-namespace` (see [link](https://docs.nginx.com/nginx-ingress-controller/installation/running-multiple-ingress-controllers/)).

The issue has been previously discussed in #2497 and https://github.com/projectcontour/contour-operator/issues/95.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>

**Marking the PR as draft, since it is just a PoC, but I'd be curious to hear any feedback.**
