### PR TITLE
docs for install envoy containers.

### DIFF
--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -41,8 +41,8 @@ $ kubectl get pods -n projectcontour -o wide
 ```
 
 You should see the following:
-- 2 Contour pods with each status **Running** and 1/1 **Ready**  
-- 1+ Envoy pod(s), with each the status **Running** and 2/2 **Ready**  
+- 2 Contour pods each with status **Running** and 1/1 **Ready**  
+- 1+ Envoy pod(s), each with the status **Running** and 2/2 **Ready**  
 
 ### Option 2: Helm
 This option requires [Helm to be installed locally][29].
@@ -141,9 +141,9 @@ $ kubectl -n projectcontour get pods
 ```
 
 You should see the following:
-- 2 Contour pods with each status **Running** and 1/1 **Ready**  
-- 1+ Envoy pod(s), each with the status **Running** and 1/1 **Ready**  
- 
+- 2 Contour pods each with status **Running** and 1/1 **Ready**  
+- 1+ Envoy pod(s), each with the status **Running** and 2/2 **Ready**  
+
 ## Test it out!
 
 Congratulations, you have installed Contour and Envoy! Let's install a web application workload and get some traffic flowing to the backend.


### PR DESCRIPTION
labels: ["release-note/not-required"]
---
Read the code 
```
internal/provisioner/objects/dataplane/dataplane.go
func desiredContainers(contour *model.Contour, contourImage, envoyImage string) ([]corev1.Container, []corev1.Container) {
containers := []corev1.Container{
		{
			Name:            ShutdownContainerName,
			Image:           contourImage,
			ImagePullPolicy: corev1.PullIfNotPresent,
			Command: []string{
				"/bin/contour",
			},
			Args: []string{
				"envoy",
				"shutdown-manager",
			},
		},
		{
			Name:            EnvoyContainerName,
			Image:           envoyImage,
			ImagePullPolicy: corev1.PullIfNotPresent,
			Command: []string{
				"envoy",
			},
			Args: []string{
				"-c",
```

The Gateway install is the same with the Yaml install.
``` 
 kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
```

So the Envoy pod maybe the 2/2 in status

---