### PR TITLE
Gateway API: clean up conditions and filter processing

### DIFF
--- a/changelogs/unreleased/5125-skriss-small.md
+++ b/changelogs/unreleased/5125-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: for routes, replace use of custom `NotImplemented` condition with the upstream `Accepted: false` condition with reason `UnsupportedValue` to match the spec.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1006,7 +1006,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 
 			headerMatches, err := gatewayHeaderMatchConditions(match.Headers)
 			if err != nil {
-				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHeaderMatchType, err.Error())
+				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, gatewayapi_v1beta1.RouteReasonUnsupportedValue, err.Error())
 				continue
 			}
 
@@ -1022,7 +1022,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 
 			queryParamMatches, err := gatewayQueryParamMatchConditions(match.QueryParams)
 			if err != nil {
-				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonQueryParamMatchType, err.Error())
+				routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, metav1.ConditionFalse, gatewayapi_v1beta1.RouteReasonUnsupportedValue, err.Error())
 				continue
 			}
 
@@ -1043,13 +1043,14 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 			urlRewriteHostname   string
 		)
 
+		// Per Gateway API docs: "Specifying a core filter multiple times
+		// has unspecified or implementation-specific conformance." Contour
+		// chooses to use the first instance of each filter type and ignore
+		// subsequent instances.
 		for _, filter := range rule.Filters {
 			switch filter.Type {
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if requestHeaderPolicy != nil {
+				if filter.RequestHeaderModifier == nil || requestHeaderPolicy != nil {
 					continue
 				}
 
@@ -1059,10 +1060,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if responseHeaderPolicy != nil {
+				if filter.ResponseHeaderModifier == nil || responseHeaderPolicy != nil {
 					continue
 				}
 
@@ -1072,102 +1070,88 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestRedirect:
-				// Get the redirect filter if there is one. Note that per Gateway API
-				// docs, "specifying a core filter multiple times has unspecified or
-				// custom conformance.", here we choose to just select the first one.
-				if redirect == nil && filter.RequestRedirect != nil {
-					var hostname string
-					if filter.RequestRedirect.Hostname != nil {
-						hostname = string(*filter.RequestRedirect.Hostname)
-					}
-
-					var portNumber uint32
-					if filter.RequestRedirect.Port != nil {
-						portNumber = uint32(*filter.RequestRedirect.Port)
-					}
-
-					var scheme string
-					if filter.RequestRedirect.Scheme != nil {
-						scheme = *filter.RequestRedirect.Scheme
-					}
-
-					var statusCode int
-					if filter.RequestRedirect.StatusCode != nil {
-						statusCode = *filter.RequestRedirect.StatusCode
-					}
-
-					var pathRewritePolicy *PathRewritePolicy
-
-					if filter.RequestRedirect.Path != nil {
-						var prefixRewrite, fullPathRewrite string
-
-						switch filter.RequestRedirect.Path.Type {
-						case gatewayapi_v1beta1.PrefixMatchHTTPPathModifier:
-							if filter.RequestRedirect.Path.ReplacePrefixMatch == nil || len(*filter.RequestRedirect.Path.ReplacePrefixMatch) == 0 {
-								prefixRewrite = "/"
-							} else {
-								prefixRewrite = *filter.RequestRedirect.Path.ReplacePrefixMatch
-							}
-						case gatewayapi_v1beta1.FullPathHTTPPathModifier:
-							if filter.RequestRedirect.Path.ReplaceFullPath == nil || len(*filter.RequestRedirect.Path.ReplaceFullPath) == 0 {
-								fullPathRewrite = "/"
-							} else {
-								fullPathRewrite = *filter.RequestRedirect.Path.ReplaceFullPath
-							}
-						default:
-							routeAccessor.AddCondition(
-								gatewayapi_v1beta1.RouteConditionAccepted,
-								metav1.ConditionFalse,
-								gatewayapi_v1beta1.RouteReasonUnsupportedValue,
-								fmt.Sprintf("HTTPRoute.Spec.Rules.Filters.RequestRedirect.Path.Type: invalid type %q: only ReplacePrefixMatch and ReplaceFullPath are supported.", filter.RequestRedirect.Path.Type),
-							)
-							continue
-						}
-
-						pathRewritePolicy = &PathRewritePolicy{
-							PrefixRewrite:   prefixRewrite,
-							FullPathRewrite: fullPathRewrite,
-						}
-					}
-
-					redirect = &Redirect{
-						Hostname:          hostname,
-						PortNumber:        portNumber,
-						Scheme:            scheme,
-						StatusCode:        statusCode,
-						PathRewritePolicy: pathRewritePolicy,
-					}
-				}
-			case gatewayapi_v1beta1.HTTPRouteFilterRequestMirror:
-				// Get the mirror filter if there is one. If there are more than one
-				// mirror filters, "NotImplemented" condition on the Route is set to
-				// status: True, with the "NotImplemented" reason.
-				if mirrorPolicy != nil {
-					routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonNotImplemented, "HTTPRoute.Spec.Rules.Filters: Only one mirror filter is supported.")
+				if filter.RequestRedirect == nil || redirect != nil {
 					continue
 				}
 
-				if filter.RequestMirror != nil {
-					mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindHTTPRoute, route.Namespace)
-					if cond != nil {
-						routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
+				var hostname string
+				if filter.RequestRedirect.Hostname != nil {
+					hostname = string(*filter.RequestRedirect.Hostname)
+				}
+
+				var portNumber uint32
+				if filter.RequestRedirect.Port != nil {
+					portNumber = uint32(*filter.RequestRedirect.Port)
+				}
+
+				var scheme string
+				if filter.RequestRedirect.Scheme != nil {
+					scheme = *filter.RequestRedirect.Scheme
+				}
+
+				var statusCode int
+				if filter.RequestRedirect.StatusCode != nil {
+					statusCode = *filter.RequestRedirect.StatusCode
+				}
+
+				var pathRewritePolicy *PathRewritePolicy
+
+				if filter.RequestRedirect.Path != nil {
+					var prefixRewrite, fullPathRewrite string
+
+					switch filter.RequestRedirect.Path.Type {
+					case gatewayapi_v1beta1.PrefixMatchHTTPPathModifier:
+						if filter.RequestRedirect.Path.ReplacePrefixMatch == nil || len(*filter.RequestRedirect.Path.ReplacePrefixMatch) == 0 {
+							prefixRewrite = "/"
+						} else {
+							prefixRewrite = *filter.RequestRedirect.Path.ReplacePrefixMatch
+						}
+					case gatewayapi_v1beta1.FullPathHTTPPathModifier:
+						if filter.RequestRedirect.Path.ReplaceFullPath == nil || len(*filter.RequestRedirect.Path.ReplaceFullPath) == 0 {
+							fullPathRewrite = "/"
+						} else {
+							fullPathRewrite = *filter.RequestRedirect.Path.ReplaceFullPath
+						}
+					default:
+						routeAccessor.AddCondition(
+							gatewayapi_v1beta1.RouteConditionAccepted,
+							metav1.ConditionFalse,
+							gatewayapi_v1beta1.RouteReasonUnsupportedValue,
+							fmt.Sprintf("HTTPRoute.Spec.Rules.Filters.RequestRedirect.Path.Type: invalid type %q: only ReplacePrefixMatch and ReplaceFullPath are supported.", filter.RequestRedirect.Path.Type),
+						)
 						continue
 					}
-					mirrorPolicy = &MirrorPolicy{
-						Cluster: &Cluster{
-							Upstream: mirrorService,
-						},
+
+					pathRewritePolicy = &PathRewritePolicy{
+						PrefixRewrite:   prefixRewrite,
+						FullPathRewrite: fullPathRewrite,
 					}
 				}
-			case gatewayapi_v1beta1.HTTPRouteFilterURLRewrite:
-				// Get the URL rewrite filter if there is one. Note that per Gateway API
-				// docs, "specifying a core filter multiple times has unspecified or
-				// custom conformance.", here we choose to just select the first one.
-				if pathRewritePolicy != nil {
+
+				redirect = &Redirect{
+					Hostname:          hostname,
+					PortNumber:        portNumber,
+					Scheme:            scheme,
+					StatusCode:        statusCode,
+					PathRewritePolicy: pathRewritePolicy,
+				}
+			case gatewayapi_v1beta1.HTTPRouteFilterRequestMirror:
+				if filter.RequestMirror == nil || mirrorPolicy != nil {
 					continue
 				}
 
-				if filter.URLRewrite == nil {
+				mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindHTTPRoute, route.Namespace)
+				if cond != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
+					continue
+				}
+				mirrorPolicy = &MirrorPolicy{
+					Cluster: &Cluster{
+						Upstream: mirrorService,
+					},
+				}
+			case gatewayapi_v1beta1.HTTPRouteFilterURLRewrite:
+				if filter.URLRewrite == nil || pathRewritePolicy != nil {
 					continue
 				}
 
@@ -1314,13 +1298,14 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 			mirrorPolicy                              *MirrorPolicy
 		)
 
+		// Per Gateway API docs: "Specifying a core filter multiple times
+		// has unspecified or implementation-specific conformance." Contour
+		// chooses to use the first instance of each filter type and ignore
+		// subsequent instances.
 		for _, filter := range rule.Filters {
 			switch filter.Type {
 			case gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if requestHeaderPolicy != nil {
+				if filter.RequestHeaderModifier == nil || requestHeaderPolicy != nil {
 					continue
 				}
 
@@ -1330,10 +1315,7 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			case gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if responseHeaderPolicy != nil {
+				if filter.ResponseHeaderModifier == nil || responseHeaderPolicy != nil {
 					continue
 				}
 
@@ -1343,27 +1325,21 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			case gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror:
-				// Get the mirror filter if there is one. If there are more than one
-				// mirror filters, "NotImplemented" condition on the Route is set to
-				// status: True, with the "NotImplemented" reason.
-				if mirrorPolicy != nil {
-					routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonNotImplemented, "GRPCRoute.Spec.Rules.Filters: Only one mirror filter is supported.")
+				if filter.RequestMirror == nil || mirrorPolicy != nil {
 					continue
 				}
 
-				if filter.RequestMirror != nil {
-					mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindGRPCRoute, route.Namespace)
-					if cond != nil {
-						routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
-						continue
-					}
-					// If protocol is not set on the service, need to set a default one based on listener's protocol type.
-					setDefaultServiceProtocol(mirrorService, listener.listener.Protocol)
-					mirrorPolicy = &MirrorPolicy{
-						Cluster: &Cluster{
-							Upstream: mirrorService,
-						},
-					}
+				mirrorService, cond := p.validateBackendObjectRef(filter.RequestMirror.BackendRef, "Spec.Rules.Filters.RequestMirror.BackendRef", KindGRPCRoute, route.Namespace)
+				if cond != nil {
+					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionType(cond.Type), cond.Status, gatewayapi_v1beta1.RouteConditionReason(cond.Reason), cond.Message)
+					continue
+				}
+				// If protocol is not set on the service, need to set a default one based on listener's protocol type.
+				setDefaultServiceProtocol(mirrorService, listener.listener.Protocol)
+				mirrorPolicy = &MirrorPolicy{
+					Cluster: &Cluster{
+						Upstream: mirrorService,
+					},
 				}
 			default:
 				routeAccessor.AddCondition(
@@ -1584,7 +1560,12 @@ func gatewayPathMatchCondition(match *gatewayapi_v1beta1.HTTPPathMatch, routeAcc
 		return &ExactMatchCondition{Path: path}, true
 	}
 
-	routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonPathMatchType, "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type and Exact match type are supported.")
+	routeAccessor.AddCondition(
+		gatewayapi_v1beta1.RouteConditionAccepted,
+		metav1.ConditionFalse,
+		gatewayapi_v1beta1.RouteReasonUnsupportedValue,
+		"HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type and Exact match type are supported.",
+	)
 	return nil, false
 }
 
@@ -1664,14 +1645,17 @@ func (p *GatewayAPIProcessor) httpClusters(routeNamespace string, backendRefs []
 			continue
 		}
 
-		var clusterRequestHeaderPolicy, clusterResponseHeaderPolicy *HeadersPolicy
+		var clusterRequestHeaderPolicy *HeadersPolicy
+		var clusterResponseHeaderPolicy *HeadersPolicy
+
+		// Per Gateway API docs: "Specifying a core filter multiple times
+		// has unspecified or implementation-specific conformance." Contour
+		// chooses to use the first instance of each filter type and ignore
+		// subsequent instances.
 		for _, filter := range backendRef.Filters {
 			switch filter.Type {
 			case gatewayapi_v1beta1.HTTPRouteFilterRequestHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if clusterRequestHeaderPolicy != nil {
+				if filter.RequestHeaderModifier == nil || clusterRequestHeaderPolicy != nil {
 					continue
 				}
 
@@ -1681,10 +1665,7 @@ func (p *GatewayAPIProcessor) httpClusters(routeNamespace string, backendRefs []
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterResponseHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if clusterResponseHeaderPolicy != nil {
+				if filter.ResponseHeaderModifier == nil || clusterResponseHeaderPolicy != nil {
 					continue
 				}
 
@@ -1694,7 +1675,12 @@ func (p *GatewayAPIProcessor) httpClusters(routeNamespace string, backendRefs []
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			default:
-				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.")
+				routeAccessor.AddCondition(
+					gatewayapi_v1beta1.RouteConditionAccepted,
+					metav1.ConditionFalse,
+					gatewayapi_v1beta1.RouteReasonUnsupportedValue,
+					"HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.",
+				)
 			}
 		}
 
@@ -1742,13 +1728,15 @@ func (p *GatewayAPIProcessor) grpcClusters(routeNamespace string, backendRefs []
 		}
 
 		var clusterRequestHeaderPolicy, clusterResponseHeaderPolicy *HeadersPolicy
+
+		// Per Gateway API docs: "Specifying a core filter multiple times
+		// has unspecified or implementation-specific conformance." Contour
+		// chooses to use the first instance of each filter type and ignore
+		// subsequent instances.
 		for _, filter := range backendRef.Filters {
 			switch filter.Type {
 			case gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if clusterRequestHeaderPolicy != nil {
+				if filter.RequestHeaderModifier == nil || clusterRequestHeaderPolicy != nil {
 					continue
 				}
 
@@ -1758,10 +1746,7 @@ func (p *GatewayAPIProcessor) grpcClusters(routeNamespace string, backendRefs []
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on request headers", err))
 				}
 			case gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier:
-				// Per Gateway API docs, "specifying a core filter multiple times has
-				// unspecified or custom conformance.", here we choose to just process
-				// the first one.
-				if clusterResponseHeaderPolicy != nil {
+				if filter.ResponseHeaderModifier == nil || clusterResponseHeaderPolicy != nil {
 					continue
 				}
 
@@ -1771,7 +1756,12 @@ func (p *GatewayAPIProcessor) grpcClusters(routeNamespace string, backendRefs []
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			default:
-				routeAccessor.AddCondition(status.ConditionNotImplemented, metav1.ConditionTrue, status.ReasonHTTPRouteFilterType, "GRPCRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.")
+				routeAccessor.AddCondition(
+					gatewayapi_v1beta1.RouteConditionAccepted,
+					metav1.ConditionFalse,
+					gatewayapi_v1beta1.RouteReasonUnsupportedValue,
+					"GRPCRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.",
+				)
 			}
 		}
 

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -4874,14 +4874,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
-							Message: "Accepted HTTPRoute",
-						},
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonPathMatchType),
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type and Exact match type are supported.",
 						},
 					},
@@ -4923,14 +4917,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
-							Message: "Accepted HTTPRoute",
-						},
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonPathMatchType),
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "HTTPRoute.Spec.Rules.PathMatch: Only Prefix match type and Exact match type are supported.",
 						},
 					},
@@ -4984,14 +4972,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
-							Message: "Accepted HTTPRoute",
-						},
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonHeaderMatchType),
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "HTTPRoute.Spec.Rules.Matches.Headers: Only Exact match type is supported",
 						},
 					},
@@ -5042,14 +5024,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Conditions: []metav1.Condition{
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.GatewayClassReasonAccepted),
-							Message: "Accepted HTTPRoute",
-						},
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonQueryParamMatchType),
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
 							Message: "HTTPRoute.Spec.Rules.Matches.QueryParams: Only Exact match type is supported",
 						},
 					},
