### PR TITLE
[provisioner] Add `ipFamilyPolicy` field to NetworkPublishing.

### DIFF
--- a/apis/projectcontour/v1alpha1/contourdeployment.go
+++ b/apis/projectcontour/v1alpha1/contourdeployment.go
@@ -263,6 +263,16 @@ type NetworkPublishing struct {
 	// +optional
 	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 
+	// IPFamilyPolicy represents the dual-stack-ness requested or required by
+	// this Service. If there is no value provided, then this field will be set
+	// to SingleStack. Services can be "SingleStack" (a single IP family),
+	// "PreferDualStack" (two IP families on dual-stack configured clusters or
+	// a single IP family on single-stack clusters), or "RequireDualStack"
+	// (two IP families on dual-stack configured clusters, otherwise fail).
+	//
+	// +optional
+	IPFamilyPolicy corev1.IPFamilyPolicy `json:"ipFamilyPolicy,omitempty"`
+
 	// ServiceAnnotations is the annotations to add to
 	// the provisioned Envoy service.
 	//

--- a/changelogs/unreleased/5386-Jean-Daniel-small.md
+++ b/changelogs/unreleased/5386-Jean-Daniel-small.md
@@ -1,0 +1,1 @@
+Gateway API: Add `ipFamilyPolicy` field to `ContourDeployment.spec.envoy.networkPublishing` to control dual-stack-ness of the generated service.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -3024,6 +3024,16 @@ spec:
                           addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
                           \n If unset, defaults to \"Local\"."
                         type: string
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail).
+                        type: string
                       serviceAnnotations:
                         additionalProperties:
                           type: string

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -3237,6 +3237,16 @@ spec:
                           addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
                           \n If unset, defaults to \"Local\"."
                         type: string
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail).
+                        type: string
                       serviceAnnotations:
                         additionalProperties:
                           type: string

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -3038,6 +3038,16 @@ spec:
                           addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
                           \n If unset, defaults to \"Local\"."
                         type: string
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail).
+                        type: string
                       serviceAnnotations:
                         additionalProperties:
                           type: string

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -3243,6 +3243,16 @@ spec:
                           addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
                           \n If unset, defaults to \"Local\"."
                         type: string
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail).
+                        type: string
                       serviceAnnotations:
                         additionalProperties:
                           type: string

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -3237,6 +3237,16 @@ spec:
                           addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
                           \n If unset, defaults to \"Local\"."
                         type: string
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail).
+                        type: string
                       serviceAnnotations:
                         additionalProperties:
                           type: string

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -327,6 +327,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					contourModel.Spec.NetworkPublishing.Envoy.ExternalTrafficPolicy = networkPublishing.ExternalTrafficPolicy
 				}
 
