### PR TITLE
internal/envoy/v3: Loosen FilterMisdirectedRequests helper

### DIFF
--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -693,7 +693,9 @@ func FilterChains(filters ...*envoy_listener_v3.Filter) []*envoy_listener_v3.Fil
 func FilterMisdirectedRequests(fqdn string) *http.HttpFilter {
 	var target string
 
-	if strings.HasPrefix(fqdn, "*.") {
+	// fqdn can be "*" to match all hostnames or a wildcard prefix
+	// e.g. "*.foo"
+	if strings.HasPrefix(fqdn, "*") {
 		// When we have a wildcard hostname, we will have already matched
 		// the filter chain on an SNI that falls under the wildcard so we
 		// retrieve that and make sure the :authority header matches.


### PR DESCRIPTION
Previously would configure the Lua script to match on requestedServerName when fqdn had a prefix of "*.". Now Gateway API allows a complete wildcard listener hostname match of "*" so this needs to be amended. Gateway API 0.7.x conformance tests surfaced this.