### PR TITLE
remove informer for ContourConfiguration

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -474,7 +474,6 @@ func (s *Server) doServe() error {
 		"httpproxies":               &contour_api_v1.HTTPProxy{},
 		"tlscertificatedelegations": &contour_api_v1.TLSCertificateDelegation{},
 		"extensionservices":         &contour_api_v1alpha1.ExtensionService{},
-		"contourconfigurations":     &contour_api_v1alpha1.ContourConfiguration{},
 		"services":                  &corev1.Service{},
 		"ingresses":                 &networking_v1.Ingress{},
 	} {

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -202,8 +202,6 @@ func (kc *KubernetesCache) Insert(obj interface{}) bool {
 		case *contour_api_v1alpha1.ExtensionService:
 			kc.extensions[k8s.NamespacedNameOf(obj)] = obj
 			return true
-		case *contour_api_v1alpha1.ContourConfiguration:
-			return false
 		default:
 			// not an interesting object
 			kc.WithField("object", obj).Error("insert unknown object")
@@ -330,8 +328,6 @@ func (kc *KubernetesCache) remove(obj interface{}) bool {
 		_, ok := kc.extensions[m]
 		delete(kc.extensions, m)
 		return ok
-	case *contour_api_v1alpha1.ContourConfiguration:
-		return false
 	default:
 		// not interesting
 		kc.WithField("object", obj).Error("remove unknown object")

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -60,6 +60,10 @@ func KindOf(obj interface{}) string {
 			return "TLSCertificateDelegation"
 		case *v1alpha1.ExtensionService:
 			return "ExtensionService"
+		case *v1alpha1.ContourConfiguration:
+			return "ContourConfiguration"
+		case *v1alpha1.ContourDeployment:
+			return "ContourDeployment"
 		case *v1.Namespace:
 			return "Namespace"
 		case *unstructured.Unstructured:

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -40,6 +40,8 @@ func TestKindOf(t *testing.T) {
 		{"HTTPProxy", &contour_api_v1.HTTPProxy{}},
 		{"TLSCertificateDelegation", &contour_api_v1.TLSCertificateDelegation{}},
 		{"ExtensionService", &v1alpha1.ExtensionService{}},
+		{"ContourConfiguration", &v1alpha1.ContourConfiguration{}},
+		{"ContourDeployment", &v1alpha1.ContourDeployment{}},
 		{"GRPCRoute", &gatewayapi_v1alpha2.GRPCRoute{}},
 		{"HTTPRoute", &gatewayapi_v1beta1.HTTPRoute{}},
 		{"TLSRoute", &gatewayapi_v1alpha2.TLSRoute{}},


### PR DESCRIPTION
ContourConfiguration is not being cached
in the DAG cache so the informer is not
needed.

Also adds ContourConfiguration and
ContourDeployment to the KindOf function
since they are known types.

I noticed this while testing #5109 because I had a ContourConfiguration in my cluster, and it was showing up in the metric output as an unknown object.