### PR TITLE
RFC: Add `--envoy-ingress-name`, and `--envoy-ingress-namespace` flags. (#4952)

### DIFF
--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -234,6 +234,12 @@ type EnvoyConfig struct {
 	// +optional
 	Service *NamespacedName `json:"service,omitempty"`
 
+	// Ingress holds Envoy service parameters for setting Ingress status.
+	//
+	// Contour's default is { namespace: "projectcontour", name: "envoy" }.
+	// +optional
+	Ingress *NamespacedName `json:"ingress,omitempty"`
+
 	// Defines the HTTP Listener for Envoy.
 	//
 	// Contour's default is { address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout" }.

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -463,6 +463,10 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_api_v1alpha
 				Name:      ctx.Config.EnvoyServiceName,
 				Namespace: ctx.Config.EnvoyServiceNamespace,
 			},
+			Ingress: &contour_api_v1alpha1.NamespacedName{
+				Name:      ctx.Config.EnvoyIngressName,
+				Namespace: ctx.Config.EnvoyIngressNamespace,
+			},
 			HTTPListener: &contour_api_v1alpha1.EnvoyListener{
 				Address:   ctx.httpAddr,
 				Port:      ctx.httpPort,

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -305,3 +305,63 @@ func coreToNetworkingLBStatus(lbs v1.LoadBalancerStatus) networking_v1.IngressLo
 		Ingress: ingress,
 	}
 }
+
+// IngressStatusLoadBalancerWatcher implements ResourceEventHandler and
+// watches for changes to the status.loadbalancer field
+// Note that we specifically *don't* inspect inside the struct, as sending empty values
+// is desirable to clear the status.
+type IngressStatusLoadBalancerWatcher struct {
+	IngressName string
+	LBStatus    chan networking_v1.IngressLoadBalancerStatus
+	Log         logrus.FieldLogger
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnAdd(obj interface{}) {
+	ingress, ok := obj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.Log.WithField("name", ingress.Name).
+		WithField("namespace", ingress.Namespace).
+		Debug("received new service address")
+
+	s.notify(ingress.Status.LoadBalancer)
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnUpdate(oldObj, newObj interface{}) {
+	ingress, ok := newObj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.Log.WithField("name", ingress.Name).
+		WithField("namespace", ingress.Namespace).
+		Debug("received new service address")
+
+	s.notify(ingress.Status.LoadBalancer)
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnDelete(obj interface{}) {
+	ingress, ok := obj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.notify(networking_v1.IngressLoadBalancerStatus{
+		Ingress: nil,
+	})
+}
+
+func (s *IngressStatusLoadBalancerWatcher) notify(lbstatus networking_v1.IngressLoadBalancerStatus) {
+	s.LBStatus <- lbstatus
+}

--- a/internal/provisioner/model/names.go
+++ b/internal/provisioner/model/names.go
@@ -32,6 +32,11 @@ func (c *Contour) EnvoyServiceName() string {
 	return "envoy-" + c.Name
 }
 
+// EnvoyIngressName returns the name of the Envoy Ingress resource.
+func (c *Contour) EnvoyIngressName() string {
+	return "envoy-" + c.Name
+}
+
 // ContourDeploymentName returns the name of the Contour Deployment resource.
 func (c *Contour) ContourDeploymentName() string {
 	return "contour-" + c.Name

--- a/internal/provisioner/objects/contourconfig/contourconfig.go
+++ b/internal/provisioner/objects/contourconfig/contourconfig.go
@@ -72,6 +72,10 @@ func setGatewayConfig(config *contour_api_v1alpha1.ContourConfiguration, contour
 		Namespace: contour.Namespace,
 		Name:      contour.EnvoyServiceName(),
 	}
+	config.Spec.Envoy.Ingress = &contour_api_v1alpha1.NamespacedName{
+		Namespace: contour.Namespace,
+		Name:      contour.EnvoyIngressName(),
+	}
 }
 
 // EnsureContourConfigDeleted deletes a ContourConfig for the provided contour, if the configured owner labels exist.

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -93,6 +93,7 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 		fmt.Sprintf("--contour-config-name=%s", contour.ContourConfigurationName()),
 		fmt.Sprintf("--leader-election-resource-name=%s", contour.LeaderElectionLeaseName()),
 		fmt.Sprintf("--envoy-service-name=%s", contour.EnvoyServiceName()),
+		fmt.Sprintf("--envoy-ingress-name=%s", contour.EnvoyIngressName()),
 		fmt.Sprintf("--kubernetes-debug=%d", contour.Spec.KubernetesLogLevel),
 	}
 

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -533,6 +533,12 @@ type Parameters struct {
 	// Name of the envoy service to inspect for Ingress status details.
 	EnvoyServiceName string `yaml:"envoy-service-name,omitempty"`
 
+	// Namespace of the envoy ingress to inspect for Ingress status details.
+	EnvoyIngressNamespace string `yaml:"envoy-ingress-namespace,omitempty"`
+
+	// Name of the envoy ingress to inspect for Ingress status details.
+	EnvoyIngressName string `yaml:"envoy-ingress-name,omitempty"`
+
 	// DefaultHTTPVersions defines the default set of HTTPS
 	// versions the proxy should accept. HTTP versions are
 	// strings of the form "HTTP/xx". Supported versions are
@@ -742,6 +748,8 @@ func Defaults() Parameters {
 		},
 		EnvoyServiceName:      "envoy",
 		EnvoyServiceNamespace: contourNamespace,
+		EnvoyIngressName:      "envoy",
+		EnvoyIngressNamespace: contourNamespace,
 		DefaultHTTPVersions:   []HTTPVersionType{},
 		Cluster: ClusterParameters{
 			DNSLookupFamily: AutoClusterDNSFamily,


### PR DESCRIPTION
https://github.com/projectcontour/contour/issues/4952

I want to add `--envoy-ingress-name` and `--envoy-ingress-namespace`.
I'm thinking something like this, what do you think?
If you like it, I can implement the rest.