### PR TITLE
Avoid comparing full objects during update to optimize performance

### DIFF
--- a/changelogs/unreleased/5064-tsaarni-small.md
+++ b/changelogs/unreleased/5064-tsaarni-small.md
@@ -1,0 +1,1 @@
+Optimize processing of HTTPProxy, Secret and other objects by avoiding full object comparison. This reduces CPU usage during object updates.

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -14,12 +14,18 @@
 package k8s
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -82,4 +88,71 @@ func isStatusEqual(objA, objB interface{}) bool {
 		}
 	}
 	return false
+}
+
+// IsObjectEqual checks if objects received during update are equal.
+//
+// Make an attempt to avoid comparing full objects since it can be very CPU intensive.
+// Prefer comparing Generation when only interested in spec changes.
+func IsObjectEqual(old, new client.Object) (bool, error) {
+
+	// Fast path for any object: when ResourceVersions are equal, the objects are equal.
+	// NOTE: This optimizes the case when controller-runtime executes full sync and sends updates for all objects.
+	if isResourceVersionEqual(old, new) {
+		return true, nil
+	}
+
+	switch old := old.(type) {
+
+	// Fast path for objects that implement Generation and where only spec changes matter.
+	// Status/annotations/labels changes are ignored.
+	// Generation is implemented in CRDs, Ingress and IngressClass.
+	case *contour_api_v1alpha1.ExtensionService,
+		*contour_api_v1.TLSCertificateDelegation:
+		return isGenerationEqual(old, new), nil
+
+	case *gatewayapi_v1beta1.GatewayClass,
+		*gatewayapi_v1beta1.Gateway,
+		*gatewayapi_v1beta1.HTTPRoute,
+		*gatewayapi_v1alpha2.TLSRoute,
+		*gatewayapi_v1beta1.ReferenceGrant,
+		*gatewayapi_v1alpha2.GRPCRoute:
+		return isGenerationEqual(old, new), nil
+
+	// Slow path: compare the content of the objects.
+	case *contour_api_v1.HTTPProxy,
+		*networking_v1.Ingress:
+		return isGenerationEqual(old, new) &&
+			apiequality.Semantic.DeepEqual(old.GetAnnotations(), new.GetAnnotations()), nil
+	case *v1.Secret:
+		if new, ok := new.(*v1.Secret); ok {
+			return reflect.DeepEqual(old.Data, new.Data), nil
+		}
+	case *v1.Service:
+		if new, ok := new.(*v1.Service); ok {
+			return apiequality.Semantic.DeepEqual(old.Spec, new.Spec) &&
+				apiequality.Semantic.DeepEqual(old.Status, new.Status) &&
+				apiequality.Semantic.DeepEqual(old.GetAnnotations(), new.GetAnnotations()), nil
+		}
+	case *v1.Endpoints:
+		if new, ok := new.(*v1.Endpoints); ok {
+			return apiequality.Semantic.DeepEqual(old.Subsets, new.Subsets), nil
+		}
+	case *v1.Namespace:
+		if new, ok := new.(*v1.Namespace); ok {
+			return apiequality.Semantic.DeepEqual(old.Labels, new.Labels), nil
+		}
+	}
+
+	// ResourceVersions are not equal and we don't know how to compare the object type.
+	// This should never happen and indicates that new type was added to the code but is missing in the switch above.
+	return false, fmt.Errorf("do not know how to compare %T", new)
+}
+
+func isGenerationEqual(a, b client.Object) bool {
+	return a.GetGeneration() == b.GetGeneration()
+}
+
+func isResourceVersionEqual(a, b client.Object) bool {
+	return a.GetResourceVersion() == b.GetResourceVersion()
 }

