### PR TITLE
internal/k8s: Fix log test pollution

### DIFF
--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -180,7 +180,7 @@ func TestServiceStatusLoadBalancerWatcherOnDelete(t *testing.T) {
 func TestStatusAddressUpdater(t *testing.T) {
 	const objName = "someobjfoo"
 
-	log := logrus.New()
+	log := fixture.NewTestLogger(t)
 	log.SetLevel(logrus.DebugLevel)
 	emptyLBStatus := v1.LoadBalancerStatus{}
 


### PR DESCRIPTION
Fixes flaky test/test pollution from test that output to stdout/err. Uses test logger instead.