### PR TITLE
tests: remove call to deprecated rand.Seed

### DIFF
--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -102,8 +102,6 @@ func setup(t *testing.T, opts ...interface{}) (cache.ResourceEventHandler, *Cont
 
 	registry := prometheus.NewRegistry()
 
-	rand.Seed(time.Now().Unix())
-
 	builder := &dag.Builder{
 		Source: dag.KubernetesCache{
 			FieldLogger: log,


### PR DESCRIPTION
Remove call to deprecated `rand.Seed()` from the test code, for go1.20 compatibility. https://pkg.go.dev/math/rand#Seed

Updates #5077

Signed-off-by: Tero Saarni <tero.saarni@est.tech>