### PR TITLE
internal/metrics: drop empty labels from dagRebuildGauge

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,7 +33,7 @@ type Metrics struct {
 	proxyValidGauge     *prometheus.GaugeVec
 	proxyOrphanedGauge  *prometheus.GaugeVec
 
-	dagRebuildGauge             *prometheus.GaugeVec
+	dagRebuildGauge             prometheus.Gauge
 	dagRebuildTotal             prometheus.Counter
 	CacheHandlerOnUpdateSummary prometheus.Summary
 	EventHandlerOperations      *prometheus.CounterVec
@@ -122,12 +122,11 @@ func NewMetrics(registry *prometheus.Registry) *Metrics {
 			},
 			[]string{"namespace"},
 		),
-		dagRebuildGauge: prometheus.NewGaugeVec(
+		dagRebuildGauge: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: DAGRebuildGauge,
 				Help: "Timestamp of the last DAG rebuild.",
 			},
-			[]string{},
 		),
 		dagRebuildTotal: prometheus.NewCounter(
 			prometheus.CounterOpts{
@@ -195,7 +194,7 @@ func (m *Metrics) Zero() {
 
 // SetDAGLastRebuilt records the last time the DAG was rebuilt.
 func (m *Metrics) SetDAGLastRebuilt(ts time.Time) {
-	m.dagRebuildGauge.WithLabelValues().Set(float64(ts.Unix()))
+	m.dagRebuildGauge.Set(float64(ts.Unix()))
 }
 
 // SetDAGRebuiltTotal records the total number of times DAG was rebuilt

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -38,6 +38,7 @@ func TestSetDAGLastRebuilt(t *testing.T) {
 				metric: DAGRebuildGauge,
 				want: []*io_prometheus_client.Metric{
 					{
+						Label: []*io_prometheus_client.LabelPair{},
 						Gauge: &io_prometheus_client.Gauge{
 							Value: func() *float64 { i := float64(1.258490098e+09); return &i }(),
 						},


### PR DESCRIPTION
The dagRebuildGauge metric was being constructed
as a GaugeVec, but with an empty label slice. This 
drops the empty label slice and changes to a plain Gauge.
There is no impact for users.

Closes #2238.

Signed-off-by: Steve Kriss <krisss@vmware.com>