### PR TITLE
Expose metric port in generated envoy containers

### DIFF
--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -135,6 +135,11 @@ func desiredContainers(contour *model.Contour, contourImage, envoyImage string) 
 		}
 		ports = append(ports, p)
 	}
+	ports = append(ports, corev1.ContainerPort{
+		Name:          "metrics",
+		ContainerPort: int32(contour.Spec.RuntimeSettings.Envoy.Metrics.Port),
+		Protocol:      corev1.ProtocolTCP,
+	})
 
 	containers := []corev1.Container{
 		{

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -292,6 +292,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 	for _, port := range cntr.Spec.NetworkPublishing.Envoy.Ports {
 		checkContainerHasPort(t, ds, port.ContainerPort)
 	}
+	checkContainerHasPort(t, ds, int32(cntr.Spec.RuntimeSettings.Envoy.Metrics.Port))
 	checkDaemonSetHasNodeSelector(t, ds, nil)
 	checkDaemonSetHasTolerations(t, ds, nil)
 	checkDaemonSecurityContext(t, ds)


### PR DESCRIPTION
This is a fix for #5232