### PR TITLE
don't generate ingress_http RouteConfig if no vhosts

### DIFF
--- a/internal/featuretests/v3/corspolicy_test.go
+++ b/internal/featuretests/v3/corspolicy_test.go
@@ -461,10 +461,5 @@ func TestCorsPolicy(t *testing.T) {
 
 	rh.OnAdd(invvhost)
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http")),
-		TypeUrl: routeType,
-	}).Status(invvhost).IsInvalid()
-
+	c.Request(routeType).HasNoResources().Status(invvhost).IsInvalid()
 }

--- a/internal/featuretests/v3/directresponsepolicy_test.go
+++ b/internal/featuretests/v3/directresponsepolicy_test.go
@@ -118,10 +118,5 @@ func TestDirectResponsePolicy_HTTProxy(t *testing.T) {
 
 	rh.OnUpdate(proxyNobody, proxyInvalid)
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -469,6 +469,13 @@ func (r *Response) Equals(want *envoy_discovery_v3.DiscoveryResponse) *Contour {
 	return r.Contour
 }
 
+// HasNoResources tests that the response retrieved from Contour has no resources.
+func (r *Response) HasNoResources() *Contour {
+	r.Helper()
+	require.Nil(r.T, r.DiscoveryResponse.Resources)
+	return r.Contour
+}
+
 // Equals(...) only checks resources, so explicitly
 // check version & nonce here and subsequently.
 func (r *Response) assertEqualVersion(t *testing.T, expected string) {

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -86,12 +86,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		rh.OnUpdate(ingressValid, ingressWrongClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- no ingress class specified
 		ingressNoClass := &networking_v1.Ingress{
@@ -102,12 +97,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		}
 		rh.OnUpdate(ingressWrongClass, ingressNoClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid ingress object
 		rh.OnAdd(ingressValid)
@@ -129,12 +119,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		rh.OnDelete(ingressValid)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 
 	// HTTPProxy
@@ -188,12 +173,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		rh.OnUpdate(proxyValid, proxyWrongClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- no ingress class specified
 		proxyNoClass := fixture.NewProxy(HTTPProxyName).
@@ -212,12 +192,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		rh.OnUpdate(proxyWrongClass, proxyNoClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid httpproxy object
 		rh.OnAdd(proxyValid)
@@ -239,12 +214,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 		rh.OnDelete(proxyValid)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 }
 
@@ -323,12 +293,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		}
 		rh.OnUpdate(ingressMatchingClass, ingressNonMatchingClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid ingress object
 		rh.OnAdd(ingressNoClass)
@@ -350,12 +315,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		rh.OnDelete(ingressNoClass)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 
 	// HTTPProxy
@@ -439,12 +399,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		rh.OnUpdate(proxyMatchingClass, proxyNonMatchingClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid httpproxy object
 		rh.OnAdd(proxyNoClass)
@@ -466,12 +421,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 		rh.OnDelete(proxyNoClass)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 }
 
@@ -599,12 +549,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 
 		rh.OnUpdate(ingressValid, ingressWrongClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// No ingress class specified.
 		ingressNoClass := &networking_v1.Ingress{
@@ -615,12 +560,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 		}
 		rh.OnUpdate(ingressWrongClass, ingressNoClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// Remove Ingress class.
 		rh.OnDelete(ingressClass)
@@ -645,12 +585,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 		rh.OnDelete(ingressValid)
 
 		// Verify ingress is gone.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 
 	// HTTPProxy
@@ -704,12 +639,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 		rh.OnUpdate(proxyValid, proxyWrongClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- no ingress class specified
 		proxyNoClass := fixture.NewProxy(HTTPProxyName).
@@ -728,12 +658,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 		rh.OnUpdate(proxyWrongClass, proxyNoClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid httpproxy object
 		rh.OnAdd(proxyValid)
@@ -755,12 +680,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 		rh.OnDelete(proxyValid)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 }
 
@@ -842,12 +762,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 		}
 		rh.OnUpdate(ingressMatchingClass, ingressNonMatchingClass)
 
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// Remove Ingress class.
 		rh.OnDelete(ingressClass)
@@ -872,12 +787,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 		rh.OnDelete(ingressMatchingClass)
 
 		// Verify ingress is gone.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 
 	// HTTPProxy
@@ -961,12 +871,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 		rh.OnUpdate(proxyMatchingClass, proxyNonMatchingClass)
 
 		// ingress class does not match ingress controller, ignored.
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 
 		// --- insert valid httpproxy object
 		rh.OnAdd(proxyNoClass)
@@ -988,11 +893,6 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 		rh.OnDelete(proxyNoClass)
 
 		// verify ingress is gone
-		c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-			Resources: resources(t,
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
-			TypeUrl: routeType,
-		})
+		c.Request(routeType).HasNoResources()
 	}
 }

--- a/internal/featuretests/v3/redirectroutepolicy_test.go
+++ b/internal/featuretests/v3/redirectroutepolicy_test.go
@@ -143,10 +143,5 @@ func TestRedirectResponsePolicy_HTTProxy(t *testing.T) {
 
 	rh.OnUpdate(proxyPrefixRewrite, proxyInvalid)
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }

--- a/internal/featuretests/v3/replaceprefix_test.go
+++ b/internal/featuretests/v3/replaceprefix_test.go
@@ -95,12 +95,7 @@ func basic(t *testing.T) {
 				}
 		})
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	}).Status(vhost).HasError(contour_api_v1.ConditionTypePrefixReplaceError, "AmbiguousReplacement", "ambiguous prefix replacement")
+	c.Request(routeType).HasNoResources().Status(vhost).HasError(contour_api_v1.ConditionTypePrefixReplaceError, "AmbiguousReplacement", "ambiguous prefix replacement")
 
 	// The replacement isn't ambiguous any more because only one of the prefixes matches.
 	vhost = update(rh, vhost,
@@ -141,12 +136,7 @@ func basic(t *testing.T) {
 				}
 		})
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	}).Status(vhost).HasError(contour_api_v1.ConditionTypePrefixReplaceError, "DuplicateReplacement", "duplicate replacement prefix '/foo'")
+	c.Request(routeType).HasNoResources().Status(vhost).HasError(contour_api_v1.ConditionTypePrefixReplaceError, "DuplicateReplacement", "duplicate replacement prefix '/foo'")
 
 	// The "/api" prefix should have precedence over the empty prefix.
 	vhost = update(rh, vhost,

--- a/internal/featuretests/v3/rootnamespaces_test.go
+++ b/internal/featuretests/v3/rootnamespaces_test.go
@@ -87,12 +87,7 @@ func TestRootNamespaces(t *testing.T) {
 	})
 
 	// assert that the route tables are present but empty.
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// hp2 is in the root namespace set.
 	hp2 := &contour_api_v1.HTTPProxy{

--- a/internal/featuretests/v3/route_test.go
+++ b/internal/featuretests/v3/route_test.go
@@ -948,7 +948,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i1, i2)
-	assertRDS(t, c, "2", nil, nil)
+	c.Request(routeType).HasNoResources()
 
 	i3 := &networking_v1.Ingress{
 		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
@@ -959,7 +959,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 		},
 	}
 	rh.OnUpdate(i2, i3)
