### PR TITLE
Add reviewer team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @maintainers will be requested for review when someone
-# opens a pull request.
-*       @projectcontour/maintainers
+# @maintainers and @reviewers will be requested for review when
+# someone opens a pull request.
+*       @projectcontour/maintainers @projectcontour/reviewers


### PR DESCRIPTION
To auto assign reviews to the members of the reviewer team