--- a/internal/k8s/helpers_test.go
+++ b/internal/k8s/helpers_test.go
@@ -1,0 +1,195 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	networking_v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func TestIsObjectEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		equals   bool
+	}{
+		{
+			name:     "Secret with content change",
+			filename: "testdata/secret-content-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "Secret with metadata change",
+			filename: "testdata/secret-metadata-change.yaml",
+			equals:   true,
+		},
+		{
+			name:     "Service with status change",
+			filename: "testdata/service-status-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "Service with annotation change",
+			filename: "testdata/service-annotation-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "Endpoint with content change",
+			filename: "testdata/endpoint-content-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "HTTPProxy with annotation change",
+			filename: "testdata/httpproxy-annotation-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "Ingress with annotation change",
+			filename: "testdata/ingress-annotation-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "Namespace with label change",
+			filename: "testdata/namespace-label-change.yaml",
+			equals:   false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = networking_v1.AddToScheme(scheme)
+	_ = contour_api_v1.AddKnownTypes(scheme)
+
+	deserializer := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := os.ReadFile(tc.filename)
+			assert.NoError(t, err)
+
+			// Each file contains two YAML records, which should be compared with each other.
+			objects := strings.Split(string(buf), "---")
+			assert.Equal(t, 2, len(objects), "expected 2 objects in file")
+
+			// Decode the objects.
+			old, _, err := deserializer.Decode([]byte(objects[0]), nil, nil)
+			assert.NoError(t, err)
+			new, _, err := deserializer.Decode([]byte(objects[1]), nil, nil)
+			assert.NoError(t, err)
+
+			got, err := IsObjectEqual(old.(client.Object), new.(client.Object))
+			assert.NoError(t, err)
+			assert.Equal(t, tc.equals, got)
+		})
+	}
+}
+
+func TestIsEqualForResourceVersion(t *testing.T) {
+	old := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			Namespace:       "default",
+			ResourceVersion: "123",
+		},
+		Data: map[string][]byte{
+			"foo": []byte("bar"),
+		},
+	}
+
+	new := old.DeepCopy()
+
+	// Objects with equal ResourceVersion should evaluate to true.
+	got, err := IsObjectEqual(old, new)
+	assert.NoError(t, err)
+	assert.True(t, got)
+
+	// Differences in data should be ignored.
+	new.Data["foo"] = []byte("baz")
+	got, err = IsObjectEqual(old, new)
+	assert.NoError(t, err)
+	assert.True(t, got)
+}
+
+// TestIsEqualFallback compares with ConfigMap objects, which are not supported.
+func TestIsEqualFallback(t *testing.T) {
+	old := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			Namespace:       "default",
+			ResourceVersion: "123",
+		},
+		Data: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	new := old.DeepCopy()
+
+	// Any object (even unsupported types) with equal ResourceVersion should evaluate to true.
+	got, err := IsObjectEqual(old, new)
+	assert.NoError(t, err)
+	assert.True(t, got)
+
+	// Unsupported types with unequal ResourceVersion should return an error.
+	new.ResourceVersion = "456"
+	got, err = IsObjectEqual(old, new)
+	assert.Error(t, err)
+	assert.False(t, got)
+}
+
+func TestIsEqualForGeneration(t *testing.T) {
+	run := func(t *testing.T, old client.Object) {
+		t.Helper()
+		new := old.DeepCopyObject().(client.Object)
+
+		// Set different ResourceVersion to ensure that Generation is the only difference.
+		old.SetResourceVersion("123")
+		new.SetResourceVersion("456")
+
+		// Objects with equal Generation should evaluate to true.
+		got, err := IsObjectEqual(old, new)
+		assert.NoError(t, err)
+		assert.True(t, got)
+
+		// Objects with unequal Generation should evaluate to false.
+		new.SetGeneration(old.GetGeneration() + 1)
+		got, err = IsObjectEqual(old, new)
+		assert.NoError(t, err)
+		assert.False(t, got)
+	}
+
+	run(t, &networking_v1.Ingress{})
+	run(t, &contour_api_v1.HTTPProxy{})
+	run(t, &contour_api_v1alpha1.ExtensionService{})
+	run(t, &contour_api_v1.TLSCertificateDelegation{})
+	run(t, &gatewayapi_v1beta1.GatewayClass{})
+	run(t, &gatewayapi_v1beta1.Gateway{})
+	run(t, &gatewayapi_v1beta1.HTTPRoute{})
+	run(t, &gatewayapi_v1alpha2.TLSRoute{})
+	run(t, &gatewayapi_v1beta1.ReferenceGrant{})
+	run(t, &gatewayapi_v1alpha2.GRPCRoute{})
+}

