### PR TITLE
Clarify TLS certificate delegation

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -406,10 +406,12 @@ type RemoteJWKS struct {
 // TLS describes tls properties. The SNI names that will be matched on
 // are described in the HTTPProxy's Spec.VirtualHost.Fqdn field.
 type TLS struct {
-	// SecretName is the name of a TLS secret in the current namespace.
+	// SecretName is the name of a TLS secret.
 	// Either SecretName or Passthrough must be specified, but not both.
 	// If specified, the named secret must contain a matching certificate
 	// for the virtual host's FQDN.
+	// The name can be optionally prefixed with namespace "namespace/name".
+	// When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
 	SecretName string `json:"secretName,omitempty"`
 	// MinimumProtocolVersion is the minimum TLS version this vhost should
 	// negotiate. Valid options are `1.2` (default) and `1.3`. Any other value
@@ -1265,6 +1267,8 @@ type DownstreamValidation struct {
 	// The client certificate must validate against the certificates in the bundle.
 	// If specified and SkipClientCertValidation is true, client certificates will
 	// be required on requests.
+	// The name can be optionally prefixed with namespace "namespace/name".
+	// When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	CACertificate string `json:"caSecret,omitempty"`
@@ -1290,6 +1294,8 @@ type DownstreamValidation struct {
 	// This field will be used to verify that a client certificate has not been revoked.
 	// CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert is true.
 	// Large CRL lists are not supported since individual secrets are limited to 1MiB in size.
+	// The name can be optionally prefixed with namespace "namespace/name".
+	// When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	CertificateRevocationList string `json:"crlSecret,omitempty"`

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1255,6 +1255,8 @@ type HeaderValue struct {
 type UpstreamValidation struct {
 	// Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
 	// The secret must contain key named ca.crt.
+	// The name can be optionally prefixed with namespace "namespace/name".
+	// When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.
 	CACertificate string `json:"caSecret"`
 	// Key which is expected to be present in the 'subjectAltName' of the presented certificate.
 	SubjectName string `json:"subjectName"`

--- a/changelogs/unreleased/5529-tsaarni-small.md
+++ b/changelogs/unreleased/5529-tsaarni-small.md
@@ -1,0 +1,1 @@
+Refactor the handling of cross-namespace references and improve documentation.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -6775,6 +6775,10 @@ spec:
                               named ca.crt. The client certificate must validate against
                               the certificates in the bundle. If specified and SkipClientCertValidation
                               is true, client certificates will be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           crlOnlyVerifyLeafCert:
@@ -6789,7 +6793,11 @@ spec:
                               to verify that a client certificate has not been revoked.
                               CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
                               is true. Large CRL lists are not supported since individual
-                              secrets are limited to 1MiB in size.
+                              secrets are limited to 1MiB in size. The name can be
+                              optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           forwardClientCertificate:
@@ -6854,11 +6862,13 @@ spec:
                           not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
+                        description: SecretName is the name of a TLS secret. Either
+                          SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN. The name can be optionally
+                          prefixed with namespace "namespace/name". When cross-namespace
+                          reference is used, TLSCertificateDelegation resource must
+                          exist in the namespace to grant access to the secret.
                         type: string
                     type: object
                 required:

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -4263,7 +4263,10 @@ spec:
                   caSecret:
                     description: Name or namespaced name of the Kubernetes secret
                       used to validate the certificate presented by the backend. The
-                      secret must contain key named ca.crt.
+                      secret must contain key named ca.crt. The name can be optionally
+                      prefixed with namespace "namespace/name". When cross-namespace
+                      reference is used, TLSCertificateDelegation resource must exist
+                      in the namespace to grant access to the secret.
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'
@@ -5802,7 +5805,11 @@ spec:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
                                   by the backend. The secret must contain key named
-                                  ca.crt.
+                                  ca.crt. The name can be optionally prefixed with
+                                  namespace "namespace/name". When cross-namespace
+                                  reference is used, TLSCertificateDelegation resource
+                                  must exist in the namespace to grant access to the
+                                  secret.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -6194,7 +6201,10 @@ spec:
                               description: Name or namespaced name of the Kubernetes
                                 secret used to validate the certificate presented
                                 by the backend. The secret must contain key named
-                                ca.crt.
+                                ca.crt. The name can be optionally prefixed with namespace
+                                "namespace/name". When cross-namespace reference is
+                                used, TLSCertificateDelegation resource must exist
+                                in the namespace to grant access to the secret.
                               type: string
                             subjectName:
                               description: Key which is expected to be present in
@@ -6512,7 +6522,11 @@ spec:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
                                     by the backend. The secret must contain key named
-                                    ca.crt.
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to
+                                    the secret.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -4476,7 +4476,10 @@ spec:
                   caSecret:
                     description: Name or namespaced name of the Kubernetes secret
                       used to validate the certificate presented by the backend. The
-                      secret must contain key named ca.crt.
+                      secret must contain key named ca.crt. The name can be optionally
+                      prefixed with namespace "namespace/name". When cross-namespace
+                      reference is used, TLSCertificateDelegation resource must exist
+                      in the namespace to grant access to the secret.
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'
@@ -6015,7 +6018,11 @@ spec:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
                                   by the backend. The secret must contain key named
-                                  ca.crt.
+                                  ca.crt. The name can be optionally prefixed with
+                                  namespace "namespace/name". When cross-namespace
+                                  reference is used, TLSCertificateDelegation resource
+                                  must exist in the namespace to grant access to the
+                                  secret.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -6407,7 +6414,10 @@ spec:
                               description: Name or namespaced name of the Kubernetes
                                 secret used to validate the certificate presented
                                 by the backend. The secret must contain key named
-                                ca.crt.
+                                ca.crt. The name can be optionally prefixed with namespace
+                                "namespace/name". When cross-namespace reference is
+                                used, TLSCertificateDelegation resource must exist
+                                in the namespace to grant access to the secret.
                               type: string
                             subjectName:
                               description: Key which is expected to be present in
@@ -6725,7 +6735,11 @@ spec:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
                                     by the backend. The secret must contain key named
-                                    ca.crt.
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to
+                                    the secret.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -6988,6 +6988,10 @@ spec:
                               named ca.crt. The client certificate must validate against
                               the certificates in the bundle. If specified and SkipClientCertValidation
                               is true, client certificates will be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           crlOnlyVerifyLeafCert:
@@ -7002,7 +7006,11 @@ spec:
                               to verify that a client certificate has not been revoked.
                               CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
                               is true. Large CRL lists are not supported since individual
-                              secrets are limited to 1MiB in size.
+                              secrets are limited to 1MiB in size. The name can be
+                              optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           forwardClientCertificate:
@@ -7067,11 +7075,13 @@ spec:
                           not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
+                        description: SecretName is the name of a TLS secret. Either
+                          SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN. The name can be optionally
+                          prefixed with namespace "namespace/name". When cross-namespace
+                          reference is used, TLSCertificateDelegation resource must
+                          exist in the namespace to grant access to the secret.
                         type: string
                     type: object
                 required:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -4277,7 +4277,10 @@ spec:
                   caSecret:
                     description: Name or namespaced name of the Kubernetes secret
                       used to validate the certificate presented by the backend. The
-                      secret must contain key named ca.crt.
+                      secret must contain key named ca.crt. The name can be optionally
+                      prefixed with namespace "namespace/name". When cross-namespace
+                      reference is used, TLSCertificateDelegation resource must exist
+                      in the namespace to grant access to the secret.
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'
@@ -5816,7 +5819,11 @@ spec:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
                                   by the backend. The secret must contain key named
-                                  ca.crt.
+                                  ca.crt. The name can be optionally prefixed with
+                                  namespace "namespace/name". When cross-namespace
+                                  reference is used, TLSCertificateDelegation resource
+                                  must exist in the namespace to grant access to the
+                                  secret.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -6208,7 +6215,10 @@ spec:
                               description: Name or namespaced name of the Kubernetes
                                 secret used to validate the certificate presented
                                 by the backend. The secret must contain key named
-                                ca.crt.
+                                ca.crt. The name can be optionally prefixed with namespace
+                                "namespace/name". When cross-namespace reference is
+                                used, TLSCertificateDelegation resource must exist
+                                in the namespace to grant access to the secret.
                               type: string
                             subjectName:
                               description: Key which is expected to be present in
@@ -6526,7 +6536,11 @@ spec:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
                                     by the backend. The secret must contain key named
-                                    ca.crt.
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to
+                                    the secret.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -6789,6 +6789,10 @@ spec:
                               named ca.crt. The client certificate must validate against
                               the certificates in the bundle. If specified and SkipClientCertValidation
                               is true, client certificates will be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           crlOnlyVerifyLeafCert:
@@ -6803,7 +6807,11 @@ spec:
                               to verify that a client certificate has not been revoked.
                               CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
                               is true. Large CRL lists are not supported since individual
-                              secrets are limited to 1MiB in size.
+                              secrets are limited to 1MiB in size. The name can be
+                              optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           forwardClientCertificate:
@@ -6868,11 +6876,13 @@ spec:
                           not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
+                        description: SecretName is the name of a TLS secret. Either
+                          SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN. The name can be optionally
+                          prefixed with namespace "namespace/name". When cross-namespace
+                          reference is used, TLSCertificateDelegation resource must
+                          exist in the namespace to grant access to the secret.
                         type: string
                     type: object
                 required:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -6994,6 +6994,10 @@ spec:
                               named ca.crt. The client certificate must validate against
                               the certificates in the bundle. If specified and SkipClientCertValidation
                               is true, client certificates will be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           crlOnlyVerifyLeafCert:
@@ -7008,7 +7012,11 @@ spec:
                               to verify that a client certificate has not been revoked.
                               CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
                               is true. Large CRL lists are not supported since individual
-                              secrets are limited to 1MiB in size.
+                              secrets are limited to 1MiB in size. The name can be
+                              optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           forwardClientCertificate:
@@ -7073,11 +7081,13 @@ spec:
                           not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
+                        description: SecretName is the name of a TLS secret. Either
+                          SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN. The name can be optionally
+                          prefixed with namespace "namespace/name". When cross-namespace
+                          reference is used, TLSCertificateDelegation resource must
+                          exist in the namespace to grant access to the secret.
                         type: string
                     type: object
                 required:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -4482,7 +4482,10 @@ spec:
                   caSecret:
                     description: Name or namespaced name of the Kubernetes secret
                       used to validate the certificate presented by the backend. The
-                      secret must contain key named ca.crt.
+                      secret must contain key named ca.crt. The name can be optionally
+                      prefixed with namespace "namespace/name". When cross-namespace
+                      reference is used, TLSCertificateDelegation resource must exist
+                      in the namespace to grant access to the secret.
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'
@@ -6021,7 +6024,11 @@ spec:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
                                   by the backend. The secret must contain key named
-                                  ca.crt.
+                                  ca.crt. The name can be optionally prefixed with
+                                  namespace "namespace/name". When cross-namespace
+                                  reference is used, TLSCertificateDelegation resource
+                                  must exist in the namespace to grant access to the
+                                  secret.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -6413,7 +6420,10 @@ spec:
                               description: Name or namespaced name of the Kubernetes
                                 secret used to validate the certificate presented
                                 by the backend. The secret must contain key named
-                                ca.crt.
+                                ca.crt. The name can be optionally prefixed with namespace
+                                "namespace/name". When cross-namespace reference is
+                                used, TLSCertificateDelegation resource must exist
+                                in the namespace to grant access to the secret.
                               type: string
                             subjectName:
                               description: Key which is expected to be present in
@@ -6731,7 +6741,11 @@ spec:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
                                     by the backend. The secret must contain key named
-                                    ca.crt.
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to
+                                    the secret.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -4476,7 +4476,10 @@ spec:
                   caSecret:
                     description: Name or namespaced name of the Kubernetes secret
                       used to validate the certificate presented by the backend. The
-                      secret must contain key named ca.crt.
+                      secret must contain key named ca.crt. The name can be optionally
+                      prefixed with namespace "namespace/name". When cross-namespace
+                      reference is used, TLSCertificateDelegation resource must exist
+                      in the namespace to grant access to the secret.
                     type: string
                   subjectName:
                     description: Key which is expected to be present in the 'subjectAltName'
@@ -6015,7 +6018,11 @@ spec:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
                                   by the backend. The secret must contain key named
-                                  ca.crt.
+                                  ca.crt. The name can be optionally prefixed with
+                                  namespace "namespace/name". When cross-namespace
+                                  reference is used, TLSCertificateDelegation resource
+                                  must exist in the namespace to grant access to the
+                                  secret.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
@@ -6407,7 +6414,10 @@ spec:
                               description: Name or namespaced name of the Kubernetes
                                 secret used to validate the certificate presented
                                 by the backend. The secret must contain key named
-                                ca.crt.
+                                ca.crt. The name can be optionally prefixed with namespace
+                                "namespace/name". When cross-namespace reference is
+                                used, TLSCertificateDelegation resource must exist
+                                in the namespace to grant access to the secret.
                               type: string
                             subjectName:
                               description: Key which is expected to be present in
@@ -6725,7 +6735,11 @@ spec:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
                                     by the backend. The secret must contain key named
-                                    ca.crt.
+                                    ca.crt. The name can be optionally prefixed with
+                                    namespace "namespace/name". When cross-namespace
+                                    reference is used, TLSCertificateDelegation resource
+                                    must exist in the namespace to grant access to
+                                    the secret.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -6988,6 +6988,10 @@ spec:
                               named ca.crt. The client certificate must validate against
                               the certificates in the bundle. If specified and SkipClientCertValidation
                               is true, client certificates will be required on requests.
+                              The name can be optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           crlOnlyVerifyLeafCert:
@@ -7002,7 +7006,11 @@ spec:
                               to verify that a client certificate has not been revoked.
                               CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
                               is true. Large CRL lists are not supported since individual
-                              secrets are limited to 1MiB in size.
+                              secrets are limited to 1MiB in size. The name can be
+                              optionally prefixed with namespace "namespace/name".
+                              When cross-namespace reference is used, TLSCertificateDelegation
+                              resource must exist in the namespace to grant access
+                              to the secret.
                             minLength: 1
                             type: string
                           forwardClientCertificate:
@@ -7067,11 +7075,13 @@ spec:
                           not both.
                         type: boolean
                       secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
+                        description: SecretName is the name of a TLS secret. Either
+                          SecretName or Passthrough must be specified, but not both.
+                          If specified, the named secret must contain a matching certificate
+                          for the virtual host's FQDN. The name can be optionally
+                          prefixed with namespace "namespace/name". When cross-namespace
+                          reference is used, TLSCertificateDelegation resource must
+                          exist in the namespace to grant access to the secret.
                         type: string
                     type: object
                 required:

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -704,6 +704,8 @@ func (p *GatewayAPIProcessor) resolveListenerSecret(certificateRefs []gatewayapi
 		meta = types.NamespacedName{Name: string(certificateRef.Name), Namespace: p.source.gateway.Namespace}
 	}
 
+	// Use LookupTLSSecretInsecure instead of LookupTLSSecret since Gateway API uses its own mechanism (ReferenceGrant, not TLSCertificateDelegation)
+	// to control access to secrets across namespaces.
 	listenerSecret, err := p.source.LookupTLSSecretInsecure(meta)
 	if err != nil {
 		gwAccessor.AddListenerCondition(

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -704,7 +704,7 @@ func (p *GatewayAPIProcessor) resolveListenerSecret(certificateRefs []gatewayapi
 		meta = types.NamespacedName{Name: string(certificateRef.Name), Namespace: p.source.gateway.Namespace}
 	}
 
-	listenerSecret, err := p.source.LookupTLSSecret(meta)
+	listenerSecret, err := p.source.LookupTLSSecretInsecure(meta)
 	if err != nil {
 		gwAccessor.AddListenerCondition(
 			listenerName,

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -325,7 +325,7 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 					if err != nil {
 						if _, ok := err.(DelegationNotPermittedError); ok {
 							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "DelegationNotPermitted",
-								"Spec.VirtualHost.TLS CRL Secret %q is invalid: %s", tls.ClientValidation.CACertificate, err)
+								"Spec.VirtualHost.TLS CRL Secret %q is invalid: %s", tls.ClientValidation.CertificateRevocationList, err)
 						} else {
 							// CRL is missing or not configured.
 							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -221,16 +221,15 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 		// Attach secrets to TLS enabled vhosts.
 		if !tls.Passthrough {
 			secretName := k8s.NamespacedNameFrom(tls.SecretName, k8s.DefaultNamespace(proxy.Namespace))
-			sec, err := p.source.LookupTLSSecret(secretName)
+			sec, err := p.source.LookupTLSSecret(secretName, proxy.Namespace)
 			if err != nil {
-				validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
-					"Spec.VirtualHost.TLS Secret %q is invalid: %s", tls.SecretName, err)
-				return
-			}
-
-			if !p.source.DelegationPermitted(secretName, proxy.Namespace) {
-				validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "DelegationNotPermitted",
-					"Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", tls.SecretName)
+				if _, ok := err.(DelegationNotPermittedError); ok {
+					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "DelegationNotPermitted",
+						"Spec.VirtualHost.TLS Secret %q certificate delegation not permitted", tls.SecretName)
+				} else {
+					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
+						"Spec.VirtualHost.TLS Secret %q is invalid: %s", tls.SecretName, err)
+				}
 				return
 			}
 
@@ -271,16 +270,15 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 					return
 				}
 
-				sec, err = p.source.LookupTLSSecret(*p.FallbackCertificate)
+				sec, err = p.source.LookupTLSSecret(*p.FallbackCertificate, proxy.Namespace)
 				if err != nil {
-					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotValid",
-						"Spec.Virtualhost.TLS Secret %q fallback certificate is invalid: %s", p.FallbackCertificate, err)
-					return
-				}
-
-				if !p.source.DelegationPermitted(*p.FallbackCertificate, proxy.Namespace) {
-					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotDelegated",
-						"Spec.VirtualHost.TLS fallback Secret %q is not configured for certificate delegation", p.FallbackCertificate)
+					if _, ok := err.(DelegationNotPermittedError); ok {
+						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotDelegated",
+							"Spec.VirtualHost.TLS Secret %q is not configured for certificate delegation", p.FallbackCertificate)
+					} else {
+						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "FallbackNotValid",
+							"Spec.Virtualhost.TLS Secret %q fallback certificate is invalid: %s", p.FallbackCertificate, err)
+					}
 					return
 				}
 
@@ -304,11 +302,16 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				}
 				if tls.ClientValidation.CACertificate != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))
