### PR TITLE
release-1.23: Bump Envoy to v1.24.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.24.5
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.24.8
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -34,7 +34,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.23.5",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.24.5",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.24.8",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.24.5
+        image: docker.io/envoyproxy/envoy:v1.24.8
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.24.5
+          image: docker.io/envoyproxy/envoy:v1.24.8
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -7040,7 +7040,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.24.5
+          image: docker.io/envoyproxy/envoy:v1.24.8
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -7033,7 +7033,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.24.5
+        image: docker.io/envoyproxy/envoy:v1.24.8
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -7027,7 +7027,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.24.5
+        image: docker.io/envoyproxy/envoy:v1.24.8
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
Routine patch bumps for Envoy dependency CVEs

See:
- https://www.envoyproxy.io/docs/envoy/v1.24.6/version_history/v1.24/v1.24.6
- https://www.envoyproxy.io/docs/envoy/v1.24.7/version_history/v1.24/v1.24.7
- https://www.envoyproxy.io/docs/envoy/v1.24.8/version_history/v1.24/v1.24.8