### PR TITLE
drop old +build tags

### DIFF
--- a/cmd/contour/gcp.go
+++ b/cmd/contour/gcp.go
@@ -12,10 +12,9 @@
 // limitations under the License.
 
 //go:build gcp
-// +build gcp
 
 package main
 
-// This file is protected by the +build gcp tag above to prevent
+// This file is protected by the go:build gcp tag above to prevent
 // the gcp dependencies from being part of the standard contour image.
 import _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/cmd/contour/oidc.go
+++ b/cmd/contour/oidc.go
@@ -12,10 +12,9 @@
 // limitations under the License.
 
 //go:build oidc
-// +build oidc
 
 package main
 
-// This file is protected by the +build oidc tag above to prevent
+// This file is protected by the go:build oidc tag above to prevent
 // the oicd dependencies from being part of the standard contour image.
 import _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"

--- a/hack/actions/check-changefile-exists.go
+++ b/hack/actions/check-changefile-exists.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build none
-// +build none
 
 // Versioning comment for rerunning jobs.
 // check-changefile-exists.go

--- a/hack/release/prepare-release.go
+++ b/hack/release/prepare-release.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build none
-// +build none
 
 package main
 

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build conformance
-// +build conformance
 
 package gatewayapi
 

--- a/test/e2e/bench/bench_test.go
+++ b/test/e2e/bench/bench_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package bench
 

--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/multiple_gateways_and_classes_test.go
+++ b/test/e2e/gateway/multiple_gateways_and_classes_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/path_condition_match_test.go
+++ b/test/e2e/gateway/path_condition_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/request_mirror_test.go
+++ b/test/e2e/gateway/request_mirror_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/response_header_modifier_test.go
+++ b/test/e2e/gateway/response_header_modifier_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/gateway/tlsroute_test.go
+++ b/test/e2e/gateway/tlsroute_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package gateway
 

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/client_cert_crl_test.go
+++ b/test/e2e/httpproxy/client_cert_crl_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/direct_response_test.go
+++ b/test/e2e/httpproxy/direct_response_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/dynamic_headers_test.go
+++ b/test/e2e/httpproxy/dynamic_headers_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/external_name_test.go
+++ b/test/e2e/httpproxy/external_name_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/fqdn_test.go
+++ b/test/e2e/httpproxy/fqdn_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/header_condition_match_test.go
+++ b/test/e2e/httpproxy/header_condition_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/host_header_rewrite_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/http_health_checks_test.go
+++ b/test/e2e/httpproxy/http_health_checks_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/https_fallback_certificate_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/https_misdirected_request_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/https_sni_enforcement_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/include_prefix_condition_test.go
+++ b/test/e2e/httpproxy/include_prefix_condition_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/local_rate_limiting_test.go
+++ b/test/e2e/httpproxy/local_rate_limiting_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/merge_slash_test.go
+++ b/test/e2e/httpproxy/merge_slash_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/multiple_ingress_classes_test.go
+++ b/test/e2e/httpproxy/multiple_ingress_classes_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/path_condition_match_test.go
+++ b/test/e2e/httpproxy/path_condition_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/path_rewrite_test.go
+++ b/test/e2e/httpproxy/path_rewrite_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/pod_restart_test.go
+++ b/test/e2e/httpproxy/pod_restart_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/query_parameter_condition_match_test.go
+++ b/test/e2e/httpproxy/query_parameter_condition_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/request_redirect_test.go
+++ b/test/e2e/httpproxy/request_redirect_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/required_field_validation_test.go
+++ b/test/e2e/httpproxy/required_field_validation_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/retry_policy_validation_test.go
+++ b/test/e2e/httpproxy/retry_policy_validation_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/root_namespaces_test.go
+++ b/test/e2e/httpproxy/root_namespaces_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package httpproxy
 

--- a/test/e2e/incluster/incluster_test.go
+++ b/test/e2e/incluster/incluster_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package incluster
 

--- a/test/e2e/incluster/leaderelection_test.go
+++ b/test/e2e/incluster/leaderelection_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package incluster
 

--- a/test/e2e/incluster/rbac_test.go
+++ b/test/e2e/incluster/rbac_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package incluster
 

--- a/test/e2e/incluster/smoke_test.go
+++ b/test/e2e/incluster/smoke_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package incluster
 

--- a/test/e2e/infra/admin_test.go
+++ b/test/e2e/infra/admin_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package infra
 

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package infra
 

--- a/test/e2e/infra/metrics_test.go
+++ b/test/e2e/infra/metrics_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package infra
 

--- a/test/e2e/ingress/backend_tls_test.go
+++ b/test/e2e/ingress/backend_tls_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/ingress/headers_policy_test.go
+++ b/test/e2e/ingress/headers_policy_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/ingress/ingress_class_test.go
+++ b/test/e2e/ingress/ingress_class_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/ingress/long_path_match_test.go
+++ b/test/e2e/ingress/long_path_match_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/ingress/tls_wildcard_host_test.go
+++ b/test/e2e/ingress/tls_wildcard_host_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package ingress
 

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/poller.go
+++ b/test/e2e/poller.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/provisioner.go
+++ b/test/e2e/provisioner.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package e2e
 

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package provisioner
 

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package upgrade
 

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 


### PR DESCRIPTION
The +build syntax has been replaced by go:build
and the old tags are no longer needed.

Signed-off-by: Steve Kriss <krisss@vmware.com>