### PR TITLE
GRPCRoute: add grpcRoute controller registration

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -806,6 +806,11 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 			s.log.WithError(err).Fatal("failed to create tlsroute-controller")
 		}
 
+		// Create and register the GRPCRoute controller with the manager.
+		if err := controller.RegisterGRPCRouteController(s.log.WithField("context", "grpcroute-controller"), mgr, eventHandler); err != nil {
+			s.log.WithError(err).Fatal("failed to create grpcroute-controller")
+		}
+
 		// Inform on ReferenceGrants.
 		if err := informOnResource(&gatewayapi_v1beta1.ReferenceGrant{}, eventHandler, mgr.GetCache()); err != nil {
 			s.log.WithError(err).WithField("resource", "referencegrants").Fatal("failed to create informer")

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -24,6 +24,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -36,6 +37,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/examples/gateway-provisioner/01-roles.yaml
+++ b/examples/gateway-provisioner/01-roles.yaml
@@ -74,6 +74,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -93,6 +94,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -7101,6 +7101,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -7113,6 +7114,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -16101,6 +16101,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -16120,6 +16121,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -7107,6 +7107,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -7119,6 +7120,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -7101,6 +7101,7 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - grpcroutes
   - httproutes
   - referencegrants
   - tlsroutes
@@ -7113,6 +7114,7 @@ rules:
   resources:
   - gatewayclasses/status
   - gateways/status
+  - grpcroutes/status
   - httproutes/status
   - tlsroutes/status
   verbs:

--- a/internal/contour/handler.go
+++ b/internal/contour/handler.go
@@ -196,6 +196,7 @@ func (e *EventHandler) onUpdate(op interface{}) bool {
 			cmpopts.IgnoreFields(gatewayapi_v1beta1.Gateway{}, "Status"),
 			cmpopts.IgnoreFields(gatewayapi_v1beta1.HTTPRoute{}, "Status"),
 			cmpopts.IgnoreFields(gatewayapi_v1alpha2.TLSRoute{}, "Status"),
+			cmpopts.IgnoreFields(gatewayapi_v1alpha2.GRPCRoute{}, "Status"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 			cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ManagedFields"),
 		) {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -44,6 +44,9 @@ func TestRegisterControllers(t *testing.T) {
 		"tlsroute controller": func(mockManager *mocks.Manager) error {
 			return controller.RegisterTLSRouteController(fixture.NewTestLogger(t), mockManager, nil)
 		},
+		"grpcroute controller": func(mockManager *mocks.Manager) error {
+			return controller.RegisterGRPCRouteController(fixture.NewTestLogger(t), mockManager, nil)
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/controller/grpcroute.go
+++ b/internal/controller/grpcroute.go
@@ -1,0 +1,77 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type grpcRouteReconciler struct {
+	client       client.Client
+	eventHandler cache.ResourceEventHandler
+	logrus.FieldLogger
+}
+
+// RegisterGRPCRouteController creates the grpcroute controller from mgr. The controller will be pre-configured
+// to watch for GRPCRoute objects across all namespaces.
+func RegisterGRPCRouteController(log logrus.FieldLogger, mgr manager.Manager, eventHandler cache.ResourceEventHandler) error {
+	r := &grpcRouteReconciler{
+		client:       mgr.GetClient(),
+		eventHandler: eventHandler,
+		FieldLogger:  log,
+	}
+	c, err := controller.NewUnmanaged("grpcroute-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+	if err := mgr.Add(&noLeaderElectionController{c}); err != nil {
+		return err
+	}
+
+	return c.Watch(&source.Kind{Type: &gatewayapi_v1alpha2.GRPCRoute{}}, &handler.EnqueueRequestForObject{})
+}
+
+func (r *grpcRouteReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+
+	// Fetch the GRPCRoute from the cache.
+	grpcRoute := &gatewayapi_v1alpha2.GRPCRoute{}
+	err := r.client.Get(ctx, request.NamespacedName, grpcRoute)
+	if errors.IsNotFound(err) {
+		r.eventHandler.OnDelete(&gatewayapi_v1alpha2.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      request.Name,
+				Namespace: request.Namespace,
+			},
+		})
+		return reconcile.Result{}, nil
+	}
+
+	// Pass the new changed object off to the eventHandler.
+	r.eventHandler.OnAdd(grpcRoute)
+
+	return reconcile.Result{}, nil
+}

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -19,8 +19,8 @@ package k8s
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies;tlscertificatedelegations;extensionservices;contourconfigurations,verbs=get;list;watch
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies/status;extensionservices/status;contourconfigurations/status,verbs=create;get;update
 
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;referencegrants,verbs=get;list;watch
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status,verbs=update
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;grpcroutes;referencegrants,verbs=get;list;watch
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;grpcroutes/status,verbs=update
 
 // +kubebuilder:rbac:groups="",resources=secrets;endpoints;services;namespaces,verbs=get;list;watch
 

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
@@ -77,8 +77,8 @@ func desiredClusterRole(name string, contour *model.Contour) *rbacv1.ClusterRole
 
 			// Gateway API resources.
 			// Note, ReferenceGrant does not currently have a .status field so it's omitted from the status rule.
-			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "referencegrants"),
-			policyRuleFor(gatewayv1alpha2.GroupName, update, "gatewayclasses/status", "gateways/status", "httproutes/status", "tlsroutes/status"),
+			policyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gatewayclasses", "gateways", "httproutes", "tlsroutes", "grpcroutes", "referencegrants"),
+			policyRuleFor(gatewayv1alpha2.GroupName, update, "gatewayclasses/status", "gateways/status", "httproutes/status", "grpcroutes/status", "tlsroutes/status"),
 
 			// Ingress resources.
 			policyRuleFor(networkingv1.GroupName, getListWatch, "ingresses"),


### PR DESCRIPTION
add registration controller and reconcile support for GRPCRotue; update handler and serve to call the registration.

Updates #4820

Signed-off-by: Yu Ying <yingy@vmware.com>