### PR TITLE
Enable HTTPProxy Fractional Mirroring

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -978,9 +978,11 @@ type Service struct {
 	// +optional
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
 	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
-	// If Mirror is true, then fractional mirroring is enabled by setting the Weight field. Omitting
-	// the Weight field or setting it to 0 will result in 100% mirroring. Setting it to an integer
-	// less than or equal to 100 will result in corresponding percentage of traffic being mirrored.
+	// If Mirror is true, then fractional mirroring can be enabled by optionally setting the Weight
+	// field. Legal values for Weight are 1-100. Omitting the Weight field will result in 100% mirroring.
+	// NOTE: Setting Weight explicitly to 0 will unexpectedly result in 100% traffic mirroring. This
+	// occurs since we cannot distinguish omitted fields from those explicitly set to their default
+	// values
 	Mirror bool `json:"mirror,omitempty"`
 	// The policy for managing request headers during proxying.
 	// +optional

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -978,6 +978,9 @@ type Service struct {
 	// +optional
 	UpstreamValidation *UpstreamValidation `json:"validation,omitempty"`
 	// If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+	// If Mirror is true, then fractional mirroring is enabled by setting the Weight field. Omitting
+	// the Weight field or setting it to 0 will result in 100% mirroring. Setting it to an integer
+	// less than or equal to 100 will result in corresponding percentage of traffic being mirrored.
 	Mirror bool `json:"mirror,omitempty"`
 	// The policy for managing request headers during proxying.
 	// +optional

--- a/changelogs/unreleased/5516-hshamji-small.md
+++ b/changelogs/unreleased/5516-hshamji-small.md
@@ -1,0 +1,1 @@
+Enable HTTPProxy Fractional Mirroring

--- a/changelogs/unreleased/5516-hshamji-small.md
+++ b/changelogs/unreleased/5516-hshamji-small.md
@@ -1,1 +1,1 @@
-Enable HTTPProxy Fractional Mirroring
+HTTPProxy: support fractional mirroring to a service by specifying `mirror: true` and a `weight` of 1-100. See the [traffic mirroring docs](https://projectcontour.io/docs/1.26/config/request-routing/#traffic-mirroring) for more information.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5637,13 +5637,15 @@ spec:
                             minimum: 1
                             type: integer
                           mirror:
-                            description: If Mirror is true the Service will receive
+                            description: 'If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route. If
-                              Mirror is true, then fractional mirroring is enabled
-                              by setting the Weight field. Omitting the Weight field
-                              or setting it to 0 will result in 100% mirroring. Setting
-                              it to an integer less than or equal to 100 will result
-                              in corresponding percentage of traffic being mirrored.
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6029,13 +6031,15 @@ spec:
                           minimum: 1
                           type: integer
                         mirror:
-                          description: If Mirror is true the Service will receive
+                          description: 'If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route. If Mirror
-                            is true, then fractional mirroring is enabled by setting
-                            the Weight field. Omitting the Weight field or setting
-                            it to 0 will result in 100% mirroring. Setting it to an
-                            integer less than or equal to 100 will result in corresponding
-                            percentage of traffic being mirrored.
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -5638,7 +5638,12 @@ spec:
                             type: integer
                           mirror:
                             description: If Mirror is true the Service will receive
-                              a read only mirror of the traffic for this route.
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring is enabled
+                              by setting the Weight field. Omitting the Weight field
+                              or setting it to 0 will result in 100% mirroring. Setting
+                              it to an integer less than or equal to 100 will result
+                              in corresponding percentage of traffic being mirrored.
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6025,7 +6030,12 @@ spec:
                           type: integer
                         mirror:
                           description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring is enabled by setting
+                            the Weight field. Omitting the Weight field or setting
+                            it to 0 will result in 100% mirroring. Setting it to an
+                            integer less than or equal to 100 will result in corresponding
+                            percentage of traffic being mirrored.
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5850,13 +5850,15 @@ spec:
                             minimum: 1
                             type: integer
                           mirror:
-                            description: If Mirror is true the Service will receive
+                            description: 'If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route. If
-                              Mirror is true, then fractional mirroring is enabled
-                              by setting the Weight field. Omitting the Weight field
-                              or setting it to 0 will result in 100% mirroring. Setting
-                              it to an integer less than or equal to 100 will result
-                              in corresponding percentage of traffic being mirrored.
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6242,13 +6244,15 @@ spec:
                           minimum: 1
                           type: integer
                         mirror:
-                          description: If Mirror is true the Service will receive
+                          description: 'If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route. If Mirror
-                            is true, then fractional mirroring is enabled by setting
-                            the Weight field. Omitting the Weight field or setting
-                            it to 0 will result in 100% mirroring. Setting it to an
-                            integer less than or equal to 100 will result in corresponding
-                            percentage of traffic being mirrored.
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5851,7 +5851,12 @@ spec:
                             type: integer
                           mirror:
                             description: If Mirror is true the Service will receive
-                              a read only mirror of the traffic for this route.
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring is enabled
+                              by setting the Weight field. Omitting the Weight field
+                              or setting it to 0 will result in 100% mirroring. Setting
+                              it to an integer less than or equal to 100 will result
+                              in corresponding percentage of traffic being mirrored.
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6238,7 +6243,12 @@ spec:
                           type: integer
                         mirror:
                           description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring is enabled by setting
+                            the Weight field. Omitting the Weight field or setting
+                            it to 0 will result in 100% mirroring. Setting it to an
+                            integer less than or equal to 100 will result in corresponding
+                            percentage of traffic being mirrored.
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -5652,7 +5652,12 @@ spec:
                             type: integer
                           mirror:
                             description: If Mirror is true the Service will receive
-                              a read only mirror of the traffic for this route.
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring is enabled
+                              by setting the Weight field. Omitting the Weight field
+                              or setting it to 0 will result in 100% mirroring. Setting
+                              it to an integer less than or equal to 100 will result
+                              in corresponding percentage of traffic being mirrored.
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6039,7 +6044,12 @@ spec:
                           type: integer
                         mirror:
                           description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring is enabled by setting
+                            the Weight field. Omitting the Weight field or setting
+                            it to 0 will result in 100% mirroring. Setting it to an
+                            integer less than or equal to 100 will result in corresponding
+                            percentage of traffic being mirrored.
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -5651,13 +5651,15 @@ spec:
                             minimum: 1
                             type: integer
                           mirror:
-                            description: If Mirror is true the Service will receive
+                            description: 'If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route. If
-                              Mirror is true, then fractional mirroring is enabled
-                              by setting the Weight field. Omitting the Weight field
-                              or setting it to 0 will result in 100% mirroring. Setting
-                              it to an integer less than or equal to 100 will result
-                              in corresponding percentage of traffic being mirrored.
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6043,13 +6045,15 @@ spec:
                           minimum: 1
                           type: integer
                         mirror:
-                          description: If Mirror is true the Service will receive
+                          description: 'If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route. If Mirror
-                            is true, then fractional mirroring is enabled by setting
-                            the Weight field. Omitting the Weight field or setting
-                            it to 0 will result in 100% mirroring. Setting it to an
-                            integer less than or equal to 100 will result in corresponding
-                            percentage of traffic being mirrored.
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5856,13 +5856,15 @@ spec:
                             minimum: 1
                             type: integer
                           mirror:
-                            description: If Mirror is true the Service will receive
+                            description: 'If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route. If
-                              Mirror is true, then fractional mirroring is enabled
-                              by setting the Weight field. Omitting the Weight field
-                              or setting it to 0 will result in 100% mirroring. Setting
-                              it to an integer less than or equal to 100 will result
-                              in corresponding percentage of traffic being mirrored.
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6248,13 +6250,15 @@ spec:
                           minimum: 1
                           type: integer
                         mirror:
-                          description: If Mirror is true the Service will receive
+                          description: 'If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route. If Mirror
-                            is true, then fractional mirroring is enabled by setting
-                            the Weight field. Omitting the Weight field or setting
-                            it to 0 will result in 100% mirroring. Setting it to an
-                            integer less than or equal to 100 will result in corresponding
-                            percentage of traffic being mirrored.
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5857,7 +5857,12 @@ spec:
                             type: integer
                           mirror:
                             description: If Mirror is true the Service will receive
-                              a read only mirror of the traffic for this route.
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring is enabled
+                              by setting the Weight field. Omitting the Weight field
+                              or setting it to 0 will result in 100% mirroring. Setting
+                              it to an integer less than or equal to 100 will result
+                              in corresponding percentage of traffic being mirrored.
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6244,7 +6249,12 @@ spec:
                           type: integer
                         mirror:
                           description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring is enabled by setting
+                            the Weight field. Omitting the Weight field or setting
+                            it to 0 will result in 100% mirroring. Setting it to an
+                            integer less than or equal to 100 will result in corresponding
+                            percentage of traffic being mirrored.
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5850,13 +5850,15 @@ spec:
                             minimum: 1
                             type: integer
                           mirror:
-                            description: If Mirror is true the Service will receive
+                            description: 'If Mirror is true the Service will receive
                               a read only mirror of the traffic for this route. If
-                              Mirror is true, then fractional mirroring is enabled
-                              by setting the Weight field. Omitting the Weight field
-                              or setting it to 0 will result in 100% mirroring. Setting
-                              it to an integer less than or equal to 100 will result
-                              in corresponding percentage of traffic being mirrored.
+                              Mirror is true, then fractional mirroring can be enabled
+                              by optionally setting the Weight field. Legal values
+                              for Weight are 1-100. Omitting the Weight field will
+                              result in 100% mirroring. NOTE: Setting Weight explicitly
+                              to 0 will unexpectedly result in 100% traffic mirroring.
+                              This occurs since we cannot distinguish omitted fields
+                              from those explicitly set to their default values'
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6242,13 +6244,15 @@ spec:
                           minimum: 1
                           type: integer
                         mirror:
-                          description: If Mirror is true the Service will receive
+                          description: 'If Mirror is true the Service will receive
                             a read only mirror of the traffic for this route. If Mirror
-                            is true, then fractional mirroring is enabled by setting
-                            the Weight field. Omitting the Weight field or setting
-                            it to 0 will result in 100% mirroring. Setting it to an
-                            integer less than or equal to 100 will result in corresponding
-                            percentage of traffic being mirrored.
+                            is true, then fractional mirroring can be enabled by optionally
+                            setting the Weight field. Legal values for Weight are
+                            1-100. Omitting the Weight field will result in 100% mirroring.
+                            NOTE: Setting Weight explicitly to 0 will unexpectedly
+                            result in 100% traffic mirroring. This occurs since we
+                            cannot distinguish omitted fields from those explicitly
+                            set to their default values'
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5851,7 +5851,12 @@ spec:
                             type: integer
                           mirror:
                             description: If Mirror is true the Service will receive
-                              a read only mirror of the traffic for this route.
+                              a read only mirror of the traffic for this route. If
+                              Mirror is true, then fractional mirroring is enabled
+                              by setting the Weight field. Omitting the Weight field
+                              or setting it to 0 will result in 100% mirroring. Setting
+                              it to an integer less than or equal to 100 will result
+                              in corresponding percentage of traffic being mirrored.
                             type: boolean
                           name:
                             description: Name is the name of Kubernetes service to
@@ -6238,7 +6243,12 @@ spec:
                           type: integer
                         mirror:
                           description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
+                            a read only mirror of the traffic for this route. If Mirror
+                            is true, then fractional mirroring is enabled by setting
+                            the Weight field. Omitting the Weight field or setting
+                            it to 0 will result in 100% mirroring. Setting it to an
+                            integer less than or equal to 100 will result in corresponding
+                            percentage of traffic being mirrored.
                           type: boolean
                         name:
                           description: Name is the name of Kubernetes service to proxy

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3842,7 +3842,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Name: "http-80",
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
-						withMirror(prefixrouteHTTPRoute("/", service(kuardService)), service(kuardService2)))),
+						withMirror(prefixrouteHTTPRoute("/", service(kuardService)), service(kuardService2), 100))),
 				},
 			),
 		},
