### PR TITLE
Add default connection buffer limits for envoy listener

### DIFF
--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -131,11 +131,13 @@ func ProxyProtocol() *envoy_listener_v3.ListenerFilter {
 
 // Listener returns a new envoy_listener_v3.Listener for the supplied address, port, and filters.
 func Listener(name, address string, port int, lf []*envoy_listener_v3.ListenerFilter, filters ...*envoy_listener_v3.Filter) *envoy_listener_v3.Listener {
+	var perConnectionBufferLimitBytes = wrapperspb.UInt32(32768)
 	l := &envoy_listener_v3.Listener{
-		Name:            name,
-		Address:         SocketAddress(address, port),
-		ListenerFilters: lf,
-		SocketOptions:   TCPKeepaliveSocketOptions(),
+		Name:                          name,
+		Address:                       SocketAddress(address, port),
+		ListenerFilters:               lf,
+		PerConnectionBufferLimitBytes: perConnectionBufferLimitBytes,
+		SocketOptions:                 TCPKeepaliveSocketOptions(),
 	}
 	if len(filters) > 0 {
 		l.FilterChains = append(


### PR DESCRIPTION
It doesn't cover the unit tests yet