-					cacert, err := p.source.LookupCASecret(secretName)
+					cacert, err := p.source.LookupCASecret(secretName, proxy.Namespace)
 					if err != nil {
-						// PeerValidationContext is requested, but cert is missing or not configured.
-						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
-							"Spec.VirtualHost.TLS client validation is invalid: invalid CA Secret %q: %s", secretName, err)
+						if _, ok := err.(DelegationNotPermittedError); ok {
+							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "DelegationNotPermitted",
+								"Spec.VirtualHost.TLS CA Secret %q is invalid: %s", tls.ClientValidation.CACertificate, err)
+						} else {
+							// PeerValidationContext is requested, but cert is missing or not configured.
+							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
+								"Spec.VirtualHost.TLS client validation is invalid: invalid CA Secret %q: %s", secretName, err)
+						}
 						return
 					}
 					dv.CACertificate = cacert
@@ -318,11 +321,17 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 				}
 				if tls.ClientValidation.CertificateRevocationList != "" {
 					secretName := k8s.NamespacedNameFrom(tls.ClientValidation.CertificateRevocationList, k8s.DefaultNamespace(proxy.Namespace))
-					crl, err := p.source.LookupCRLSecret(secretName)
+					crl, err := p.source.LookupCRLSecret(secretName, proxy.Namespace)
 					if err != nil {
-						// CRL is missing or not configured.
-						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
-							"Spec.VirtualHost.TLS client validation is invalid: invalid CRL Secret %q: %s", secretName, err)
+						if _, ok := err.(DelegationNotPermittedError); ok {
+							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "DelegationNotPermitted",
+								"Spec.VirtualHost.TLS CRL Secret %q is invalid: %s", tls.ClientValidation.CACertificate, err)
+						} else {
+							// CRL is missing or not configured.
+							validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
+								"Spec.VirtualHost.TLS client validation is invalid: invalid CRL Secret %q: %s", secretName, err)
+						}
+						return
 					}
 					dv.CRL = crl
 					dv.OnlyVerifyLeafCertCrl = tls.ClientValidation.OnlyVerifyLeafCertCrl