@@ -6818,12 +6794,6 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []metav1.Condition{
 						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonNotImplemented),
-							Message: "HTTPRoute.Spec.Rules.Filters: Only one mirror filter is supported.",
-						},
-						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 							Status:  contour_api_v1.ConditionTrue,
 							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
@@ -7139,16 +7109,10 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []metav1.Condition{
 						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonHTTPRouteFilterType),
-							Message: "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.",
-						},
-						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
-							Message: "Accepted HTTPRoute",
+							Status:  contour_api_v1.ConditionFalse,
+							Reason:  string(gatewayapi_v1beta1.RouteReasonUnsupportedValue),
+							Message: "HTTPRoute.Spec.Rules.BackendRef.Filters: Only RequestHeaderModifier and ResponseHeaderModifier type is supported.",
 						},
 					},
 				},
@@ -9504,12 +9468,6 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []metav1.Condition{
-						{
-							Type:    string(status.ConditionNotImplemented),
-							Status:  contour_api_v1.ConditionTrue,
-							Reason:  string(status.ReasonNotImplemented),
-							Message: "GRPCRoute.Spec.Rules.Filters: Only one mirror filter is supported.",
-						},
 						{
 							Type:    string(gatewayapi_v1beta1.RouteConditionAccepted),
 							Status:  contour_api_v1.ConditionTrue,

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -26,24 +26,16 @@ import (
 )
 
 const (
-	ConditionNotImplemented   gatewayapi_v1beta1.RouteConditionType = "NotImplemented"
 	ConditionValidBackendRefs gatewayapi_v1beta1.RouteConditionType = "ValidBackendRefs"
 	ConditionValidMatches     gatewayapi_v1beta1.RouteConditionType = "ValidMatches"
 )
 
 const (
-	ReasonNotImplemented                gatewayapi_v1beta1.RouteConditionReason = "NotImplemented"
-	ReasonPathMatchType                 gatewayapi_v1beta1.RouteConditionReason = "PathMatchType"
-	ReasonHeaderMatchType               gatewayapi_v1beta1.RouteConditionReason = "HeaderMatchType"
-	ReasonQueryParamMatchType           gatewayapi_v1beta1.RouteConditionReason = "QueryParamMatchType"
-	ReasonHTTPRouteFilterType           gatewayapi_v1beta1.RouteConditionReason = "HTTPRouteFilterType"
 	ReasonDegraded                      gatewayapi_v1beta1.RouteConditionReason = "Degraded"
-	ReasonErrorsExist                   gatewayapi_v1beta1.RouteConditionReason = "ErrorsExist"
 	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
 	ReasonInvalidPathMatch              gatewayapi_v1beta1.RouteConditionReason = "InvalidPathMatch"
 	ReasonInvalidMethodMatch            gatewayapi_v1beta1.RouteConditionReason = "InvalidMethodMatch"
 	ReasonInvalidGateway                gatewayapi_v1beta1.RouteConditionReason = "InvalidGateway"
-	ReasonListenersNotReady             gatewayapi_v1beta1.RouteConditionReason = "ListenersNotReady"
 )
 
 // RouteStatusUpdate represents an atomic update to a


### PR DESCRIPTION
Replaces custom condition types/reasons with
upstream ones, and cleans up filter processing
for consistency.

Closes #5103.

Signed-off-by: Steve Kriss <krisss@vmware.com>