### PR TITLE
Gateway API: set redirect port to listener port if not specified

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1121,6 +1121,15 @@ func (p *GatewayAPIProcessor) computeHTTPRoute(route *gatewayapi_v1beta1.HTTPRou
 				// custom conformance.", here we choose to just select the first one.
 				if redirect == nil && filter.RequestRedirect != nil {
 					redirect = filter.RequestRedirect
+
+					// Ref. https://github.com/envoyproxy/envoy/issues/17318, Envoy drops
+					// the request port from the redirect location if a port is not specified
+					// in the redirect config, so if the redirect filter does not specify
+					// a port, use the Listener's port.
+					if filter.RequestRedirect.Port == nil || *filter.RequestRedirect.Port == 0 {
+						redirect.Port = ref.To(listener.listener.Port)
+					}
+
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestMirror:
 				// Get the mirror filter if there is one. If there are more than one

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -48,13 +48,7 @@ func TestGatewayConformance(t *testing.T) {
 		// Keep the list of skipped features in sync with
 		// test/scripts/run-gateway-conformance.sh.
 		SkipTests: []string{
-			// These are skipped because the tests check for the
-			// original request port in the returned Location
-			// header which Envoy is stripping.
-			// See: https://github.com/envoyproxy/envoy/issues/17318
-			"HTTPRouteRedirectHostAndStatus",
 			"HTTPRouteRedirectPath",
-			"HTTPRouteRedirectScheme",
 		},
 	})
 	cSuite.Setup(t)


### PR DESCRIPTION
(See https://github.com/projectcontour/contour/commit/dca8657f9e7e79b524ca1752c1774f186488f1b8 only)

So this _works_, it passes the conformance tests and works for non-standard ports as well. I'd say we should maybe not explicitly set the port redirect if the Listener is using a standard 80/443 port, since it results in `:80` / `:443` always being appended to the redirect location, except that would cause us to fail the conformance test since it requires a port on the redirect location whether it's a standard port number or not, though that test behavior is debatable.