### PR TITLE
internal/dag: Add GRPCRoute support in gatewayapi processor

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -38,6 +38,7 @@ import (
 const (
 	KindHTTPRoute = "HTTPRoute"
 	KindTLSRoute  = "TLSRoute"
+	KindGRPCRoute = "GRPCRoute"
 	KindGateway   = "Gateway"
 )
 
@@ -270,6 +271,72 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 						metav1.ConditionTrue,
 						gatewayapi_v1beta1.RouteReasonAccepted,
 						"Accepted TLSRoute",
+					)
+				}
+			}
+		}()
+	}
+
+	// Compute each GRPCRoute for each Listener that it potentially attaches to.
+	for _, grpcRoute := range p.source.grpcroutes {
+		func() {
+			routeAccessor, commit := p.dag.StatusCache.RouteConditionsAccessor(
+				k8s.NamespacedNameOf(grpcRoute),
+				grpcRoute.Generation,
+				&gatewayapi_v1alpha2.GRPCRoute{},
+			)
+			defer commit()
+
+			for _, routeParentRef := range grpcRoute.Spec.ParentRefs {
+				// If this parent ref is to a different Gateway, ignore it.
+				if !gatewayapi.IsRefToGateway(routeParentRef, k8s.NamespacedNameOf(p.source.gateway)) {
+					continue
+				}
+
+				routeParentStatusAccessor := routeAccessor.StatusUpdateFor(routeParentRef)
+
+				// If the Gateway is invalid, set status on the route and we're done.
+				if gatewayNotProgrammedCondition != nil {
+					routeParentStatusAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, status.ReasonInvalidGateway, "Invalid Gateway")
+					return
+				}
+
+				// Get the list of listeners that are (a) included by this parent ref, and
+				// (b) allow the route (based on kind, namespace).
+				allowedListeners := p.getListenersForRouteParentRef(routeParentRef, grpcRoute.Namespace, KindGRPCRoute, readyListeners, routeParentStatusAccessor)
+				if len(allowedListeners) == 0 {
+					continue
+				}
+
+				// Keep track of the number of intersecting hosts
+				// between the route and all allowed listeners for
+				// this parent ref so that we can set the appropriate
+				// route parent status condition if there were none.
+				hostCount := 0
+
+				for _, listener := range allowedListeners {
+					attached, hosts := p.computeGRPCRoute(grpcRoute, routeParentStatusAccessor, listener)
+
+					if attached {
+						listenerAttachedRoutes[string(listener.listener.Name)]++
+					}
+
+					hostCount += hosts.Len()
+				}
+
+				if hostCount == 0 {
+					routeParentStatusAccessor.AddCondition(
+						gatewayapi_v1beta1.RouteConditionAccepted,
+						metav1.ConditionFalse,
+						gatewayapi_v1beta1.RouteReasonNoMatchingListenerHostname,
+						"No intersecting hostnames were found between the listener and the route.",
+					)
+				} else {
+					routeParentStatusAccessor.AddCondition(
+						gatewayapi_v1beta1.RouteConditionAccepted,
+						metav1.ConditionTrue,
+						gatewayapi_v1beta1.RouteReasonAccepted,
+						"Accepted GRPCRoute",
 					)
 				}
 			}
@@ -594,8 +661,10 @@ func (p *GatewayAPIProcessor) getListenerRouteKinds(listener gatewayapi_v1beta1.
 	if len(listener.AllowedRoutes.Kinds) == 0 {
 		switch listener.Protocol {
 		case gatewayapi_v1beta1.HTTPProtocolType:
+			// TODO: add KindGRPCRoute - need to update status_test.go
 			return []gatewayapi_v1beta1.Kind{KindHTTPRoute}
 		case gatewayapi_v1beta1.HTTPSProtocolType:
+			// TODO: add KindGRPCRoute - need to update status_test.go
 			return []gatewayapi_v1beta1.Kind{KindHTTPRoute}
 		case gatewayapi_v1beta1.TLSProtocolType:
 			return []gatewayapi_v1beta1.Kind{KindTLSRoute}
@@ -615,13 +684,13 @@ func (p *GatewayAPIProcessor) getListenerRouteKinds(listener gatewayapi_v1beta1.
 			)
 			continue
 		}
-		if routeKind.Kind != KindHTTPRoute && routeKind.Kind != KindTLSRoute {
+		if routeKind.Kind != KindHTTPRoute && routeKind.Kind != KindTLSRoute && routeKind.Kind != KindGRPCRoute {
 			gwAccessor.AddListenerCondition(
 				string(listener.Name),
 				gatewayapi_v1beta1.ListenerConditionResolvedRefs,
 				metav1.ConditionFalse,
 				gatewayapi_v1beta1.ListenerReasonInvalidRouteKinds,
-				fmt.Sprintf("Kind %q is not supported, kind must be %q or %q", routeKind.Kind, KindHTTPRoute, KindTLSRoute),
+				fmt.Sprintf("Kind %q is not supported, kind must be %q or %q or %q", routeKind.Kind, KindHTTPRoute, KindTLSRoute, KindGRPCRoute),
 			)
 			continue
 		}
@@ -1098,7 +1167,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				}
 
 				var err error
-				requestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, filter.Type)
+				requestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, string(filter.Type))
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
@@ -1111,7 +1180,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				}
 
 				var err error
