### PR TITLE
test/e2e: Delete dependent objects in background

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -942,7 +942,7 @@ func (d *Deployment) DumpContourLogs() error {
 func (d *Deployment) EnsureDeleted(obj client.Object) error {
 	// Delete the object; if it already doesn't exist,
 	// then we're done.
-	err := d.client.Delete(context.Background(), obj)
+	err := d.client.Delete(context.Background(), obj, &client.DeleteOptions{PropagationPolicy: ref.To(metav1.DeletePropagationBackground)})
 	if api_errors.IsNotFound(err) {
 		return nil
 	}


### PR DESCRIPTION
Suppresses warning from API server/controller-runtime

```
time="2023-06-05T16:22:27Z" level=info msg="child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning" caller="logr.go:278" logger=KubeAPIWarningLogger
```