### PR TITLE
support query param regex matching in Gateway API

### DIFF
--- a/changelogs/unreleased/5310-padlar-small.md
+++ b/changelogs/unreleased/5310-padlar-small.md
@@ -1,0 +1,1 @@
+Gateway API: support regular expressions in HTTPRoute query param match type.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1673,11 +1673,11 @@ func gatewayQueryParamMatchConditions(matches []gatewayapi_v1beta1.HTTPQueryPara
 			matchType = HeaderMatchTypeExact
 		case gatewayapi_v1beta1.QueryParamMatchRegularExpression:
 			if err := ValidateRegex(match.Value); err != nil {
-				return nil, fmt.Errorf("FIXME: Invalid value for RegularExpression match type is specified")
+				return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.QueryParams: Invalid value for RegularExpression match type is specified")
 			}
 			matchType = HeaderMatchTypeRegex
 		default:
-			return nil, fmt.Errorf("FIXME: Only support Exact or RegularExpression match types")
+			return nil, fmt.Errorf("HTTPRoute.Spec.Rules.Matches.QueryParams: Only Exact and RegularExpression match types are supported")
 		}
 
 		// If multiple match conditions are found for the same value,


### PR DESCRIPTION
fixes #5262 