### PR TITLE
test/e2e: lower provisioner upgrade threshold

### DIFF
--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -281,7 +281,13 @@ var _ = Describe("When upgrading", func() {
 				f.T().Logf("Total requests: %d, successful requests: %d\n", totalRequests, successfulRequests)
 				require.Greater(f.T(), totalRequests, uint(0))
 				successPercentage := 100 * float64(successfulRequests) / float64(totalRequests)
-				require.Greaterf(f.T(), successPercentage, float64(90.0), "success rate of %.2f%% less than 90%", successPercentage)
+				// Success threshold is somewhat arbitrary but less than the standalone
+				// Contour upgrade threshold because the Gateway provisioner does not
+				// currently fully upgrade the control plane before the data plane which
+				// can lead to additional downtime when both are upgrading at the same
+				// time.
+				// ref. https://github.com/projectcontour/contour/issues/5375.
+				require.Greaterf(f.T(), successPercentage, float64(80.0), "success rate of %.2f%% less than 80%", successPercentage)
 			})
 		})
 	})


### PR DESCRIPTION
Lowers the provisioner upgrade successful requests threshold to accommodate the fact that the
provisioner does not fully upgrade the control plane before the data plane.

I saw this flake at least once, so doing this for now until #5375 can be completed.