### PR TITLE
Fix dag rebuild trigger when Secret object changes

### DIFF
--- a/changelogs/unreleased/5463-tsaarni-small.md
+++ b/changelogs/unreleased/5463-tsaarni-small.md
@@ -1,0 +1,1 @@
+Update of CRL Secret did not trigger DAG rebuild / reload when it was not co-located in the same Secret with CA certificate.

--- a/changelogs/unreleased/5463-tsaarni-small.md
+++ b/changelogs/unreleased/5463-tsaarni-small.md
@@ -1,1 +1,1 @@
-Update of CRL Secret did not trigger DAG rebuild / reload when it was not co-located in the same Secret with CA certificate.
+DAG rebuild fixes: Update of CRL Secret did not trigger reload when it was not co-located in the same Secret with CA certificate, update of TLS Secret did not trigger reload when using `Ingress.spec.tls.secretName` with certificate delegation and `projectcontour.io/tls-cert-namespace` annotation.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -520,7 +520,7 @@ func (kc *KubernetesCache) secretTriggersRebuild(secretObj *v1.Secret) bool {
 
 	for _, ingress := range kc.ingresses {
 		for _, tls := range ingress.Spec.TLS {
-			if secret == k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ingress),  k8s.DefaultNamespace(ingress.Namespace)) {
+			if secret == k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ingress), k8s.DefaultNamespace(ingress.Namespace)) {
 				return true
 			}
 		}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -501,8 +501,8 @@ func isRefToService(ref gatewayapi_v1beta1.BackendObjectReference, service *v1.S
 // secretTriggersRebuild returns true if this secret is referenced by an Ingress
 // or HTTPProxy object, or by the configuration file. If the secret is not in the same namespace
 // it must be mentioned by a TLSCertificateDelegation.
-func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
-	if _, isCA := secret.Data[CACertificateKey]; isCA {
+func (kc *KubernetesCache) secretTriggersRebuild(secretObj *v1.Secret) bool {
+	if _, isCA := secretObj.Data[CACertificateKey]; isCA {
 		// locating a secret validation usage involves traversing each
 		// proxy object, determining if there is a valid delegation,
 		// and if the reference the secret as a certificate. The DAG already
@@ -511,38 +511,56 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 		return true
 	}
 
-	delegations := make(map[string]bool) // targetnamespace/secretname to bool
+	secret := types.NamespacedName{
+		Namespace: secretObj.Namespace,
+		Name:      secretObj.Name,
+	}
 
-	// TODO(youngnick): Check if this is required.
+	delegatedForAnyNamespace := false // True if this secret has been delegated to any namespace.
+	delegations := []string{}         // List of namespaces that this secret has been delegated to.
+
+	// Collect all delegations for this secret.
 	for _, d := range kc.tlscertificatedelegations {
 		for _, cd := range d.Spec.Delegations {
-			for _, n := range cd.TargetNamespaces {
-				delegations[n+"/"+cd.SecretName] = true
+			if secretObj.Namespace == d.Namespace && secretObj.Name == cd.SecretName {
+				for _, namespace := range cd.TargetNamespaces {
+					if namespace == "*" {
+						// No need to check other delegations since any namespace is allowed.
+						delegatedForAnyNamespace = true
+						break
+					}
+					delegations = append(delegations, namespace)
+				}
 			}
 		}
 	}
 
-	for _, ingress := range kc.ingresses {
-		if ingress.Namespace == secret.Namespace {
-			for _, tls := range ingress.Spec.TLS {
-				if tls.SecretName == secret.Name {
-					return true
-				}
-			}
+	// Compare returns true if the changedSecret is the same as the referredSecret and delegation is permitted.
+	compare := func(changedSecret, referredSecret types.NamespacedName, namespaceOfReferrer string) bool {
+		// If the secret is in the same namespace as the referring object, then compare the names.
+		if changedSecret.Namespace == namespaceOfReferrer && changedSecret == referredSecret {
+			return true
 		}
-		if delegations[ingress.Namespace+"/"+secret.Name] {
-			for _, tls := range ingress.Spec.TLS {
-				if tls.SecretName == secret.Namespace+"/"+secret.Name {
-					return true
-				}
+
+		// If the secret is delegated to any namespace, then compare the names.
+		if delegatedForAnyNamespace && changedSecret == referredSecret {
+			return true
+		}
+
+		// If the secret is delegated to the namespace of the referring object, then compare the names.
+		for _, namespace := range delegations {
+			if namespace == namespaceOfReferrer && changedSecret == referredSecret {
+				return true
 			}
 		}
 
-		if delegations["*/"+secret.Name] {
-			for _, tls := range ingress.Spec.TLS {
-				if tls.SecretName == secret.Namespace+"/"+secret.Name {
-					return true
-				}
+		return false
+	}
+
+	for _, ingress := range kc.ingresses {
+		for _, tls := range ingress.Spec.TLS {
+			if compare(secret, k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(ingress.Namespace)), ingress.Namespace) {
+				return true
 			}
 		}
 	}
@@ -559,28 +577,19 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 			continue
 		}
 
-		if proxy.Namespace == secret.Namespace && tls.SecretName == secret.Name {
+		if compare(secret, k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(proxy.Namespace)), proxy.Namespace) {
 			return true
 		}
-		if delegations[proxy.Namespace+"/"+secret.Name] {
-			if tls.SecretName == secret.Namespace+"/"+secret.Name {
-				return true
-			}
-		}
-		if delegations["*/"+secret.Name] {
-			if tls.SecretName == secret.Namespace+"/"+secret.Name {
-				return true
-			}
-		}
+
 		cv := tls.ClientValidation
-		if cv != nil && proxy.Namespace == secret.Namespace && cv.CertificateRevocationList == secret.Name {
+		if cv != nil && compare(secret, k8s.NamespacedNameFrom(cv.CertificateRevocationList, k8s.DefaultNamespace(proxy.Namespace)), proxy.Namespace) {
 			return true
 		}
 	}
 
 	// Secrets referred by the configuration file shall also trigger rebuild.
 	for _, s := range kc.ConfiguredSecretRefs {
-		if s.Namespace == secret.Namespace && s.Name == secret.Name {
+		if secret == *s {
 			return true
 		}
 	}
@@ -592,7 +601,7 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 			}
 
 			for _, certificateRef := range listener.TLS.CertificateRefs {
-				if isRefToSecret(certificateRef, secret, kc.gateway.Namespace) {
+				if isRefToSecret(certificateRef, secretObj, kc.gateway.Namespace) {
 					return true
 				}
 			}

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -572,6 +572,10 @@ func (kc *KubernetesCache) secretTriggersRebuild(secret *v1.Secret) bool {
 				return true
 			}
 		}
+		cv := tls.ClientValidation
+		if cv != nil && proxy.Namespace == secret.Namespace && cv.CertificateRevocationList == secret.Name {
+			return true
+		}
 	}
 
 	// Secrets referred by the configuration file shall also trigger rebuild.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -520,7 +520,7 @@ func (kc *KubernetesCache) secretTriggersRebuild(secretObj *v1.Secret) bool {
 
 	for _, ingress := range kc.ingresses {
 		for _, tls := range ingress.Spec.TLS {
-			if secret == k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ingress)) {
+			if secret == k8s.NamespacedNameFrom(tls.SecretName, k8s.TLSCertAnnotationNamespace(ingress),  k8s.DefaultNamespace(ingress.Namespace)) {
 				return true
 			}
 		}

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -123,7 +123,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 						Name:      "www",
 						Namespace: "extra",
 						Annotations: map[string]string{
-							"projectcontour.io/tls-delegation-namespace": "default",
+							"projectcontour.io/tls-cert-namespace": "default",
 						},
 					},
 					Spec: networking_v1.IngressSpec{
@@ -164,7 +164,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 						Name:      "www",
 						Namespace: "extra",
 						Annotations: map[string]string{
-							"projectcontour.io/tls-delegation-namespace": "default",
+							"projectcontour.io/tls-cert-namespace": "default",
 						},
 					},
 					Spec: networking_v1.IngressSpec{


### PR DESCRIPTION
Update of CRL Secret did not trigger DAG rebuild when it was not co-located in the same Secret with CA certificate. The effect was that CRL secret was not recognized if it was created after the HTTPProxy and updates to CRL content were not taken into use.

Trigger for DAG rebuild was also missing for Ingress when using certificate delegation via `projectcontour.io/tls-cert-namespace` annotation (Ingress v1 does not anymore allow `/` as part of secret name). It is also fixed in this PR.

Fixes #5462
Fixes #5538