### PR TITLE
internal/sorter: Fix sorting for Query parameter matches

### DIFF
--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -205,10 +205,6 @@ func (s queryParamMatchConditionSorter) Less(i, j int) bool {
 			}
 		case dag.QueryParamMatchTypePresent:
 			if s[j].MatchType == dag.QueryParamMatchTypePresent {
-				// The match that is case sensitive sorts first.
-				if s[i].IgnoreCase != s[j].IgnoreCase {
-					return !s[i].IgnoreCase
-				}
 				return false
 			}
 		}

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -55,7 +55,10 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 			return false
 		default:
 			// The match that is not inverted sorts first.
-			return !a.Invert
+			if a.Invert != b.Invert {
+				return !a.Invert
+			}
+			return false
 		}
 	}
 
@@ -100,7 +103,113 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 		case dag.HeaderMatchTypePresent:
 			if s[j].MatchType == dag.HeaderMatchTypePresent {
 				// The match that is not inverted sorts first.
-				return !s[i].Invert
+				if s[i].Invert != s[j].Invert {
+					return !s[i].Invert
+				}
+				return false
+			}
+		}
+		return false
+	}
+}
+
+// Sorts QueryParameterMatchCondition objects, first by the query param name,
+// then by their matcher condition type and value.
+type queryParamMatchConditionSorter []dag.QueryParamMatchCondition
+
+func (s queryParamMatchConditionSorter) Len() int      { return len(s) }
+func (s queryParamMatchConditionSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s queryParamMatchConditionSorter) Less(i, j int) bool {
+	compareValue := func(a dag.QueryParamMatchCondition, b dag.QueryParamMatchCondition) bool {
+		switch strings.Compare(a.Value, b.Value) {
+		case -1:
+			return true
+		case 1:
+			return false
+		default:
+			// The match that is case sensitive sorts first.
+			if a.IgnoreCase != b.IgnoreCase {
+				return !a.IgnoreCase
+			}
+			return false
+		}
+	}
+
+	val := strings.Compare(s[i].Name, s[j].Name)
+	switch val {
+	case -1:
+		return true
+	case 1:
+		return false
+	default:
+		switch s[i].MatchType {
+		case dag.QueryParamMatchTypeExact:
+			// Exact matches are most specific so they sort first.
+			switch s[j].MatchType {
+			case dag.QueryParamMatchTypeExact:
+				return compareValue(s[i], s[j])
+			case dag.QueryParamMatchTypeRegex:
+				return true
+			case dag.QueryParamMatchTypePrefix:
+				return true
+			case dag.QueryParamMatchTypeSuffix:
+				return true
+			case dag.QueryParamMatchTypeContains:
+				return true
+			case dag.QueryParamMatchTypePresent:
+				return true
+			}
+		case dag.QueryParamMatchTypeRegex:
+			// Regex matches sort ahead of Prefix matches.
+			switch s[j].MatchType {
+			case dag.QueryParamMatchTypeRegex:
+				return compareValue(s[i], s[j])
+			case dag.QueryParamMatchTypePrefix:
+				return true
+			case dag.QueryParamMatchTypeSuffix:
+				return true
+			case dag.QueryParamMatchTypeContains:
+				return true
+			case dag.QueryParamMatchTypePresent:
+				return true
+			}
+		case dag.QueryParamMatchTypePrefix:
+			// Prefix matches sort ahead of Suffix matches.
+			switch s[j].MatchType {
+			case dag.QueryParamMatchTypePrefix:
+				return compareValue(s[i], s[j])
+			case dag.QueryParamMatchTypeSuffix:
+				return true
+			case dag.QueryParamMatchTypeContains:
+				return true
+			case dag.QueryParamMatchTypePresent:
+				return true
+			}
+		case dag.QueryParamMatchTypeSuffix:
+			// Suffix matches sort ahead of Contains matches.
+			switch s[j].MatchType {
+			case dag.QueryParamMatchTypeSuffix:
+				return compareValue(s[i], s[j])
+			case dag.QueryParamMatchTypeContains:
+				return true
+			case dag.QueryParamMatchTypePresent:
+				return true
+			}
+		case dag.QueryParamMatchTypeContains:
+			// Contains matches sort ahead of Present matches.
+			switch s[j].MatchType {
+			case dag.QueryParamMatchTypeContains:
+				return compareValue(s[i], s[j])
+			case dag.QueryParamMatchTypePresent:
+				return true
+			}
+		case dag.QueryParamMatchTypePresent:
+			if s[j].MatchType == dag.QueryParamMatchTypePresent {
+				// The match that is case sensitive sorts first.
+				if s[i].IgnoreCase != s[j].IgnoreCase {
+					return !s[i].IgnoreCase
+				}
+				return false
 			}
 		}
 		return false
@@ -139,12 +248,14 @@ func longestRouteByHeaderAndQueryParamConditions(lhs, rhs *dag.Route) bool {
 		}
 	}
 
-	// QueryParamMatchConditions are equal length: compare name item by item.
-	// We can do this simple comparison since we only have one match type, will
-	// need to expand this with a sorter for query params if we introduce more.
+	// QueryParamMatchConditions are equal length: compare item by item.
 	for i := 0; i < len(lhs.QueryParamMatchConditions); i++ {
-		if lhs.QueryParamMatchConditions[i].Name != rhs.QueryParamMatchConditions[i].Name {
-			return lhs.QueryParamMatchConditions[i].Name < rhs.QueryParamMatchConditions[i].Name
+		qPair := make([]dag.QueryParamMatchCondition, 2)
+		qPair[0] = lhs.QueryParamMatchConditions[i]
+		qPair[1] = rhs.QueryParamMatchConditions[i]
+
+		if queryParamMatchConditionSorter(qPair).Less(0, 1) {
+			return true
 		}
 	}
 
@@ -310,6 +421,8 @@ func For(v interface{}) sort.Interface {
 		return routeSorter(v)
 	case []dag.HeaderMatchCondition:
 		return headerMatchConditionSorter(v)
+	case []dag.QueryParamMatchCondition:
+		return queryParamMatchConditionSorter(v)
 	case []*envoy_cluster_v3.Cluster:
 		return clusterSorter(v)
 	case []*envoy_endpoint_v3.ClusterLoadAssignment:

--- a/internal/sorter/sorter.go
+++ b/internal/sorter/sorter.go
@@ -106,7 +106,6 @@ func (s headerMatchConditionSorter) Less(i, j int) bool {
 				if s[i].Invert != s[j].Invert {
 					return !s[i].Invert
 				}
-				return false
 			}
 		}
 		return false
@@ -204,9 +203,6 @@ func (s queryParamMatchConditionSorter) Less(i, j int) bool {
 				return true
 			}
 		case dag.QueryParamMatchTypePresent:
-			if s[j].MatchType == dag.QueryParamMatchTypePresent {
-				return false
-			}
 		}
 		return false
 	}

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -30,15 +30,12 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func shuffleRoutes(routes []*dag.Route) []*dag.Route {
-	shuffled := make([]*dag.Route, len(routes))
-
-	copy(shuffled, routes)
-
-	rand.Shuffle(len(shuffled), func(i, j int) {
+func shuffleSlice[T any](original []T) []T {
+	shuffled := make([]T, len(original))
+	copy(shuffled, original)
+	rand.Shuffle(len(original), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
-
 	return shuffled
 }
 
@@ -150,6 +147,58 @@ func presentHeader(name string) dag.HeaderMatchCondition {
 	}
 }
 
+func ignoreCaseQueryParam(h dag.QueryParamMatchCondition) dag.QueryParamMatchCondition {
+	h.IgnoreCase = true
+	return h
+}
+
+func exactQueryParam(name string, value string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypeExact,
+		Value:     value,
+	}
+}
+
+func prefixQueryParam(name string, value string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypePrefix,
+		Value:     value,
+	}
+}
+
+func suffixQueryParam(name string, value string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypeSuffix,
+		Value:     value,
+	}
+}
+
+func regexQueryParam(name string, value string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypeRegex,
+		Value:     value,
+	}
+}
+
+func containsQueryParam(name string, value string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypeContains,
+		Value:     value,
+	}
+}
+
+func presentQueryParam(name string) dag.QueryParamMatchCondition {
+	return dag.QueryParamMatchCondition{
+		Name:      name,
+		MatchType: dag.QueryParamMatchTypePresent,
+	}
+}
+
 // Routes that have a higher priority should be sorted first when compared to
 // others that have identical path matches, number of header matches, and
 // number of query matches.