@@ -374,22 +383,16 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 						return
 					}
 
-					// If the CACertificate name in the UpstreamValidation is namespaced and the namespace
-					// is not the proxy's namespace, check if the referenced secret is permitted to be
-					// delegated to the proxy's namespace.
-					// By default, a non-namespaced CACertificate is expected to reside in the proxy's namespace.
 					caCertNamespacedName := k8s.NamespacedNameFrom(jwtProvider.RemoteJWKS.UpstreamValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))
-
-					if !p.source.DelegationPermitted(caCertNamespacedName, proxy.Namespace) {
-						validCond.AddErrorf(contour_api_v1.ConditionTypeJWTVerificationError, "RemoteJWKSCACertificateNotDelegated",
-							"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation.CACertificate Secret %q is not configured for certificate delegation", caCertNamespacedName)
-						return
-					}
-
-					uv, err = p.source.LookupUpstreamValidation(jwtProvider.RemoteJWKS.UpstreamValidation, caCertNamespacedName)
+					uv, err = p.source.LookupUpstreamValidation(jwtProvider.RemoteJWKS.UpstreamValidation, caCertNamespacedName, proxy.Namespace)
 					if err != nil {
-						validCond.AddErrorf(contour_api_v1.ConditionTypeJWTVerificationError, "RemoteJWKSUpstreamValidationInvalid",
-							"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: %s", err)
+						if _, ok := err.(DelegationNotPermittedError); ok {
+							validCond.AddErrorf(contour_api_v1.ConditionTypeJWTVerificationError, "RemoteJWKSCACertificateNotDelegated",
+								"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation.CACertificate Secret %q is not configured for certificate delegation", caCertNamespacedName)
+						} else {
+							validCond.AddErrorf(contour_api_v1.ConditionTypeJWTVerificationError, "RemoteJWKSUpstreamValidationInvalid",
+								"Spec.VirtualHost.JWTProviders.RemoteJWKS.UpstreamValidation is invalid: %s", err)
+						}
 						return
 					}
 				}