@@ -3884,8 +3884,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Name: "http-80",
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
-						withMirror(prefixrouteHTTPRoute("/", service(kuardService)), service(kuardService2)),
-						withMirror(segmentPrefixHTTPRoute("/another-match", service(kuardService)), service(kuardService2)),
+						withMirror(prefixrouteHTTPRoute("/", service(kuardService)), service(kuardService2), 100),
+						withMirror(segmentPrefixHTTPRoute("/another-match", service(kuardService)), service(kuardService2), 100),
 					)),
 				},
 			),
@@ -5704,7 +5704,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				&Listener{
 					Name: "http-80",
 					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
-						withMirror(exactrouteGRPCRoute("/io.projectcontour/Login", grpcService(kuardService, "h2c")), grpcService(kuardService2, "h2c")))),
+						withMirror(exactrouteGRPCRoute("/io.projectcontour/Login", grpcService(kuardService, "h2c")), grpcService(kuardService2, "h2c"), 100))),
 				},
 			),
 		},
@@ -11171,7 +11171,7 @@ func TestDAGInsert(t *testing.T) {
 					Port: 8080,
 					VirtualHosts: virtualhosts(
 						virtualhost("example.com",
-							withMirror(prefixroute("/", service(s1)), service(s2)),
+							withMirror(prefixroute("/", service(s1)), service(s2), 100),
 						),
 					),
 				},