@@ -189,7 +238,7 @@ func TestSortRoutesPriority(t *testing.T) {
 			Priority:           2,
 			PathMatchCondition: matchPrefixSegment("/"),
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "z-query-param", Value: "query-value"},
+				containsQueryParam("z-query-param", "query-value"),
 			},
 		},
 		{
@@ -198,14 +247,14 @@ func TestSortRoutesPriority(t *testing.T) {
 			Priority:           3,
 			PathMatchCondition: matchPrefixSegment("/"),
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "a-query-param", Value: "query-value"},
+				exactQueryParam("a-query-param", "query-value"),
 			},
 		},
 		{
 			Priority:           3,
 			PathMatchCondition: matchPrefixSegment("/"),
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "b-query-param", Value: "query-value"},
+				exactQueryParam("b-query-param", "query-value"),
 			},
 		},
 		{
@@ -214,7 +263,7 @@ func TestSortRoutesPriority(t *testing.T) {
 		},
 	}
 
-	have := shuffleRoutes(want)
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -266,7 +315,7 @@ func TestSortRoutesPathMatch(t *testing.T) {
 		},
 	}
 
-	have := shuffleRoutes(want)
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -274,6 +323,24 @@ func TestSortRoutesPathMatch(t *testing.T) {
 
 func TestSortRoutesLongestHeaders(t *testing.T) {
 	want := []*dag.Route{
+		{
+			// More conditions sort higher.
+			PathMatchCondition: matchExact("/pathexact"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("header-name", "header-value"),
+				exactHeader("header-name-2", "header-value"),
+				exactHeader("header-name-3", "header-value"),
+			},
+		},
+		{
+			// Per-element name comparison means this sorts later.
+			PathMatchCondition: matchExact("/pathexact"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("header-name", "header-value"),
+				exactHeader("header-name-2", "header-value"),
+				exactHeader("header-name-999", "header-value"),
+			},
+		},
 		{
 			// Although the header names are the same, this value
 			// should sort before the next one because it is
@@ -348,7 +415,7 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 		},
 	}
 
-	have := shuffleRoutes(want)
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -357,52 +424,96 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 func TestSortRoutesQueryParams(t *testing.T) {
 	want := []*dag.Route{
 		{
-
 			PathMatchCondition: matchExact("/"),
+			// More match conditions sort higher.
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "query-param-1", Value: "query-value-1"},
-				{Name: "query-param-2", Value: "query-value-2"},
-				{Name: "query-param-3", Value: "query-value-3"},
+				containsQueryParam("query-param-1", "query-value-1"),
+				containsQueryParam("query-param-2", "query-value-2"),
+				containsQueryParam("query-param-3", "query-value-3"),
 			},
 		},
 		{
-
 			PathMatchCondition: matchExact("/"),
 			// If same number of matches, sort on element-by-element
-			// comparison of each query param name provided.
+			// comparison of query param name.
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "aaa-query-param-1", Value: "query-value-1"},
-				{Name: "query-param-2", Value: "query-value-2"},
+				exactQueryParam("aaa-param", "val"),
+				exactQueryParam("query-param-1", "query-value-1"),
 			},
 		},
 		{
-
 			PathMatchCondition: matchExact("/"),
-			// If same number of matches, sort on element-by-element
-			// comparison of each query param name provided.
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "query-param-1", Value: "query-value-1"},
-				{Name: "bbb-query-param-2", Value: "query-value-2"},
+				exactQueryParam("bbb-param", "val"),
+				exactQueryParam("query-param-1", "query-value-1"),
 			},
 		},
 		{
-
 			PathMatchCondition: matchExact("/"),
+			// Exact is most specific.
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "query-param-1", Value: "query-value-1"},
-				{Name: "query-param-2", Value: "query-value-2"},
+				exactQueryParam("query-param-1", "query-value-1"),
 			},
 		},
 		{
-
+			PathMatchCondition: matchExact("/"),
+			// If matching type, sort on value.
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				exactQueryParam("query-param-1", "query-value-1-other"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			// If matching type, value, sort on case sensitivity.
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				ignoreCaseQueryParam(exactQueryParam("query-param-1", "query-value-1-other")),
+			},
+		},
+		{
 			PathMatchCondition: matchExact("/"),
 			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
-				{Name: "query-param-1", Value: "query-value-1"},
+				regexQueryParam("query-param-1", "query-value-1"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				prefixQueryParam("query-param-1", "query-value-1"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				suffixQueryParam("query-param-1", "query-value-1"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				containsQueryParam("query-param-1", "query-value-1"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				presentQueryParam("query-param-1"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				prefixQueryParam("query-param-2", "query-value-2"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/"),
+			QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+				prefixQueryParam("query-param-2", "query-value-2-after"),
 			},
 		},
 	}
 
-	have := shuffleRoutes(want)
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -414,10 +525,7 @@ func TestSortSecrets(t *testing.T) {
 		{Name: "second"},
 	}
 
-	have := []*envoy_tls_v3.Secret{
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -436,14 +544,7 @@ func TestSortHeaderMatchConditions(t *testing.T) {
 		exactHeader("long-header-name", "long-header-value"),
 	}
 
-	have := []dag.HeaderMatchCondition{
-		want[5],
-		want[4],
-		want[3],
-		want[0],
-		want[2],
-		want[1],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -460,14 +561,7 @@ func TestSortHeaderMatchConditionsInverted(t *testing.T) {
 		invertHeaderMatch(presentHeader("header-name")),
 	}
 
-	have := []dag.HeaderMatchCondition{
-		want[5],
-		want[4],
-		want[3],
-		want[2],
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -486,16 +580,34 @@ func TestSortHeaderMatchConditionsValue(t *testing.T) {
 		containsHeader("header-name", "c"),
 	}
 
-	have := []dag.HeaderMatchCondition{
-		want[6],
-		want[5],
-		want[4],
-		want[7],
-		want[2],
-		want[1],
-		want[0],
-		want[3],
+	have := shuffleSlice(want)
+
+	sort.Stable(For(have))
+	assert.Equal(t, want, have)
+}
+
+func TestSortQueryParamMatchConditionsValue(t *testing.T) {
+	want := []dag.QueryParamMatchCondition{
+		exactQueryParam("query-name", "a"),
+		ignoreCaseQueryParam(exactQueryParam("query-name", "a")),
+		exactQueryParam("query-name", "b"),
+		exactQueryParam("query-name", "c"),
+		regexQueryParam("query-name", "a"),
+		ignoreCaseQueryParam(regexQueryParam("query-name", "a")),
+		regexQueryParam("query-name", "b"),
+		prefixQueryParam("query-name", "a"),
+		ignoreCaseQueryParam(prefixQueryParam("query-name", "a")),
+		prefixQueryParam("query-name", "b"),
+		suffixQueryParam("query-name", "a"),
+		ignoreCaseQueryParam(suffixQueryParam("query-name", "a")),
+		suffixQueryParam("query-name", "b"),
+		containsQueryParam("query-name", "a"),
+		ignoreCaseQueryParam(containsQueryParam("query-name", "a")),
+		containsQueryParam("query-name", "b"),
+		containsQueryParam("query-name", "c"),
 	}
+
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -507,10 +619,7 @@ func TestSortClusters(t *testing.T) {
 		{Name: "second"},
 	}
 
-	have := []*envoy_cluster_v3.Cluster{
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -522,10 +631,7 @@ func TestSortClusterLoadAssignments(t *testing.T) {
 		{ClusterName: "second"},
 	}
 
-	have := []*envoy_endpoint_v3.ClusterLoadAssignment{
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -547,11 +653,7 @@ func TestSortHTTPWeightedClusters(t *testing.T) {
 		},
 	}
 
-	have := []*envoy_route_v3.WeightedCluster_ClusterWeight{
-		want[2],
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -573,11 +675,7 @@ func TestSortTCPWeightedClusters(t *testing.T) {
 		},
 	}
 
-	have := []*tcp.TcpProxy_WeightedCluster_ClusterWeight{
-		want[2],
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
@@ -589,10 +687,7 @@ func TestSortListeners(t *testing.T) {
 		{Name: "second"},
 	}
 
-	have := []*envoy_listener_v3.Listener{
-		want[1],
-		want[0],
-	}
+	have := shuffleSlice(want)
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -262,11 +262,7 @@ func TestSortRoutesPriority(t *testing.T) {
 			PathMatchCondition: matchPrefixSegment("/"),
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortRoutesPathMatch(t *testing.T) {
@@ -314,11 +310,7 @@ func TestSortRoutesPathMatch(t *testing.T) {
 			PathMatchCondition: matchPrefixSegment("/path/p"),
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortRoutesLongestHeaders(t *testing.T) {
@@ -414,11 +406,7 @@ func TestSortRoutesLongestHeaders(t *testing.T) {
 			PathMatchCondition: matchPrefixString("/path"),
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortRoutesQueryParams(t *testing.T) {
@@ -512,11 +500,7 @@ func TestSortRoutesQueryParams(t *testing.T) {
 			},
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortSecrets(t *testing.T) {
@@ -524,11 +508,7 @@ func TestSortSecrets(t *testing.T) {
 		{Name: "first"},
 		{Name: "second"},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortHeaderMatchConditions(t *testing.T) {
@@ -543,11 +523,7 @@ func TestSortHeaderMatchConditions(t *testing.T) {
 		presentHeader("header-name"),
 		exactHeader("long-header-name", "long-header-value"),
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortHeaderMatchConditionsInverted(t *testing.T) {
@@ -560,11 +536,7 @@ func TestSortHeaderMatchConditionsInverted(t *testing.T) {
 		presentHeader("header-name"),
 		invertHeaderMatch(presentHeader("header-name")),
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortHeaderMatchConditionsValue(t *testing.T) {
@@ -579,11 +551,7 @@ func TestSortHeaderMatchConditionsValue(t *testing.T) {
 		containsHeader("header-name", "b"),
 		containsHeader("header-name", "c"),
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortQueryParamMatchConditionsValue(t *testing.T) {
@@ -605,12 +573,9 @@ func TestSortQueryParamMatchConditionsValue(t *testing.T) {
 		ignoreCaseQueryParam(containsQueryParam("query-name", "a")),
 		containsQueryParam("query-name", "b"),
 		containsQueryParam("query-name", "c"),
+		presentQueryParam("query-name"),
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortClusters(t *testing.T) {
@@ -618,11 +583,7 @@ func TestSortClusters(t *testing.T) {
 		{Name: "first"},
 		{Name: "second"},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortClusterLoadAssignments(t *testing.T) {
@@ -630,11 +591,7 @@ func TestSortClusterLoadAssignments(t *testing.T) {
 		{ClusterName: "first"},
 		{ClusterName: "second"},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortHTTPWeightedClusters(t *testing.T) {
@@ -652,11 +609,7 @@ func TestSortHTTPWeightedClusters(t *testing.T) {
 			Weight: wrapperspb.UInt32(20),
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortTCPWeightedClusters(t *testing.T) {
@@ -674,11 +627,7 @@ func TestSortTCPWeightedClusters(t *testing.T) {
 			Weight: 20,
 		},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortListeners(t *testing.T) {
@@ -686,11 +635,7 @@ func TestSortListeners(t *testing.T) {
 		{Name: "first"},
 		{Name: "second"},
 	}
-
-	have := shuffleSlice(want)
-
-	sort.Stable(For(have))
-	assert.Equal(t, want, have)
+	shuffleAndCheckSort(t, want)
 }
 
 func TestSortFilterChains(t *testing.T) {
@@ -729,4 +674,16 @@ func TestSortFilterChains(t *testing.T) {
 
 	sort.Stable(For(have))
 	assert.Equal(t, want, have)
+}
+
+func shuffleAndCheckSort[T any](t *testing.T, want []T) {
+	t.Helper()
+
+	// Run multiple trials so we catch any ordering/stability errors.
+	for i := 0; i < 10; i++ {
+		have := shuffleSlice(want)
+
+		sort.Stable(For(have))
+		assert.Equal(t, want, have)
+	}
 }

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -135,8 +135,7 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 
 // sortRoutes sorts the given Route slice in place. Routes are ordered
 // first by path match type, path match value via string comparison and
-// then by the length of the HeaderMatch slice (if any). The HeaderMatch
-// slice is also ordered by the matching header name.
+// then by the header and query param match conditions.
 // We sort dag.Route objects before converting to Envoy types to ensure
 // more accurate ordering of route matches. Contour route match types may
 // be implemented by Envoy route match types that change over time, or by
@@ -148,6 +147,7 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 func sortRoutes(routes []*dag.Route) {
 	for _, r := range routes {
 		sort.Stable(sorter.For(r.HeaderMatchConditions))
+		sort.Stable(sorter.For(r.QueryParamMatchConditions))
 	}
 
 	sort.Stable(sorter.For(routes))

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -3531,6 +3531,37 @@ func TestSortLongestRouteFirst(t *testing.T) {
 			}},
 		},
 
+		// The path and the length of query param condition list are equal,
+		// so we should order lexicographically by query param name.
+		"query params sort stably by name": {
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+					{Name: "zzz-2", MatchType: "present"},
+					{Name: "zzz-1", MatchType: "present"},
+				},
+			}, {
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+					{Name: "aaa-2", MatchType: "present"},
+					{Name: "aaa-1", MatchType: "present"},
+				},
+			}},
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+					{Name: "aaa-1", MatchType: "present"},
+					{Name: "aaa-2", MatchType: "present"},
+				},
+			}, {
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				QueryParamMatchConditions: []dag.QueryParamMatchCondition{
+					{Name: "zzz-1", MatchType: "present"},
+					{Name: "zzz-2", MatchType: "present"},
+				},
+			}},
+		},
+
 		// If we have multiple conditions on the same header, ensure
 		// that we order on the match type too.
 		"headers order by match type": {
@@ -3556,6 +3587,31 @@ func TestSortLongestRouteFirst(t *testing.T) {
 			}},
 		},
 
+		// If we have multiple conditions on the same query param, ensure
+		// that we order on the match type too.
+		"query params order by match type": {
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+			}, {
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "param-1", MatchType: "present"},
+					{Name: "param-2", MatchType: "present", Invert: true},
+					{Name: "param-1", MatchType: "exact", Value: "foo"},
+				},
+			}},
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "param-1", MatchType: "exact", Value: "foo"},
+					{Name: "param-1", MatchType: "present"},
+					{Name: "param-2", MatchType: "present", Invert: true},
+				},
+			}, {
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+			}},
+		},
+
 		// Verify that we always order the headers, even if
 		// we don't need to compare the header conditions to
 		// order multiple routes with the same prefix.
@@ -3574,6 +3630,28 @@ func TestSortLongestRouteFirst(t *testing.T) {
 					{Name: "x-request-1", MatchType: "exact", Value: "foo"},
 					{Name: "x-request-1", MatchType: "present"},
 					{Name: "x-request-2", MatchType: "present", Invert: true},
+				},
+			}},
+		},
+
+		// Verify that we always order the query params, even if
+		// we don't need to compare the conditions to
+		// order multiple routes with the same prefix.
+		"query params order in single route": {
+			routes: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "param-1", MatchType: "present"},
+					{Name: "param-2", MatchType: "present", Invert: true},
+					{Name: "param-1", MatchType: "exact", Value: "foo"},
+				},
+			}},
+			want: []*dag.Route{{
+				PathMatchCondition: &dag.PrefixMatchCondition{Prefix: "/"},
+				HeaderMatchConditions: []dag.HeaderMatchCondition{
+					{Name: "param-1", MatchType: "exact", Value: "foo"},
+					{Name: "param-1", MatchType: "present"},
+					{Name: "param-2", MatchType: "present", Invert: true},
 				},
 			}},
 		},


### PR DESCRIPTION
Needs to take into account match type, value, case sensitivity

Also ensures query param match conditions on routes in sorted order

Fixes a small issue in the header condition sorter as well.