-				responseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, filter.Type)
+				responseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, string(filter.Type))
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
@@ -1232,7 +1301,11 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 		if redirect != nil {
 			routes = p.redirectRoutes(matchconditions, requestHeaderPolicy, responseHeaderPolicy, redirect, priority)
 		} else {
-			routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, rule.BackendRefs, routeAccessor, priority, pathRewritePolicy)
+			// Get clusters from rule backendRefs
+			clusters, totalWeight, ok := p.HTTPClusters(route.Namespace, rule.BackendRefs, routeAccessor)
+			if ok {
+				routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, routeAccessor, priority, pathRewritePolicy)
+			}
 		}
 
 		// Add each route to the relevant vhost(s)/svhosts(s).
@@ -1254,6 +1327,211 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 	}
 
 	return programmed, hosts
+}
+
+func (p *GatewayAPIProcessor) computeGRPCRoute(route *gatewayapi_v1alpha2.GRPCRoute, routeAccessor *status.RouteParentStatusUpdate, listener *listenerInfo) (bool, sets.Set[string]) {
+	hosts, errs := p.computeHosts(route.Spec.Hostnames, gatewayapi.HostnameDeref(listener.listener.Hostname))
+	for _, err := range errs {
+		// The Gateway API spec does not indicate what to do if syntactically
+		// invalid hostnames make it through, we're using our best judgment here.
+		// Theoretically these should be prevented by the combination of kubebuilder
+		// and admission webhook validations.
+		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, err.Error())
+	}
+
+	// If there were no intersections between the listener hostname and the
+	// route hostnames, the route is not programmed for this listener.
+	if len(hosts) == 0 {
+		return false, nil
+	}
+
+	var programmed bool
+	for ruleIndex, rule := range route.Spec.Rules {
+		// Get match conditions for the rule.
+		var matchconditions []*matchConditions
+		for _, match := range rule.Matches {
+			// Convert method match to path match
+			pathMatch, ok := gatewayGRPCMethodMatchCondition(match.Method, routeAccessor)
+			if !ok {
+				continue
+			}
+
+			headerMatches, err := gatewayGRPCHeaderMatchConditions(match.Headers)
+			if err != nil {
+				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHeaderMatchType, err.Error())
+				continue
+			}
+
+			matchconditions = append(matchconditions, &matchConditions{
+				path:    pathMatch,
+				headers: headerMatches,
+			})
+		}
+
+		// Process rule-level filters.
+		var (
+			requestHeaderPolicy, responseHeaderPolicy *HeadersPolicy
+			mirrorPolicy                              *MirrorPolicy
+		)
+
+		for _, filter := range rule.Filters {
+			switch filter.Type {
+			case gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier:
+				// Per Gateway API docs, "specifying a core filter multiple times has
+				// unspecified or custom conformance.", here we choose to just process
+				// the first one.
+				if requestHeaderPolicy != nil {
+					continue
+				}
+
+				var err error
+				requestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, string(filter.Type))
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
+				}
+			case gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier:
+				// Per Gateway API docs, "specifying a core filter multiple times has
+				// unspecified or custom conformance.", here we choose to just process
+				// the first one.
+				if responseHeaderPolicy != nil {
+					continue
+				}
+
+				var err error
+				responseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, string(filter.Type))
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
+				}
+			case gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror:
+				// Get the mirror filter if there is one. If there are more than one
+				// mirror filters, "NotImplemented" condition on the Route is set to
+				// status: True, with the "NotImplemented" reason.
+				if mirrorPolicy != nil {
+					routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonNotImplemented, "GRPCRoute.Spec.Rules.Filters: Only one mirror filter is supported.")
+					continue
+				}
+
+				if filter.RequestMirror != nil {
+					mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindGRPCRoute, route.Namespace)
+					if cond != nil {
+						routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
+						continue
+					}
+					mirrorPolicy = &MirrorPolicy{
+						Cluster: &Cluster{
+							Upstream: mirrorService,
+						},
+					}
+				}
+			default:
+				routeAccessor.AddCondition(
+					gatewayapi_v1beta1.RouteConditionAccepted,
+					metav1.ConditionFalse,
+					gatewayapi_v1beta1.RouteReasonUnsupportedValue,
+					fmt.Sprintf("GRPCRoute.Spec.Rules.Filters: invalid type %q: only RequestHeaderModifier, ResponseHeaderModifier and RequestMirror are supported.", filter.Type),
+				)
+			}
+		}
+
+		// Priority is used to ensure if there are multiple matching route rules
+		// within an GRPCRoute, the one that comes first in the list has
+		// precedence. We treat lower values as higher priority so we use the
+		// index of the rule to ensure rules that come first have a higher
+		// priority. All dag.Routes generated from a single GRPCRoute rule have
+		// the same priority.
+		priority := uint8(ruleIndex)
+
+		// Get our list of routes based on whether it's a redirect or a cluster-backed route.
+		// Note that we can end up with multiple routes here since the match conditions are
+		// logically "OR"-ed, which we express as multiple routes, each with one of the
+		// conditions, all with the same action.
+		var routes []*Route
+
+		clusters, totalWeight, ok := p.GRPCClusters(route.Namespace, rule.BackendRefs, routeAccessor)
+		if ok {
+			routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, routeAccessor, priority, nil)
+		}
+
+		// Add each route to the relevant vhost(s)/svhosts(s).
+		for host := range hosts {
+			for _, route := range routes {
+				switch {
+				case listener.tlsSecret != nil:
+					svhost := p.dag.EnsureSecureVirtualHost(host)
+					svhost.Secret = listener.tlsSecret
+					svhost.AddRoute(route)
+				default:
+					vhost := p.dag.EnsureVirtualHost(host)
+					vhost.AddRoute(route)
+				}
+
+				programmed = true
+			}
+		}
+	}
+
+	return programmed, hosts
+}
+
+func gatewayGRPCMethodMatchCondition(match *gatewayapi_v1alpha2.GRPCMethodMatch, routeAccessor *status.RouteParentStatusUpdate) (MatchCondition, bool) {
+	if match == nil {
+		return nil, true
+	}
+
+	// Type specifies how to match against the service and/or method.
+	// Support: Core (Exact with service and method specified)
+	// Not Support: Implementation-specific (Exact with method specified but no service specified)
+	// Not Support: Implementation-specific (RegularExpression)
+
+	// Support "Exact" match type only. If match type is not specified, use "Exact" as default.
+	if match.Type != nil && *match.Type != gatewayapi_v1alpha2.GRPCMethodMatchExact {
+		routeAccessor.AddCondition(status.ConditionValidMatches, metav1.ConditionFalse, status.ReasonInvalidMethodMatch, "GRPCRoute.Spec.Rules.Matches.Method: Only Exact match type is supported.")
+		return nil, false
+	}
+
+	if match.Service == nil || isBlank(*match.Service) {
+		routeAccessor.AddCondition(status.ConditionValidMatches, metav1.ConditionFalse, status.ReasonInvalidMethodMatch, "GRPCRoute.Spec.Rules.Matches.Method: Service need be configured.")
+		return nil, false
+	}
+
+	if match.Method == nil || isBlank(*match.Method) {
+		routeAccessor.AddCondition(status.ConditionValidMatches, metav1.ConditionFalse, status.ReasonInvalidMethodMatch, "GRPCRoute.Spec.Rules.Matches.Method: Method need be configured.")
+		return nil, false
+	}
+
+	// Convert service and method into path
+	path := *match.Service + "/" + *match.Method
+
+	return &ExactMatchCondition{Path: path}, true
+}
+
+func gatewayGRPCHeaderMatchConditions(matches []gatewayapi_v1alpha2.GRPCHeaderMatch) ([]HeaderMatchCondition, error) {
+	var headerMatchConditions []HeaderMatchCondition
+	seenNames := sets.New[string]()
+
+	for _, match := range matches {
+		// "Exact" is the default if not defined in the object, and
+		// the only supported match type.
+		if match.Type != nil && *match.Type != gatewayapi_v1beta1.HeaderMatchExact {
+			return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported")
+		}
+
+		// If multiple match conditions are found for the same header name (case-insensitive),
+		// use the first one and ignore subsequent ones.
+		upperName := strings.ToUpper(string(match.Name))
+		if seenNames.Has(upperName) {
+			continue
+		}
+		seenNames.Insert(upperName)
+
+		headerMatchConditions = append(headerMatchConditions, HeaderMatchCondition{
+			MatchType: HeaderMatchTypeExact,
+			Name:      string(match.Name),
+			Value:     match.Value,
+		})
+	}
+
+	return headerMatchConditions, nil
 }
 
 // validateBackendRef verifies that the specified BackendRef is valid.
