### PR TITLE
hack: change back to random image tag

### DIFF
--- a/test/scripts/install-contour-working.sh
+++ b/test/scripts/install-contour-working.sh
@@ -44,8 +44,9 @@ if ! kind::cluster::exists "$CLUSTERNAME" ; then
     exit 2
 fi
 
-# Set the image tag to match the current git hash + dirty flag.
-VERSION=$(git describe --exclude="*" --always --dirty)
+# Set (pseudo) random image tag to trigger restarts at every deployment.
+# TODO: Come up with a scheme that doesn't fill up the dev environment with randomly-tagged images.
+VERSION="v$$"
 
 # Build the image.
 make -C ${REPO} container IMAGE=ghcr.io/projectcontour/contour VERSION=${VERSION}

--- a/test/scripts/install-provisioner-working.sh
+++ b/test/scripts/install-provisioner-working.sh
@@ -28,8 +28,9 @@ if ! kind::cluster::exists "$CLUSTERNAME" ; then
     exit 2
 fi
 
-# Set the image tag to match the current git hash + dirty flag if repo has modifications.
-VERSION=$(git describe --exclude="*" --always --dirty)
+# Set (pseudo) random image tag to trigger restarts at every deployment.
+# TODO: Come up with a scheme that doesn't fill up the dev environment with randomly-tagged images.
+VERSION="v$$"
 
 # Build the Contour Provisioner image.
 make -C ${REPO} container IMAGE=ghcr.io/projectcontour/contour VERSION=${VERSION}


### PR DESCRIPTION
Contour should be automatically restarted each time the install scripts deploy a new build (as discussed https://github.com/projectcontour/contour/pull/5238#discussion_r1165994971)

Signed-off-by: Tero Saarni <tero.saarni@est.tech>