### PR TITLE
[release-1.22] [do not merge] bump Envoy to 1.23.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.7
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.23.12
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/CHANGELOG-v1.20.0.md
+++ b/changelogs/CHANGELOG-v1.20.0.md
@@ -195,7 +195,7 @@ This change should be a no-op for most users, however be sure to re-apply the re
 
 Adds a `Path` & `Prefix` field to the `HTTPProxy.Spec.Route.RequestRedirectPolicy` which allows
 for redirects to also specify the path or prefix to redirect to. When specified, an
-HTTP 302 response will be sent to the requestor with the new path or prefix specified.
+HTTP 302 response will be sent to the requester with the new path or prefix specified.
 
 _Note: Only one of path or prefix can be specified on a single route._
 

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -33,7 +33,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	config := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.22.6",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.7",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.23.12",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -56,7 +56,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.7
+        image: docker.io/envoyproxy/envoy:v1.23.12
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.23.7
+          image: docker.io/envoyproxy/envoy:v1.23.12
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -5169,7 +5169,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.23.7
+          image: docker.io/envoyproxy/envoy:v1.23.12
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -5161,7 +5161,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.7
+        image: docker.io/envoyproxy/envoy:v1.23.12
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -5156,7 +5156,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.23.7
+        image: docker.io/envoyproxy/envoy:v1.23.12
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/posts/2020-01-16-announcing-contour-1.1.md
+++ b/site/content/posts/2020-01-16-announcing-contour-1.1.md
@@ -24,7 +24,7 @@ The header request policy has the following configuration:
 The following example takes requests from `headers.projectcontour.io/` and applies the following logic:
 
 * Adds the header `X-Foo: bar` to any request before it is proxied to the Kubernetes service named `s1` and removes the header `X-Baz`
-* After the request is processed by service `s1`, the response back to the requestor will have the header `X-Service-Name: s1` added and will remove the header `X-Internal-Secret`
+* After the request is processed by service `s1`, the response back to the requester will have the header `X-Service-Name: s1` added and will remove the header `X-Internal-Secret`
 
 ```yaml
 apiVersion: projectcontour.io/v1


### PR DESCRIPTION
Just testing compatibility with the latest Envoy patch release, but as this Contour minor version is out of support, we will not be releasing a patch for it.