### PR TITLE
Gateway provisioner: release leader election on shutdown

### DIFF
--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -132,13 +132,14 @@ func createManager(restConfig *rest.Config, provisionerConfig *gatewayProvisione
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, manager.Options{
-		Scheme:                     scheme,
-		LeaderElection:             provisionerConfig.leaderElection,
-		LeaderElectionResourceLock: "leases",
-		LeaderElectionID:           provisionerConfig.leaderElectionID,
-		LeaderElectionNamespace:    provisionerConfig.leaderElectionNamespace,
-		MetricsBindAddress:         provisionerConfig.metricsBindAddress,
-		Logger:                     ctrl.Log.WithName("contour-gateway-provisioner"),
+		Scheme:                        scheme,
+		LeaderElection:                provisionerConfig.leaderElection,
+		LeaderElectionResourceLock:    "leases",
+		LeaderElectionID:              provisionerConfig.leaderElectionID,
+		LeaderElectionNamespace:       provisionerConfig.leaderElectionNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		MetricsBindAddress:            provisionerConfig.metricsBindAddress,
+		Logger:                        ctrl.Log.WithName("contour-gateway-provisioner"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)


### PR DESCRIPTION
This matches behavior for the `contour serve`
command and enables upgrades/restarts to happen
faster.

ref. https://github.com/projectcontour/contour/blob/main/cmd/contour/serve.go#L271