### PR TITLE
golangci-lint: use go run locally, tidy config file

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.1
+          version: v1.51.2
           # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
           # is resolved
           args: --build-tags=e2e,conformance,gcp,oidc,none

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,10 +15,6 @@ linters:
   - gocritic
   - forbidigo
 
-# TODO(jpeach): enable these later:
-#  - gocyclo
-#  - gocognit
-
 linters-settings:
   misspell:
     ignore-words:
@@ -37,26 +33,13 @@ linters-settings:
       - http.DefaultTransport
 
 issues:
-  exclude:
-  # TODO(jpeach): exclude unparam warnings about functions that always receive
-  # the same arguments. We should clean those up some time.
-  - always receives
   exclude-rules:
+  - linters:
+    - unparam
+    text: "always receives"
   - path: zz_generated
     linters:
     - goimports
-  - linters:
-    - golint
-    text: "var `ingress_https` should be `ingressHTTPS`"
-  - linters:
-    - golint
-    text: "var `ingress_http` should be `ingressHTTP`"
-  - linters:
-    - golint
-    text: "returns unexported type"
-  - linters:
-    - golint
-    text: "don't use ALL_CAPS in Go names; use CamelCase"
   - path: test/e2e
     linters:
       - bodyclose

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -1,23 +1,3 @@
 #! /usr/bin/env bash
 
-readonly PROGNAME="golangci-lint"
-
-if command -v ${PROGNAME} >/dev/null; then
-	# TODO(jpeach): check this won't self-exec ...
-	exec ${PROGNAME} "$@"
-fi
-
-if command -v docker >/dev/null; then
-	exec docker run \
-		--rm \
-		--volume $(pwd):/app \
-		--workdir /app \
-		golangci/golangci-lint:v1.51.1 ${PROGNAME} "$@"
-fi
-
-cat <<EOF
-Unable to run golang-ci. Please check installation instructions:
-	https://github.com/golangci/golangci-lint#install
-EOF
-
-exit 69 # EX_UNAVAILABLE
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2 "$@"


### PR DESCRIPTION
- bump patch version to v1.51.2
- use `go run` when running golangci-lint locally (pins version and faster than running in Docker)
- clean up config file to remove obsolete config and comments

Hold until #5424 is merged