### PR TITLE
main: Bump Envoy to 1.25.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.25.2
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.25.4
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/5250-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/5250-sunjayBhatia-minor.md
@@ -1,0 +1,3 @@
+## Bump Envoy to 1.25.4 for CVE patches
+
+Updates to Envoy v1.25.4. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.25.4/version_history/v1.25/v1.25.4) for more information about the content of the release. Details on the addressed CVEs can be found [here](https://github.com/envoyproxy/envoy/releases/tag/v1.25.4).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -34,7 +34,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.25.2",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.25.4",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.2
+        image: docker.io/envoyproxy/envoy:v1.25.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.25.2
+          image: docker.io/envoyproxy/envoy:v1.25.4
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -7725,7 +7725,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.25.2
+          image: docker.io/envoyproxy/envoy:v1.25.4
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -7718,7 +7718,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.2
+        image: docker.io/envoyproxy/envoy:v1.25.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -7712,7 +7712,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.2
+        image: docker.io/envoyproxy/envoy:v1.25.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.25.2][31]         | 1.26, 1.25, 1.24    | [main][50]       | v1alpha2, v1beta1   |
+| main            | [1.25.4][32]         | 1.26, 1.25, 1.24    | N/A              | v1alpha2, v1beta1   |
 | 1.24.2          | [1.25.2][31]         | 1.26, 1.25, 1.24    | N/A              | v1alpha2, v1beta1   |
 | 1.24.1          | [1.25.1][28]         | 1.26, 1.25, 1.24    | N/A              | v1alpha2, v1beta1   |
 | 1.24.0          | [1.25.0][25]         | 1.26, 1.25, 1.24    | [1.24.0][75]     | v1alpha2, v1beta1   |
@@ -146,6 +146,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [29]: https://www.envoyproxy.io/docs/envoy/v1.23.5/version_history/v1.23/v1.23.5
 [30]: https://www.envoyproxy.io/docs/envoy/v1.24.3/version_history/v1.24/v1.24.3
 [31]: https://www.envoyproxy.io/docs/envoy/v1.25.2/version_history/v1.25/v1.25.2
+[32]: https://www.envoyproxy.io/docs/envoy/v1.25.4/version_history/v1.25/v1.25.4
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.25.2"
+      envoy: "1.25.4"
       kubernetes:
         - "1.26"
         - "1.25"


### PR DESCRIPTION
Adding as a "minor" tag to bump up the priority in release notes for the CVEs