@@ -904,21 +907,17 @@ func (p *HTTPProxyProcessor) computeRoutes(
 
 			var uv *PeerValidationContext
 			if (protocol == "tls" || protocol == "h2") && service.UpstreamValidation != nil {
-				// If the CACertificate name in the UpstreamValidation is namespaced and the namespace
-				// is not the proxy's namespace, check if the referenced secret is permitted to be
-				// delegated to the proxy's namespace.
-				// By default, a non-namespaced CACertificate is expected to reside in the proxy's namespace.
 				caCertNamespacedName := k8s.NamespacedNameFrom(service.UpstreamValidation.CACertificate, k8s.DefaultNamespace(proxy.Namespace))
-				if !p.source.DelegationPermitted(caCertNamespacedName, proxy.Namespace) {
-					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "CACertificateNotDelegated",
-						"service.UpstreamValidation.CACertificate Secret %q is not configured for certificate delegation", caCertNamespacedName)
-					return nil
-				}
 				// we can only validate TLS connections to services that talk TLS
-				uv, err = p.source.LookupUpstreamValidation(service.UpstreamValidation, caCertNamespacedName)
+				uv, err = p.source.LookupUpstreamValidation(service.UpstreamValidation, caCertNamespacedName, proxy.Namespace)
 				if err != nil {
-					validCond.AddErrorf(contour_api_v1.ConditionTypeServiceError, "TLSUpstreamValidation",
-						"Service [%s:%d] TLS upstream validation policy error: %s", service.Name, service.Port, err)
+					if _, ok := err.(DelegationNotPermittedError); ok {
+						validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "CACertificateNotDelegated",
+							"service.UpstreamValidation.CACertificate Secret %q is not configured for certificate delegation", caCertNamespacedName)
+					} else {
+						validCond.AddErrorf(contour_api_v1.ConditionTypeServiceError, "TLSUpstreamValidation",
+							"Service [%s:%d] TLS upstream validation policy error: %s", service.Name, service.Port, err)
+					}
 					return nil
 				}
 			}
