### PR TITLE
Gateway API: support regex path and header match

### DIFF
--- a/changelogs/unreleased/5239-fangfpeng-small.md
+++ b/changelogs/unreleased/5239-fangfpeng-small.md
@@ -1,0 +1,1 @@
+Gateway API: support regex path/header match for HTTPRoute and regex header match for GRPCRoute.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1877,7 +1877,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Port: 8080,
 					VirtualHosts: virtualhosts(
 						virtualhost("test.projectcontour.io",
-							regrexrouteHTTPRoute("/bl+og", service(kuardService))),
+							regexrouteHTTPRoute("/bl+og", service(kuardService))),
 					),
 				},
 			),
@@ -14659,7 +14659,7 @@ func exactrouteHTTPRoute(path string, first *Service, rest ...*Service) *Route {
 	}
 }
 
-func regrexrouteHTTPRoute(path string, first *Service, rest ...*Service) *Route {
+func regexrouteHTTPRoute(path string, first *Service, rest ...*Service) *Route {
 	services := append([]*Service{first}, rest...)
 	return &Route{
 		PathMatchCondition: &RegexMatchCondition{Regex: path},

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1575,7 +1575,7 @@ func gatewayHeaderMatchConditions(matches []gatewayapi_v1beta1.HTTPHeaderMatch) 
 			case gatewayapi_v1beta1.HeaderMatchRegularExpression:
 				matchType = HeaderMatchTypeRegex
 			default:
-				return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
+				return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
 			}
 		}
 

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1404,12 +1404,17 @@ func gatewayGRPCHeaderMatchConditions(matches []gatewayapi_v1alpha2.GRPCHeaderMa
 	for _, match := range matches {
 		// "Exact" and "RegularExpression" are the only supported match types. If match type is not specified, use "Exact" as default.
 		var matchType string
-		if match.Type == nil || *match.Type == gatewayapi_v1beta1.HeaderMatchExact {
+		if match.Type == nil {
 			matchType = HeaderMatchTypeExact
-		} else if *match.Type == gatewayapi_v1beta1.HeaderMatchRegularExpression {
-			matchType = HeaderMatchTypeRegex
 		} else {
-			return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
+			switch *match.Type {
+			case gatewayapi_v1beta1.HeaderMatchExact:
+				matchType = HeaderMatchTypeExact
+			case gatewayapi_v1beta1.HeaderMatchRegularExpression:
+				matchType = HeaderMatchTypeRegex
+			default:
+				return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
+			}
 		}
 
 		// If multiple match conditions are found for the same header name (case-insensitive),
@@ -1538,11 +1543,11 @@ func gatewayPathMatchCondition(match *gatewayapi_v1beta1.HTTPPathMatch, routeAcc
 			return nil, false
 		}
 
-		if *match.Type == gatewayapi_v1beta1.PathMatchExact {
-			return &ExactMatchCondition{Path: path}, true
-		} else {
+		if *match.Type == gatewayapi_v1beta1.PathMatchRegularExpression {
 			return &RegexMatchCondition{Regex: path}, true
 		}
+
+		return &ExactMatchCondition{Path: path}, true
 	}
 
 	routeAccessor.AddCondition(
@@ -1561,12 +1566,17 @@ func gatewayHeaderMatchConditions(matches []gatewayapi_v1beta1.HTTPHeaderMatch) 
 	for _, match := range matches {
 		// "Exact" and "RegularExpression" are the only supported match types. If match type is not specified, use "Exact" as default.
 		var matchType string
-		if match.Type == nil || *match.Type == gatewayapi_v1beta1.HeaderMatchExact {
+		if match.Type == nil {
 			matchType = HeaderMatchTypeExact
-		} else if *match.Type == gatewayapi_v1beta1.HeaderMatchRegularExpression {
-			matchType = HeaderMatchTypeRegex
 		} else {
-			return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
+			switch *match.Type {
+			case gatewayapi_v1beta1.HeaderMatchExact:
+				matchType = HeaderMatchTypeExact
+			case gatewayapi_v1beta1.HeaderMatchRegularExpression:
+				matchType = HeaderMatchTypeRegex
+			default:
+				return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact type and RegularExpressionmatch type are supported")
+			}
 		}
 
 		// If multiple match conditions are found for the same header name (case-insensitive),

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1404,20 +1404,16 @@ func gatewayGRPCHeaderMatchConditions(matches []gatewayapi_v1alpha2.GRPCHeaderMa
 	for _, match := range matches {
 		// "Exact" and "RegularExpression" are the only supported match types. If match type is not specified, use "Exact" as default.
 		var matchType string
-		if match.Type == nil {
+		switch ref.Val(match.Type, gatewayapi_v1beta1.HeaderMatchExact) {
+		case gatewayapi_v1beta1.HeaderMatchExact:
 			matchType = HeaderMatchTypeExact
-		} else {
-			switch *match.Type {
-			case gatewayapi_v1beta1.HeaderMatchExact:
-				matchType = HeaderMatchTypeExact
-			case gatewayapi_v1beta1.HeaderMatchRegularExpression:
-				if err := ValidateRegex(match.Value); err != nil {
-					return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Invalid value for RegularExpression match type is specified")
-				}
-				matchType = HeaderMatchTypeRegex
-			default:
-				return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type and RegularExpression match type are supported")
+		case gatewayapi_v1beta1.HeaderMatchRegularExpression:
+			if err := ValidateRegex(match.Value); err != nil {
+				return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Invalid value for RegularExpression match type is specified")
 			}
+			matchType = HeaderMatchTypeRegex
+		default:
+			return nil, fmt.Errorf("GRPCRoute.Spec.Rules.Matches.Headers: Only Exact match type and RegularExpression match type are supported")
 		}
 
 		// If multiple match conditions are found for the same header name (case-insensitive),
@@ -1573,20 +1569,16 @@ func gatewayHeaderMatchConditions(matches []gatewayapi_v1beta1.HTTPHeaderMatch) 
 	for _, match := range matches {
 		// "Exact" and "RegularExpression" are the only supported match types. If match type is not specified, use "Exact" as default.
 		var matchType string
-		if match.Type == nil {
+		switch ref.Val(match.Type, gatewayapi_v1beta1.HeaderMatchExact) {
+		case gatewayapi_v1beta1.HeaderMatchExact:
 			matchType = HeaderMatchTypeExact
-		} else {
-			switch *match.Type {
-			case gatewayapi_v1beta1.HeaderMatchExact:
-				matchType = HeaderMatchTypeExact
-			case gatewayapi_v1beta1.HeaderMatchRegularExpression:
-				if err := ValidateRegex(match.Value); err != nil {
-					return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Invalid value for RegularExpression match type is specified")
-				}
-				matchType = HeaderMatchTypeRegex
-			default:
-				return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Only Exact match type and RegularExpression match type are supported")
+		case gatewayapi_v1beta1.HeaderMatchRegularExpression:
+			if err := ValidateRegex(match.Value); err != nil {
+				return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Invalid value for RegularExpression match type is specified")
 			}
+			matchType = HeaderMatchTypeRegex
+		default:
+			return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.Headers: Only Exact match type and RegularExpression match type are supported")
 		}
 
 		// If multiple match conditions are found for the same header name (case-insensitive),

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -4918,7 +4918,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							},
 							Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
 								{
-									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")), // <---- uknown type to break the test
+									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
 									Name:  gatewayapi_v1beta1.HTTPHeaderName("foo"),
 									Value: "bar",
 								},
@@ -9229,7 +9229,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 							},
 							Headers: []gatewayapi_v1alpha2.GRPCHeaderMatch{
 								{
-									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")),
+									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
 									Name:  gatewayapi_v1alpha2.GRPCHeaderName("foo"),
 									Value: "bar",
 								},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -85,7 +85,7 @@ func HTTPRouteMatch(pathType gatewayapi_v1beta1.PathMatchType, value string) []g
 func HTTPHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value string) []gatewayapi_v1beta1.HTTPHeaderMatch {
 	return []gatewayapi_v1beta1.HTTPHeaderMatch{
 		{
-			Type:  ref.To(gatewayapi_v1beta1.HeaderMatchExact),
+			Type:  ref.To(matchType),
 			Name:  gatewayapi_v1beta1.HTTPHeaderName(name),
 			Value: value,
 		},
@@ -173,10 +173,10 @@ func GRPCMethodMatch(matchType gatewayapi_v1alpha2.GRPCMethodMatchType, service 
 	}
 }
 
-func GRPCHeaderMatch(name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
+func GRPCHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
 	return []gatewayapi_v1alpha2.GRPCHeaderMatch{
 		{
-			Type:  ref.To(gatewayapi_v1beta1.HeaderMatchExact),
+			Type:  ref.To(matchType),
 			Name:  gatewayapi_v1alpha2.GRPCHeaderName(name),
 			Value: value,
 		},


### PR DESCRIPTION
- support regex path and regex header match for HTTPRoute.
- support regex header match for GRPCRoute.

Fixes #3357
Fixes #5219