-	assertRDS(t, c, "2", nil, nil)
+	c.Request(routeType).HasNoResources()
 
 	i4 := &networking_v1.Ingress{
 		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
@@ -998,7 +998,7 @@ func TestRDSIngressClassAnnotation(t *testing.T) {
 	), nil)
 
 	rh.OnUpdate(i5, i3)
-	assertRDS(t, c, "5", nil, nil)
+	c.Request(routeType).HasNoResources()
 }
 
 // issue 523, check for data races caused by accidentally

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -152,12 +152,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// proxy2 has a TCPProxy with multiple services,
 	// each with an explicit weight.
@@ -208,12 +203,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// proxy3 has a TCPProxy with multiple services,
 	// each with no weight specified.
@@ -264,12 +254,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// proxy4 has a TCPProxy with multiple services,
 	// some with weights specified and some without.
@@ -321,12 +306,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }
 
 func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
@@ -536,12 +516,7 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// TLSRoute with multiple weighted services.
 	route2 := &gatewayapi_v1alpha2.TLSRoute{
@@ -595,10 +570,5 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }

--- a/internal/featuretests/v3/tcpproxy_test.go
+++ b/internal/featuretests/v3/tcpproxy_test.go
@@ -201,12 +201,7 @@ func TestTCPProxyDelegation(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }
 
 // Assert that when a spec.vhost.tls spec is present with tls.passthrough
@@ -380,12 +375,7 @@ func TestTCPProxyTLSBackend(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }
 
 // Assert that TCPProxy + a http service can be used to expose a ingress_http
@@ -804,14 +794,7 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			// ingress_http and ingress_https should be empty
-			// as hp1 is not valid.
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	hp2 := &contour_api_v1.HTTPProxy{
 		ObjectMeta: hp1.ObjectMeta,
@@ -850,14 +833,7 @@ func TestTCPProxyMissingTLS(t *testing.T) {
 		TypeUrl: listenerType,
 	})
 
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			// ingress_http and ingress_https should be empty
-			// as hp2 is not valid.
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 }
 
 // "Cookie" and "RequestHash" policies are not valid on TCPProxy.