@@ -16223,11 +16223,12 @@ func prefixSegment(prefix string) MatchCondition {
 func exact(path string) MatchCondition  { return &ExactMatchCondition{Path: path} }
 func regex(regex string) MatchCondition { return &RegexMatchCondition{Regex: regex} }
 
-func withMirror(r *Route, mirror *Service) *Route {
+func withMirror(r *Route, mirror *Service, weight int64) *Route {
 	r.MirrorPolicy = &MirrorPolicy{
 		Cluster: &Cluster{
 			Upstream: mirror,
 		},
+		Weight: weight,
 	}
 	return r
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -438,6 +438,7 @@ type PathRewritePolicy struct {
 // MirrorPolicy defines the mirroring policy for a route.
 type MirrorPolicy struct {
 	Cluster *Cluster
+	Weight  int64
 }
 
 // HeadersPolicy defines how headers are managed during forwarding

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1217,6 +1217,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 					Cluster: &Cluster{
 						Upstream: mirrorService,
 					},
+					Weight: 100,
 				}
 			case gatewayapi_v1beta1.HTTPRouteFilterURLRewrite:
 				if filter.URLRewrite == nil || pathRewritePolicy != nil {
@@ -1408,6 +1409,7 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 					Cluster: &Cluster{
 						Upstream: mirrorService,
 					},
+					Weight: 100,
 				}
 			default:
 				routeAccessor.AddCondition(

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -993,8 +993,9 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				return nil
 			}
 			if service.Mirror {
-				// Default value if weight is omitted is 0. Setting this to 100 to retain backward-compat behavior.
-				// Edge case is a user intentionally/explicitly setting the Weight to 0 (ie. disabling the mirror).
+				// The default value if Weight is omitted is 0. To retain backwards compatibility omitted weights
+				// will be treated as 100% mirroring. This means that explicit 0 weights will also result in 100%
+				// mirroring. The Mirror field must be set to false or removed to disable the mirror.
 				if service.Weight == 0 {
 					r.MirrorPolicy = &MirrorPolicy{
 						Cluster: c,

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -993,8 +993,18 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				return nil
 			}
 			if service.Mirror {
-				r.MirrorPolicy = &MirrorPolicy{
-					Cluster: c,
+				// Default value if weight is omitted is 0. Setting this to 100 to retain backward-compat behavior.
+				// Edge case is a user intentionally/explicitly setting the Weight to 0 (ie. disabling the mirror).
+				if service.Weight == 0 {
+					r.MirrorPolicy = &MirrorPolicy{
+						Cluster: c,
+						Weight:  100,
+					}
+				} else {
+					r.MirrorPolicy = &MirrorPolicy{
+						Cluster: c,
+						Weight:  service.Weight,
+					}
 				}
 			} else {
 				r.Clusters = append(r.Clusters, c)

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -993,8 +993,9 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				return nil
 			}
 			if service.Mirror {
-				// The default value if Weight is omitted is 0. To retain backwards compatibility omitted weights
-				// will be treated as 100% mirroring. This means that explicit 0 weights will also result in 100%
+				// Legal Weight values are 1-100. The default value of a float64 if Weight is omitted
+				// is 0. To retain backwards compatibility omitted weights will be treated as 100% mirroring.
+				// EDGE CASE: This means that explicitly setting Weight to 0 will also result in 100%
 				// mirroring. The Mirror field must be set to false or removed to disable the mirror.
 				if service.Weight == 0 {
 					r.MirrorPolicy = &MirrorPolicy{

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"text/template"
 
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_rbac_v3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -483,6 +485,12 @@ func mirrorPolicy(r *dag.Route) []*envoy_route_v3.RouteAction_RequestMirrorPolic
 
 	return []*envoy_route_v3.RouteAction_RequestMirrorPolicy{{
 		Cluster: envoy.Clustername(r.MirrorPolicy.Cluster),
+		RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   uint32(r.MirrorPolicy.Weight),
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+		},
 	}}
 }
 

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_rbac_v3 "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -699,6 +701,7 @@ func TestRouteRoute(t *testing.T) {
 							},
 						},
 					},
+					Weight: 100,
 				},
 			},
 			want: &envoy_route_v3.Route_Route{
@@ -708,7 +711,12 @@ func TestRouteRoute(t *testing.T) {
 					},
 					RequestMirrorPolicies: []*envoy_route_v3.RouteAction_RequestMirrorPolicy{{
 						Cluster: "default/kuard/8080/da39a3ee5e",
-					}},
+						RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+							DefaultValue: &envoy_type_v3.FractionalPercent{
+								Numerator:   100,
+								Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+							},
+						}}},
 				},
 			},
 		},

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -19,6 +19,8 @@ import (
 	"path"
 	"time"
 
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -273,10 +275,15 @@ func withIdleTimeout(route *envoy_route_v3.Route_Route, timeout time.Duration) *
 	return route
 }
 