@@ -1429,17 +1707,18 @@ func gatewayQueryParamMatchConditions(matches []gatewayapi_v1beta1.HTTPQueryPara
 	return dagMatchConditions, nil
 }
 
-// clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and backendRefs.
-func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy, mirrorPolicy *MirrorPolicy, backendRefs []gatewayapi_v1beta1.HTTPBackendRef, routeAccessor *status.RouteParentStatusUpdate, priority uint8, pathRewritePolicy *PathRewritePolicy) []*Route {
+// HTTPClusters builds clusters from backendRef.
+func (p *GatewayAPIProcessor) HTTPClusters(routeNamespace string, backendRefs []gatewayapi_v1beta1.HTTPBackendRef, routeAccessor *status.RouteParentStatusUpdate) ([]*Cluster, uint32, bool) {
+	totalWeight := uint32(0)
+
 	if len(backendRefs) == 0 {
 		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
-		return nil
+		return nil, totalWeight, false
 	}
 
 	var clusters []*Cluster
 
 	// Validate the backend refs.
-	totalWeight := uint32(0)
 	for _, backendRef := range backendRefs {
 		service, cond := p.validateBackendRef(backendRef.BackendRef, KindHTTPRoute, routeNamespace)
 		if cond != nil {
@@ -1459,7 +1738,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 				}
 
 				var err error
-				clusterRequestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, filter.Type)
+				clusterRequestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, string(filter.Type))
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
@@ -1472,7 +1751,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 				}
 
 				var err error
