### PR TITLE
internal/provisioner: Do not use hard-coded values, but configuration defined ports.

### DIFF
--- a/changelogs/unreleased/5233-Jean-Daniel-small.md
+++ b/changelogs/unreleased/5233-Jean-Daniel-small.md
@@ -1,0 +1,1 @@
+Gateway API: Envoy containers manifests should use value from `envoy.health.port` and `envoy.metrics.port` if they are defined in `ContourDeployment.spec.runtimeSettings`.


### PR DESCRIPTION
 This fix an issue with envoy pods generated by contour provisioner.

Envoy pods are never declared `Ready` when using a custom health port.
Envoy exposes the wrong port in prometheus annotations when using a custom metrics port.
