### PR TITLE
fix: nil pointer on global extauth when `authPolicy.context` not configured.

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -675,7 +675,7 @@ func (s *Server) setupGlobalExternalAuthentication(contourConfiguration contour_
 	}
 
 	var context map[string]string
-	if contourConfiguration.GlobalExternalAuthorization.AuthPolicy.Context != nil {
+	if contourConfiguration.GlobalExternalAuthorization.AuthPolicy != nil {
 		context = contourConfiguration.GlobalExternalAuthorization.AuthPolicy.Context
 	}
 


### PR DESCRIPTION
This change fixes a nil pointer when the `authPolicy.context` is not configured for global external auth on the contour configuration.