-				clusterResponseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, filter.Type)
+				clusterResponseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, string(filter.Type))
 				if err != nil {
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
@@ -1502,6 +1781,89 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 			TimeoutPolicy:         ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
 		})
 	}
+	return clusters, totalWeight, true
+}
+
+// GRPCClusters builds clusters from backendRef.
+func (p *GatewayAPIProcessor) GRPCClusters(routeNamespace string, backendRefs []gatewayapi_v1alpha2.GRPCBackendRef, routeAccessor *status.RouteParentStatusUpdate) ([]*Cluster, uint32, bool) {
+	totalWeight := uint32(0)
+
+	if len(backendRefs) == 0 {
+		routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, "At least one Spec.Rules.BackendRef must be specified.")
+		return nil, totalWeight, false
+	}
+
+	var clusters []*Cluster
+
+	// Validate the backend refs.
+	for _, backendRef := range backendRefs {
+		service, cond := p.validateBackendRef(backendRef.BackendRef, KindGRPCRoute, routeNamespace)
+		if cond != nil {
+			routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
+			continue
+		}
+
+		var clusterRequestHeaderPolicy, clusterResponseHeaderPolicy *HeadersPolicy
+		for _, filter := range backendRef.Filters {
+			switch filter.Type {
+			case gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier:
+				// Per Gateway API docs, "specifying a core filter multiple times has
+				// unspecified or custom conformance.", here we choose to just process
+				// the first one.
+				if clusterRequestHeaderPolicy != nil {
+					continue
+				}
+
+				var err error
+				clusterRequestHeaderPolicy, err = headersPolicyGatewayAPI(filter.RequestHeaderModifier, string(filter.Type))
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
+				}
+			case gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier:
+				// Per Gateway API docs, "specifying a core filter multiple times has
+				// unspecified or custom conformance.", here we choose to just process
+				// the first one.
+				if clusterResponseHeaderPolicy != nil {
+					continue
+				}
+
+				var err error
+				clusterResponseHeaderPolicy, err = headersPolicyGatewayAPI(filter.ResponseHeaderModifier, string(filter.Type))
+				if err != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
+				}
+			default:
+				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "GRPCRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.")
+			}
+		}
+
+		// Route defaults to a weight of "1" unless otherwise specified.
+		routeWeight := uint32(1)
+		if backendRef.Weight != nil {
+			routeWeight = uint32(*backendRef.Weight)
+		}
+
+		// Keep track of all the weights for this set of backend refs. This will be
+		// used later to understand if all the weights are set to zero.
+		totalWeight += routeWeight
+
+		// https://github.com/projectcontour/contour/issues/3593
+		service.Weighted.Weight = routeWeight
+		clusters = append(clusters, &Cluster{
+			Upstream:              service,
+			Weight:                routeWeight,
+			Protocol:              service.Protocol,
+			RequestHeadersPolicy:  clusterRequestHeaderPolicy,
+			ResponseHeadersPolicy: clusterResponseHeaderPolicy,
+			TimeoutPolicy:         ClusterTimeoutPolicy{ConnectTimeout: p.ConnectTimeout},
+		})
+	}
+	return clusters, totalWeight, true
+}
+
+// clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and backendRefs.
+func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy,
+	mirrorPolicy *MirrorPolicy, clusters []*Cluster, totalWeight uint32, routeAccessor *status.RouteParentStatusUpdate, priority uint8, pathRewritePolicy *PathRewritePolicy) []*Route {
 
 	var routes []*Route
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -661,11 +661,9 @@ func (p *GatewayAPIProcessor) getListenerRouteKinds(listener gatewayapi_v1beta1.
 	if len(listener.AllowedRoutes.Kinds) == 0 {
 		switch listener.Protocol {
 		case gatewayapi_v1beta1.HTTPProtocolType:
-			// TODO: add KindGRPCRoute - need to update status_test.go
-			return []gatewayapi_v1beta1.Kind{KindHTTPRoute}
+			return []gatewayapi_v1beta1.Kind{KindHTTPRoute, KindGRPCRoute}
 		case gatewayapi_v1beta1.HTTPSProtocolType:
-			// TODO: add KindGRPCRoute - need to update status_test.go
-			return []gatewayapi_v1beta1.Kind{KindHTTPRoute}
+			return []gatewayapi_v1beta1.Kind{KindHTTPRoute, KindGRPCRoute}
 		case gatewayapi_v1beta1.TLSProtocolType:
 			return []gatewayapi_v1beta1.Kind{KindTLSRoute}
 		}

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1518,7 +1518,7 @@ func gatewayGRPCHeaderMatchConditions(matches []gatewayapi_v1alpha2.GRPCHeaderMa
 		// "Exact" is the default if not defined in the object, and
 		// the only supported match type.
 		if match.Type != nil && *match.Type != gatewayapi_v1beta1.HeaderMatchExact {
-			return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported.")
+			return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported")
 		}
 
 		// If multiple match conditions are found for the same header name (case-insensitive),

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1302,7 +1302,7 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 			// Get clusters from rule backendRefs
 			clusters, totalWeight, ok := p.HTTPClusters(route.Namespace, rule.BackendRefs, routeAccessor)
 			if ok {
-				routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, routeAccessor, priority, pathRewritePolicy)
+				routes = p.clusterRoutes(matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, priority, pathRewritePolicy)
 			}
 		}
 
@@ -1447,7 +1447,7 @@ func (p *GatewayAPIProcessor) computeGRPCRoute(route *gatewayapi_v1alpha2.GRPCRo
 
 		clusters, totalWeight, ok := p.GRPCClusters(route.Namespace, rule.BackendRefs, routeAccessor)
 		if ok {
-			routes = p.clusterRoutes(route.Namespace, matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, routeAccessor, priority, nil)
+			routes = p.clusterRoutes(matchconditions, requestHeaderPolicy, responseHeaderPolicy, mirrorPolicy, clusters, totalWeight, priority, nil)
 		}
 
 		// Add each route to the relevant vhost(s)/svhosts(s).
@@ -1860,8 +1860,8 @@ func (p *GatewayAPIProcessor) GRPCClusters(routeNamespace string, backendRefs []
 }
 
 // clusterRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and backendRefs.
-func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy,
-	mirrorPolicy *MirrorPolicy, clusters []*Cluster, totalWeight uint32, routeAccessor *status.RouteParentStatusUpdate, priority uint8, pathRewritePolicy *PathRewritePolicy) []*Route {
+func (p *GatewayAPIProcessor) clusterRoutes(matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy,
+	mirrorPolicy *MirrorPolicy, clusters []*Cluster, totalWeight uint32, priority uint8, pathRewritePolicy *PathRewritePolicy) []*Route {
 
 	var routes []*Route
 

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	networking_v1 "k8s.io/api/networking/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -204,7 +205,7 @@ func headersPolicyRoute(policy *contour_api_v1.HeadersPolicy, allowHostRewrite b
 
 // headersPolicyGatewayAPI builds a *HeaderPolicy for the supplied HTTPHeaderFilter.
 // TODO: Take care about the order of operators once https://github.com/kubernetes-sigs/gateway-api/issues/480 was solved.
-func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPolicyType gatewayapi_v1beta1.HTTPRouteFilterType) (*HeadersPolicy, error) {
+func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPolicyType string) (*HeadersPolicy, error) {
 	var (
 		set         = make(map[string]string, len(hf.Set))
 		add         = make(map[string]string, len(hf.Add))
@@ -219,7 +220,8 @@ func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPoli
 			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
 			continue
 		}
-		if key == "Host" && headerPolicyType == gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier {
+		if key == "Host" && (headerPolicyType == string(gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier) ||
+			headerPolicyType == string(gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier)) {
 			hostRewrite = setHeader.Value
 			continue
 		}
@@ -235,7 +237,8 @@ func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPoli
 			errlist = append(errlist, fmt.Errorf("duplicate header addition: %q", key))
 			continue
 		}
-		if key == "Host" && headerPolicyType == gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier {
+		if key == "Host" && (headerPolicyType == string(gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier) ||
+			headerPolicyType == string(gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier)) {
 			hostRewrite = addHeader.Value
 			continue
 		}

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -3905,6 +3905,20 @@ func TestDAGStatus(t *testing.T) {
 }
 
 func validGatewayStatusUpdate(listenerName string, kind gatewayapi_v1beta1.Kind, attachedRoutes int) []*status.GatewayStatusUpdate {
+	// This applies to tests that the listener doesn't have allowed kind configured
+	// hence the wanted allowed kind is determined by the listener protocol only.
+	var supportedKinds []gatewayapi_v1beta1.RouteGroupKind
+	supportedKinds = append(supportedKinds, gatewayapi_v1beta1.RouteGroupKind{
+		Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+		Kind:  kind,
+	})
+	if kind == "HTTPRoute" {
+		supportedKinds = append(supportedKinds, gatewayapi_v1beta1.RouteGroupKind{
+			Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			Kind:  "GRPCRoute",
+		})
+	}
+
 	return []*status.GatewayStatusUpdate{
 		{
 			FullName: types.NamespacedName{Namespace: "projectcontour", Name: "contour"},
@@ -3921,12 +3935,7 @@ func validGatewayStatusUpdate(listenerName string, kind gatewayapi_v1beta1.Kind,
 				listenerName: {
 					Name:           gatewayapi_v1beta1.SectionName(listenerName),
 					AttachedRoutes: int32(attachedRoutes),
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
-						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-							Kind:  kind,
-						},
-					},
+					SupportedKinds: supportedKinds,
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
@@ -5108,6 +5117,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -5255,6 +5268,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -5345,6 +5362,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -5437,6 +5458,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -5527,6 +5552,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -5619,6 +5648,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -5874,6 +5907,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
+							},
 						},
 						Conditions: []metav1.Condition{
 							{
@@ -5891,6 +5928,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							{
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
+							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: []metav1.Condition{
@@ -5995,6 +6036,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
+							},
 						},
 						Conditions: []metav1.Condition{
 							{
@@ -6012,6 +6057,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							{
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
+							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: []metav1.Condition{
@@ -6105,6 +6154,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
+							},
 						},
 						Conditions: []metav1.Condition{
 							{
@@ -6196,6 +6249,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							{
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
+							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: []metav1.Condition{
@@ -6355,6 +6412,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							{
 								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 								Kind:  "HTTPRoute",
+							},
+							{
+								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: []metav1.Condition{
@@ -7142,6 +7203,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -7378,6 +7443,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -7441,6 +7510,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -7554,6 +7627,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -7782,6 +7859,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -7836,6 +7917,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{
@@ -7898,6 +7983,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
+						},
 					},
 					Conditions: []metav1.Condition{
 						{
@@ -7952,6 +8041,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						{
 							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
 							Kind:  "HTTPRoute",
+						},
+						{
+							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Kind:  "GRPCRoute",
 						},
 					},
 					Conditions: []metav1.Condition{

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -8806,14 +8806,8 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted GRPCRoute",
-						},
-						{
-							Type:    string(status.ConditionValidMatches),
 							Status:  contour_api_v1.ConditionFalse,
-							Reason:  string(status.ReasonMethodMatchType),
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "GRPCRoute.Spec.Rules.Matches.Method: Only Exact match type is supported.",
 						},
 					},
@@ -8855,12 +8849,6 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted GRPCRoute",
-						},
-						{
-							Type:    string(status.ConditionValidMatches),
 							Status:  contour_api_v1.ConditionFalse,
 							Reason:  string(status.ReasonInvalidMethodMatch),
 							Message: "GRPCRoute.Spec.Rules.Matches.Method: Both Service and Method need be configured.",
@@ -8904,12 +8892,6 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted GRPCRoute",
-						},
-						{
-							Type:    string(status.ConditionValidMatches),
 							Status:  contour_api_v1.ConditionFalse,
 							Reason:  string(status.ReasonInvalidMethodMatch),
 							Message: "GRPCRoute.Spec.Rules.Matches.Method: Both Service and Method need be configured.",
@@ -8969,14 +8951,8 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted GRPCRoute",
-						},
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonHeaderMatchType),
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported",
 						},
 					},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -8977,7 +8977,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 							Type:    string(status.ConditionNotImplemented),
 							Status:  contour_api_v1.ConditionTrue,
 							Reason:  string(status.ReasonHeaderMatchType),
-							Message: "GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported.",
+							Message: "GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported",
 						},
 					},
 				},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -7265,7 +7265,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
 							Reason:  string(gatewayapi_v1beta1.ListenerReasonInvalidRouteKinds),
-							Message: "Kind \"FooRoute\" is not supported, kind must be \"HTTPRoute\" or \"TLSRoute\"",
+							Message: "Kind \"FooRoute\" is not supported, kind must be \"HTTPRoute\" or \"TLSRoute\" or \"GRPCRoute\"",
 						},
 					},
 				},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -149,6 +149,29 @@ func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayap
 	}
 }
 
+func GRPCRouteMatch(methodType gatewayapi_v1alpha2.GRPCMethodMatchType, service, method string) []gatewayapi_v1alpha2.GRPCRouteMatch {
+	return []gatewayapi_v1alpha2.GRPCRouteMatch{
+		{
+			Method: &gatewayapi_v1alpha2.GRPCMethodMatch{
+				Type:    ref.To(methodType),
+				Service: ref.To(service),
+				Method:  ref.To(method),
+			},
+		},
+	}
+}
+
+func GRPCBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1alpha2.GRPCBackendRef {
+	return []gatewayapi_v1alpha2.GRPCBackendRef{
+		{
+			BackendRef: gatewayapi_v1beta1.BackendRef{
+				BackendObjectReference: ServiceBackendObjectRef(serviceName, port),
+				Weight:                 &weight,
+			},
+		},
+	}
+}
+
 // IsRefToGateway returns whether the provided parent ref is a reference
 // to a Gateway with the given namespace/name, irrespective of whether a
 // section/listener name has been specified (i.e. a parent ref to a listener

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -37,6 +37,7 @@ const (
 	ReasonHeaderMatchType               gatewayapi_v1beta1.RouteConditionReason = "HeaderMatchType"
 	ReasonQueryParamMatchType           gatewayapi_v1beta1.RouteConditionReason = "QueryParamMatchType"
 	ReasonHTTPRouteFilterType           gatewayapi_v1beta1.RouteConditionReason = "HTTPRouteFilterType"
+	ReasonMethodMatchType               gatewayapi_v1beta1.RouteConditionReason = "MethodMatchType"
 	ReasonDegraded                      gatewayapi_v1beta1.RouteConditionReason = "Degraded"
 	ReasonErrorsExist                   gatewayapi_v1beta1.RouteConditionReason = "ErrorsExist"
 	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -41,6 +41,7 @@ const (
 	ReasonErrorsExist                   gatewayapi_v1beta1.RouteConditionReason = "ErrorsExist"
 	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
 	ReasonInvalidPathMatch              gatewayapi_v1beta1.RouteConditionReason = "InvalidPathMatch"
+	ReasonInvalidMethodMatch            gatewayapi_v1beta1.RouteConditionReason = "InvalidMethodMatch"
 	ReasonInvalidGateway                gatewayapi_v1beta1.RouteConditionReason = "InvalidGateway"
 	ReasonListenersNotReady             gatewayapi_v1beta1.RouteConditionReason = "ListenersNotReady"
 )
@@ -174,6 +175,20 @@ func (r *RouteStatusUpdate) Mutate(obj client.Object) client.Object {
 		route.Status.Parents = newRouteParentStatuses
 
 		return route
+	case *gatewayapi_v1alpha2.GRPCRoute:
+		route := o.DeepCopy()
+
+		// Get all the RouteParentStatuses that are for other Gateways.
+		for _, rps := range o.Status.Parents {
+			if !gatewayapi.IsRefToGateway(rps.ParentRef, r.GatewayRef) {
+				newRouteParentStatuses = append(newRouteParentStatuses, rps)
+			}
+		}
+
+		route.Status.Parents = newRouteParentStatuses
+
+		return route
+
 	default:
 		panic(fmt.Sprintf("Unsupported %T object %s/%s in RouteConditionsUpdate status mutator", obj, r.FullName.Namespace, r.FullName.Name))
 	}


### PR DESCRIPTION
Implement gatewayapi_processor.go for building GRPCRoute dag.

todos:
- add GRPCRoute into allowed route kinds for listener with HTTP/HTTPS protocol This needs quite some changes on status_test.go for wanted SupportedKinds for listeners with http/http protocols.
- add unit tests

Updates #4820

Signed-off-by: Fang Peng <fpeng@vmware.com>