-func withMirrorPolicy(route *envoy_route_v3.Route_Route, mirror string) *envoy_route_v3.Route_Route {
+func withMirrorPolicy(route *envoy_route_v3.Route_Route, mirror string, weight int64) *envoy_route_v3.Route_Route {
 	route.Route.RequestMirrorPolicies = []*envoy_route_v3.RouteAction_RequestMirrorPolicy{{
 		Cluster: mirror,
-	}}
+		RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   uint32(weight),
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+		}}}
 	return route
 }
 

--- a/internal/featuretests/v3/mirrorpolicy_test.go
+++ b/internal/featuretests/v3/mirrorpolicy_test.go
@@ -66,7 +66,7 @@ func TestMirrorPolicy(t *testing.T) {
 				envoy_v3.VirtualHost(p1.Spec.VirtualHost.Fqdn,
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
-						Action: withMirrorPolicy(routeCluster("default/kuard/8080/da39a3ee5e"), "default/mirror/8080/da39a3ee5e"),
+						Action: withMirrorPolicy(routeCluster("default/kuard/8080/da39a3ee5e"), "default/mirror/8080/da39a3ee5e", 100),
 					},
 				),
 			),
@@ -82,5 +82,54 @@ func TestMirrorPolicy(t *testing.T) {
 			cluster("default/mirror/8080/da39a3ee5e", "default/mirror", "default_mirror_8080"),
 		),
 		TypeUrl: clusterType,