--- a/internal/k8s/testdata/endpoint-content-change.yaml
+++ b/internal/k8s/testdata/endpoint-content-change.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  annotations:
+    endpoints.kubernetes.io/last-change-trigger-time: "2023-02-09T15:06:20Z"
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "85303"
+  uid: 6cb4c5f2-60b2-4240-b2a3-91111c7e2527
+subsets:
+- addresses:
+  - ip: 10.244.1.4
+    nodeName: contour-worker
+    targetRef:
+      kind: Pod
+      name: echoserver-59db9c5778-cfwhz
+      namespace: default
+      uid: b0014607-0e3b-461e-8b06-df4407fa7a44
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  annotations:
+    endpoints.kubernetes.io/last-change-trigger-time: "2023-02-09T19:56:07Z"
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "112662"
+  uid: 6cb4c5f2-60b2-4240-b2a3-91111c7e2527
+subsets:
+- addresses:
+  - ip: 10.244.1.5
+    nodeName: contour-worker
+    targetRef:
+      kind: Pod
+      name: echoserver-59db9c5778-5wdhj
+      namespace: default
+      uid: 84878472-00b6-4ae2-b1fd-5508c900707c
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP

--- a/internal/k8s/testdata/httpproxy-annotation-change.yaml
+++ b/internal/k8s/testdata/httpproxy-annotation-change.yaml
@@ -1,0 +1,62 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"projectcontour.io/v1","kind":"HTTPProxy","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"routes":[{"services":[{"name":"echoserver","port":80}]}],"virtualhost":{"fqdn":"echoserver.127-0-0-101.nip.io"}}}
+  creationTimestamp: "2023-02-08T18:32:43Z"
+  generation: 1
+  name: echoserver
+  namespace: default
+  resourceVersion: "84327"
+  uid: fd31fdfc-bbcd-46c3-af0d-8907da000320
+spec:
+  routes:
+  - services:
+    - name: echoserver
+      port: 80
+  virtualhost:
+    fqdn: echoserver.127-0-0-101.nip.io
+status:
+  conditions:
+  - lastTransitionTime: "2023-02-09T14:56:45Z"
+    message: Valid HTTPProxy
+    observedGeneration: 1
+    reason: Valid
+    status: "True"
+    type: Valid
+  currentStatus: valid
+  description: Valid HTTPProxy
+  loadBalancer: {}
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"projectcontour.io/v1","kind":"HTTPProxy","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"routes":[{"services":[{"name":"echoserver","port":80}]}],"virtualhost":{"fqdn":"echoserver.127-0-0-101.nip.io"}}}
+    kubernetes.io/ingress.class: my-ingress
+  creationTimestamp: "2023-02-08T18:32:43Z"
+  generation: 1
+  name: echoserver
+  namespace: default
+  resourceVersion: "205411"
+  uid: fd31fdfc-bbcd-46c3-af0d-8907da000320
+spec:
+  routes:
+  - services:
+    - name: echoserver
+      port: 80
+  virtualhost:
+    fqdn: echoserver.127-0-0-101.nip.io
+status:
+  conditions:
+  - lastTransitionTime: "2023-02-09T14:56:45Z"
+    message: Valid HTTPProxy
+    observedGeneration: 1
+    reason: Valid
+    status: "True"
+    type: Valid
+  currentStatus: valid
+  description: Valid HTTPProxy
+  loadBalancer: {}

--- a/internal/k8s/testdata/ingress-annotation-change.yaml
+++ b/internal/k8s/testdata/ingress-annotation-change.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"defaultBackend":{"service":{"name":"echoserver","port":{"number":80}}}}}
+  creationTimestamp: "2023-02-13T13:44:04Z"
+  generation: 1
+  name: echoserver
+  namespace: default
+  resourceVersion: "205783"
+  uid: 83e07d0d-c2dc-4314-a02c-0409838ad343
+spec:
+  defaultBackend:
+    service:
+      name: echoserver
+      port:
+        number: 80
+status:
+  loadBalancer: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"defaultBackend":{"service":{"name":"echoserver","port":{"number":80}}}}}
+    projectcontour.io/tls-minimum-protocol-version: "1.3"
+  creationTimestamp: "2023-02-13T13:44:04Z"
+  generation: 1
+  name: echoserver
+  namespace: default
+  resourceVersion: "205981"
+  uid: 83e07d0d-c2dc-4314-a02c-0409838ad343
+spec:
+  defaultBackend:
+    service:
+      name: echoserver
+      port:
+        number: 80
+status:
+  loadBalancer: {}

