### PR TITLE
hack: change CRD YAML temp dir template

### DIFF
--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 readonly HERE=$(cd "$(dirname "$0")" && pwd)
 readonly REPO=$(cd "${HERE}/.." && pwd)
-readonly TEMPDIR=$(mktemp -d crd.XXXXXX)
+readonly TEMPDIR=$(mktemp -d crd-XXXXXX)
 
 # Optional first arg is the paths pattern.
 readonly PATHS="${1:-"./apis/..."}"


### PR DESCRIPTION
Workaround for the following controller-gen issue: https://github.com/kubernetes-sigs/controller-tools/issues/734