### PR TITLE
Fix configmap word in docs.

### DIFF
--- a/site/content/docs/1.23/guides/gateway-api.md
+++ b/site/content/docs/1.23/guides/gateway-api.md
@@ -108,7 +108,7 @@ This command creates:
 - Envoy DaemonSet / Service
 - Contour ConfigMap
 
-Update the Contour config map to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
+Update the Contour configmap to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
 
 ```shell
 kubectl apply -f - <<EOF

--- a/site/content/docs/1.23/guides/global-rate-limiting.md
+++ b/site/content/docs/1.23/guides/global-rate-limiting.md
@@ -184,7 +184,7 @@ spec:
     response: 100ms  
 ```
 
-Update the Contour config map to have the following RLS configuration:
+Update the Contour configmap to have the following RLS configuration:
 
 ```yaml
 apiVersion: v1

--- a/site/content/docs/1.24/guides/gateway-api.md
+++ b/site/content/docs/1.24/guides/gateway-api.md
@@ -108,7 +108,7 @@ This command creates:
 - Envoy DaemonSet / Service
 - Contour ConfigMap
 
-Update the Contour config map to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
+Update the Contour configmap to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
 
 ```shell
 kubectl apply -f - <<EOF

--- a/site/content/docs/1.24/guides/global-rate-limiting.md
+++ b/site/content/docs/1.24/guides/global-rate-limiting.md
@@ -184,7 +184,7 @@ spec:
     response: 100ms  
 ```
 
-Update the Contour config map to have the following RLS configuration:
+Update the Contour configmap to have the following RLS configuration:
 
 ```yaml
 apiVersion: v1

--- a/site/content/docs/1.25/guides/gateway-api.md
+++ b/site/content/docs/1.25/guides/gateway-api.md
@@ -108,7 +108,7 @@ This command creates:
 - Envoy DaemonSet / Service
 - Contour ConfigMap
 
-Update the Contour config map to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
+Update the Contour configmap to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
 
 ```shell
 kubectl apply -f - <<EOF

--- a/site/content/docs/1.25/guides/global-rate-limiting.md
+++ b/site/content/docs/1.25/guides/global-rate-limiting.md
@@ -184,7 +184,7 @@ spec:
     response: 100ms  
 ```
 
-Update the Contour config map to have the following RLS configuration:
+Update the Contour configmap to have the following RLS configuration:
 
 ```yaml
 apiVersion: v1

--- a/site/content/docs/main/guides/gateway-api.md
+++ b/site/content/docs/main/guides/gateway-api.md
@@ -108,7 +108,7 @@ This command creates:
 - Envoy DaemonSet / Service
 - Contour ConfigMap
 
-Update the Contour config map to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
+Update the Contour configmap to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
 
 ```shell
 kubectl apply -f - <<EOF

--- a/site/content/docs/main/guides/global-rate-limiting.md
+++ b/site/content/docs/main/guides/global-rate-limiting.md
@@ -184,7 +184,7 @@ spec:
     response: 100ms  
 ```
 
-Update the Contour config map to have the following RLS configuration:
+Update the Contour configmap to have the following RLS configuration:
 
 ```yaml
 apiVersion: v1

--- a/site/content/guides/gateway-api.md
+++ b/site/content/guides/gateway-api.md
@@ -109,7 +109,7 @@ This command creates:
 - Envoy DaemonSet / Service
 - Contour ConfigMap
 
-Update the Contour config map to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
+Update the Contour configmap to enable Gateway API processing by specifying a gateway controller name, and restart Contour to pick up the config change:
 
 ```shell
 kubectl apply -f - <<EOF

--- a/site/content/guides/global-rate-limiting.md
+++ b/site/content/guides/global-rate-limiting.md
@@ -185,7 +185,7 @@ spec:
     response: 100ms  
 ```
 
-Update the Contour config map to have the following RLS configuration:
+Update the Contour configmap to have the following RLS configuration:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
name: Pull request

about: The configmap is k8s's terminology , and can not be separated.
docs change 'config map to configmap , its will be more k8s terminology word.'

labels: ["release-note/not-required"]