--- a/internal/k8s/testdata/namespace-label-change.yaml
+++ b/internal/k8s/testdata/namespace-label-change.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: "2023-03-02T17:31:09Z"
+  labels:
+    kubernetes.io/metadata.name: default
+  name: default
+  resourceVersion: "11368"
+  uid: 49ff2754-c682-410c-818f-d28975dde44e
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: "2023-03-02T17:31:09Z"
+  labels:
+    foo: bar
+    kubernetes.io/metadata.name: default
+  name: default
+  resourceVersion: "11519"
+  uid: 49ff2754-c682-410c-818f-d28975dde44e
+spec:
+  finalizers:
+  - kubernetes
+status:
+  phase: Active

--- a/internal/k8s/testdata/secret-content-change.yaml
+++ b/internal/k8s/testdata/secret-content-change.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  file: aGVsbG8=
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"aGVsbG8="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-secret","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-secret
+  namespace: default
+  resourceVersion: "62125"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+type: Opaque
+---
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-secret","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-secret
+  namespace: default
+  resourceVersion: "62159"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+type: Opaque

--- a/internal/k8s/testdata/secret-metadata-change.yaml
+++ b/internal/k8s/testdata/secret-metadata-change.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-secret","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-secret
+  namespace: default
+  resourceVersion: "62159"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+type: Opaque
+---
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: Secret
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"Secret","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-secret","namespace":"default"}}
+    my-annotation: foo
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  labels:
+    my-label: bar
+  name: my-secret
+  namespace: default
+  resourceVersion: "72965"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+type: Opaque

--- a/internal/k8s/testdata/service-annotation-change.yaml
+++ b/internal/k8s/testdata/service-annotation-change.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"ports":[{"name":"http","port":80,"targetPort":"http-api"}],"selector":{"app.kubernetes.io/name":"echoserver"}}}
+    projectcontour.io/max-connections: "2048"
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "206553"
+  uid: e3718d68-c0db-47a0-9d84-87cd525cccd6
+spec:
+  clusterIP: 10.96.24.18
+  clusterIPs:
+  - 10.96.24.18
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http-api
+  selector:
+    app.kubernetes.io/name: echoserver
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"ports":[{"name":"http","port":80,"targetPort":"http-api"}],"selector":{"app.kubernetes.io/name":"echoserver"}}}
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "206580"
+  uid: e3718d68-c0db-47a0-9d84-87cd525cccd6
+spec:
+  clusterIP: 10.96.24.18
+  clusterIPs:
+  - 10.96.24.18
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http-api
+  selector:
+    app.kubernetes.io/name: echoserver
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/internal/k8s/testdata/service-status-change.yaml
+++ b/internal/k8s/testdata/service-status-change.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"ports":[{"name":"http","port":80,"targetPort":"http-api"}],"selector":{"app.kubernetes.io/name":"echoserver"}}}
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "81735"
+  uid: e3718d68-c0db-47a0-9d84-87cd525cccd6
+spec:
+  clusterIP: 10.96.24.18
+  clusterIPs:
+  - 10.96.24.18
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http-api
+  selector:
+    app.kubernetes.io/name: echoserver
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"echoserver","namespace":"default"},"spec":{"ports":[{"name":"http","port":80,"targetPort":"http-api"}],"selector":{"app.kubernetes.io/name":"echoserver"}}}
+  creationTimestamp: "2023-02-09T14:55:33Z"
+  name: echoserver
+  namespace: default
+  resourceVersion: "35103"
+  uid: e3718d68-c0db-47a0-9d84-87cd525cccd6
+spec:
+  clusterIP: 10.96.24.18
+  clusterIPs:
+  - 10.96.24.18
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http-api
+  selector:
+    app.kubernetes.io/name: echoserver
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.2.3.4


### PR DESCRIPTION
This change optimizes processing of `HTTPProxy`, `Secret` and other objects by avoiding full object comparison. This reduces CPU usage during object updates.

Comparing the full objects with `cmp.Equal()` during `EventHandler.onUpdate()` was very costly, which was especially visible in big clusters with a lot of objects. In general, the load caused by `cmp.Equal()` during update was overwhelming compared to the load that Contour otherwise generates in total.

For objects that implement `generation` it can be used, instead of comparing the full object. Generation is updated only when object spec is updated. Updates to `status` or `annotations` fields will not trigger new generation, which needs to be considered separately for objects where those changes matter.

Fixes #5024.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>