### PR TITLE
trivy-scan: rename security-checks to scanners

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ matrix.branch }}
       - uses: aquasecurity/trivy-action@0.9.2
         with:
-          security-checks: vuln
+          scanners: vuln
           scan-type: 'fs'
           format: 'sarif'
           output: 'trivy-results.sarif'


### PR DESCRIPTION
ref. https://github.com/aquasecurity/trivy-action/releases/tag/0.9.2