+				if networkPublishing.IPFamilyPolicy != "" {
+					contourModel.Spec.NetworkPublishing.Envoy.IPFamilyPolicy = networkPublishing.IPFamilyPolicy
+				}
+
 				contourModel.Spec.NetworkPublishing.Envoy.ServiceAnnotations = networkPublishing.ServiceAnnotations
 			}
 

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -1023,6 +1023,7 @@ func TestGatewayReconcile(t *testing.T) {
 						NetworkPublishing: &contourv1alpha1.NetworkPublishing{
 							Type:                  contourv1alpha1.NodePortServicePublishingType,
 							ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+							IPFamilyPolicy:        corev1.IPFamilyPolicyPreferDualStack,
 							ServiceAnnotations: map[string]string{
 								"key-1": "val-1",
 								"key-2": "val-2",
@@ -1083,6 +1084,7 @@ func TestGatewayReconcile(t *testing.T) {
 				}
 				require.NoError(t, r.client.Get(context.Background(), keyFor(svc), svc))
 				assert.Equal(t, corev1.ServiceExternalTrafficPolicyTypeCluster, svc.Spec.ExternalTrafficPolicy)
+				assert.Equal(t, ref.To(corev1.IPFamilyPolicyPreferDualStack), svc.Spec.IPFamilyPolicy)
 				assert.Equal(t, corev1.ServiceTypeNodePort, svc.Spec.Type)
 				require.Len(t, svc.Annotations, 2)
 				assert.Equal(t, "val-1", svc.Annotations["key-1"])

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -184,6 +184,14 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					invalidParamsMessages = append(invalidParamsMessages, msg)
 				}
 
+				switch params.Spec.Envoy.NetworkPublishing.IPFamilyPolicy {
+				case "", corev1.IPFamilyPolicySingleStack, corev1.IPFamilyPolicyPreferDualStack, corev1.IPFamilyPolicyRequireDualStack:
+				default:
+					msg := fmt.Sprintf("invalid ContourDeployment spec.envoy.networkPublishing.ipFamilyPolicy %q, must be SingleStack, PreferDualStack or RequireDualStack",
+						params.Spec.Envoy.NetworkPublishing.IPFamilyPolicy)
+					invalidParamsMessages = append(invalidParamsMessages, msg)
+				}
+
 				switch params.Spec.Envoy.NetworkPublishing.ExternalTrafficPolicy {
 				case "", corev1.ServiceExternalTrafficPolicyTypeCluster, corev1.ServiceExternalTrafficPolicyTypeLocal:
 				default:

--- a/internal/provisioner/controller/gatewayclass_test.go
+++ b/internal/provisioner/controller/gatewayclass_test.go
@@ -384,6 +384,40 @@ func TestGatewayClassReconcile(t *testing.T) {
 				Reason: string(gatewayv1beta1.GatewayClassReasonInvalidParameters),
 			},
 		},
+		"gatewayclass controlled by us with a valid parametersRef but invalid parameter values for IPFamilyPolicy gets Accepted: false condition": {
+			gatewayClass: &gatewayv1beta1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gatewayclass-1",
+				},
+				Spec: gatewayv1beta1.GatewayClassSpec{
+					ControllerName: "projectcontour.io/gateway-controller",
+					ParametersRef: &gatewayv1beta1.ParametersReference{
+						Group:     "projectcontour.io",
+						Kind:      "ContourDeployment",
+						Name:      "gatewayclass-params",
+						Namespace: ref.To(gatewayv1beta1.Namespace("projectcontour")),
+					},
+				},
+			},
+			params: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Envoy: &contourv1alpha1.EnvoySettings{
+						NetworkPublishing: &contourv1alpha1.NetworkPublishing{
+							IPFamilyPolicy: "invalid-external-traffic-policy",
+						},
+					},
+				},
+			},
+			wantCondition: &metav1.Condition{
+				Type:   string(gatewayv1beta1.GatewayClassConditionStatusAccepted),
+				Status: metav1.ConditionFalse,
+				Reason: string(gatewayv1beta1.GatewayClassReasonInvalidParameters),
+			},
+		},
 		"gatewayclass with status from previous generation is updated": {
 			gatewayClass: &gatewayv1beta1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/provisioner/equality/equality.go
+++ b/internal/provisioner/equality/equality.go
@@ -98,6 +98,11 @@ func ClusterIPServiceChanged(current, expected *corev1.Service) (*corev1.Service
 		changed = true
 	}
 
+	if !apiequality.Semantic.DeepEqual(current.Spec.IPFamilyPolicy, expected.Spec.IPFamilyPolicy) {
+		updated.Spec.IPFamilyPolicy = expected.Spec.IPFamilyPolicy
+		changed = true
+	}
+
 	if !apiequality.Semantic.DeepEqual(current.Spec.SessionAffinity, expected.Spec.SessionAffinity) {
 		updated.Spec.SessionAffinity = expected.Spec.SessionAffinity
 		changed = true
@@ -157,6 +162,11 @@ func LoadBalancerServiceChanged(current, expected *corev1.Service) (*corev1.Serv
 		changed = true
 	}
 
+	if !apiequality.Semantic.DeepEqual(current.Spec.IPFamilyPolicy, expected.Spec.IPFamilyPolicy) {
+		updated.Spec.IPFamilyPolicy = expected.Spec.IPFamilyPolicy
+		changed = true
+	}
+
 	if !apiequality.Semantic.DeepEqual(current.Spec.SessionAffinity, expected.Spec.SessionAffinity) {
 		updated.Spec.SessionAffinity = expected.Spec.SessionAffinity
 		changed = true
@@ -210,6 +220,11 @@ func NodePortServiceChanged(current, expected *corev1.Service) (*corev1.Service,
 
 	if !apiequality.Semantic.DeepEqual(current.Spec.ExternalTrafficPolicy, expected.Spec.ExternalTrafficPolicy) {
 		updated.Spec.ExternalTrafficPolicy = expected.Spec.ExternalTrafficPolicy
+		changed = true
+	}
+
+	if !apiequality.Semantic.DeepEqual(current.Spec.IPFamilyPolicy, expected.Spec.IPFamilyPolicy) {
+		updated.Spec.IPFamilyPolicy = expected.Spec.IPFamilyPolicy
 		changed = true
 	}
 

--- a/internal/provisioner/equality/equality_test.go
+++ b/internal/provisioner/equality/equality_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/objects/dataplane"
 	"github.com/projectcontour/contour/internal/provisioner/objects/deployment"
 	"github.com/projectcontour/contour/internal/provisioner/objects/service"
+	"github.com/projectcontour/contour/internal/ref"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -303,6 +304,13 @@ func TestClusterIpServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if ip family policy changed",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.IPFamilyPolicy = ref.To(corev1.IPFamilyPolicyRequireDualStack)
+			},
+			expect: true,
+		},
+		{
 			description: "if service type changed",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -429,6 +437,13 @@ func TestLoadBalancerServiceChanged(t *testing.T) {
 			expect: true,
 		},
 		{
+			description: "if ip family policy changed",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.IPFamilyPolicy = ref.To(corev1.IPFamilyPolicyRequireDualStack)
+			},
+			expect: true,
+		},
+		{
 			description: "if annotations have changed",
 			mutate: func(svc *corev1.Service) {
 				svc.Annotations = map[string]string{}
@@ -516,6 +531,13 @@ func TestNodePortServiceChanged(t *testing.T) {
 			description: "if the number of ports changed",
 			mutate: func(svc *corev1.Service) {
 				svc.Spec.Ports = append(svc.Spec.Ports, svc.Spec.Ports[0])
+			},
+			expect: true,
+		},
+		{
+			description: "if ip family policy changed",
+			mutate: func(svc *corev1.Service) {
+				svc.Spec.IPFamilyPolicy = ref.To(corev1.IPFamilyPolicyRequireDualStack)
 			},
 			expect: true,
 		},

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -46,6 +46,7 @@ func Default(namespace, name string) *Contour {
 				Envoy: EnvoyNetworkPublishing{
 					Type:                  LoadBalancerServicePublishingType,
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					IPFamilyPolicy:        corev1.IPFamilyPolicySingleStack,
 				},
 			},
 			EnvoyDaemonSetUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
@@ -363,6 +364,11 @@ type EnvoyNetworkPublishing struct {
 
 	// ServiceAnnotations is a set of annotations to add to the provisioned Envoy service.
 	ServiceAnnotations map[string]string
+
+	// IPFamilyPolicy represents the dual-stack-ness requested or required by
+	// this Service. If there is no value provided, then this field will be set
+	// to SingleStack.
+	IPFamilyPolicy corev1.IPFamilyPolicy
 
 	// ExternalTrafficPolicy describes how nodes distribute service traffic they
 	// receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs,

--- a/internal/provisioner/objects/service/service.go
+++ b/internal/provisioner/objects/service/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/objects"
 	"github.com/projectcontour/contour/internal/provisioner/objects/dataplane"
 	"github.com/projectcontour/contour/internal/provisioner/objects/deployment"
+	"github.com/projectcontour/contour/internal/ref"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -248,6 +249,10 @@ func DesiredEnvoyService(contour *model.Contour) *corev1.Service {
 		} else if providerParams.Type == model.GCPLoadBalancerProvider {
 			svc.Spec.LoadBalancerIP = *providerParams.GCP.Address
 		}
+	}
+
+	if contour.Spec.NetworkPublishing.Envoy.IPFamilyPolicy != "" {
+		svc.Spec.IPFamilyPolicy = ref.To(contour.Spec.NetworkPublishing.Envoy.IPFamilyPolicy)
 	}
 
 	epType := contour.Spec.NetworkPublishing.Envoy.Type

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -7720,6 +7720,26 @@ and LoadBalancer IPs).</p>
 </tr>
 <tr>
 <td style="white-space:nowrap">
+<code>ipFamilyPolicy</code>
+<br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#ipfamilypolicy-v1-core">
+Kubernetes core/v1.IPFamilyPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPFamilyPolicy represents the dual-stack-ness requested or required by
+this Service. If there is no value provided, then this field will be set
+to SingleStack. Services can be &ldquo;SingleStack&rdquo; (a single IP family),
+&ldquo;PreferDualStack&rdquo; (two IP families on dual-stack configured clusters or
+a single IP family on single-stack clusters), or &ldquo;RequireDualStack&rdquo;
+(two IP families on dual-stack configured clusters, otherwise fail).</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>serviceAnnotations</code>
 <br>
 <em>


### PR DESCRIPTION
Add ipFamilyPolicy field to Envoy NetworkPublishing definition.

Fixes #5308