### PR TITLE
Bump go to 1.20.5

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -10,7 +10,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.20.4
+  GO_VERSION: 1.20.5
 jobs:
   e2e-envoy-xds:
     runs-on: ubuntu-latest

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -11,7 +11,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.20.4
+  GO_VERSION: 1.20.5
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.20.4
+BUILD_BASE_IMAGE ?= golang:1.20.5
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/5502-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5502-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates to Go 1.20.5. See the [Go release notes](https://go.dev/doc/devel/release#go1.20) for more information.


### PR DESCRIPTION
For CVEs, see release notes: https://go.dev/doc/devel/release#go1.20