### PR TITLE
internal/dag: fix method match of GRPCRoute

### DIFF
--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1432,6 +1432,13 @@ func (p *GatewayAPIProcessor) computeGRPCRoute(route *gatewayapi_v1alpha2.GRPCRo
 			})
 		}
 
+		// If no matches are specified, the implementation MUST match every gRPC request.
+		if rule.Matches == nil {
+			matchconditions = append(matchconditions, &matchConditions{
+				path: &PrefixMatchCondition{Prefix: "/"},
+			})
+		}
+
 		// Process rule-level filters.
 		var (
 			requestHeaderPolicy, responseHeaderPolicy *HeadersPolicy

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1540,8 +1540,9 @@ func (p *GatewayAPIProcessor) computeGRPCRoute(route *gatewayapi_v1alpha2.GRPCRo
 }
 
 func gatewayGRPCMethodMatchCondition(match *gatewayapi_v1alpha2.GRPCMethodMatch, routeAccessor *status.RouteParentStatusUpdate) (MatchCondition, bool) {
+	// If method match is not specified, all services and methods will match.
 	if match == nil {
-		return nil, true
+		return &PrefixMatchCondition{Prefix: "/"}, true
 	}
 
 	// Type specifies how to match against the service and/or method.
@@ -1561,7 +1562,7 @@ func gatewayGRPCMethodMatchCondition(match *gatewayapi_v1alpha2.GRPCMethodMatch,
 	}
 
 	// Convert service and method into path
-	path := *match.Service + "/" + *match.Method
+	path := "/" + *match.Service + "/" + *match.Method
 
 	return &ExactMatchCondition{Path: path}, true
 }

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1433,7 +1433,7 @@ func (p *GatewayAPIProcessor) computeGRPCRoute(route *gatewayapi_v1alpha2.GRPCRo
 		}
 
 		// If no matches are specified, the implementation MUST match every gRPC request.
-		if rule.Matches == nil {
+		if len(rule.Matches) == 0 {
 			matchconditions = append(matchconditions, &matchConditions{
 				path: &PrefixMatchCondition{Prefix: "/"},
 			})

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -9458,7 +9458,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", "GRPCRoute", 1),
 	})
 
-	run(t, "grpcroute: more than one RequestMirror filters in HTTPRoute.Spec.Rules.Filters", testcase{
+	run(t, "grpcroute: more than one RequestMirror filters in GRPCRoute.Spec.Rules.Filters", testcase{
 		objs: []interface{}{
 			kuardService,
 			kuardService2,


### PR DESCRIPTION
- need to add a leading slash in the path
- need to add a prefix match if method match is not specified.

Updates #4820