### PR TITLE
test/conformance: only skip specific failing test case

### DIFF
--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -59,12 +59,6 @@ func TestGatewayConformance(t *testing.T) {
 		EnableAllSupportedFeatures: true,
 		// Keep the list of skipped features in sync with
 		// test/scripts/run-gateway-conformance.sh.
-		SkipTests: []string{
-			// Checks for the original request port in the returned Location
-			// header which Envoy is stripping.
-			// See: https://github.com/envoyproxy/envoy/issues/17318
-			tests.HTTPRouteRedirectPortAndScheme.ShortName,
-		},
 		ExemptFeatures: sets.New(
 			suite.SupportMesh,
 		),


### PR DESCRIPTION
Take 2 on this, using `go test -skip`. It's a little uglier, but IMO worth it to get the rest of the test coverage from that test.

See https://github.com/skriss/contour/actions/runs/5591856217/jobs/10223702289 for a verbose run that shows the individual test case being skipped.