### PR TITLE
internal/dag: Fix for duplicate include detection

### DIFF
--- a/changelogs/unreleased/5296-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5296-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Fix HTTPProxy duplicate include detection. If we have multiple distinct includes on the same path but different headers or query parameters, duplicates of any include conditions after the first were not detected.

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1570,6 +1570,7 @@ func includeMatchConditionsIdentical(includeConds []contour_api_v1.MatchConditio
 		for i := range ag.headerConds {
 			if ag.headerConds[i] != includeHeaderConds[i] {
 				headerCondsIdentical = false
+				break
 			}
 		}
 		if !headerCondsIdentical {
@@ -1578,15 +1579,26 @@ func includeMatchConditionsIdentical(includeConds []contour_api_v1.MatchConditio
 
 		// Now compare (sorted) query param conditions element-by-element.
 		// If any mismatch, we can return early.
+		queryParamCondsIdentical := true
 		for i := range ag.queryParamConds {
 			if ag.queryParamConds[i] != includeQueryParamConds[i] {
-				return false
+				queryParamCondsIdentical = false
+				break
 			}
+		}
+		if !queryParamCondsIdentical {
+			continue
 		}
 		// If we get here, all header and query param conditions
 		// must be equal.
 		return true
 	}
+
+	// Save the seen path and header/query conditions.
+	seenConds[pathPrefix] = append(seenConds[pathPrefix], matchConditionAggregate{
+		headerConds:     includeHeaderConds,
+		queryParamConds: includeQueryParamConds,
+	})
 
 	return false
 }


### PR DESCRIPTION
If we have an include on a certain path, then a different valid include condition on that same path, duplicates of the later include conditions were not detected.

This actually does not need to be backported to the 1.24 release as that introduced the improved duplicate detection behavior, but did add the seen path/header conditions to the map, see here: https://github.com/projectcontour/contour/blob/v1.24.3/internal/dag/httpproxy_processor.go#L1441