### PR TITLE
test/e2e: Debugging fixes

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -634,6 +634,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 			"--kubeconfig=" + d.kubeConfig,
 			"--contour-config-name=" + contourConfiguration.Name,
 			"--disable-leader-election",
+			"--debug",
 		}, additionalArgs...)
 
 		configReferenceName = contourConfiguration.Name
@@ -667,6 +668,7 @@ func (d *Deployment) StartLocalContour(config *config.Parameters, contourConfigu
 			"--kubeconfig=" + d.kubeConfig,
 			"--config-path=" + configFile.Name(),
 			"--disable-leader-election",
+			"--debug",
 		}, additionalArgs...)
 
 		configReferenceName = configFile.Name()

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -80,6 +81,7 @@ func testGatewayMultipleQueryParamMatch(namespace string, gateway types.Namespac
 				Path:      path,
 				Condition: e2e.HasStatusCode(200),
 			})
+			require.NotNil(t, res)
 			if !assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode) {
 				continue
 			}

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectcontour/contour/internal/ref"
 	"github.com/projectcontour/contour/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -91,6 +92,7 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 			Host:      "tls-gateway.projectcontour.io",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res)
 		assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		assert.Equal(t, "echo-insecure", f.GetEchoResponseBody(res.Body).Service)
 
@@ -99,6 +101,7 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 			Host:      "tls-gateway.projectcontour.io",
 			Condition: e2e.HasStatusCode(200),
 		})
+		require.NotNil(t, res)
 		assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
 		assert.Equal(t, "echo-secure", f.GetEchoResponseBody(res.Body).Service)
 	})

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -291,6 +291,7 @@ func (h *HTTP) requestUntil(makeRequest func() (*http.Response, error), conditio
 	if err := wait.PollUntilContextTimeout(context.Background(), h.RetryInterval, h.RetryTimeout, true, func(ctx context.Context) (bool, error) {
 		r, err := makeRequest()
 		if err != nil {
+			h.t.Logf("request error: %s", err)
 			// if there was an error, we want to keep
 			// retrying, so just return false, not an
 			// error.


### PR DESCRIPTION
- use --debug flag on local contour invocation to get more logs
- more non-nil assertions to prevent panics
- print error from making requests in requestUntil helper

Related to debugging failures like: https://github.com/projectcontour/contour/actions/runs/5255150370/jobs/9494687568