### PR TITLE
cmd/contour: optional CRDs

### DIFF
--- a/changelogs/unreleased/5080-nsimons-minor.md
+++ b/changelogs/unreleased/5080-nsimons-minor.md
@@ -1,0 +1,8 @@
+## Allow Disabling Features
+
+The `contour serve` command takes a new optional flag, `--disable-feature`, that allows disabling
+certain features.
+
+Currently this flag can be used to disable the informer for ExtensionService resources,
+effectively making the ExtensionService CRD optional in the cluster.
+To do this, use the flag as follows: `--disable-feature=extensionservices`

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -87,6 +87,9 @@ type serveContext struct {
 
 	// Leader election configuration.
 	LeaderElection LeaderElection
+
+	// Features disabled by the user.
+	disabledFeatures []string
 }
 
 type ServerConfig struct {

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -50,6 +50,7 @@ Many of these flags are mirrored in the [Contour Configuration File](#configurat
 | `--use-proxy-protocol`                                   | Use PROXY protocol for all listeners                                   |
 | `--accesslog-format=<envoy\|json>`                       | Format for Envoy access logs                                           |
 | `--disable-leader-election`                              | Disable leader election mechanism                                      |
+| `--disable-feature=<extensionservices>`                  | Do not start an informer for the specified resources.                  |
 | `--leader-election-lease-duration`                       | The duration of the leadership lease.                                  |
 | `--leader-election-renew-deadline`                       | The duration leader will retry refreshing leadership before giving up. |
 | `--leader-election-retry-period`                         | The interval which Contour will attempt to acquire leadership lease.   |

--- a/site/content/docs/main/deploy-options.md
+++ b/site/content/docs/main/deploy-options.md
@@ -201,6 +201,12 @@ Next, pass `--envoy-service-http-port=80 --envoy-service-https-port=443` to the 
 This is best paired with a DaemonSet (perhaps paired with Node affinity) to ensure that a single instance of Contour runs on each Node.
 See the [AWS NLB tutorial][10] as an example.
 
+## Disabling Features
+
+You can run Contour with certain features disabled by passing `--disable-feature` flag to the Contour `serve` command.
+Currently this flag can be used to disable the informer for ExtensionService resources, effectively making the ExtensionService CRD optional in the cluster.
+To do this, use the flag as follows: `--disable-feature=extensionservices`
+
 ## Upgrading Contour/Envoy
 
 At times, it's needed to upgrade Contour, the version of Envoy, or both.


### PR DESCRIPTION
Allow disabling certain informers for CRDs by passing a command line flag to the serve command. This makes the corresponding CRD effectively optional.

I'd like some feedback on the terminology. Would the audience of the documents necessarily know what an `informer` is? Also `feature` is quite generic, but I tried to explain the intended meaning in this context. I'm open to other suggestions.

I tried to look for a good place to write some tests, but I didn't find much related to the flags. I have tested manually with the CRDs present/missing in my cluster.

Fixes #4684

Signed-off-by: Niklas Simons <niklas.simons@est.tech>