### PR TITLE
test/e2e: clone DefaultTransport and disable keep-alives for metrics & admin

### DIFF
--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -146,8 +146,20 @@ func (h *HTTP) MetricsRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) 
 		opt(req)
 	}
 
+	// Clone the DefaultTransport and disable keep alives
+	// so we don't reuse connections within this method or
+	// across multiple calls to this method. This helps
+	// prevent requests from inadvertently being made to
+	// a draining Listener.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
 	makeRequest := func() (*http.Response, error) {
-		return http.DefaultClient.Do(req)
+		return client.Do(req)
 	}
 
 	return h.requestUntil(makeRequest, opts.Condition)
@@ -164,8 +176,20 @@ func (h *HTTP) AdminRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
 		opt(req)
 	}
 
+	// Clone the DefaultTransport and disable keep alives
+	// so we don't reuse connections within this method or
+	// across multiple calls to this method. This helps
+	// prevent requests from inadvertently being made to
+	// a draining Listener.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
 	makeRequest := func() (*http.Response, error) {
-		return http.DefaultClient.Do(req)
+		return client.Do(req)
 	}
 
 	return h.requestUntil(makeRequest, opts.Condition)

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -91,6 +91,28 @@ func OptSetQueryParams(queryParams map[string]string) func(*http.Request) {
 	}
 }
 
+// httpClient returns an *http.Client with its own transport
+// and keep alives disabled.
+func httpClient(opts ...func(*http.Client)) *http.Client {
+	// Clone the DefaultTransport and disable keep alives
+	// so we don't reuse connections within this method or
+	// across multiple calls to this method. This helps
+	// prevent requests from inadvertently being made to
+	// a draining Listener.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
 // RequestUntil repeatedly makes HTTP requests with the provided
 // parameters until "condition" returns true or the timeout is reached.
 // It always returns the last HTTP response received.
@@ -103,20 +125,7 @@ func (h *HTTP) RequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
 		opt(req)
 	}
 
-	// Clone the DefaultTransport and disable keep alives
-	// so we don't reuse connections within this method or
-	// across multiple calls to this method. This helps
-	// prevent requests from inadvertently being made to
-	// a draining Listener.
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DisableKeepAlives = true
-
-	client := &http.Client{
-		Transport: transport,
-	}
-	for _, opt := range opts.ClientOpts {
-		opt(client)
-	}
+	client := httpClient(opts.ClientOpts...)
 
 	makeRequest := func() (*http.Response, error) {
 		return client.Do(req)
@@ -146,17 +155,7 @@ func (h *HTTP) MetricsRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) 
 		opt(req)
 	}
 
-	// Clone the DefaultTransport and disable keep alives
-	// so we don't reuse connections within this method or
-	// across multiple calls to this method. This helps
-	// prevent requests from inadvertently being made to
-	// a draining Listener.
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DisableKeepAlives = true
-
-	client := &http.Client{
-		Transport: transport,
-	}
+	client := httpClient(opts.ClientOpts...)
 
 	makeRequest := func() (*http.Response, error) {
 		return client.Do(req)
@@ -176,17 +175,7 @@ func (h *HTTP) AdminRequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
 		opt(req)
 	}
 
-	// Clone the DefaultTransport and disable keep alives
-	// so we don't reuse connections within this method or
-	// across multiple calls to this method. This helps
-	// prevent requests from inadvertently being made to
-	// a draining Listener.
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DisableKeepAlives = true
-
-	client := &http.Client{
-		Transport: transport,
-	}
+	client := httpClient(opts.ClientOpts...)
 
 	makeRequest := func() (*http.Response, error) {
 		return client.Do(req)
@@ -230,24 +219,17 @@ func (h *HTTP) SecureRequestUntil(opts *HTTPSRequestOpts) (*HTTPResponse, bool) 
 		opt(req)
 	}
 
-	// Clone the DefaultTransport and disable keep alives
-	// so we don't reuse connections within this method or
-	// across multiple calls to this method. This helps
-	// prevent requests from inadvertently being made to
-	// a draining Listener.
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DisableKeepAlives = true
+	client := httpClient()
+	transport := client.Transport.(*http.Transport)
+
 	transport.TLSClientConfig = &tls.Config{
 		ServerName: opts.Host,
 		//nolint:gosec
 		InsecureSkipVerify: true,
 	}
+
 	for _, opt := range opts.TLSConfigOpts {
 		opt(transport.TLSClientConfig)
-	}
-
-	client := &http.Client{
-		Transport: transport,
 	}
 
 	makeRequest := func() (*http.Response, error) {


### PR DESCRIPTION
Repeats the change from #5210 for requests to
the metrics and admin listeners.