### PR TITLE
services referenced by a GRPCRoute dont trigger a DAG rebuild

### DIFF
--- a/changelogs/unreleased/5485-yanggangtony-small.md
+++ b/changelogs/unreleased/5485-yanggangtony-small.md
@@ -1,0 +1,1 @@
+Service change now triggers update for GRPCRoute.

--- a/internal/dag/cache.go
+++ b/internal/dag/cache.go
@@ -439,6 +439,16 @@ func (kc *KubernetesCache) serviceTriggersRebuild(service *v1.Service) bool {
 		}
 	}
 
+	for _, route := range kc.grpcroutes {
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				if isRefToService(backend.BackendObjectReference, service, route.Namespace) {
+					return true
+				}
+			}
+		}
+	}
+
 	for _, route := range kc.httproutes {
 		for _, rule := range route.Spec.Rules {
 			for _, backend := range rule.BackendRefs {

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -1948,6 +1948,20 @@ func TestServiceTriggersRebuild(t *testing.T) {
 		}
 	}
 
+	grpcRoute := func(namespace, name string) *gatewayapi_v1alpha2.GRPCRoute {
+		return &gatewayapi_v1alpha2.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
+				Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
+					BackendRefs: gatewayapi.GRPCRouteBackendRef(name, 80, 1),
+				}},
+			},
+		}
+	}
+
 	httpRoute := func(namespace, name string) *gatewayapi_v1beta1.HTTPRoute {
 		return &gatewayapi_v1beta1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2070,6 +2084,30 @@ func TestServiceTriggersRebuild(t *testing.T) {
 			cache: cache(
 				service("default", "service-1"),
 				tcpProxy("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"grpcroute exists in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				grpcRoute("default", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: true,
+		},
+		"grpcroute does not exist in same namespace as service": {
+			cache: cache(
+				service("default", "service-1"),
+				grpcRoute("user", "service-1"),
+			),
+			svc:  service("default", "service-1"),
+			want: false,
+		},
+		"grpcroute does not use same name as service": {
+			cache: cache(
+				service("default", "service-1"),
+				grpcRoute("default", "service"),
 			),
 			svc:  service("default", "service-1"),
 			want: false,


### PR DESCRIPTION
/kind bug
Fixes #5476 

labels: ["release-note/small"]


The [serviceTriggersRebuild](https://github.com/projectcontour/contour/blob/main/internal/dag/cache.go#L387) method determines whether a Service change should trigger a DAG rebuild, based on whether the Service is referenced by any routing config. It looks like we forgot to add code to check GRPCRoutes for Service references here. That should be added and look similar to the existing checks for HTTPRoutes and TLSRoutes.

```release-note
Add  check GRPCRoutes for Service references .
```