### PR TITLE
test: use helper to generate ObjectMeta

### DIFF
--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -2950,7 +2950,7 @@ func TestDAGStatus(t *testing.T) {
 	run(t, "fallback and client auth is invalid", testcase{
 		objs: []interface{}{fixture.SecretRootsCert, proxyAuthFallback},
 		want: map[types.NamespacedName]contour_api_v1.DetailedCondition{
-			{Name: proxyAuthFallback.Name, Namespace: proxyAuthFallback.Namespace}: fixture.NewValidCondition().
+			{Name: proxyAuthFallback.Name, Namespace: proxyAuthFallback.Namespace}: fixture.NewValidCondition().WithGeneration(proxyAuthFallback.Generation).
 				WithError(contour_api_v1.ConditionTypeTLSError, "TLSIncompatibleFeatures", "Spec.Virtualhost.TLS fallback & client authorization are incompatible"),
 		},
 	})

--- a/internal/featuretests/v3/backendcavalidation_test.go
+++ b/internal/featuretests/v3/backendcavalidation_test.go
@@ -46,10 +46,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 		WithPorts(v1.ServicePort{Name: "securebackend", Port: 443, TargetPort: intstr.FromInt(8080)})
 
 	p1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
 			Routes: []contour_api_v1.Route{{
@@ -85,10 +82,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	})
 
 	p2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
 			Routes: []contour_api_v1.Route{{
@@ -137,10 +131,7 @@ func TestClusterServiceTLSBackendCAValidation(t *testing.T) {
 	rh.OnDelete(p2)
 
 	hp1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "www.example.com"},
 			Routes: []contour_api_v1.Route{{

--- a/internal/featuretests/v3/ingressclass_test.go
+++ b/internal/featuretests/v3/ingressclass_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/projectcontour/contour/internal/ref"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -51,13 +50,9 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 	{
 		// --- ingress class matches explicitly
 		ingressValid := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "linkerd",
-				},
-			},
+			ObjectMeta: fixture.ObjectMetaWithAnnotations(IngressName, map[string]string{
+				"kubernetes.io/ingress.class": "linkerd",
+			}),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -81,13 +76,9 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		// --- wrong ingress class specified
 		ingressWrongClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "invalid",
-				},
-			},
+			ObjectMeta: fixture.ObjectMetaWithAnnotations(IngressName, map[string]string{
+				"kubernetes.io/ingress.class": "invalid",
+			}),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -104,10 +95,7 @@ func TestIngressClassAnnotation_Configured(t *testing.T) {
 
 		// --- no ingress class specified
 		ingressNoClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -276,10 +264,7 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 	{
 		// --- no ingress class specified
 		ingressNoClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -303,13 +288,9 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		// --- matching ingress class specified
 		ingressMatchingClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "contour",
-				},
-			},
+			ObjectMeta: fixture.ObjectMetaWithAnnotations(IngressName, map[string]string{
+				"kubernetes.io/ingress.class": "contour",
+			}),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -333,13 +314,9 @@ func TestIngressClassAnnotation_NotConfigured(t *testing.T) {
 
 		// --- non-matching ingress class specified
 		ingressNonMatchingClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "invalid",
-				},
-			},
+			ObjectMeta: fixture.ObjectMetaWithAnnotations(IngressName, map[string]string{
+				"kubernetes.io/ingress.class": "invalid",
+			}),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -576,9 +553,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 	rh.OnAdd(svc)
 
 	ingressClass := networking_v1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testingressclass",
-		},
+		ObjectMeta: fixture.ObjectMeta("testingressclass"),
 		Spec: networking_v1.IngressClassSpec{
 			Controller: "something",
 		},
