### PR TITLE
GRPCRoute: add unit test cases

### DIFF
--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -691,6 +691,36 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			},
 			want: []int{1},
 		},
+		"route kind only allowed by first listener for GRPCRoute": {
+			routeParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+			routeNamespace: "projectcontour",
+			routeKind:      "GRPCRoute",
+			listeners: []*listenerInfo{
+				{
+					listener: gatewayapi_v1beta1.Listener{
+						Name: "http-1",
+						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								From: ref.To(gatewayapi_v1beta1.NamespacesFromSame),
+							},
+						},
+					},
+					allowedKinds: []gatewayapi_v1beta1.Kind{"GRPCRoute"},
+				},
+				{
+					listener: gatewayapi_v1beta1.Listener{
+						Name: "http-2",
+						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								From: ref.To(gatewayapi_v1beta1.NamespacesFromSame),
+							},
+						},
+					},
+					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+				},
+			},
+			want: []int{0},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -8751,8 +8751,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
-						Matches:     gatewayapi.GRPCRouteMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "com.example.service", "Login"),
-						BackendRefs: gatewayapi.GRPCBackendRef("kuard", 8080, 1),
+						Matches: []gatewayapi_v1alpha2.GRPCRouteMatch{{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "com.example.service", "Login"),
+						}},
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
@@ -8793,8 +8795,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
 						// RegularExpression type not yet supported
-						Matches:     gatewayapi.GRPCRouteMatch(gatewayapi_v1alpha2.GRPCMethodMatchRegularExpression, "com.example.service", "Login"),
-						BackendRefs: gatewayapi.GRPCBackendRef("kuard", 8080, 1),
+						Matches: []gatewayapi_v1alpha2.GRPCRouteMatch{{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1alpha2.GRPCMethodMatchRegularExpression, "com.example.service", "Login"),
+						}},
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
@@ -8836,8 +8840,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
-						Matches:     gatewayapi.GRPCRouteMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "", "Login"),
-						BackendRefs: gatewayapi.GRPCBackendRef("kuard", 8080, 1),
+						Matches: []gatewayapi_v1alpha2.GRPCRouteMatch{{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "", "Login"),
+						}},
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
@@ -8879,8 +8885,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
-						Matches:     gatewayapi.GRPCRouteMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "com.example.service", ""),
-						BackendRefs: gatewayapi.GRPCBackendRef("kuard", 8080, 1),
+						Matches: []gatewayapi_v1alpha2.GRPCRouteMatch{{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1alpha2.GRPCMethodMatchExact, "com.example.service", ""),
+						}},
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 					}},
 				},
 			}},
@@ -8937,7 +8945,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 								},
 							},
 						}},
-						BackendRefs: gatewayapi.GRPCBackendRef("kuard", 8080, 1),
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -167,7 +167,7 @@ func GRPCRouteBackendRef(serviceName string, port int, weight int32) []gatewayap
 
 func GRPCMethodMatch(matchType gatewayapi_v1alpha2.GRPCMethodMatchType, service string, method string) *gatewayapi_v1alpha2.GRPCMethodMatch {
 	return &gatewayapi_v1alpha2.GRPCMethodMatch{
-		Type:    ref.To(gatewayapi_v1alpha2.GRPCMethodMatchType(matchType)),
+		Type:    ref.To(matchType),
 		Service: ref.To(service),
 		Method:  ref.To(method),
 	}
@@ -176,7 +176,7 @@ func GRPCMethodMatch(matchType gatewayapi_v1alpha2.GRPCMethodMatchType, service 
 func GRPCHeaderMatch(name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
 	return []gatewayapi_v1alpha2.GRPCHeaderMatch{
 		{
-			Type:  ref.To(gatewayapi_v1beta1.HeaderMatchExact), //grpcroute_types.go def not using gatewayapi_v1alpha2.GRPCHeaderMatchExact,
+			Type:  ref.To(gatewayapi_v1beta1.HeaderMatchExact),
 			Name:  gatewayapi_v1alpha2.GRPCHeaderName(name),
 			Value: value,
 		},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -149,25 +149,36 @@ func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayap
 	}
 }
 
-func GRPCRouteMatch(methodType gatewayapi_v1alpha2.GRPCMethodMatchType, service, method string) []gatewayapi_v1alpha2.GRPCRouteMatch {
-	return []gatewayapi_v1alpha2.GRPCRouteMatch{
+func GRPCRouteBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1alpha2.GRPCBackendRef {
+	return []gatewayapi_v1alpha2.GRPCBackendRef{
 		{
-			Method: &gatewayapi_v1alpha2.GRPCMethodMatch{
-				Type:    ref.To(methodType),
-				Service: ref.To(service),
-				Method:  ref.To(method),
-			},
+			BackendRef: gatewayapi_v1alpha2.BackendRef{
+				BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
+					Group: ref.To(gatewayapi_v1beta1.Group("")),
+					Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
+					Name:  gatewayapi_v1alpha2.ObjectName(serviceName),
+					Port:  ref.To(gatewayapi_v1beta1.PortNumber(port)),
+				},
+				Weight: &weight},
+			Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{},
 		},
 	}
 }
 
-func GRPCBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1alpha2.GRPCBackendRef {
-	return []gatewayapi_v1alpha2.GRPCBackendRef{
+func GRPCMethodMatch(matchType gatewayapi_v1alpha2.GRPCMethodMatchType, service string, method string) *gatewayapi_v1alpha2.GRPCMethodMatch {
+	return &gatewayapi_v1alpha2.GRPCMethodMatch{
+		Type:    ref.To(gatewayapi_v1alpha2.GRPCMethodMatchType(matchType)),
+		Service: ref.To(service),
+		Method:  ref.To(method),
+	}
+}
+
+func GRPCHeaderMatch(name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
+	return []gatewayapi_v1alpha2.GRPCHeaderMatch{
 		{
-			BackendRef: gatewayapi_v1beta1.BackendRef{
-				BackendObjectReference: ServiceBackendObjectRef(serviceName, port),
-				Weight:                 &weight,
-			},
+			Type:  ref.To(gatewayapi_v1beta1.HeaderMatchExact), //grpcroute_types.go def not using gatewayapi_v1alpha2.GRPCHeaderMatchExact,
+			Name:  gatewayapi_v1alpha2.GRPCHeaderName(name),
+			Value: value,
 		},
 	}
 }

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -37,7 +37,6 @@ const (
 	ReasonHeaderMatchType               gatewayapi_v1beta1.RouteConditionReason = "HeaderMatchType"
 	ReasonQueryParamMatchType           gatewayapi_v1beta1.RouteConditionReason = "QueryParamMatchType"
 	ReasonHTTPRouteFilterType           gatewayapi_v1beta1.RouteConditionReason = "HTTPRouteFilterType"
-	ReasonMethodMatchType               gatewayapi_v1beta1.RouteConditionReason = "MethodMatchType"
 	ReasonDegraded                      gatewayapi_v1beta1.RouteConditionReason = "Degraded"
 	ReasonErrorsExist                   gatewayapi_v1beta1.RouteConditionReason = "ErrorsExist"
 	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"


### PR DESCRIPTION
Adding GRPCRoute test cases for TestGetListenersForRotueParentRef and TestDAGInsertGatewayAPI
Fix mirror service default protocol type