### PR TITLE
cmd/contour: Failure setting GOMAXPROCS is non-fatal

### DIFF
--- a/changelogs/unreleased/5427-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/5427-sunjayBhatia-minor.md
@@ -1,0 +1,5 @@
+## Failures to automatically set GOMAXPROCS are no longer fatal
+
+In some (particularly local development) environments the [automaxprocs](https://github.com/uber-go/automaxprocs) library fails due to the cgroup namespace setup.
+This failure is no longer fatal for Contour.
+Contour will now simply log the error and continue with the automatic GOMAXPROCS detection ignored.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -34,7 +34,7 @@ func main() {
 	// set GOMAXPROCS
 	_, err := maxprocs.Set(maxprocs.Logger(log.Printf))
 	if err != nil {
-		log.WithError(err).Fatal("failed to set GOMAXPROCS")
+		log.WithError(err).Error("failed to set GOMAXPROCS")
 	}
 
 	// NOTE: when add a new subcommand, we'll have to remember to add it to 'TestOptionFlagsAreSorted'


### PR DESCRIPTION
This is an issue in certain local development and other environments where cgroup namespaces are distinct per container. The automaxprocs library errors with 'path <foo> is not a descendent of mount point root <foo>/kubelet and cannot be exposed from "/sys/fs/cgroup/misc/kubelet"'