+	})
+}
+
+func TestFractionalMirrorPolicy(t *testing.T) {
+	rh, c, done := setup(t, func(reh *contour.EventHandler) {})
+	defer done()
+
+	svc1 := fixture.NewService("kuard").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
+	svc2 := fixture.NewService("mirror").
+		WithPorts(v1.ServicePort{Port: 8080, TargetPort: intstr.FromInt(8080)})
+	rh.OnAdd(svc1)
+	rh.OnAdd(svc2)
+
+	p1 := &contour_api_v1.HTTPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple",
+			Namespace: svc1.Namespace,
+		},
+		Spec: contour_api_v1.HTTPProxySpec{
+			VirtualHost: &contour_api_v1.VirtualHost{Fqdn: "example.com"},
+			Routes: []contour_api_v1.Route{{
+				Conditions: matchconditions(prefixMatchCondition("/")),
+				Services: []contour_api_v1.Service{{
+					Name: svc1.Name,
+					Port: 8080,
+				}, {
+					Name:   svc2.Name,
+					Port:   8080,
+					Mirror: true,
+					Weight: 15,
+				}},
+			}},
+		},
+	}
+	rh.OnAdd(p1)
+
+	c.Request(routeType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			envoy_v3.RouteConfiguration("ingress_http",
+				envoy_v3.VirtualHost(p1.Spec.VirtualHost.Fqdn,
+					&envoy_route_v3.Route{
+						Match:  routePrefix("/"),
+						Action: withMirrorPolicy(routeCluster("default/kuard/8080/da39a3ee5e"), "default/mirror/8080/da39a3ee5e", 15),
+					},
+				),
+			),
+		),
+		TypeUrl: routeType,
 	})
 }

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
@@ -4085,6 +4087,12 @@ func routeConfigurations(rcs ...*envoy_route_v3.RouteConfiguration) map[string]*
 func withMirrorPolicy(route *envoy_route_v3.Route_Route, mirror string) *envoy_route_v3.Route_Route {
 	route.Route.RequestMirrorPolicies = []*envoy_route_v3.RouteAction_RequestMirrorPolicy{{
 		Cluster: mirror,
+		RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+			DefaultValue: &envoy_type_v3.FractionalPercent{
+				Numerator:   100,
+				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+			},
+		},
 	}}
 	return route
 }

