### PR TITLE
Remove dots in certgen job name

### DIFF
--- a/changelogs/unreleased/5484-tsaarni-small.md
+++ b/changelogs/unreleased/5484-tsaarni-small.md
@@ -1,0 +1,1 @@
+Certgen job name in example deployment manifest is now generated using pattern `contour-certgen-v1-26-0` instead of `contour-certgen-v1.26.0` to follow Kubernetes pod naming rules.

--- a/hack/release/make-release-tag.sh
+++ b/hack/release/make-release-tag.sh
@@ -47,10 +47,12 @@ for example in examples/contour/03-envoy.yaml examples/deployment/03-envoy-deplo
 done
 
 # Update the certgen job name to the new version.
+# Dot in the version is replaced with a dash to make it a valid pod name.
 for example in examples/contour/02-job-certgen.yaml ; do
     run::sed \
-        "-es|contour-certgen-main|contour-certgen-$NEWVERS|" \
-        "-es|contour-certgen-$OLDVERS|contour-certgen-$NEWVERS|" \
+        "-es|contour-certgen-main|contour-certgen-${NEWVERS//./-}|" \
+        "-es|contour-certgen-$OLDVERS|contour-certgen-${NEWVERS//./-}|" \
+        "-es|contour-certgen-${OLDVERS//./-}|contour-certgen-${NEWVERS//./-}|" \
         "$example"
 done
 


### PR DESCRIPTION
Avoids Kubernetes warning when deploying contour.

Fixes #5483