### PR TITLE
Refactor internal/envoy/v3 package helper functions

### DIFF
--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -104,7 +104,8 @@ func main() {
 		if err := envoy.ValidAdminAddress(bootstrapCtx.AdminAddress); err != nil {
 			log.WithField("flag", "--admin-address").WithError(err).Fatal("failed to parse bootstrap args")
 		}
-		if err := envoy_v3.WriteBootstrap(bootstrapCtx); err != nil {
+		cg := envoy_v3.NewConfigGenerator()
+		if err := cg.WriteBootstrap(bootstrapCtx); err != nil {
 			log.WithError(err).Fatal("failed to write bootstrap configuration")
 		}
 	case certgenApp.FullCommand():

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -441,11 +441,12 @@ func (s *Server) doServe() error {
 	// due to their high update rate and their orthogonal nature.
 	endpointHandler := xdscache_v3.NewEndpointsTranslator(s.log.WithField("context", "endpointstranslator"))
 
+	configGen := envoy_v3.NewConfigGenerator()
 	resources := []xdscache.ResourceCache{
-		xdscache_v3.NewListenerCache(listenerConfig, *contourConfiguration.Envoy.Metrics, *contourConfiguration.Envoy.Health, *contourConfiguration.Envoy.Network.EnvoyAdminPort),
+		xdscache_v3.NewListenerCache(listenerConfig, *contourConfiguration.Envoy.Metrics, *contourConfiguration.Envoy.Health, *contourConfiguration.Envoy.Network.EnvoyAdminPort, configGen),
 		xdscache_v3.NewSecretsCache(envoy_v3.StatsSecrets(contourConfiguration.Envoy.Metrics.TLS)),
 		&xdscache_v3.RouteCache{},
-		&xdscache_v3.ClusterCache{},
+		xdscache_v3.NewClusterCache(configGen),
 		endpointHandler,
 		&xdscache_v3.RuntimeCache{},
 	}

--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -25,13 +25,12 @@ import (
 // UpstreamTLSContext creates an envoy_v3_tls.UpstreamTlsContext. By default
 // UpstreamTLSContext returns a HTTP/1.1 TLS enabled context. A list of
 // additional ALPN protocols can be provided.
-func UpstreamTLSContext(peerValidationContext *dag.PeerValidationContext, sni string, clientSecret *dag.Secret, alpnProtocols ...string) *envoy_v3_tls.UpstreamTlsContext {
+func (g *ConfigGenerator) UpstreamTLSContext(peerValidationContext *dag.PeerValidationContext, sni string, clientSecret *dag.Secret, alpnProtocols ...string) *envoy_v3_tls.UpstreamTlsContext {
 	var clientSecretConfigs []*envoy_v3_tls.SdsSecretConfig
 	if clientSecret != nil {
-		clientSecretConfigs = []*envoy_v3_tls.SdsSecretConfig{{
-			Name:      envoy.Secretname(clientSecret),
-			SdsConfig: ConfigSource("contour"),
-		}}
+		clientSecretConfigs = []*envoy_v3_tls.SdsSecretConfig{
+			g.sdsSecretConfig(envoy.Secretname(clientSecret)),
+		}
 	}
 
 	context := &envoy_v3_tls.UpstreamTlsContext{
@@ -105,7 +104,7 @@ func validationContext(ca []byte, subjectName string, skipVerifyPeerCert bool, c
 }
 
 // DownstreamTLSContext creates a new DownstreamTlsContext.
-func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_tls.TlsParameters_TlsProtocol, cipherSuites []string, peerValidationContext *dag.PeerValidationContext, alpnProtos ...string) *envoy_v3_tls.DownstreamTlsContext {
+func (g *ConfigGenerator) DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_tls.TlsParameters_TlsProtocol, cipherSuites []string, peerValidationContext *dag.PeerValidationContext, alpnProtos ...string) *envoy_v3_tls.DownstreamTlsContext {
 	context := &envoy_v3_tls.DownstreamTlsContext{
 		CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 			TlsParams: &envoy_v3_tls.TlsParameters{
@@ -113,10 +112,9 @@ func DownstreamTLSContext(serverSecret *dag.Secret, tlsMinProtoVersion envoy_v3_
 				TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
 				CipherSuites:              cipherSuites,
 			},
-			TlsCertificateSdsSecretConfigs: []*envoy_v3_tls.SdsSecretConfig{{
-				Name:      envoy.Secretname(serverSecret),
-				SdsConfig: ConfigSource("contour"),
-			}},
+			TlsCertificateSdsSecretConfigs: []*envoy_v3_tls.SdsSecretConfig{
+				g.sdsSecretConfig(envoy.Secretname(serverSecret)),
+			},
 			AlpnProtocols: alpnProtos,
 		},
 	}

--- a/internal/envoy/v3/auth_test.go
+++ b/internal/envoy/v3/auth_test.go
@@ -112,7 +112,8 @@ func TestUpstreamTLSContext(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := UpstreamTLSContext(tc.validation, tc.externalName, nil, tc.alpnProtocols...)
+			cg := NewConfigGenerator()
+			got := cg.UpstreamTLSContext(tc.validation, tc.externalName, nil, tc.alpnProtocols...)
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -2056,7 +2056,8 @@ func TestBootstrap(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			steps, gotError := bootstrap(&tc.config)
+			cg := NewConfigGenerator()
+			steps, gotError := cg.bootstrap(&tc.config)
 			assert.Equal(t, gotError != nil, tc.wantedError)
 
 			gotConfigs := map[string]proto.Message{}

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -264,22 +264,6 @@ func clusterCommonLBConfig() *envoy_cluster_v3.Cluster_CommonLbConfig {
 	}
 }
 
-// ConfigSource returns a *envoy_core_v3.ConfigSource for cluster.
-func (g *ConfigGenerator) ConfigSource() *envoy_core_v3.ConfigSource {
-	return &envoy_core_v3.ConfigSource{
-		ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
-		ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
-			ApiConfigSource: &envoy_core_v3.ApiConfigSource{
-				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
-				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
-				GrpcServices: []*envoy_core_v3.GrpcService{
-					grpcService(g.xdsServerClusterName, "", timeout.DefaultSetting()),
-				},
-			},
-		},
-	}
-}
-
 // ClusterDiscoveryType returns the type of a ClusterDiscovery as a Cluster_type.
 func ClusterDiscoveryType(t envoy_cluster_v3.Cluster_DiscoveryType) *envoy_cluster_v3.Cluster_Type {
 	return &envoy_cluster_v3.Cluster_Type{Type: t}

--- a/internal/envoy/v3/cluster.go
+++ b/internal/envoy/v3/cluster.go
@@ -60,7 +60,7 @@ func (g *ConfigGenerator) Cluster(c *dag.Cluster) *envoy_cluster_v3.Cluster {
 	case 0:
 		// external name not set, cluster will be discovered via EDS
 		cluster.ClusterDiscoveryType = ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS)
-		cluster.EdsClusterConfig = g.edsconfig("contour", service)
+		cluster.EdsClusterConfig = g.edsconfig(service)
 	default:
 		// external name set, use hard coded DNS name
 		// external name set to LOGICAL_DNS when user selects the ALL loookup family
@@ -216,7 +216,7 @@ func (g *ConfigGenerator) DNSNameCluster(c *dag.DNSNameCluster) *envoy_cluster_v
 	return cluster
 }
 
-func (g *ConfigGenerator) edsconfig(cluster string, service *dag.Service) *envoy_cluster_v3.Cluster_EdsClusterConfig {
+func (g *ConfigGenerator) edsconfig(service *dag.Service) *envoy_cluster_v3.Cluster_EdsClusterConfig {
 	return &envoy_cluster_v3.Cluster_EdsClusterConfig{
 		EdsConfig: g.ConfigSource(),
 		ServiceName: xds.ClusterLoadAssignmentName(

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestCluster(t *testing.T) {
+	cg := NewConfigGenerator()
+
 	s1 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kuard",
@@ -126,7 +128,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 			},
@@ -141,7 +143,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TypedExtensionProtocolOptions: map[string]*anypb.Any{
@@ -166,11 +168,11 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TransportSocket: UpstreamTLSTransportSocket(
-					UpstreamTLSContext(nil, "", nil, "h2"),
+					cg.UpstreamTLSContext(nil, "", nil, "h2"),
 				),
 				TypedExtensionProtocolOptions: map[string]*anypb.Any{
 					"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protobuf.MustMarshalAny(
@@ -270,11 +272,11 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TransportSocket: UpstreamTLSTransportSocket(
-					UpstreamTLSContext(nil, "", nil),
+					cg.UpstreamTLSContext(nil, "", nil),
 				),
 			},
 		},
@@ -290,7 +292,7 @@ func TestCluster(t *testing.T) {
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				LoadAssignment:       ExternalNameClusterLoadAssignment(service(svcExternal, "tls")),
 				TransportSocket: UpstreamTLSTransportSocket(
-					UpstreamTLSContext(nil, "projectcontour.local", nil),
+					cg.UpstreamTLSContext(nil, "projectcontour.local", nil),
 				),
 			},
 		},
@@ -308,11 +310,11 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TransportSocket: UpstreamTLSTransportSocket(
-					UpstreamTLSContext(
+					cg.UpstreamTLSContext(
 						&dag.PeerValidationContext{
 							CACertificate: secret,
 							SubjectName:   "foo.bar.io",
@@ -340,7 +342,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -368,7 +370,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -396,7 +398,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -424,7 +426,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -444,7 +446,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RANDOM,
@@ -460,7 +462,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -476,7 +478,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 			},
@@ -496,7 +498,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				IgnoreHealthOnHostRemoval: true,
@@ -522,11 +524,11 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TransportSocket: UpstreamTLSTransportSocket(
-					UpstreamTLSContext(nil, "", clientSecret),
+					cg.UpstreamTLSContext(nil, "", clientSecret),
 				),
 			},
 		},
@@ -540,7 +542,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				ConnectTimeout: durationpb.New(10 * time.Second),
@@ -556,7 +558,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TypedExtensionProtocolOptions: map[string]*anypb.Any{
@@ -589,7 +591,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				LbConfig: &envoy_cluster_v3.Cluster_RoundRobinLbConfig_{
@@ -623,7 +625,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_LEAST_REQUEST,
@@ -653,7 +655,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				PerConnectionBufferLimitBytes: wrapperspb.UInt32(32768),
@@ -669,7 +671,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TypedExtensionProtocolOptions: map[string]*anypb.Any{
@@ -701,7 +703,7 @@ func TestCluster(t *testing.T) {
 				AltStatName:          "default_kuard_443",
 				ClusterDiscoveryType: ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   ConfigSource("contour"),
+					EdsConfig:   defaultConfigSource,
 					ServiceName: "default/kuard/http",
 				},
 				TypedExtensionProtocolOptions: map[string]*anypb.Any{
@@ -725,7 +727,8 @@ func TestCluster(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := Cluster(tc.cluster)
+			cg := NewConfigGenerator()
+			got := cg.Cluster(tc.cluster)
 			want := clusterDefaults()
 
 			proto.Merge(want, tc.want)
@@ -736,6 +739,7 @@ func TestCluster(t *testing.T) {
 }
 
 func TestDNSNameCluster(t *testing.T) {
+	cg := NewConfigGenerator()
 	tests := map[string]struct {
 		cluster *dag.DNSNameCluster
 		want    *envoy_cluster_v3.Cluster
@@ -854,7 +858,7 @@ func TestDNSNameCluster(t *testing.T) {
 						},
 					},
 				},
-				TransportSocket: UpstreamTLSTransportSocket(UpstreamTLSContext(nil, "foo.projectcontour.io", nil)),
+				TransportSocket: UpstreamTLSTransportSocket(cg.UpstreamTLSContext(nil, "foo.projectcontour.io", nil)),
 			},
 		},
 		"HTTPS cluster with upstream validation": {
@@ -894,7 +898,7 @@ func TestDNSNameCluster(t *testing.T) {
 						},
 					},
 				},
-				TransportSocket: UpstreamTLSTransportSocket(UpstreamTLSContext(&dag.PeerValidationContext{
+				TransportSocket: UpstreamTLSTransportSocket(cg.UpstreamTLSContext(&dag.PeerValidationContext{
 					CACertificate: &dag.Secret{
 						Object: &v1.Secret{
 							Data: map[string][]byte{
@@ -910,7 +914,8 @@ func TestDNSNameCluster(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := DNSNameCluster(tc.cluster)
+			cg := NewConfigGenerator()
+			got := cg.DNSNameCluster(tc.cluster)
 			want := clusterDefaults()
 
 			proto.Merge(want, tc.want)
@@ -1081,7 +1086,7 @@ func TestLBPolicy(t *testing.T) {
 }
 
 func TestClusterCommonLBConfig(t *testing.T) {
-	got := ClusterCommonLBConfig()
+	got := clusterCommonLBConfig()
 	want := &envoy_cluster_v3.Cluster_CommonLbConfig{
 		HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
 			Value: 0,

--- a/internal/envoy/v3/config_generator.go
+++ b/internal/envoy/v3/config_generator.go
@@ -1,0 +1,32 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+const defaultXDSServerClusterName = "contour"
+
+// ConfigGenerator holds common configuration that can be applied across
+// various Envoy xDS resource types to reduce duplication. It should
+// typically be instantiated once and shared between various consumers
+// that need to generate Envoy config.
+type ConfigGenerator struct {
+	// Name of xDS server Cluster. Referenced in ConfigSources across
+	// various resources.
+	xdsServerClusterName string
+}
+
+func NewConfigGenerator() *ConfigGenerator {
+	return &ConfigGenerator{
+		xdsServerClusterName: defaultXDSServerClusterName,
+	}
+}

--- a/internal/envoy/v3/config_generator.go
+++ b/internal/envoy/v3/config_generator.go
@@ -13,6 +13,11 @@
 
 package v3
 
+import (
+	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/projectcontour/contour/internal/timeout"
+)
+
 const defaultXDSServerClusterName = "contour"
 
 // ConfigGenerator holds common configuration that can be applied across
@@ -28,5 +33,21 @@ type ConfigGenerator struct {
 func NewConfigGenerator() *ConfigGenerator {
 	return &ConfigGenerator{
 		xdsServerClusterName: defaultXDSServerClusterName,
+	}
+}
+
+// ConfigSource returns a *envoy_core_v3.ConfigSource for cluster.
+func (g *ConfigGenerator) ConfigSource() *envoy_core_v3.ConfigSource {
+	return &envoy_core_v3.ConfigSource{
+		ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+		ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
+			ApiConfigSource: &envoy_core_v3.ApiConfigSource{
+				ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+				TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+				GrpcServices: []*envoy_core_v3.GrpcService{
+					grpcService(g.xdsServerClusterName, "", timeout.DefaultSetting()),
+				},
+			},
+		},
 	}
 }

--- a/internal/envoy/v3/fixture_test.go
+++ b/internal/envoy/v3/fixture_test.go
@@ -1,0 +1,49 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
+var defaultConfigSource = &envoy_core_v3.ConfigSource{
+	ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+	ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
+		ApiConfigSource: &envoy_core_v3.ApiConfigSource{
+			ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+			TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+			GrpcServices: []*envoy_core_v3.GrpcService{
+				{
+					TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+							ClusterName: "contour",
+							Authority:   "contour",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// // httpConnectionManager creates a new HTTP Connection Manager filter
+// // for the supplied route, access log, and client request timeout.
+// func httpConnectionManager(routename string, accesslogger []*accesslog_v3.AccessLog, requestTimeout time.Duration) *envoy_listener_v3.Filter {
+// 	cg := NewConfigGenerator()
+// 	return cg.HTTPConnectionManagerBuilder().
+// 		RouteConfigName(routename).
+// 		MetricsPrefix(routename).
+// 		AccessLoggers(accesslogger).
+// 		RequestTimeout(timeout.DurationSetting(requestTimeout)).
+// 		DefaultFilters().
+// 		Get()
+// }

--- a/internal/envoy/v3/ratelimit.go
+++ b/internal/envoy/v3/ratelimit.go
@@ -147,7 +147,7 @@ func GlobalRateLimitFilter(config *GlobalRateLimitConfig) *http.HttpFilter {
 				Timeout:         envoy.Timeout(config.Timeout),
 				FailureModeDeny: !config.FailOpen,
 				RateLimitService: &ratelimit_config_v3.RateLimitServiceConfig{
-					GrpcService:         GrpcService(dag.ExtensionClusterName(config.ExtensionService), config.SNI, timeout.DefaultSetting()),
+					GrpcService:         grpcService(dag.ExtensionClusterName(config.ExtensionService), config.SNI, timeout.DefaultSetting()),
 					TransportApiVersion: envoy_core_v3.ApiVersion_V3,
 				},
 				EnableXRatelimitHeaders:        enableXRateLimitHeaders(config.EnableXRateLimitHeaders),

--- a/internal/envoy/v3/secret.go
+++ b/internal/envoy/v3/secret.go
@@ -40,3 +40,10 @@ func Secret(s *dag.Secret) *envoy_tls_v3.Secret {
 		},
 	}
 }
+
+func (g *ConfigGenerator) sdsSecretConfig(secretName string) *envoy_tls_v3.SdsSecretConfig {
+	return &envoy_tls_v3.SdsSecretConfig{
+		Name:      secretName,
+		SdsConfig: g.ConfigSource(),
+	}
+}

--- a/internal/envoy/v3/socket_test.go
+++ b/internal/envoy/v3/socket_test.go
@@ -25,27 +25,16 @@ import (
 )
 
 func TestUpstreamTLSTransportSocket(t *testing.T) {
-	tests := map[string]struct {
-		ctxt *envoy_tls_v3.UpstreamTlsContext
-		want *envoy_core_v3.TransportSocket
-	}{
-		"h2": {
-			ctxt: UpstreamTLSContext(nil, "", nil, "h2"),
-			want: &envoy_core_v3.TransportSocket{
-				Name: "envoy.transport_sockets.tls",
-				ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
-					TypedConfig: protobuf.MustMarshalAny(UpstreamTLSContext(nil, "", nil, "h2")),
-				},
-			},
+	cg := NewConfigGenerator()
+	context := cg.UpstreamTLSContext(nil, "", nil, "h2")
+	want := &envoy_core_v3.TransportSocket{
+		Name: "envoy.transport_sockets.tls",
+		ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: protobuf.MustMarshalAny(context),
 		},
 	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := UpstreamTLSTransportSocket(tc.ctxt)
-			protobuf.ExpectEqual(t, tc.want, got)
-		})
-	}
+	got := UpstreamTLSTransportSocket(context)
+	protobuf.ExpectEqual(t, want, got)
 }
 
 func TestDownstreamTLSTransportSocket(t *testing.T) {
@@ -61,25 +50,14 @@ func TestDownstreamTLSTransportSocket(t *testing.T) {
 			},
 		},
 	}
-	tests := map[string]struct {
-		ctxt *envoy_tls_v3.DownstreamTlsContext
-		want *envoy_core_v3.TransportSocket
-	}{
-		"default/tls": {
-			ctxt: DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, nil, "client-subject-name", "h2", "http/1.1"),
-			want: &envoy_core_v3.TransportSocket{
-				Name: "envoy.transport_sockets.tls",
-				ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
-					TypedConfig: protobuf.MustMarshalAny(DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, nil, "client-subject-name", "h2", "http/1.1")),
-				},
-			},
+	cg := NewConfigGenerator()
+	context := cg.DownstreamTLSContext(serverSecret, envoy_tls_v3.TlsParameters_TLSv1_2, nil, nil, "client-subject-name", "h2", "http/1.1")
+	want := &envoy_core_v3.TransportSocket{
+		Name: "envoy.transport_sockets.tls",
+		ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: protobuf.MustMarshalAny(context),
 		},
 	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := DownstreamTLSTransportSocket(tc.ctxt)
-			protobuf.ExpectEqual(t, tc.want, got)
-		})
-	}
+	got := DownstreamTLSTransportSocket(context)
+	protobuf.ExpectEqual(t, want, got)
 }

--- a/internal/envoy/v3/stats_test.go
+++ b/internal/envoy/v3/stats_test.go
@@ -69,7 +69,8 @@ func TestStatsListeners(t *testing.T) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
 			t.Helper()
-			got := StatsListeners(tc.metrics, tc.health)
+			cg := NewConfigGenerator()
+			got := cg.StatsListeners(tc.metrics, tc.health)
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
 	}
@@ -158,7 +159,7 @@ func TestStatsListeners(t *testing.T) {
 							},
 							TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
 								Name:      "metrics-tls-certificate",
-								SdsConfig: ConfigSource("contour"),
+								SdsConfig: defaultConfigSource,
 							}},
 						},
 					},
@@ -247,12 +248,12 @@ func TestStatsListeners(t *testing.T) {
 							},
 							TlsCertificateSdsSecretConfigs: []*envoy_tls_v3.SdsSecretConfig{{
 								Name:      "metrics-tls-certificate",
-								SdsConfig: ConfigSource("contour"),
+								SdsConfig: defaultConfigSource,
 							}},
 							ValidationContextType: &envoy_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
 								ValidationContextSdsSecretConfig: &envoy_tls_v3.SdsSecretConfig{
 									Name:      "metrics-ca-certificate",
-									SdsConfig: ConfigSource("contour"),
+									SdsConfig: defaultConfigSource,
 								},
 							},
 						},

--- a/internal/envoy/v3/tracing.go
+++ b/internal/envoy/v3/tracing.go
@@ -49,7 +49,7 @@ func TracingConfig(tracing *EnvoyTracingConfig) *http.HttpConnectionManager_Trac
 			Name: "envoy.tracers.opentelemetry",
 			ConfigType: &envoy_config_trace_v3.Tracing_Http_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_config_trace_v3.OpenTelemetryConfig{
-					GrpcService: GrpcService(dag.ExtensionClusterName(tracing.ExtensionService), tracing.SNI, tracing.Timeout),
+					GrpcService: grpcService(dag.ExtensionClusterName(tracing.ExtensionService), tracing.SNI, tracing.Timeout),
 					ServiceName: tracing.ServiceName,
 				}),
 			},

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -201,7 +201,7 @@ func TestBackendClientAuthenticationWithExtensionService(t *testing.T) {
 	rh.OnAdd(ext)
 
 	tlsSocket := envoy_v3.UpstreamTLSTransportSocket(
-		envoy_v3.UpstreamTLSContext(
+		envoy_v3.NewConfigGenerator().UpstreamTLSContext(
 			&dag.PeerValidationContext{
 				CACertificate: &dag.Secret{Object: &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{

--- a/internal/featuretests/v3/cluster_test.go
+++ b/internal/featuretests/v3/cluster_test.go
@@ -415,7 +415,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 				AltStatName:          "default_kuard_8080",
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: "default/kuard",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -448,7 +448,7 @@ func TestClusterCircuitbreakerAnnotations(t *testing.T) {
 				AltStatName:          "default_kuard_8080",
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: "default/kuard",
 				},
 				CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -560,7 +560,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				AltStatName:          "default_kuard_80",
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: "default/kuard",
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RANDOM,
@@ -570,7 +570,7 @@ func TestClusterLoadBalancerStrategyPerRoute(t *testing.T) {
 				AltStatName:          "default_kuard_80",
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: "default/kuard",
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_LEAST_REQUEST,

--- a/internal/featuretests/v3/externalname_test.go
+++ b/internal/featuretests/v3/externalname_test.go
@@ -42,6 +42,8 @@ func TestExternalNameService(t *testing.T) {
 	rh, c, done := setup(t, enableExternalNameService(t))
 	defer done()
 
+	cg := envoy_v3.NewConfigGenerator()
+
 	s1 := fixture.NewService("kuard").
 		WithSpec(v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
@@ -219,7 +221,7 @@ func TestExternalNameService(t *testing.T) {
 				},
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(
-						envoy_v3.UpstreamTLSContext(nil, "external.address", nil, "h2"),
+						cg.UpstreamTLSContext(nil, "external.address", nil, "h2"),
 					),
 				},
 			),
@@ -271,7 +273,7 @@ func TestExternalNameService(t *testing.T) {
 				externalNameCluster("default/kuard/80/f9439c1de8", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(
-						envoy_v3.UpstreamTLSContext(nil, "external.address", nil),
+						cg.UpstreamTLSContext(nil, "external.address", nil),
 					),
 				},
 			),
@@ -312,7 +314,7 @@ func TestExternalNameService(t *testing.T) {
 				externalNameCluster("default/kuard/80/7d449598f5", "default/kuard", "default_kuard_80", "foo.io", 80),
 				&envoy_cluster_v3.Cluster{
 					TransportSocket: envoy_v3.UpstreamTLSTransportSocket(
-						envoy_v3.UpstreamTLSContext(nil, "foo.io", nil),
+						cg.UpstreamTLSContext(nil, "foo.io", nil),
 					),
 				},
 			),

--- a/internal/featuretests/v3/global_authorization_test.go
+++ b/internal/featuretests/v3/global_authorization_test.go
@@ -67,7 +67,7 @@ func globalExternalAuthorizationFilterExists(t *testing.T, rh ResourceEventHandl
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: listenerType,
@@ -105,7 +105,7 @@ func globalExternalAuthorizationFilterExistsTLS(t *testing.T, rh ResourceEventHa
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -179,7 +179,7 @@ func globalExternalAuthorizationWithTLSGlobalAuthDisabled(t *testing.T, rh Resou
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -243,7 +243,7 @@ func globalExternalAuthorizationWithMergedAuthPolicy(t *testing.T, rh ResourceEv
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	c.Request(listenerType).Equals(&envoy_discovery_v3.DiscoveryResponse{
 		TypeUrl: listenerType,
@@ -317,7 +317,7 @@ func globalExternalAuthorizationWithMergedAuthPolicyTLS(t *testing.T, rh Resourc
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -438,7 +438,7 @@ func globalExternalAuthorizationWithTLSAuthOverride(t *testing.T, rh ResourceEve
 
 	// replace the default filter chains with an HCM that includes the global
 	// extAuthz filter.
-	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM())
+	httpListener.FilterChains = envoy_v3.FilterChains(getGlobalExtAuthHCM(c))
 
 	httpsListener := &envoy_listener_v3.Listener{
 		Name:    "ingress_https",
@@ -582,8 +582,8 @@ func TestGlobalAuthorization(t *testing.T) {
 }
 
 // getGlobalExtAuthHCM returns a HTTP Connection Manager with Global External Authorization configured.
-func getGlobalExtAuthHCM() *envoy_listener_v3.Filter {
-	return envoy_v3.HTTPConnectionManagerBuilder().
+func getGlobalExtAuthHCM(c *Contour) *envoy_listener_v3.Filter {
+	return c.cg.HTTPConnectionManagerBuilder().
 		RouteConfigName("ingress_http").
 		MetricsPrefix("ingress_http").
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).

--- a/internal/featuretests/v3/globalratelimit_test.go
+++ b/internal/featuretests/v3/globalratelimit_test.go
@@ -65,7 +65,7 @@ func globalRateLimitFilterExists(t *testing.T, rh ResourceEventHandlerWrapper, c
 
 	// replace the default filter chains with an HCM that includes the global
 	// rate limit filter.
-	hcm := envoy_v3.HTTPConnectionManagerBuilder().
+	hcm := c.cg.HTTPConnectionManagerBuilder().
 		RouteConfigName("ingress_http").
 		MetricsPrefix("ingress_http").
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).

--- a/internal/featuretests/v3/jwtverification_test.go
+++ b/internal/featuretests/v3/jwtverification_test.go
@@ -175,10 +175,8 @@ func TestJWTVerification(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},
@@ -660,10 +658,8 @@ func TestJWTVerification(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},
@@ -814,10 +810,8 @@ func TestJWTVerification(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},
@@ -978,10 +972,8 @@ func TestJWTVerification(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},
@@ -1124,10 +1116,8 @@ func TestJWTVerification(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},
@@ -1345,10 +1335,8 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 		TypeUrl: clusterType,
 		Resources: resources(t,
 			&envoy_cluster_v3.Cluster{
-				Name: "dnsname/https/jwt.example.com",
-				ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{
-					Type: envoy_cluster_v3.Cluster_STRICT_DNS,
-				},
+				Name:                 "dnsname/https/jwt.example.com",
+				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_STRICT_DNS),
 				CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
 					HealthyPanicThreshold: &envoy_type_v3.Percent{Value: 0},
 				},

--- a/internal/featuretests/v3/loadbalancerpolicy_test.go
+++ b/internal/featuretests/v3/loadbalancerpolicy_test.go
@@ -60,7 +60,7 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -112,7 +112,7 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -122,7 +122,7 @@ func TestLoadBalancerPolicySessionAffinity(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_8080",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -197,7 +197,7 @@ func TestLoadBalancerPolicyRequestHashHeader(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -267,7 +267,7 @@ func TestLoadBalancerPolicyRequestHashSourceIP(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -340,7 +340,7 @@ func TestLoadBalancerPolicyRequestHashQueryParameter(t *testing.T) {
 				ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 				AltStatName:          s1.Namespace + "_" + s1.Name + "_80",
 				EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-					EdsConfig:   envoy_v3.ConfigSource("contour"),
+					EdsConfig:   c.cg.ConfigSource(),
 					ServiceName: s1.Namespace + "/" + s1.Name,
 				},
 				LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,

--- a/internal/featuretests/v3/timeouts_test.go
+++ b/internal/featuretests/v3/timeouts_test.go
@@ -60,7 +60,7 @@ func TestTimeoutsNotSpecified(t *testing.T) {
 
 	httpListener := defaultHTTPListener()
 	httpListener.FilterChains = envoy_v3.FilterChains(
-		envoy_v3.HTTPConnectionManagerBuilder().
+		envoy_v3.NewConfigGenerator().HTTPConnectionManagerBuilder().
 			RouteConfigName(xdscache_v3.ENVOY_HTTP_LISTENER).
 			MetricsPrefix(xdscache_v3.ENVOY_HTTP_LISTENER).
 			AccessLoggers(envoy_v3.FileAccessLogEnvoy(xdscache_v3.DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -114,7 +114,7 @@ func TestNonZeroTimeoutsSpecified(t *testing.T) {
 	rh.OnAdd(hp1)
 
 	httpListener := defaultHTTPListener()
-	httpListener.FilterChains = envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+	httpListener.FilterChains = envoy_v3.FilterChains(envoy_v3.NewConfigGenerator().HTTPConnectionManagerBuilder().
 		RouteConfigName(xdscache_v3.ENVOY_HTTP_LISTENER).
 		MetricsPrefix(xdscache_v3.ENVOY_HTTP_LISTENER).
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy(xdscache_v3.DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).

--- a/internal/featuretests/v3/tlsprotocolversion_test.go
+++ b/internal/featuretests/v3/tlsprotocolversion_test.go
@@ -119,7 +119,7 @@ func TestTLSMinimumProtocolVersion(t *testing.T) {
 		FilterChains: []*envoy_listener_v3.FilterChain{
 			envoy_v3.FilterChainTLS(
 				"kuard.example.com",
-				envoy_v3.DownstreamTLSContext(
+				envoy_v3.NewConfigGenerator().DownstreamTLSContext(
 					&dag.Secret{Object: sec1},
 					envoy_tls_v3.TlsParameters_TLSv1_3,
 					nil,

--- a/internal/featuretests/v3/tracing_test.go
+++ b/internal/featuretests/v3/tracing_test.go
@@ -113,7 +113,7 @@ func TestTracing(t *testing.T) {
 	rh.OnAdd(p)
 
 	httpListener := defaultHTTPListener()
-	httpListener.FilterChains = envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+	httpListener.FilterChains = envoy_v3.FilterChains(envoy_v3.NewConfigGenerator().HTTPConnectionManagerBuilder().
 		RouteConfigName(xdscache_v3.ENVOY_HTTP_LISTENER).
 		MetricsPrefix(xdscache_v3.ENVOY_HTTP_LISTENER).
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy(xdscache_v3.DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).

--- a/internal/xdscache/v3/cluster.go
+++ b/internal/xdscache/v3/cluster.go
@@ -33,6 +33,13 @@ type ClusterCache struct {
 	mu     sync.Mutex
 	values map[string]*envoy_cluster_v3.Cluster
 	contour.Cond
+	cg *envoy_v3.ConfigGenerator
+}
+
+func NewClusterCache(cg *envoy_v3.ConfigGenerator) *ClusterCache {
+	return &ClusterCache{
+		cg: cg,
+	}
 }
 
 // Update replaces the contents of the cache with the supplied map.
@@ -82,20 +89,20 @@ func (c *ClusterCache) OnChange(root *dag.DAG) {
 	for _, cluster := range root.GetClusters() {
 		name := envoy.Clustername(cluster)
 		if _, ok := clusters[name]; !ok {
-			clusters[name] = envoy_v3.Cluster(cluster)
+			clusters[name] = c.cg.Cluster(cluster)
 		}
 	}
 
 	for name, ec := range root.GetExtensionClusters() {
 		if _, ok := clusters[name]; !ok {
-			clusters[name] = envoy_v3.ExtensionCluster(ec)
+			clusters[name] = c.cg.ExtensionCluster(ec)
 		}
 	}
 
 	for _, cluster := range root.GetDNSNameClusters() {
 		name := envoy.DNSNameClusterName(cluster)
 		if _, ok := clusters[name]; !ok {
-			clusters[name] = envoy_v3.DNSNameCluster(cluster)
+			clusters[name] = c.cg.DNSNameCluster(cluster)
 		}
 	}
 

--- a/internal/xdscache/v3/cluster_test.go
+++ b/internal/xdscache/v3/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/protobuf"
@@ -45,23 +46,13 @@ func TestClusterCacheContents(t *testing.T) {
 		"simple": {
 			contents: clustermap(
 				&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			want: []proto.Message{
 				cluster(&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			},
 		},
@@ -86,61 +77,36 @@ func TestClusterCacheQuery(t *testing.T) {
 		"exact match": {
 			contents: clustermap(
 				&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			query: []string{"default/kuard/443/da39a3ee5e"},
 			want: []proto.Message{
 				cluster(&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			},
 		},
 		"partial match": {
 			contents: clustermap(
 				&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			query: []string{"default/kuard/443/da39a3ee5e", "foo/bar/baz"},
 			want: []proto.Message{
 				cluster(&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			},
 		},
 		"no match": {
 			contents: clustermap(
 				&envoy_cluster_v3.Cluster{
-					Name:                 "default/kuard/443/da39a3ee5e",
-					AltStatName:          "default_kuard_443",
-					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
-					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
-						ServiceName: "default/kuard",
-					},
+					Name:        "default/kuard/443/da39a3ee5e",
+					AltStatName: "default_kuard_443",
 				}),
 			query: []string{"foo/bar/baz"},
 			want:  nil,
@@ -191,7 +157,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_kuard_443",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/kuard",
 					},
 				}),
@@ -227,7 +193,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_kuard_443",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/kuard/https",
 					},
 				}),
@@ -267,7 +233,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_kuard_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/kuard/http",
 					},
 					TypedExtensionProtocolOptions: map[string]*anypb.Any{
@@ -309,7 +275,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "beurocratic-company-test-domain-1_tiny-cog-department-test-instance_443",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "beurocratic-company-test-domain-1/tiny-cog-department-test-instance/svc-0",
 					},
 				}),
@@ -357,7 +323,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 				},
@@ -366,7 +332,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_8080",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/alt",
 					},
 				},
@@ -410,7 +376,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 					HealthChecks: []*envoy_core_v3.HealthCheck{{
@@ -472,7 +438,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 					HealthChecks: []*envoy_core_v3.HealthCheck{{
@@ -529,7 +495,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 				},
@@ -573,7 +539,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 					LbPolicy: envoy_cluster_v3.Cluster_LEAST_REQUEST,
@@ -618,7 +584,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 					LbPolicy: envoy_cluster_v3.Cluster_RANDOM,
@@ -670,7 +636,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 					LbPolicy: envoy_cluster_v3.Cluster_RING_HASH,
@@ -717,7 +683,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_backend_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/backend/http",
 					},
 				},
@@ -761,7 +727,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_kuard_80",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/kuard/http",
 					},
 					CircuitBreakers: &envoy_cluster_v3.CircuitBreakers{
@@ -810,7 +776,7 @@ func TestClusterVisit(t *testing.T) {
 					AltStatName:          "default_kuard_443",
 					ClusterDiscoveryType: envoy_v3.ClusterDiscoveryType(envoy_cluster_v3.Cluster_EDS),
 					EdsClusterConfig: &envoy_cluster_v3.Cluster_EdsClusterConfig{
-						EdsConfig:   envoy_v3.ConfigSource("contour"),
+						EdsConfig:   defaultConfigSource,
 						ServiceName: "default/kuard/https",
 					},
 				}),
@@ -819,7 +785,7 @@ func TestClusterVisit(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var cc ClusterCache
+			cc := NewClusterCache(envoy_v3.NewConfigGenerator())
 			cc.OnChange(buildDAG(t, tc.objs...))
 			protobuf.ExpectEqual(t, tc.want, cc.values)
 		})
@@ -847,8 +813,12 @@ func cluster(c *envoy_cluster_v3.Cluster) *envoy_cluster_v3.Cluster {
 	// NOTE: Keep this in sync with envoy.defaultCluster().
 	defaults := &envoy_cluster_v3.Cluster{
 		ConnectTimeout: durationpb.New(2 * time.Second),
-		CommonLbConfig: envoy_v3.ClusterCommonLBConfig(),
-		LbPolicy:       envoy_cluster_v3.Cluster_ROUND_ROBIN,
+		CommonLbConfig: &envoy_cluster_v3.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &envoy_type.Percent{ // Disable HealthyPanicThreshold
+				Value: 0,
+			},
+		},
+		LbPolicy: envoy_cluster_v3.Cluster_ROUND_ROBIN,
 	}
 
 	proto.Merge(defaults, c)
@@ -861,4 +831,24 @@ func clustermap(clusters ...*envoy_cluster_v3.Cluster) map[string]*envoy_cluster
 		m[c.Name] = cluster(c)
 	}
 	return m
+}
+
+var defaultConfigSource = &envoy_core_v3.ConfigSource{
+	ResourceApiVersion: envoy_core_v3.ApiVersion_V3,
+	ConfigSourceSpecifier: &envoy_core_v3.ConfigSource_ApiConfigSource{
+		ApiConfigSource: &envoy_core_v3.ApiConfigSource{
+			ApiType:             envoy_core_v3.ApiConfigSource_GRPC,
+			TransportApiVersion: envoy_core_v3.ApiVersion_V3,
+			GrpcServices: []*envoy_core_v3.GrpcService{
+				{
+					TargetSpecifier: &envoy_core_v3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &envoy_core_v3.GrpcService_EnvoyGrpc{
+							ClusterName: "contour",
+							Authority:   "contour",
+						},
+					},
+				},
+			},
+		},
+	},
 }

--- a/internal/xdscache/v3/listener_test.go
+++ b/internal/xdscache/v3/listener_test.go
@@ -53,17 +53,13 @@ func TestListenerCacheContents(t *testing.T) {
 		},
 		"simple": {
 			contents: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 			}),
 			want: []proto.Message{
 				&envoy_listener_v3.Listener{
-					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+					Name:    ENVOY_HTTP_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				},
 			},
 		},
@@ -87,44 +83,34 @@ func TestListenerCacheQuery(t *testing.T) {
 	}{
 		"exact match": {
 			contents: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 			}),
 			query: []string{ENVOY_HTTP_LISTENER},
 			want: []proto.Message{
 				&envoy_listener_v3.Listener{
-					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+					Name:    ENVOY_HTTP_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				},
 			},
 		},
 		"partial match": {
 			contents: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 			}),
 			query: []string{ENVOY_HTTP_LISTENER, "stats-listener"},
 			want: []proto.Message{
 				&envoy_listener_v3.Listener{
-					Name:          ENVOY_HTTP_LISTENER,
-					Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-					FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+					Name:    ENVOY_HTTP_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				},
 			},
 		},
 		"no match": {
 			contents: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 			}),
 			query: []string{"stats-listener"},
 			want:  nil,
@@ -142,8 +128,9 @@ func TestListenerCacheQuery(t *testing.T) {
 }
 
 func TestListenerVisit(t *testing.T) {
+	cg := envoy_v3.NewConfigGenerator()
 	httpsFilterFor := func(vhost string) *envoy_listener_v3.Filter {
-		return envoy_v3.HTTPConnectionManagerBuilder().
+		return cg.HTTPConnectionManagerBuilder().
 			AddFilter(envoy_v3.FilterMisdirectedRequests(vhost)).
 			DefaultFilters().
 			MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -152,7 +139,7 @@ func TestListenerVisit(t *testing.T) {
 			Get()
 	}
 
-	fallbackCertFilter := envoy_v3.HTTPConnectionManagerBuilder().
+	fallbackCertFilter := cg.HTTPConnectionManagerBuilder().
 		DefaultFilters().
 		MetricsPrefix(ENVOY_HTTPS_LISTENER).
 		RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -194,12 +181,7 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(defaultHTTPListener()),
 		},
 		"one http only httpproxy": {
 			objs: []any{
@@ -237,12 +219,7 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(defaultHTTPListener()),
 		},
 		"simple ingress with secret": {
 			objs: []any{
@@ -290,26 +267,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"whatever.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
-				}},
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"whatever.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
+					}},
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"multiple tls ingress with secrets should be sorted": {
 			objs: []any{
@@ -379,32 +354,30 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"sortedfirst.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("sortedfirst.example.com")),
-				}, {
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"sortedsecond.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("sortedsecond.example.com")),
-				}},
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"sortedfirst.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("sortedfirst.example.com")),
+					}, {
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"sortedsecond.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("sortedsecond.example.com")),
+					}},
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"simple ingress with missing secret": {
 			objs: []any{
@@ -452,12 +425,7 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(defaultHTTPListener()),
 		},
 		"simple httpproxy with secret": {
 			objs: []any{
@@ -503,26 +471,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"www.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"www.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"ingress with allow-http: false": {
 			objs: []any{
@@ -661,7 +627,7 @@ func TestListenerVisit(t *testing.T) {
 				ListenerFilters: envoy_v3.ListenerFilters(
 					envoy_v3.ProxyProtocol(),
 				),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
+				FilterChains:  defaultFilterChains,
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			}, &envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -731,9 +697,15 @@ func TestListenerVisit(t *testing.T) {
 				},
 			},
 			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy("/tmp/http_access.log", "", nil, v1alpha1.LogLevelInfo), 0)),
+				Name:    ENVOY_HTTP_LISTENER,
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
+				FilterChains: envoy_v3.FilterChains(envoy_v3.NewConfigGenerator().
+					HTTPConnectionManagerBuilder().
+					RouteConfigName(ENVOY_HTTP_LISTENER).
+					MetricsPrefix(ENVOY_HTTP_LISTENER).
+					AccessLoggers(envoy_v3.FileAccessLogEnvoy("/tmp/http_access.log", "", nil, v1alpha1.LogLevelInfo)).
+					DefaultFilters().
+					Get()),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			}, &envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTPS_LISTENER,
@@ -746,7 +718,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"whatever.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("whatever.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -806,26 +778,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"whatever.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"whatever.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"tls-min-protocol-version from config overridden by annotation": {
 			ListenerConfig: ListenerConfig{
@@ -879,26 +849,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"whatever.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"whatever.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"), // note, cannot downgrade from the configured version
+						Filters:         envoy_v3.Filters(httpsFilterFor("whatever.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"tls-min-protocol-version from config overridden by httpproxy": {
 			ListenerConfig: ListenerConfig{
@@ -948,26 +916,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"www.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"), // note, cannot downgrade from the configured version
-					Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"www.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_3, nil, "h2", "http/1.1"), // note, cannot downgrade from the configured version
+						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"tls-cipher-suites from config": {
 			ListenerConfig: ListenerConfig{
@@ -1019,26 +985,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"www.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, []string{"ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384"}, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"www.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, []string{"ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384"}, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"httpproxy with fallback certificate and with request timeout set": {
 			fallbackCertificate: &types.NamespacedName{
@@ -1110,7 +1074,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1126,7 +1090,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1140,7 +1104,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1226,7 +1190,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1242,7 +1206,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1256,7 +1220,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1342,7 +1306,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1358,7 +1322,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1372,7 +1336,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1458,7 +1422,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1474,7 +1438,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1488,7 +1452,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1574,7 +1538,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1590,7 +1554,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1604,7 +1568,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1690,7 +1654,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -1706,7 +1670,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -1720,7 +1684,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -1797,33 +1761,31 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"www.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-				}, {
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						TransportProtocol: "tls",
-					},
-					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(fallbackCertFilter),
-					Name:            "fallback-certificate",
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"www.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
+					}, {
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							TransportProtocol: "tls",
+						},
+						TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(fallbackCertFilter),
+						Name:            "fallback-certificate",
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"multiple httpproxies with fallback certificate": {
 			fallbackCertificate: &types.NamespacedName{
@@ -1911,42 +1873,40 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{
-					{
-						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-							ServerNames: []string{"www.another.com"},
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{
+						{
+							FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+								ServerNames: []string{"www.another.com"},
+							},
+							TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+							Filters:         envoy_v3.Filters(httpsFilterFor("www.another.com")),
 						},
-						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-						Filters:         envoy_v3.Filters(httpsFilterFor("www.another.com")),
-					},
-					{
-						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-							ServerNames: []string{"www.example.com"},
+						{
+							FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+								ServerNames: []string{"www.example.com"},
+							},
+							TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+							Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
 						},
-						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-					},
-					{
-						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-							TransportProtocol: "tls",
-						},
-						TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-						Filters:         envoy_v3.Filters(fallbackCertFilter),
-						Name:            "fallback-certificate",
-					}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+						{
+							FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+								TransportProtocol: "tls",
+							},
+							TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+							Filters:         envoy_v3.Filters(fallbackCertFilter),
+							Name:            "fallback-certificate",
+						}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"httpproxy with fallback certificate - no cert passed": {
 			fallbackCertificate: &types.NamespacedName{
@@ -2056,26 +2016,24 @@ func TestListenerVisit(t *testing.T) {
 					},
 				},
 			},
-			want: listenermap(&envoy_listener_v3.Listener{
-				Name:          ENVOY_HTTP_LISTENER,
-				Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains:  envoy_v3.FilterChains(envoy_v3.HTTPConnectionManager(ENVOY_HTTP_LISTENER, envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo), 0)),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}, &envoy_listener_v3.Listener{
-				Name:    ENVOY_HTTPS_LISTENER,
-				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
-				FilterChains: []*envoy_listener_v3.FilterChain{{
-					FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
-						ServerNames: []string{"www.example.com"},
-					},
-					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
-				}},
-				ListenerFilters: envoy_v3.ListenerFilters(
-					envoy_v3.TLSInspector(),
-				),
-				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
-			}),
+			want: listenermap(
+				defaultHTTPListener(),
+				&envoy_listener_v3.Listener{
+					Name:    ENVOY_HTTPS_LISTENER,
+					Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+					FilterChains: []*envoy_listener_v3.FilterChain{{
+						FilterChainMatch: &envoy_listener_v3.FilterChainMatch{
+							ServerNames: []string{"www.example.com"},
+						},
+						TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
+						Filters:         envoy_v3.Filters(httpsFilterFor("www.example.com")),
+					}},
+					ListenerFilters: envoy_v3.ListenerFilters(
+						envoy_v3.TLSInspector(),
+					),
+					SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+				},
+			),
 		},
 		"httpproxy with connection idle timeout set in listener config": {
 			ListenerConfig: ListenerConfig{
@@ -2122,7 +2080,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2178,7 +2136,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2234,7 +2192,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2290,7 +2248,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2346,7 +2304,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2409,7 +2367,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2426,7 +2384,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -2484,7 +2442,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2539,7 +2497,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2594,7 +2552,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2648,7 +2606,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2711,7 +2669,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2728,7 +2686,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -2795,7 +2753,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2812,7 +2770,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -2879,7 +2837,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2896,7 +2854,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -2963,7 +2921,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -2980,7 +2938,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -3046,7 +3004,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName("ingress_http").
 					MetricsPrefix("ingress_http").
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, v1alpha1.LogLevelInfo)).
@@ -3137,7 +3095,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -3176,7 +3134,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -3290,7 +3248,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
 						DefaultFilters().
@@ -3328,7 +3286,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -3364,7 +3322,7 @@ func TestListenerVisit(t *testing.T) {
 						TransportProtocol: "tls",
 					},
 					TransportSocket: transportSocket("fallbacksecret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
 						RouteConfigName(ENVOY_FALLBACK_ROUTECONFIG).
@@ -3445,7 +3403,7 @@ func TestListenerVisit(t *testing.T) {
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
 				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManagerBuilder().
+					cg.HTTPConnectionManagerBuilder().
 						RouteConfigName(ENVOY_HTTP_LISTENER).
 						MetricsPrefix(ENVOY_HTTP_LISTENER).
 						AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -3506,7 +3464,7 @@ func TestListenerVisit(t *testing.T) {
 			want: listenermap(&envoy_listener_v3.Listener{
 				Name:    ENVOY_HTTP_LISTENER,
 				Address: envoy_v3.SocketAddress("0.0.0.0", 8080),
-				FilterChains: envoy_v3.FilterChains(envoy_v3.HTTPConnectionManagerBuilder().
+				FilterChains: envoy_v3.FilterChains(cg.HTTPConnectionManagerBuilder().
 					RouteConfigName(ENVOY_HTTP_LISTENER).
 					MetricsPrefix(ENVOY_HTTP_LISTENER).
 					AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
@@ -3523,7 +3481,7 @@ func TestListenerVisit(t *testing.T) {
 						ServerNames: []string{"www.example.com"},
 					},
 					TransportSocket: transportSocket("secret", envoy_tls_v3.TlsParameters_TLSv1_2, nil, "h2", "http/1.1"),
-					Filters: envoy_v3.Filters(envoy_v3.HTTPConnectionManagerBuilder().
+					Filters: envoy_v3.Filters(cg.HTTPConnectionManagerBuilder().
 						AddFilter(envoy_v3.FilterMisdirectedRequests("www.example.com")).
 						DefaultFilters().
 						MetricsPrefix(ENVOY_HTTPS_LISTENER).
@@ -3544,6 +3502,7 @@ func TestListenerVisit(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			lc := ListenerCache{
 				Config: tc.ListenerConfig,
+				cg:     envoy_v3.NewConfigGenerator(),
 			}
 			lc.OnChange(buildDAGFallback(t, tc.fallbackCertificate, tc.objs...))
 			protobuf.ExpectEqual(t, tc.want, lc.values)
@@ -3563,7 +3522,7 @@ func transportSocket(secretname string, tlsMinProtoVersion envoy_tls_v3.TlsParam
 		},
 	}
 	return envoy_v3.DownstreamTLSTransportSocket(
-		envoy_v3.DownstreamTLSContext(secret, tlsMinProtoVersion, cipherSuites, nil, alpnprotos...),
+		envoy_v3.NewConfigGenerator().DownstreamTLSContext(secret, tlsMinProtoVersion, cipherSuites, nil, alpnprotos...),
 	)
 }
 
@@ -3573,4 +3532,23 @@ func listenermap(listeners ...*envoy_listener_v3.Listener) map[string]*envoy_lis
 		m[l.Name] = l
 	}
 	return m
+}
+
+var defaultFilterChains = envoy_v3.FilterChains(
+	envoy_v3.NewConfigGenerator().
+		HTTPConnectionManagerBuilder().
+		RouteConfigName(ENVOY_HTTP_LISTENER).
+		MetricsPrefix(ENVOY_HTTP_LISTENER).
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy(DEFAULT_HTTP_ACCESS_LOG, "", nil, v1alpha1.LogLevelInfo)).
+		DefaultFilters().
+		Get(),
+)
+
+func defaultHTTPListener() *envoy_listener_v3.Listener {
+	return &envoy_listener_v3.Listener{
+		Name:          ENVOY_HTTP_LISTENER,
+		Address:       envoy_v3.SocketAddress("0.0.0.0", 8080),
+		FilterChains:  defaultFilterChains,
+		SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
+	}
 }


### PR DESCRIPTION
This is a precursor to making changes for adding the ability to configure Contour/Envoy to use ADS (Aggregated Discovery Service). That change requires changing all of the `ConfigSource` references to specify an ADS source, rather than what we have today, which is the gRPC config source. As the code stands today, changing the `envoy_v3.ConfigSource()` method would need a new parameter or conditional logic around the call *everywhere it is currently called*, which is a lot of places in just implementation code, not to mention tests.

The current approach taken in this PR is to create a new type to hold common configuration (like details about `ConfigSource` parameters that are common to all xDS resources we generate) to hang helper methods off of. This way, consumers like the `Listener/ClusterCache` do not need to know details about the `ConfigSource` we want to program, the `envoy/v3` package `ConfigGenerator` knows and we can limit the testing/blast radius of common configuration changes to that object.

Another hope I have is that we can start to reduce the usage of implementation code in test assertions, this sort of change will force us to reevaluate how we set up our tests a bit.

First commit is the main implementation changes, second and beyond for fixing tests, adding new ones, further changes.

This isn't complete, but wanted to get feedback before I went too too far down.