@@ -590,10 +565,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 	{
 		// Spec.IngressClassName matches.
 		ingressValid := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				IngressClassName: ref.To("testingressclass"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
@@ -618,10 +590,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 
 		// Spec.IngressClassName does not match.
 		ingressWrongClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				IngressClassName: ref.To("wrongingressclass"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
@@ -639,10 +608,7 @@ func TestIngressClassResource_Configured(t *testing.T) {
 
 		// No ingress class specified.
 		ingressNoClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -807,9 +773,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 	rh.OnAdd(svc)
 
 	ingressClass := networking_v1.IngressClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "contour",
-		},
+		ObjectMeta: fixture.ObjectMeta("contour"),
 		Spec: networking_v1.IngressClassSpec{
 			Controller: "something",
 		},
@@ -821,10 +785,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 	{
 		// No class specified.
 		ingressNoClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				DefaultBackend: featuretests.IngressBackend(svc),
 			},
@@ -848,10 +809,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 
 		// Spec.IngressClassName matches.
 		ingressMatchingClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				IngressClassName: ref.To("contour"),
 				DefaultBackend:   featuretests.IngressBackend(svc),
@@ -876,10 +834,7 @@ func TestIngressClassResource_NotConfigured(t *testing.T) {
 
 		// Spec.IngressClassName does not match.
 		ingressNonMatchingClass := &networking_v1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      IngressName,
-				Namespace: Namespace,
-			},
+			ObjectMeta: fixture.ObjectMeta(IngressName),
 			Spec: networking_v1.IngressSpec{
 				IngressClassName: ref.To("notcontour"),
 				DefaultBackend:   featuretests.IngressBackend(svc),

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -73,10 +73,7 @@ func TestNonTLSListener(t *testing.T) {
 
 	// i1 is a simple ingress, no hostname, no tls.
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("default/simple"),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(svc1),
 		},
@@ -94,13 +91,8 @@ func TestNonTLSListener(t *testing.T) {
 
 	// i2 is the same as i1 but has the kubernetes.io/ingress.allow-http: "false" annotation
 	i2 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.allow-http": "false",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("default/simple", map[string]string{
+			"kubernetes.io/ingress.allow-http": "false"}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(svc1),
 		},
@@ -118,13 +110,8 @@ func TestNonTLSListener(t *testing.T) {
 	// i3 is similar to i2, but uses the ingress.kubernetes.io/force-ssl-redirect: "true" annotation
 	// to force 80 -> 443 upgrade
 	i3 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"ingress.kubernetes.io/force-ssl-redirect": "true",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("default/simple",
+			map[string]string{"ingress.kubernetes.io/force-ssl-redirect": "true"}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(svc1),
 		},
@@ -173,10 +160,7 @@ func TestTLSListener(t *testing.T) {
 
 	// i1 is a tls ingress
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: networking_v1.IngressSpec{
 			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
@@ -233,13 +217,9 @@ func TestTLSListener(t *testing.T) {
 
 	// i2 is the same as i1 but has the kubernetes.io/ingress.allow-http: "false" annotation
 	i2 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.allow-http": "false",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("simple", map[string]string{
+			"kubernetes.io/ingress.allow-http": "false",
+		}),
 		Spec: networking_v1.IngressSpec{
 			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
@@ -1066,10 +1046,7 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 
 	// p1 is a tls httpproxy
 	p1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",
@@ -1124,10 +1101,7 @@ func TestHTTPProxyMinimumTLSVersion(t *testing.T) {
 
 	// p2 is a tls httpproxy
 	p2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",

--- a/internal/featuretests/v3/replaceprefix_test.go
+++ b/internal/featuretests/v3/replaceprefix_test.go
@@ -32,6 +32,7 @@ func update(rh cache.ResourceEventHandler, old *contour_api_v1.HTTPProxy, modify
 
 	modify(updated)
 
+	fixture.UpdateObjectVersion(&updated.ObjectMeta)
 	rh.OnUpdate(old, updated)
 	return updated
 }

--- a/internal/featuretests/v3/retrypolicy_test.go
+++ b/internal/featuretests/v3/retrypolicy_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -38,15 +37,11 @@ func TestRetryPolicy(t *testing.T) {
 	rh.OnAdd(s1)
 
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hello",
-			Namespace: s1.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/retry-on":        "5xx,gateway-error",
-				"projectcontour.io/num-retries":     "7",
-				"projectcontour.io/per-try-timeout": "120ms",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("hello", map[string]string{
+			"projectcontour.io/retry-on":        "5xx,gateway-error",
+			"projectcontour.io/num-retries":     "7",
+			"projectcontour.io/per-try-timeout": "120ms",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(s1),
 		},
@@ -68,14 +63,11 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	i2 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "hello", Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/retry-on":        "5xx,gateway-error",
-				"projectcontour.io/num-retries":     "7",
-				"projectcontour.io/per-try-timeout": "120ms",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("hello", map[string]string{
+			"projectcontour.io/retry-on":        "5xx,gateway-error",
+			"projectcontour.io/num-retries":     "7",
+			"projectcontour.io/per-try-timeout": "120ms",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(s1),
 		},
@@ -97,14 +89,11 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	i3 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "hello", Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/retry-on":        "5xx,gateway-error",
-				"projectcontour.io/num-retries":     "7",
-				"projectcontour.io/per-try-timeout": "120ms",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("hello", map[string]string{
+			"projectcontour.io/retry-on":        "5xx,gateway-error",
+			"projectcontour.io/num-retries":     "7",
+			"projectcontour.io/per-try-timeout": "120ms",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(s1),
 		},
@@ -126,14 +115,11 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	i4 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "hello", Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/retry-on":        "5xx,gateway-error",
-				"projectcontour.io/num-retries":     "-1",
-				"projectcontour.io/per-try-timeout": "120ms",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("hello", map[string]string{
+			"projectcontour.io/retry-on":        "5xx,gateway-error",
+			"projectcontour.io/num-retries":     "-1",
+			"projectcontour.io/per-try-timeout": "120ms",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(s1),
 		},
@@ -155,14 +141,11 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	i5 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "hello", Namespace: "default",
-			Annotations: map[string]string{
-				"projectcontour.io/retry-on":        "5xx,gateway-error",
-				"projectcontour.io/num-retries":     "0",
-				"projectcontour.io/per-try-timeout": "120ms",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("hello", map[string]string{
+			"projectcontour.io/retry-on":        "5xx,gateway-error",
+			"projectcontour.io/num-retries":     "0",
+			"projectcontour.io/per-try-timeout": "120ms",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(s1),
 		},
@@ -186,10 +169,7 @@ func TestRetryPolicy(t *testing.T) {
 	rh.OnDelete(i5)
 
 	hp1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test3.test.com"},
 			Routes: []contour_api_v1.Route{{
@@ -221,10 +201,7 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	hp2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test3.test.com"},
 			Routes: []contour_api_v1.Route{{
@@ -256,10 +233,7 @@ func TestRetryPolicy(t *testing.T) {
 	})
 
 	hp3 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test3.test.com"},
 			Routes: []contour_api_v1.Route{{

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -40,10 +40,7 @@ func TestHTTPProxy_RouteWithAServiceWeight(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}))
 
 	proxy1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
 			Routes: []contour_api_v1.Route{{
@@ -68,10 +65,7 @@ func TestHTTPProxy_RouteWithAServiceWeight(t *testing.T) {
 	), nil)
 
 	proxy2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
 			Routes: []contour_api_v1.Route{{
@@ -112,10 +106,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 
 	// proxy1 has a TCPProxy with a single service.
 	proxy1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.test.com",
@@ -171,10 +162,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	// proxy2 has a TCPProxy with multiple services,
 	// each with an explicit weight.
 	proxy2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.test.com",
@@ -230,10 +218,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	// proxy3 has a TCPProxy with multiple services,
 	// each with no weight specified.
 	proxy3 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.test.com",
@@ -289,10 +274,7 @@ func TestHTTPProxy_TCPProxyWithAServiceWeight(t *testing.T) {
 	// proxy4 has a TCPProxy with multiple services,
 	// some with weights specified and some without.
 	proxy4 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "tcpproxy.test.com",
@@ -358,10 +340,8 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}))
 
 	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gc",
-		},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: fixture.ObjectMeta("test-gc"),
 		Spec: gatewayapi_v1beta1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
@@ -395,14 +375,10 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 
 	// HTTPRoute with a single weight.
 	route1 := &gatewayapi_v1beta1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":  "contour",
-				"type": "controller",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
+			"app":  "contour",
+			"type": "controller",
+		}),
 		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1beta1.ParentReference{
@@ -432,14 +408,10 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 
 	// HTTPRoute with multiple weights.
 	route2 := &gatewayapi_v1beta1.HTTPRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":  "contour",
-				"type": "controller",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
+			"app":  "contour",
+			"type": "controller",
+		}),
 		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1beta1.ParentReference{
@@ -483,10 +455,8 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 		WithPorts(v1.ServicePort{Port: 443, TargetPort: intstr.FromInt(8443)}))
 
 	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gc",
-		},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: fixture.ObjectMeta("test-gc"),
 		Spec: gatewayapi_v1beta1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
@@ -523,14 +493,10 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 
 	// TLSRoute with a single service/weight.
 	route1 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":  "contour",
-				"type": "controller",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
+			"app":  "contour",
+			"type": "controller",
+		}),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
@@ -579,14 +545,10 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 
 	// TLSRoute with multiple weighted services.
 	route2 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app":  "contour",
-				"type": "controller",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
+			"app":  "contour",
+			"type": "controller",
+		}),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{

--- a/internal/featuretests/v3/timeoutpolicy_test.go
+++ b/internal/featuretests/v3/timeoutpolicy_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -39,13 +38,9 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	rh.OnAdd(svc)
 
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-ing",
-			Namespace: svc.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/response-timeout": "1m20s",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
+			"projectcontour.io/response-timeout": "1m20s",
+		}),
 		Spec: networking_v1.IngressSpec{
 			DefaultBackend: featuretests.IngressBackend(svc),
 		},
@@ -68,13 +63,9 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 
 	i2 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-ing",
-			Namespace: svc.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/response-timeout": "infinity",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
+			"projectcontour.io/response-timeout": "infinity",
+		}),
 		Spec: i1.Spec,
 	}
 	rh.OnUpdate(i1, i2)
@@ -95,13 +86,9 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 
 	i3 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-ing",
-			Namespace: svc.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/response-timeout": "monday",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
+			"projectcontour.io/response-timeout": "monday",
+		}),
 		Spec: i2.Spec,
 	}
 	rh.OnUpdate(i2, i3)
@@ -122,14 +109,10 @@ func TestTimeoutPolicyRequestTimeout(t *testing.T) {
 	})
 
 	i4 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kuard-ing",
-			Namespace: svc.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/request-timeout":  "90s",
-				"projectcontour.io/response-timeout": "99s",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("kuard-ing", map[string]string{
+			"projectcontour.io/request-timeout":  "90s",
+			"projectcontour.io/response-timeout": "99s",
+		}),
 		Spec: i2.Spec,
 	}
 	rh.OnUpdate(i3, i4)
@@ -291,10 +274,7 @@ func TestTimeoutPolicyIdleConnectionTimeout(t *testing.T) {
 
 func httpProxyWithTimoutPolicy(svc *v1.Service, tp *contour_api_v1.TimeoutPolicy) *contour_api_v1.HTTPProxy {
 	return &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: svc.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "test2.test.com"},
 			Routes: []contour_api_v1.Route{{

--- a/internal/featuretests/v3/tlscertificatedelegation_test.go
+++ b/internal/featuretests/v3/tlscertificatedelegation_test.go
@@ -57,10 +57,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// add an httpproxy in a different namespace mentioning secret/wildcard.
 	p1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
@@ -91,10 +88,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// t1 is a TLSCertificateDelegation that permits default to access secret/wildcard
 	t1 := &contour_api_v1.TLSCertificateDelegation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delegation",
-			Namespace: sec1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("secret/delegation"),
 		Spec: contour_api_v1.TLSCertificateDelegationSpec{
 			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: sec1.Name,
@@ -131,10 +125,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// t2 is a TLSCertificateDelegation that permits access to secret/wildcard from all namespaces.
 	t2 := &contour_api_v1.TLSCertificateDelegation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delegation",
-			Namespace: sec1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("secret/delegation"),
 		Spec: contour_api_v1.TLSCertificateDelegationSpec{
 			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: sec1.Name,
@@ -157,10 +148,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// t3 is a TLSCertificateDelegation that permits access to secret/different all namespaces.
 	t3 := &contour_api_v1.TLSCertificateDelegation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delegation",
-			Namespace: sec1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("secret/delegation"),
 		Spec: contour_api_v1.TLSCertificateDelegationSpec{
 			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: "different",
@@ -181,10 +169,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// t4 is a TLSCertificateDelegation that permits access to secret/wildcard from the kube-secret namespace.
 	t4 := &contour_api_v1.TLSCertificateDelegation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delegation",
-			Namespace: sec1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("secret/delegation"),
 		Spec: contour_api_v1.TLSCertificateDelegationSpec{
 			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: sec1.Name,
@@ -208,10 +193,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// add a httpproxy in a different namespace mentioning secret/wildcard.
 	hp1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "example.com",
@@ -239,10 +221,7 @@ func TestTLSCertificateDelegation(t *testing.T) {
 	})
 
 	t5 := &contour_api_v1.TLSCertificateDelegation{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "delegation",
-			Namespace: sec1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("secret/delegation"),
 		Spec: contour_api_v1.TLSCertificateDelegationSpec{
 			Delegations: []contour_api_v1.CertificateDelegation{{
 				SecretName: sec1.Name,
@@ -274,13 +253,9 @@ func TestTLSCertificateDelegation(t *testing.T) {
 
 	// add an ingress in a different namespace mentioning secret wildcard from namespace secret via annotation.
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/tls-cert-namespace": sec1.Namespace,
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("simple", map[string]string{
+			"projectcontour.io/tls-cert-namespace": sec1.Namespace,
+		}),
 		Spec: networking_v1.IngressSpec{
 			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"example.com"},

--- a/internal/featuretests/v3/tlsprotocolversion_test.go
+++ b/internal/featuretests/v3/tlsprotocolversion_test.go
@@ -48,10 +48,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 	rh.OnAdd(s1)
 
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: networking_v1.IngressSpec{
 			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
@@ -91,13 +88,9 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 	})
 
 	i2 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: sec1.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/tls-minimum-protocol-version": "1.3",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("simple", map[string]string{
+			"projectcontour.io/tls-minimum-protocol-version": "1.3",
+		}),
 		Spec: networking_v1.IngressSpec{
 			TLS: []networking_v1.IngressTLS{{
 				Hosts:      []string{"kuard.example.com"},
@@ -148,10 +141,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 	rh.OnDelete(i2)
 
 	hp1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{
 				Fqdn: "kuard.example.com",

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -44,10 +44,8 @@ func TestTLSRoute(t *testing.T) {
 	rh.OnAdd(svcAnother)
 
 	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-gc",
-		},
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: fixture.ObjectMeta("test-gc"),
 		Spec: gatewayapi_v1beta1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
@@ -62,10 +60,7 @@ func TestTLSRoute(t *testing.T) {
 	})
 
 	gatewayPassthrough := &gatewayapi_v1beta1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "contour",
-			Namespace: "projectcontour",
-		},
+		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
 		Spec: gatewayapi_v1beta1.GatewaySpec{
 			Listeners: []gatewayapi_v1beta1.Listener{{
 				Port:     443,
@@ -85,10 +80,7 @@ func TestTLSRoute(t *testing.T) {
 	rh.OnAdd(gatewayPassthrough)
 
 	route1 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("basic"),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
@@ -137,10 +129,7 @@ func TestTLSRoute(t *testing.T) {
 
 	// Route2 doesn't define any SNIs, so this should become the default backend.
 	route2 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("basic"),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
@@ -187,10 +176,7 @@ func TestTLSRoute(t *testing.T) {
 	})
 
 	route3 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("basic"),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
@@ -205,10 +191,7 @@ func TestTLSRoute(t *testing.T) {
 	}
 
 	route4 := &gatewayapi_v1alpha2.TLSRoute{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "basic-wildcard",
-			Namespace: "default",
-		},
+		ObjectMeta: fixture.ObjectMeta("basic-wildcard"),
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{

--- a/internal/featuretests/v3/websockets_test.go
+++ b/internal/featuretests/v3/websockets_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/projectcontour/contour/internal/fixture"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -37,13 +36,9 @@ func TestWebsocketsIngress(t *testing.T) {
 	rh.OnAdd(s1)
 
 	i1 := &networking_v1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ws",
-			Namespace: s1.Namespace,
-			Annotations: map[string]string{
-				"projectcontour.io/websocket-routes": "/ws2",
-			},
-		},
+		ObjectMeta: fixture.ObjectMetaWithAnnotations("ws", map[string]string{
+			"projectcontour.io/websocket-routes": "/ws2",
+		}),
 		Spec: networking_v1.IngressSpec{
 			Rules: []networking_v1.IngressRule{{
 				Host: "websocket.hello.world",
@@ -89,10 +84,7 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 	rh.OnAdd(s2)
 
 	hp1 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "websocket.hello.world"},
 			Routes: []contour_api_v1.Route{{
@@ -143,10 +135,7 @@ func TestWebsocketHTTPProxy(t *testing.T) {
 	})
 
 	hp2 := &contour_api_v1.HTTPProxy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple",
-			Namespace: s1.Namespace,
-		},
+		ObjectMeta: fixture.ObjectMeta("simple"),
 		Spec: contour_api_v1.HTTPProxySpec{
 			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "websocket.hello.world"},
 			Routes: []contour_api_v1.Route{{

--- a/internal/fixture/meta.go
+++ b/internal/fixture/meta.go
@@ -14,10 +14,14 @@
 package fixture
 
 import (
+	"strconv"
 	"strings"
+	"sync/atomic"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var generation int64
 
 // ObjectMeta cracks a Kubernetes object name string of the form
 // "namespace/name" into a metav1.ObjectMeta struct. If the namespace
@@ -25,20 +29,42 @@ import (
 func ObjectMeta(nameStr string) metav1.ObjectMeta {
 	// NOTE: We don't use k8s.NamespacedNameFrom here, because that
 	// would generate an import cycle.
+
+	// NOTE: Not all objects have a generation field.
+	// In this helper function we do not know the type of the object where the return value gets used
+
 	v := strings.SplitN(nameStr, "/", 2)
 	switch len(v) {
 	case 1:
 		// No '/' separator.
-		return metav1.ObjectMeta{
+		return *UpdateObjectVersion(&metav1.ObjectMeta{
 			Name:        v[0],
 			Namespace:   metav1.NamespaceDefault,
 			Annotations: map[string]string{},
-		}
+		})
 	default:
-		return metav1.ObjectMeta{
+		return *UpdateObjectVersion(&metav1.ObjectMeta{
 			Name:        v[1],
 			Namespace:   v[0],
 			Annotations: map[string]string{},
-		}
+		})
 	}
+}
+
+// ObjectMetaWithAnnotations returns an ObjectMeta with the given annotations.
+func ObjectMetaWithAnnotations(nameStr string, annotations map[string]string) metav1.ObjectMeta {
+	meta := ObjectMeta(nameStr)
+	meta.Annotations = annotations
+	return meta
+}
+
+func UpdateObjectVersion(meta *metav1.ObjectMeta) *metav1.ObjectMeta {
+	meta.Generation = nextGeneration()
+	meta.ResourceVersion = strconv.FormatInt(meta.Generation, 10)
+	return meta
+}
+
+// nextGeneration returns the next generation number.
+func nextGeneration() int64 {
+	return atomic.AddInt64(&generation, 1)
 }


### PR DESCRIPTION
Test objects were previously created with uninitialized `ResourceVersion` and `Generation` since the values did not matter when complete object content was compared to detect updates.

This change is preparation for #5064 and introduces a helper function to generate unique `ObjectMeta`. Test cases that depend on object update are changed to use the helper instead of hardcoded initialization. Since the number of objects constructed by test suite is extremely high and change is manual, this PR does not attempt to change _all occurrences_.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>