### PR TITLE
internal/sorter: Routes with method matching get precedence

### DIFF
--- a/changelogs/unreleased/5434-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/5434-sunjayBhatia-minor.md
@@ -1,0 +1,6 @@
+## Routes with HTTP Method matching have higher precedence
+
+For conformance with Gateway API v0.7.1+, routes that utilize HTTP method matching now have an explicit precedence over routes with header/query matches.
+See the [Gateway API documentation](https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/apis/v1beta1/httproute_types.go#L163-L167) for a description of this precedence order.
+
+This change applies not only to HTTPRoute but also HTTPProxy method matches (implemented in configuration via a header match on the `:method` header).

--- a/internal/sorter/sorter_test.go
+++ b/internal/sorter/sorter_test.go
@@ -313,6 +313,37 @@ func TestSortRoutesPathMatch(t *testing.T) {
 	shuffleAndCheckSort(t, want)
 }
 
+func TestSortRoutesMethod(t *testing.T) {
+	want := []*dag.Route{
+		{
+			// Comes first since it also has header matches.
+			PathMatchCondition: matchExact("/something"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("X-Other-Header-1", "foo"),
+				exactHeader(":method", "POST"),
+				exactHeader("X-Other-Header-3", "baz"),
+			},
+		},
+		{
+			// Comes next since it has a method match which
+			// has higher precedence over multiple header matches.
+			PathMatchCondition: matchExact("/something"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader(":method", "POST"),
+			},
+		},
+		{
+			PathMatchCondition: matchExact("/something"),
+			HeaderMatchConditions: []dag.HeaderMatchCondition{
+				exactHeader("X-Other-Header-1", "foo"),
+				exactHeader("X-Other-Header-2", "bar"),
+			},
+		},
+	}
+	shuffleAndCheckSort(t, want)
+
+}
+
 func TestSortRoutesLongestHeaders(t *testing.T) {
 	want := []*dag.Route{
 		{


### PR DESCRIPTION
This is to support Gateway API conformance, release 0.7.1 dictates that HTTP method comes before length of header matches in the precendence order for choosing routes.

Since we currently implement method matching in the DAG by adding a :method header match, this solution finds any :method headers being matched on and first determines precedence of two routes being compared based on that. If method matches are equal (both present or not present), then we go ahead with comparing the remaining header matches.

Since HTTPProxy provides this ability as well, this will affect priority of routes from HTTPProxies, not just Gateway API HTTPRoute.

Alternately we could add a method field directly to the dag.Route struct and implement method matching that way. We may want to in that case also sanitize the header matches to make sure we properly collect matches on the :method header, or disallow using them in HTTPRoute, etc.

See gateway API docs: https://github.com/kubernetes-sigs/gateway-api/blob/v0.7.1/apis/v1beta1/httproute_types.go#L163-L167