### PR TITLE
tooling improvements for patch releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/tsaarni/certyaml v0.9.1
 	github.com/vektra/mockery/v2 v2.21.1
+	golang.org/x/mod v0.8.0
 	golang.org/x/oauth2 v0.6.0
 	gonum.org/v1/plot v0.12.0
 	google.golang.org/genproto v0.0.0-20230117162540-28d6b9783ac4
@@ -111,7 +112,6 @@ require (
 	github.com/xhit/go-str2duration v1.2.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/image v0.5.0 // indirect
-	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/site/content/resources/release-process.md
+++ b/site/content/resources/release-process.md
@@ -55,7 +55,6 @@ export CONTOUR_OPERATOR_UPSTREAM_REMOTE_NAME=upstream
 1. Add the new release to the compatibility matrix (`site/content/resources/compatibility-matrix.md`).
 1. Add the new release to the compatibility YAML (`/versions.yaml`). Be sure to mark this new version as supported and mark oldest currently supported version as no longer supported.
 1. Update `.github/workflows/trivy-scan.yaml` to add new release branch and remove oldest listed (should always be 3 latest branches listed).
-1. Document upgrade instructions for the new release (`site/content/resources/upgrading.md`).
 1. Commit all changes, push the branch, and PR it into `main`.
 
 ### Branch and tag release
@@ -193,9 +192,8 @@ git cherry-pick <SHA>
     ```bash
     go run ./hack/release/prepare-release.go $CONTOUR_PREVIOUS_VERSION $CONTOUR_RELEASE_VERSION $KUBERNETES_MIN_VERSION $KUBERNETES_MAX_VERSION
     ```
-1. Proofread the release notes and do any reordering, rewording, reformatting necessary. Note that you will likely have to delete changelog entries that were not part of this patch release, as well as empty sections in the changelog.
+1. Fill in the changelog with the changes being backported, and delete any irrelevant sections. Delete any associated "unreleased" changelog files from `changelogs/unreleased`.
 1. Add the new release to the compatibility matrix (`/site/content/resources/compatibility-matrix.md`).
-1. Document upgrade instructions for the new release (`/site/content/resources/upgrading.md`).
 1. Add the new release to the compatibility YAML (`/versions.yaml`).
 1. Commit all changes, push the branch, and PR it into `main`.
 


### PR DESCRIPTION
For patch releases:
- Generates an empty changelog to be filled in manually since many unreleased changelogs likely do not apply 
- Does not delete unreleased changelogs since many are likely to not be for the patch release
- Inserts the new docs version in the correct order in the list
- Only updates latest_version if it truly is the latest
- Inserts the TOC mapping in the correct order in the list

Updates #5059.

For reviewers, you can try the following to examine the output:

```shell
# patch of a previous minor release, NOT the latest semver release
go run ./hack/release/prepare-release.go v1.23.3 v1.23.4 1.23 1.25
```
or 
```shell
# patch of the current minor release, IS the latest semver release
go run ./hack/release/prepare-release.go v1.24.1 v1.24.2 1.23 1.25
```
or 
```shell
# new minor release, IS the latest semver release
go run ./hack/release/prepare-release.go v1.25.0 1.23 1.25
```