### PR TITLE
cmd/contour: pass Logger to CLI

### DIFF
--- a/cmd/contour/cli.go
+++ b/cmd/contour/cli.go
@@ -38,9 +38,10 @@ import (
 
 // registerCli registers the cli subcommand and flags
 // with the Application provided.
-func registerCli(app *kingpin.Application) (*kingpin.CmdClause, *Client) {
+func registerCli(app *kingpin.Application, log *logrus.Logger) (*kingpin.CmdClause, *Client) {
+	client := Client{Log: log}
+
 	cli := app.Command("cli", "A CLI client for the Contour Kubernetes ingress controller.")
-	var client Client
 	cli.Flag("cafile", "CA bundle file for connecting to a TLS-secured Contour.").Envar("CLI_CAFILE").StringVar(&client.CAFile)
 	cli.Flag("cert-file", "Client certificate file for connecting to a TLS-secured Contour.").Envar("CLI_CERT_FILE").StringVar(&client.ClientCert)
 	cli.Flag("contour", "Contour host:port.").Default("127.0.0.1:8001").StringVar(&client.ContourAddr)
@@ -48,6 +49,7 @@ func registerCli(app *kingpin.Application) (*kingpin.CmdClause, *Client) {
 	cli.Flag("key-file", "Client key file for connecting to a TLS-secured Contour.").Envar("CLI_KEY_FILE").StringVar(&client.ClientKey)
 	cli.Flag("nack", "NACK all responses (for testing).").BoolVar(&client.Nack)
 	cli.Flag("node-id", "Node ID for the CLI client to use.").Envar("CLI_NODE_ID").Default("ContourCLI").StringVar(&client.NodeID)
+
 	return cli, &client
 }
 

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -42,7 +42,7 @@ func main() {
 
 	certgenApp, certgenConfig := registerCertGen(app)
 
-	cli, client := registerCli(app)
+	cli, client := registerCli(app, log)
 
 	var resources []string
 	cds := cli.Command("cds", "Watch services.")

--- a/cmd/contour/contour_test.go
+++ b/cmd/contour/contour_test.go
@@ -33,6 +33,7 @@ func assertOptionFlagsAreSorted(t *testing.T, cmd *kingpin.CmdClause) {
 
 func TestOptionFlagsAreSorted(t *testing.T) {
 	app := kingpin.New("contour_option_flags_are_sorted", "Assert contour options are sorted")
+	log := logrus.StandardLogger()
 
 	bootstrap, _ := registerBootstrap(app)
 	assertOptionFlagsAreSorted(t, bootstrap)
@@ -40,11 +41,10 @@ func TestOptionFlagsAreSorted(t *testing.T) {
 	certgen, _ := registerCertGen(app)
 	assertOptionFlagsAreSorted(t, certgen)
 
-	cli, _ := registerCli(app)
+	cli, _ := registerCli(app, log)
 	assertOptionFlagsAreSorted(t, cli)
 
 	envoyCmd := app.Command("envoy", "Sub-command for envoy actions.")
-	log := logrus.StandardLogger()
 
 	sdmShutdown, _ := registerShutdown(envoyCmd, log)
 	assertOptionFlagsAreSorted(t, sdmShutdown)


### PR DESCRIPTION
Passes a Logger to the CLI to fix a null
pointer exception.

Signed-off-by: Steve Kriss <krisss@vmware.com>