### PR TITLE
Gateway API: support RequestRedirect path rewrite

### DIFF
--- a/changelogs/unreleased/5068-skriss-small.md
+++ b/changelogs/unreleased/5068-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: support the `path` field on the HTTPRoute RequestRedirect filter.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -224,14 +224,9 @@ type Redirect struct {
 	// use. Valid options are 301 or 302.
 	StatusCode int
 
-	// Path is the path to swap the url during a redirect.
-	// Valid options start with a `/`.
-	Path string
-
-	// Prefix is the value to swap with the  prefix of the url
-	// during a redirect.
-	// Valid options start with a `/`.
-	Prefix string
+	// PathRewritePolicy is the policy for rewriting
+	// the path during redirect.
+	PathRewritePolicy *PathRewritePolicy
 }
 
 // Route defines the properties of a route to a Cluster.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1080,11 +1080,12 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 
 		// Process rule-level filters.
 		var (
-			requestHeaderPolicy, responseHeaderPolicy *HeadersPolicy
-			redirect                                  *gatewayapi_v1beta1.HTTPRequestRedirectFilter
-			mirrorPolicy                              *MirrorPolicy
-			pathRewritePolicy                         *PathRewritePolicy
-			urlRewriteHostname                        string
+			requestHeaderPolicy  *HeadersPolicy
+			responseHeaderPolicy *HeadersPolicy
+			redirect             *Redirect
+			mirrorPolicy         *MirrorPolicy
+			pathRewritePolicy    *PathRewritePolicy
+			urlRewriteHostname   string
 		)
 
 		for _, filter := range rule.Filters {
@@ -1120,7 +1121,32 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				// docs, "specifying a core filter multiple times has unspecified or
 				// custom conformance.", here we choose to just select the first one.
 				if redirect == nil && filter.RequestRedirect != nil {
-					redirect = filter.RequestRedirect
+					var hostname string
+					if filter.RequestRedirect.Hostname != nil {
+						hostname = string(*filter.RequestRedirect.Hostname)
+					}
+
+					var portNumber uint32
+					if filter.RequestRedirect.Port != nil {
+						portNumber = uint32(*filter.RequestRedirect.Port)
+					}
+
+					var scheme string
+					if filter.RequestRedirect.Scheme != nil {
+						scheme = *filter.RequestRedirect.Scheme
+					}
+
+					var statusCode int
+					if filter.RequestRedirect.StatusCode != nil {
+						statusCode = *filter.RequestRedirect.StatusCode
+					}
+
+					redirect = &Redirect{
+						Hostname:   hostname,
+						PortNumber: portNumber,
+						Scheme:     scheme,
+						StatusCode: statusCode,
+					}
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestMirror:
 				// Get the mirror filter if there is one. If there are more than one
@@ -1559,27 +1585,7 @@ func (p *GatewayAPIProcessor) clusterRoutes(routeNamespace string, matchConditio
 }
 
 // redirectRoutes builds a []*dag.Route for the supplied set of matchConditions, headerPolicies and redirect.
-func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy, redirect *gatewayapi_v1beta1.HTTPRequestRedirectFilter, priority uint8) []*Route {
-	var hostname string
-	if redirect.Hostname != nil {
-		hostname = string(*redirect.Hostname)
-	}
-
-	var portNumber uint32
-	if redirect.Port != nil {
-		portNumber = uint32(*redirect.Port)
-	}
-
-	var scheme string
-	if redirect.Scheme != nil {
-		scheme = *redirect.Scheme
-	}
-
-	var statusCode int
-	if redirect.StatusCode != nil {
-		statusCode = *redirect.StatusCode
-	}
-
+func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions, requestHeaderPolicy *HeadersPolicy, responseHeaderPolicy *HeadersPolicy, redirect *Redirect, priority uint8) []*Route {
 	var routes []*Route
 
 	// Per Gateway API: "Each match is independent,
@@ -1588,13 +1594,8 @@ func (p *GatewayAPIProcessor) redirectRoutes(matchConditions []*matchConditions,
 	// we create a separate route per match.
 	for _, mc := range matchConditions {
 		routes = append(routes, &Route{
-			Priority: priority,
-			Redirect: &Redirect{
-				Hostname:   hostname,
-				Scheme:     scheme,
-				PortNumber: portNumber,
-				StatusCode: statusCode,
-			},
+			Priority:              priority,
+			Redirect:              redirect,
 			PathMatchCondition:    mc.path,
 			HeaderMatchConditions: mc.headers,
 			RequestHeadersPolicy:  requestHeaderPolicy,

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1579,23 +1579,26 @@ func redirectRoutePolicy(redirect *contour_api_v1.HTTPRequestRedirectPolicy) (*R
 		return nil, fmt.Errorf("cannot specify both redirect path and redirect prefix")
 	}
 
-	var path string
+	var pathRewritePolicy *PathRewritePolicy
 	if redirect.Path != nil {
-		path = *redirect.Path
+		if pathRewritePolicy == nil {
+			pathRewritePolicy = &PathRewritePolicy{}
+		}
+		pathRewritePolicy.FullPathRewrite = *redirect.Path
 	}
-
-	var prefix string
 	if redirect.Prefix != nil {
-		prefix = *redirect.Prefix
+		if pathRewritePolicy == nil {
+			pathRewritePolicy = &PathRewritePolicy{}
+		}
+		pathRewritePolicy.PrefixRewrite = *redirect.Prefix
 	}
 
 	return &Redirect{
-		Hostname:   hostname,
-		Scheme:     scheme,
-		PortNumber: portNumber,
-		StatusCode: statusCode,
-		Path:       path,
-		Prefix:     prefix,
+		Hostname:          hostname,
+		Scheme:            scheme,
+		PortNumber:        portNumber,
+		StatusCode:        statusCode,
+		PathRewritePolicy: pathRewritePolicy,
 	}, nil
 }
 

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1694,7 +1694,9 @@ func TestRouteRedirect(t *testing.T) {
 		},
 		"path specified": {
 			redirect: &dag.Redirect{
-				Path: "/blog",
+				PathRewritePolicy: &dag.PathRewritePolicy{
+					FullPathRewrite: "/blog",
+				},
 			},
 			want: &envoy_route_v3.Route_Redirect{
 				Redirect: &envoy_route_v3.RedirectAction{
@@ -1706,12 +1708,33 @@ func TestRouteRedirect(t *testing.T) {
 		},
 		"prefix specified": {
 			redirect: &dag.Redirect{
-				Prefix: "/blog",
+				PathRewritePolicy: &dag.PathRewritePolicy{
+					PrefixRewrite: "/blog",
+				},
 			},
 			want: &envoy_route_v3.Route_Redirect{
 				Redirect: &envoy_route_v3.RedirectAction{
 					PathRewriteSpecifier: &envoy_route_v3.RedirectAction_PrefixRewrite{
 						PrefixRewrite: "/blog",
+					},
+				},
+			},
+		},
+		"prefix regex remove specified": {
+			redirect: &dag.Redirect{
+				PathRewritePolicy: &dag.PathRewritePolicy{
+					PrefixRegexRemove: "^/blog/*",
+				},
+			},
+			want: &envoy_route_v3.Route_Redirect{
+				Redirect: &envoy_route_v3.RedirectAction{
+					PathRewriteSpecifier: &envoy_route_v3.RedirectAction_RegexRewrite{
+						RegexRewrite: &matcher.RegexMatchAndSubstitute{
+							Pattern: &matcher.RegexMatcher{
+								Regex: "^/blog/*",
+							},
+							Substitution: "/",
+						},
 					},
 				},
 			},
@@ -1730,7 +1753,9 @@ func TestRouteRedirect(t *testing.T) {
 				Scheme:     "https",
 				PortNumber: 8443,
 				StatusCode: 302,
-				Path:       "/blog",
+				PathRewritePolicy: &dag.PathRewritePolicy{
+					FullPathRewrite: "/blog",
+				},
 			},
 			want: &envoy_route_v3.Route_Redirect{
 				Redirect: &envoy_route_v3.RedirectAction{


### PR DESCRIPTION
Adds support for the Path field on the HTTPRoute
RequestRedirect filter.

Closes #4964.

Signed-off-by: Steve Kriss <krisss@vmware.com>
Co-authored-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

I have manually run the Gateway API conformance tests against this PR, with the host check removed since we're having some issues with that, and can confirm all tests pass.