### PR TITLE
Bump Envoy to v1.26.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.26.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.26.2
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/5449-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5449-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.26.2. See the [release notes here](https://www.envoyproxy.io/docs/envoy/v1.26.2/version_history/v1.26/v1.26.2).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -34,7 +34,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.26.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.26.2",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.26.1
+        image: docker.io/envoyproxy/envoy:v1.26.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.26.1
+          image: docker.io/envoyproxy/envoy:v1.26.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -8019,7 +8019,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.26.1
+          image: docker.io/envoyproxy/envoy:v1.26.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8012,7 +8012,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.26.1
+        image: docker.io/envoyproxy/envoy:v1.26.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -8006,7 +8006,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.26.1
+        image: docker.io/envoyproxy/envoy:v1.26.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.26.1][35]         | 1.27, 1.26, 1.25    | N/A              | v1alpha2, v1beta1   |
+| main            | [1.26.2][37]         | 1.27, 1.26, 1.25    | N/A              | v1alpha2, v1beta1   |
 | 1.25.0          | [1.26.1][35]         | 1.27, 1.26, 1.25    | N/A              | v1alpha2, v1beta1   |
 | 1.24.4          | [1.25.6][36]         | 1.26, 1.25, 1.24    | N/A              | v1alpha2, v1beta1   |
 | 1.24.3          | [1.25.4][32]         | 1.26, 1.25, 1.24    | N/A              | v1alpha2, v1beta1   |
@@ -156,6 +156,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [34]: https://www.envoyproxy.io/docs/envoy/v1.23.7/version_history/v1.23/v1.23.7
 [35]: https://www.envoyproxy.io/docs/envoy/v1.26.1/version_history/v1.26/v1.26.1
 [36]: https://www.envoyproxy.io/docs/envoy/v1.25.6/version_history/v1.25/v1.25.6
+[37]: https://www.envoyproxy.io/docs/envoy/v1.26.2/version_history/v1.26/v1.26.2
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.26.1"
+      envoy: "1.26.2"
       kubernetes:
         - "1.27"
         - "1.26"


### PR DESCRIPTION
Routine patch bump for Envoy dependency CVEs

See:
https://www.envoyproxy.io/docs/envoy/v1.26.2/version_history/v1.26/v1.26.2