### PR TITLE
internal/dag: GetServiceClusters no longer returns ExternalName clusters

### DIFF
--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -241,6 +241,14 @@ func (d *DAG) GetServiceClusters() []*ServiceCluster {
 	var res []*ServiceCluster
 
 	for _, cluster := range d.GetClusters() {
+		// We do not use EDS with clusters configured for ExternalName
+		// Services, so skip over returning these. We do not want to
+		// return extra endpoint resources in a snapshot that Envoy
+		// does not request. Especially with ADS, this is discouraged.
+		if len(cluster.Upstream.ExternalName) > 0 {
+			continue
+		}
+
 		// A Service has only one WeightedService entry. Fake up a
 		// ServiceCluster so that the visitor can pretend to not
 		// know this.

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -271,3 +271,27 @@ func TestGetSingleListener(t *testing.T) {
 		assert.NoError(t, gotErr)
 	})
 }
+
+func TestGetServiceClusters(t *testing.T) {
+	d := &DAG{
+		Listeners: map[string]*Listener{
+			"http-1": {
+				VirtualHosts: []*VirtualHost{
+					{
+						Routes: map[string]*Route{
+							"foo": {
+								Clusters: []*Cluster{
+									{Upstream: &Service{ExternalName: "bar.com"}},
+									{Upstream: &Service{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// We should only get one cluster since the other is for an ExternalName
+	// service.
+	assert.Len(t, d.GetServiceClusters(), 1)
+}


### PR DESCRIPTION
This method is used by the EndpointsTranslator on dag change to recalculate the relevant endpoints to send to Envoy. Since we do not use EDS to configure endpoints for Clusters that come from ExternalName Services, we no longer collect ServiceClusters associated with these Clusters. This is required for ADS, as go-control-plane will not respond to requests if the snapshot contains resources that were not requested.