### PR TITLE
internal/envoy/v3: Trim trailing slashes from path separated prefix match

### DIFF
--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -194,7 +194,9 @@ func PathRouteMatch(pathMatchCondition dag.MatchCondition) *envoy_route_v3.Route
 		case dag.PrefixMatchSegment:
 			return &envoy_route_v3.RouteMatch{
 				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
-					PathSeparatedPrefix: c.Prefix,
+					// Trim trailing slash as PathSeparatedPrefix expects
+					// no trailing slashes.
+					PathSeparatedPrefix: strings.TrimSuffix(c.Prefix, "/"),
 				},
 			}
 		case dag.PrefixMatchString:

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -196,7 +196,7 @@ func PathRouteMatch(pathMatchCondition dag.MatchCondition) *envoy_route_v3.Route
 				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
 					// Trim trailing slash as PathSeparatedPrefix expects
 					// no trailing slashes.
-					PathSeparatedPrefix: strings.TrimSuffix(c.Prefix, "/"),
+					PathSeparatedPrefix: strings.TrimRight(c.Prefix, "/"),
 				},
 			}
 		case dag.PrefixMatchString:

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1513,6 +1513,19 @@ func TestRouteMatch(t *testing.T) {
 				},
 			},
 		},
+		"path prefix match segment multiple trailing slashes": {
+			route: &dag.Route{
+				PathMatchCondition: &dag.PrefixMatchCondition{
+					Prefix:          "/foo///",
+					PrefixMatchType: dag.PrefixMatchSegment,
+				},
+			},
+			want: &envoy_route_v3.RouteMatch{
+				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/foo",
+				},
+			},
+		},
 		"path exact": {
 			route: &dag.Route{
 				PathMatchCondition: &dag.ExactMatchCondition{

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1500,6 +1500,19 @@ func TestRouteMatch(t *testing.T) {
 				},
 			},
 		},
+		"path prefix match segment trailing slash": {
+			route: &dag.Route{
+				PathMatchCondition: &dag.PrefixMatchCondition{
+					Prefix:          "/foo/",
+					PrefixMatchType: dag.PrefixMatchSegment,
+				},
+			},
+			want: &envoy_route_v3.RouteMatch{
+				PathSpecifier: &envoy_route_v3.RouteMatch_PathSeparatedPrefix{
+					PathSeparatedPrefix: "/foo",
+				},
+			},
+		},
 		"path exact": {
 			route: &dag.Route{
 				PathMatchCondition: &dag.ExactMatchCondition{


### PR DESCRIPTION
Found when testing out
https://github.com/kubernetes-sigs/gateway-api/pull/1855

We could also do this higher up in dag processing but this seems like the common/failsafe option.