### PR TITLE
internal/k8s: Make log test flush timeout more lenient

### DIFF
--- a/internal/k8s/log_test.go
+++ b/internal/k8s/log_test.go
@@ -34,7 +34,7 @@ import (
 const (
 	// klog automatic flush interval is 5s but we can wait for less time to pass
 	// since we proactively call klog.Flush().
-	klogFlushWaitTime     = time.Millisecond * 30
+	klogFlushWaitTime     = time.Millisecond * 100
 	klogFlushWaitInterval = time.Millisecond * 1
 )
 


### PR DESCRIPTION
To try to prevent osx flakes