### PR TITLE
internal/dag: Listener processor uses HTTP/S addresses for Gateway Listeners

### DIFF
--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -5775,7 +5775,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					FieldLogger:  fixture.NewTestLogger(t),
 				},
 				Processors: []Processor{
-					&ListenerProcessor{},
+					&ListenerProcessor{
+						HTTPAddress:  "0.0.0.0",
+						HTTPSAddress: "0.0.0.0",
+					},
 					&GatewayAPIProcessor{
 						FieldLogger: fixture.NewTestLogger(t),
 					},
@@ -15005,7 +15008,10 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 					FieldLogger:  fixture.NewTestLogger(t),
 				},
 				Processors: []Processor{
-					&ListenerProcessor{},
+					&ListenerProcessor{
+						HTTPAddress:  "0.0.0.0",
+						HTTPSAddress: "0.0.0.0",
+					},
 					&IngressProcessor{
 						FieldLogger: fixture.NewTestLogger(t),
 					},

--- a/internal/dag/listener_processor.go
+++ b/internal/dag/listener_processor.go
@@ -36,10 +36,14 @@ func (p *ListenerProcessor) Run(dag *DAG, cache *KubernetesCache) {
 		dag.HasDynamicListeners = true
 
 		for _, port := range gatewayapi.ValidateListeners(cache.gateway.Spec.Listeners).Ports {
+			address := p.HTTPAddress
+			if port.Protocol == "https" {
+				address = p.HTTPSAddress
+			}
 			dag.Listeners[port.Name] = &Listener{
 				Name:          port.Name,
 				Protocol:      port.Protocol,
-				Address:       "0.0.0.0",
+				Address:       address,
 				Port:          int(port.ContainerPort),
 				vhostsByName:  map[string]*VirtualHost{},
 				svhostsByName: map[string]*SecureVirtualHost{},


### PR DESCRIPTION
Use existing config flags/fields for HTTP/S listen addresses to configure Envoy Listeners when in Gateway mode.

Fixes: #5480