### PR TITLE
Use http constants instead of string

### DIFF
--- a/cmd/contour/shutdownmanager_test.go
+++ b/cmd/contour/shutdownmanager_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestShutdownManager_HealthzHandler(t *testing.T) {
 	// Create a request to pass to our handler
-	req, err := http.NewRequest("GET", "/healthz", nil)
+	req, err := http.NewRequest(http.MethodGet, "/healthz", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestShutdownManager_ShutdownReadyHandler_Success(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "/shutdown", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/shutdown", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestShutdownManager_ShutdownReadyHandler_ClientCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "/shutdown", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/shutdown", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -16,6 +16,7 @@ package v3
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"regexp"
 	"sort"
 	"strings"
@@ -272,9 +273,9 @@ func routeRedirect(redirect *dag.Redirect) *envoy_route_v3.Route_Redirect {
 
 	// Envoy's default is a 301 if not otherwise specified.
 	switch redirect.StatusCode {
-	case 301:
+	case http.StatusMovedPermanently:
 		r.Redirect.ResponseCode = envoy_route_v3.RedirectAction_MOVED_PERMANENTLY
-	case 302:
+	case http.StatusFound:
 		r.Redirect.ResponseCode = envoy_route_v3.RedirectAction_FOUND
 	}
 


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

When I read the code, I noticed that some special library calls used custom strings as arguments. Therefore, it is recommended to use package constants instead of strings

I hope the above suggestions can help contribute to the community. Thank you