@@ -948,7 +947,8 @@ func (p *HTTPProxyProcessor) computeRoutes(
 
 			var clientCertSecret *Secret
 			if p.ClientCertificate != nil {
-				clientCertSecret, err = p.source.LookupTLSSecret(*p.ClientCertificate)
+				// Since the client certificate is configured by admin, explicit delegation is not required.
+				clientCertSecret, err = p.source.LookupTLSSecretInsecure(*p.ClientCertificate)
 				if err != nil {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "SecretNotValid",
 						"tls.envoy-client-certificate Secret %q is invalid: %s", p.ClientCertificate, err)

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -4560,7 +4560,9 @@ string
 </td>
 <td>
 <p>Name or namespaced name of the Kubernetes secret used to validate the certificate presented by the backend.
-The secret must contain key named ca.crt.</p>
+The secret must contain key named ca.crt.
+The name can be optionally prefixed with namespace &ldquo;namespace/name&rdquo;.
+When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -1022,7 +1022,9 @@ string
 The secret must contain key named ca.crt.
 The client certificate must validate against the certificates in the bundle.
 If specified and SkipClientCertValidation is true, client certificates will
-be required on requests.</p>
+be required on requests.
+The name can be optionally prefixed with namespace &ldquo;namespace/name&rdquo;.
+When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.</p>
 </td>
 </tr>
 <tr>
@@ -1075,7 +1077,9 @@ string
 The secret must contain key named crl.pem.
 This field will be used to verify that a client certificate has not been revoked.
 CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert is true.
-Large CRL lists are not supported since individual secrets are limited to 1MiB in size.</p>
+Large CRL lists are not supported since individual secrets are limited to 1MiB in size.
+The name can be optionally prefixed with namespace &ldquo;namespace/name&rdquo;.
+When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.</p>
 </td>
 </tr>
 <tr>
@@ -4304,10 +4308,12 @@ string
 </em>
 </td>
 <td>
-<p>SecretName is the name of a TLS secret in the current namespace.
+<p>SecretName is the name of a TLS secret.
 Either SecretName or Passthrough must be specified, but not both.
 If specified, the named secret must contain a matching certificate
-for the virtual host&rsquo;s FQDN.</p>
+for the virtual host&rsquo;s FQDN.
+The name can be optionally prefixed with namespace &ldquo;namespace/name&rdquo;.
+When cross-namespace reference is used, TLSCertificateDelegation resource must exist in the namespace to grant access to the secret.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This change unifies handling of cross-namespace certificate delegation for all secret references: TLS certificate, CA certificate, CRL file.