### PR TITLE
fix upgrade from version for RC tags

### DIFF
--- a/test/scripts/get-contour-upgrade-from-version.sh
+++ b/test/scripts/get-contour-upgrade-from-version.sh
@@ -5,8 +5,13 @@ set -o nounset
 set -o pipefail
 
 if CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
-  # We are on a tag, so find previous tag to this one.
-  git tag -l --sort=-v:refname | grep -v 'alpha\|beta\|rc' | grep -A1 -x $CURRENT_TAG | tail -1
+  # We are on a tag, so find previous tag to this one:
+  # - list them sorted in reverse semver order
+  # - find the current tag + the 5 previous (enough to filter out pre-release tags and still be left with a previous release tag)
+  # - exclude the current tag (which may be a pre-release or not)
+  # - exclude all remaining pre-release tags
+  # - get the highest remaining tag
+  git tag -l --sort=-v:refname | grep -A5 -x $CURRENT_TAG | grep -v -x $CURRENT_TAG | grep -v 'alpha\|beta\|rc' | head -n 1
 elif git describe --tags --abbrev=0 | grep -q -v v1.2.0; then
   # Note: Contour v1.2.0 was improperly tagged on main so we
   # ignore it to ensure we dont hit that case here.


### PR DESCRIPTION
Closes #5328.

Ran this logic on a bunch of different pre-release and release tags and all looks good:

```
v1.25.0-rc.2 -> v1.24.4
v1.25.0-rc.1 -> v1.24.4
v1.24.4 -> v1.24.3
v1.24.0 -> v1.23.5
```