### PR TITLE
internal/dag: Allow REQ operator to use HTTP/2 pseudo-headers in headers policy

### DIFF
--- a/changelogs/unreleased/5130-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5130-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+`%REQ()` operator in request/response header policies now properly supports HTTP/2 pseudo-headers, header fallbacks, and truncating header values.

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -318,7 +318,7 @@ func escapeHeaderValue(value string, dynamicHeaders map[string]string) string {
 		escapedValue = strings.ReplaceAll(escapedValue, "%%"+envoyVar+"%%", "%"+envoyVar+"%")
 	}
 	// REQ(header-name)
-	var validReqEnvoyVar = regexp.MustCompile(`%(%REQ\(:?[\w-]+(\?:?[\w-]+)?\)%)%`)
+	var validReqEnvoyVar = regexp.MustCompile(`%(%REQ\(:?[\w-]+(\?:?[\w-]+)?\)(:\d+)?%)%`)
 	escapedValue = validReqEnvoyVar.ReplaceAllString(escapedValue, "$1")
 	return escapedValue
 }

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -318,7 +318,7 @@ func escapeHeaderValue(value string, dynamicHeaders map[string]string) string {
 		escapedValue = strings.ReplaceAll(escapedValue, "%%"+envoyVar+"%%", "%"+envoyVar+"%")
 	}
 	// REQ(header-name)
-	var validReqEnvoyVar = regexp.MustCompile(`%(%REQ\([\w-]+\)%)%`)
+	var validReqEnvoyVar = regexp.MustCompile(`%(%REQ\(:?[\w-]+(\?:?[\w-]+)?\)%)%`)
 	escapedValue = validReqEnvoyVar.ReplaceAllString(escapedValue, "$1")
 	return escapedValue
 }

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -414,6 +414,20 @@ func TestHeadersPolicy(t *testing.T) {
 				},
 			},
 		},
+		"valid Envoy REQ header unescaped truncated": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Host",
+					Value: "%REQ(Host):9%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Host": "%REQ(Host):9%",
+				},
+			},
+		},
 		"valid Envoy REQ http/2 pseudo-header unescaped": {
 			hp: &contour_api_v1.HeadersPolicy{
 				Set: []contour_api_v1.HeaderValue{{
@@ -439,6 +453,34 @@ func TestHeadersPolicy(t *testing.T) {
 			want: HeadersPolicy{
 				Set: map[string]string{
 					"X-Request-Foo-Fallback": "%REQ(X-Foo?X-Bar)%",
+				},
+			},
+		},
+		"valid Envoy REQ header if not present truncated": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Foo-Fallback",
+					Value: "%REQ(X-Foo?X-Bar):10%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Foo-Fallback": "%REQ(X-Foo?X-Bar):10%",
+				},
+			},
+		},
+		"Envoy REQ header if not present invalid truncation": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Foo-Fallback",
+					Value: "%REQ(X-Foo?X-Bar):baz%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Foo-Fallback": "%%REQ(X-Foo?X-Bar):baz%%",
 				},
 			},
 		},

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -414,6 +414,48 @@ func TestHeadersPolicy(t *testing.T) {
 				},
 			},
 		},
+		"valid Envoy REQ http/2 pseudo-header unescaped": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Path",
+					Value: "%REQ(:PATH)%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Path": "%REQ(:PATH)%",
+				},
+			},
+		},
+		"valid Envoy REQ header if not present": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Foo-Fallback",
+					Value: "%REQ(X-Foo?X-Bar)%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Foo-Fallback": "%REQ(X-Foo?X-Bar)%",
+				},
+			},
+		},
+		"valid Envoy REQ header if not present http/2 pseudo-header": {
+			hp: &contour_api_v1.HeadersPolicy{
+				Set: []contour_api_v1.HeaderValue{{
+					Name:  "X-Request-Path-Fallback",
+					Value: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+				}},
+			},
+			dhp: HeadersPolicy{},
+			want: HeadersPolicy{
+				Set: map[string]string{
+					"X-Request-Path-Fallback": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+				},
+			},
+		},
 		"invalid Envoy REQ header is escaped": {
 			hp: &contour_api_v1.HeadersPolicy{
 				Set: []contour_api_v1.HeaderValue{{


### PR DESCRIPTION
Also allows header fallback configuration %REQ(If-Present?X-Fallback)%