--- a/site/content/docs/1.20/config/request-routing.md
+++ b/site/content/docs/1.20/config/request-routing.md
@@ -192,6 +192,7 @@ The mirror traffic is considered _read only_, any response by the mirror will be
 
 This service can be useful for recording traffic for later replay or for smoke testing new deployments.
 
+Without specifying an integer `weight` for the service, 100% of traffic will be mirrored. A non-zero integer weight <=100 directs the corresponding percentage of traffic to the mirror service. 
 ```yaml
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy

--- a/site/content/docs/1.20/config/request-routing.md
+++ b/site/content/docs/1.20/config/request-routing.md
@@ -192,7 +192,6 @@ The mirror traffic is considered _read only_, any response by the mirror will be
 
 This service can be useful for recording traffic for later replay or for smoke testing new deployments.
 
-Without specifying an integer `weight` for the service, 100% of traffic will be mirrored. A non-zero integer weight <=100 directs the corresponding percentage of traffic to the mirror service. 
 ```yaml
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3846,7 +3846,10 @@ bool
 </em>
 </td>
 <td>
-<p>If Mirror is true the Service will receive a read only mirror of the traffic for this route.</p>
+<p>If Mirror is true the Service will receive a read only mirror of the traffic for this route.
+If Mirror is true, then fractional mirroring is enabled by setting the Weight field. Omitting
+the Weight field or setting it to 0 will result in 100% mirroring. Setting it to an integer
+less than or equal to 100 will result in corresponding percentage of traffic being mirrored.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3847,9 +3847,11 @@ bool
 </td>
 <td>
 <p>If Mirror is true the Service will receive a read only mirror of the traffic for this route.
-If Mirror is true, then fractional mirroring is enabled by setting the Weight field. Omitting
-the Weight field or setting it to 0 will result in 100% mirroring. Setting it to an integer
-less than or equal to 100 will result in corresponding percentage of traffic being mirrored.</p>
+If Mirror is true, then fractional mirroring can be enabled by optionally setting the Weight
+field. Legal values for Weight are 1-100. Omitting the Weight field will result in 100% mirroring.
+NOTE: Setting Weight explicitly to 0 will unexpectedly result in 100% traffic mirroring. This
+occurs since we cannot distinguish omitted fields from those explicitly set to their default
+values</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -257,6 +257,7 @@ The mirror traffic is considered _read only_, any response by the mirror will be
 
 This service can be useful for recording traffic for later replay or for smoke testing new deployments.
 
+Without specifying an integer `weight` for the service, 100% of traffic will be mirrored. A non-zero integer weight <=100 directs the corresponding percentage of traffic to the mirror service.
 ```yaml
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -257,7 +257,7 @@ The mirror traffic is considered _read only_, any response by the mirror will be
 
 This service can be useful for recording traffic for later replay or for smoke testing new deployments.
 
-Without specifying an integer `weight` for the service, 100% of traffic will be mirrored. A non-zero integer weight <=100 directs the corresponding percentage of traffic to the mirror service.
+`weight` can be optionally set (in the space of integers 1-100) to mirror the corresponding percent of traffic (ie. `weight: 5` mirrors 5% of traffic). Omitting the `weight` field results in 100% traffic mirroring. There is unexpected behavior if `weight` is explicitly set to 0, 100% traffic will be mirrored. This occurs because we cannot distinguish undefined variables from explicitly setting them to default values, and omission of a `weight` must mirror full traffic.
 ```yaml
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy


### PR DESCRIPTION
Fixes #1889
Fixes #5495

internal/dag: & internal/envoy/v3:
- Updated internal MirrorPolicy struct to with a `weight` field;
- The `weight` attribute on an HTTPProxy mirrored service is overloaded to also mean an integer percent of traffic to be sent to the mirrored service;
- The GatewayAPI does not describe fractional mirroring so mirroring is kept at 100%;
- Added test confirming that HTTProxy mirror `weight` is correctly propagated to Envoy config;
- Updated docs;

Signed-off-by: Hassan Shamji [hshamji@etsy.com](mailto:hshamji@etsy.com)