### PR TITLE
Increase `bootstrapCmd` timeout

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -488,15 +488,7 @@ func (d *Deployment) EnsureResourcesForLocalContour() error {
 		return err
 	}
 
-	bootstrapCmdCompletionTimeout := 2 * time.Second
-
-	select {
-	case <-session.Exited:
-	case <-time.After(bootstrapCmdCompletionTimeout):
-		session.Kill()
-		return fmt.Errorf("Timeout waiting for bootstrap cmd %s", bootstrapCmd.String())
-	}
-
+	session.Wait("2s")
 	bootstrapContents, err := io.ReadAll(bFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
Locally when running the test the default timeout `bootstrapCmd` 1sec is not enough and I can't run the e2e tests. Small code change to increase the timeout.