--- a/internal/featuretests/v3/timeoutpolicy_test.go
+++ b/internal/featuretests/v3/timeoutpolicy_test.go
@@ -137,12 +137,7 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	rh.OnAdd(p1)
 
 	// check timeout policy with malformed response timeout is not propagated
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	p2 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Response: "3m"})
 	rh.OnUpdate(p1, p2)
@@ -192,12 +187,7 @@ func TestTimeoutPolicyIdleStreamTimeout(t *testing.T) {
 	rh.OnAdd(p1)
 
 	// check timeout policy with malformed response timeout is not propagated
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	p2 := httpProxyWithTimoutPolicy(svc, &contour_api_v1.TimeoutPolicy{Idle: "3m"})
 	rh.OnUpdate(p1, p2)

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -120,12 +120,7 @@ func TestTLSRoute(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	// Route2 doesn't define any SNIs, so this should become the default backend.
 	route2 := &gatewayapi_v1alpha2.TLSRoute{
@@ -168,12 +163,7 @@ func TestTLSRoute(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	route3 := &gatewayapi_v1alpha2.TLSRoute{
 		ObjectMeta: fixture.ObjectMeta("basic"),
@@ -240,12 +230,7 @@ func TestTLSRoute(t *testing.T) {
 	})
 
 	// check that ingress_http is empty
-	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
-		Resources: resources(t,
-			envoy_v3.RouteConfiguration("ingress_http"),
-		),
-		TypeUrl: routeType,
-	})
+	c.Request(routeType).HasNoResources()
 
 	rh.OnDelete(route1)
 	rh.OnDelete(route2)

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -91,11 +91,13 @@ func (c *RouteCache) OnChange(root *dag.DAG) {
 	// 	- one for all the HTTP vhost routes -- "ingress_http"
 	//	- one per svhost -- "https/<vhost fqdn>"
 	//	- one for fallback cert (if configured) -- "ingress_fallbackcert"
-	routeConfigs := map[string]*envoy_route_v3.RouteConfiguration{
-		ENVOY_HTTP_LISTENER: envoy_v3.RouteConfiguration(ENVOY_HTTP_LISTENER),
-	}
+	routeConfigs := map[string]*envoy_route_v3.RouteConfiguration{}
 
 	for vhost, routes := range root.GetVirtualHostRoutes() {
+		if routeConfigs[ENVOY_HTTP_LISTENER] == nil {
+			routeConfigs[ENVOY_HTTP_LISTENER] = envoy_v3.RouteConfiguration(ENVOY_HTTP_LISTENER)
+		}
+
 		sortRoutes(routes)
 		routeConfigs[ENVOY_HTTP_LISTENER].VirtualHosts = append(routeConfigs[ENVOY_HTTP_LISTENER].VirtualHosts,
 			envoy_v3.VirtualHostAndRoutes(vhost, routes, false, nil))

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -145,9 +145,7 @@ func TestRouteVisit(t *testing.T) {
 	}{
 		"nothing": {
 			objs: nil,
-			want: routeConfigurations(
-				envoy_v3.RouteConfiguration("ingress_http"),
-			),
+			want: routeConfigurations(),
 		},
 		"one http only ingress with service": {
 			objs: []interface{}{
@@ -522,7 +520,6 @@ func TestRouteVisit(t *testing.T) {
 				},
 			},
 			want: routeConfigurations(
-				envoy_v3.RouteConfiguration("ingress_http"),
 				envoy_v3.RouteConfiguration("https/www.example.com",
 					envoy_v3.VirtualHost("www.example.com",
 						&envoy_route_v3.Route{
@@ -1412,9 +1409,7 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: routeConfigurations(
-				envoy_v3.RouteConfiguration("ingress_http"), // should be blank, no fqdn defined.
-			),
+			want: routeConfigurations(),
 		},
 		"httpproxy with pathPrefix": {
 			objs: []interface{}{
@@ -3235,7 +3230,7 @@ func TestRouteVisit(t *testing.T) {
 					},
 				},
 			},
-			want: routeConfigurations(envoy_v3.RouteConfiguration("ingress_http")),
+			want: routeConfigurations(),
 		},
 		"httpproxy with fallback certificate - no fqdn enabled": {
 			fallbackCertificate: &types.NamespacedName{


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

Ran into this while working on some refactoring for multiple Listeners, and I'm not sure why we generate/send an empty `ingress_http` RouteConfiguration if there are no vhosts, since we're not generating a Listener/HCM to reference the RouteConfiguration in this case. For HTTPS, we're only generating the RouteConfigs if there are vhosts.

Does anyone see an issue with changing this behavior? I'll have a bunch of unit tests to update but E2E's look like they pass just fine with the change in place.



