### PR TITLE
Reduce the memory footprint by optimizing Kubernetes informer cache

### DIFF
--- a/changelogs/unreleased/5099-tsaarni-small.md
+++ b/changelogs/unreleased/5099-tsaarni-small.md
@@ -1,0 +1,1 @@
+Optimized the memory usage when handling Secrets in Kubernetes client informer cache.


### PR DESCRIPTION
This PR tries to avoid storing data in controller-runtime / client-go cache when we know for sure we do not need it.

While working on https://github.com/projectcontour/contour/pull/5064#issuecomment-1424616124 it was discovered that considerable time was spent on processing `Secrets` of type `helm.sh/release.v1`. These secrets contain the helm manifest, and they are just noise for Contour. Besides CPU impact, there is also memory footprint impact, since these `Secrets` can get large. See related discussion [cert-manager/cert-manager#5220](https://www.github.com/cert-manager/cert-manager/issues/5220).

I was looking for ways to avoid caching objects that fail to fulfil given criteria. I found one: [`SelectorByObject`](https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/use-selectors-at-cache.md). It is based on filtering at the API server side by using [selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). Unfortunately, selectors will not be flexible enough for this use case.

Another approach was making the objects smaller by providing custom [transform function](https://www.github.com/kubernetes-sigs/controller-runtime/pull/1805). The change presented in this PR uses transform function to set `Secret.data` to `nil` for objects that clearly are not relevant for Contour.

Yet another approach, although more complicated: [metadata-only watches](https://www.github.com/kubernetes-sigs/controller-runtime/pull/1174) are interesting from security perspective. It is not desirable that a process holds _all_ `Secrets` of the cluster needlessly in memory. As a side effect, the approach could also lower memory footprint. Curiously, the "actual" data can find its way to metadata too, in a form of `last-applied-configuration` annotation, see for example [here](https://www.github.com/kubernetes/kubernetes/issues/23564) and [here](https://www.github.com/kubernetes/kubernetes/issues/29923). To solve this problem, one could combine metadata-only watches with transform function.

**NOTE1** I have not found an obvious way to prove if there is a meaningful impact to memory footprint from this change.

**NOTE2** If this optimization has been discussed already before, sorry for the repeat!
