### PR TITLE
enable websockets for Gateway listeners

### DIFF
--- a/changelogs/unreleased/5524-skriss-small.md
+++ b/changelogs/unreleased/5524-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: enable websockets upgrade by default.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -1951,6 +1951,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						virtualhost("test.projectcontour.io",
 							prefixrouteHTTPRoute("/", service(kuardService)),
 						)),
+					EnableWebsockets: true,
 				},
 			),
 		},
@@ -16203,10 +16204,12 @@ func listeners(ls ...*Listener) []*Listener {
 			listener.Protocol = "http"
 			listener.Address = "0.0.0.0"
 			listener.Port = 8080
+			listener.EnableWebsockets = true
 		case "https-443":
 			listener.Protocol = "https"
 			listener.Address = "0.0.0.0"
 			listener.Port = 8443
+			listener.EnableWebsockets = true
 		}
 	}
 

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -890,6 +890,10 @@ type Listener struct {
 	// This cannot be used with VirtualHosts/SecureVirtualHosts
 	// on a given Listener.
 	TCPProxy *TCPProxy
+
+	// EnableWebsockets defines whether to enable the websocket
+	// upgrade.
+	EnableWebsockets bool
 }
 
 // TCPProxy represents a cluster of TCP endpoints.

--- a/internal/dag/listener_processor.go
+++ b/internal/dag/listener_processor.go
@@ -41,12 +41,13 @@ func (p *ListenerProcessor) Run(dag *DAG, cache *KubernetesCache) {
 				address = p.HTTPSAddress
 			}
 			dag.Listeners[port.Name] = &Listener{
-				Name:          port.Name,
-				Protocol:      port.Protocol,
-				Address:       address,
-				Port:          int(port.ContainerPort),
-				vhostsByName:  map[string]*VirtualHost{},
-				svhostsByName: map[string]*SecureVirtualHost{},
+				Name:             port.Name,
+				Protocol:         port.Protocol,
+				Address:          address,
+				Port:             int(port.ContainerPort),
+				EnableWebsockets: true,
+				vhostsByName:     map[string]*VirtualHost{},
+				svhostsByName:    map[string]*SecureVirtualHost{},
 			}
 		}
 	} else {

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -167,6 +167,12 @@ type httpConnectionManagerBuilder struct {
 	numTrustedHops                uint32
 	tracingConfig                 *http.HttpConnectionManager_Tracing
 	maxRequestsPerConnection      *uint32
+	enableWebsockets              bool
+}
+
+func (b *httpConnectionManagerBuilder) EnableWebsockets(enable bool) *httpConnectionManagerBuilder {
+	b.enableWebsockets = enable
+	return b
 }
 
 // RouteConfigName sets the name of the RDS element that contains
@@ -525,6 +531,14 @@ func (b *httpConnectionManagerBuilder) Get() *envoy_listener_v3.Filter {
 	// if maxConnectionsPerRequest is defined, set it.
 	if b.maxRequestsPerConnection != nil {
 		cm.CommonHttpProtocolOptions.MaxRequestsPerConnection = wrapperspb.UInt32(*b.maxRequestsPerConnection)
+	}
+
+	if b.enableWebsockets {
+		cm.UpgradeConfigs = append(cm.UpgradeConfigs,
+			&http.HttpConnectionManager_UpgradeConfig{
+				UpgradeType: "websocket",
+			},
+		)
 	}
 
 	return &envoy_listener_v3.Filter{

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -449,6 +449,15 @@ func httpsFilterFor(vhost string) *envoy_listener_v3.Filter {
 		Get()
 }
 
+func httpFilterForGateway() *envoy_listener_v3.Filter {
+	return envoy_v3.HTTPConnectionManagerBuilder().
+		DefaultFilters().
+		RouteConfigName("http-80").
+		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		EnableWebsockets(true).
+		Get()
+}
+
 func httpsFilterForGateway(listener, vhost string) *envoy_listener_v3.Filter {
 	return envoy_v3.HTTPConnectionManagerBuilder().
 		AddFilter(envoy_v3.FilterMisdirectedRequests(vhost)).
@@ -456,6 +465,7 @@ func httpsFilterForGateway(listener, vhost string) *envoy_listener_v3.Filter {
 		RouteConfigName(path.Join(listener, vhost)).
 		MetricsPrefix(listener).
 		AccessLoggers(envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo)).
+		EnableWebsockets(true).
 		Get()
 }
 

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -1466,11 +1466,9 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 		TypeUrl: listenerType,
 		Resources: resources(t,
 			&envoy_listener_v3.Listener{
-				Name:    "http-80",
-				Address: envoy_v3.SocketAddress("127.0.0.100", 8080),
-				FilterChains: envoy_v3.FilterChains(
-					envoy_v3.HTTPConnectionManager("http-80", envoy_v3.FileAccessLogEnvoy("/dev/stdout", "", nil, contour_api_v1alpha1.LogLevelInfo), 0),
-				),
+				Name:          "http-80",
+				Address:       envoy_v3.SocketAddress("127.0.0.100", 8080),
+				FilterChains:  envoy_v3.FilterChains(httpFilterForGateway()),
 				SocketOptions: envoy_v3.TCPKeepaliveSocketOptions(),
 			},
 		),

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -386,6 +386,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 				Tracing(envoy_v3.TracingConfig(envoyTracingConfig(cfg.TracingConfig))).
 				AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 				AddFilter(httpGlobalExternalAuthConfig(cfg.GlobalExternalAuthConfig)).
+				EnableWebsockets(listener.EnableWebsockets).
 				Get()
 
 			listeners[listener.Name] = envoy_v3.Listener(
@@ -455,6 +456,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 					ForwardClientCertificate(forwardClientCertificate).
 					MaxRequestsPerConnection(cfg.MaxRequestsPerConnection).
+					EnableWebsockets(listener.EnableWebsockets).
 					Get()
 
 				filters = envoy_v3.Filters(cm)
@@ -520,6 +522,7 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					AddFilter(envoy_v3.GlobalRateLimitFilter(envoyGlobalRateLimitConfig(cfg.RateLimitConfig))).
 					ForwardClientCertificate(forwardClientCertificate).
 					MaxRequestsPerConnection(cfg.MaxRequestsPerConnection).
+					EnableWebsockets(listener.EnableWebsockets).
 					Get()
 
 				// Default filter chain

--- a/site/content/docs/main/config/websockets.md
+++ b/site/content/docs/main/config/websockets.md
@@ -23,3 +23,5 @@ spec:
     - name: chat-app
       port: 80
 ```
+
+If you are using Gateway API, websockets are enabled by default at the Listener level.


### PR DESCRIPTION
Closes #5241.

I had another look at all the context around this, and I can't see any issue with just enabling this by default, which tells envoy to pass the `Connection: Upgrade` and `Upgrade: websocket` headers to the upstream rather than returning a 403. However, given that the classic/non-Gateway API websockets behavior is and has been opt-in for a long time, I don't think we should necessarily change that now. 