### PR TITLE
test/scripts: fix upgrade from version

### DIFF
--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -11,15 +11,10 @@ elif git describe --tags --abbrev=0 | grep -q -v v1.2.0; then
   # Note: Contour v1.2.0 was improperly tagged on main so we
   # ignore it to ensure we dont hit that case here.
 
-  # We should be on a release branch with an existing tag.
-  # Check the branch name and error if it does not contain release.
-  # Tags should not be added to non-release branches.
-  if git branch --show-current | grep -q release; then
-    git describe --tags --abbrev=0
-  else
-    echo 'Error: invalid tag on branch'
-    exit 1
-  fi
+  # We have a tag in our commit history, so we should
+  # be on a release branch or a feature branch from a
+  # release branch, with an existing tag.
+  git describe --tags --abbrev=0
 else
   # We are on a release branch with no tag created yet, main, or some
   # other checkout, so just use the latest tag.


### PR DESCRIPTION
Properly detect upgrade from version on
feature branches based off release branches.

Closes #5184.