### PR TITLE
remove vcert replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/projectcontour/contour
 
 go 1.19
 
-// remove once https://github.com/cert-manager/cert-manager/issues/5953 is fixed
-replace github.com/Venafi/vcert/v4 => github.com/jetstack/vcert/v4 v4.9.6-0.20230127103832-3aa3dfd6613d
-
 require (
 	dario.cat/mergo v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
https://github.com/cert-manager/cert-manager/issues/5953 is now closed and included in cert-manager 1.12.2, so looks like we don't need this anymore.

Running `go list -modfile=go.mod -m all` now works fine.