### PR TITLE
Add dependabot config for release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 
 version: 2
 updates:
-- package-ecosystem: "gomod"
+# main branch targets
+- target-branch: main
+  package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "weekly"
@@ -12,7 +14,8 @@ updates:
   - release-note/none-required
   reviewers:
   - projectcontour/maintainers
-- package-ecosystem: "github-actions"
+- target-branch: main
+  package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
@@ -22,3 +25,92 @@ updates:
   reviewers:
   - projectcontour/maintainers
   
+# release branch N targets
+- target-branch: release-1.25
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/dependency
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
+- target-branch: release-1.25
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/tooling
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
+
+# release branch N-1 targets
+- target-branch: release-1.24
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/dependency
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
+- target-branch: release-1.24
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/tooling
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
+
+# release branch N-2 targets
+- target-branch: release-1.23
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/dependency
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers
+- target-branch: release-1.23
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - update-types:
+    - "version-update:semver-major"
+    - "version-update:semver-minor"
+  labels:
+  - area/tooling
+  - release-note/none-required
+  reviewers:
+  - projectcontour/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:
@@ -46,7 +47,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:
@@ -62,7 +64,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:
@@ -76,7 +79,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:
@@ -92,7 +96,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:
@@ -106,7 +111,8 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - update-types:
+  - dependency-name: "*"
+    update-types:
     - "version-update:semver-major"
     - "version-update:semver-minor"
   labels:

--- a/site/content/resources/release-process.md
+++ b/site/content/resources/release-process.md
@@ -89,7 +89,7 @@ git push ${CONTOUR_UPSTREAM_REMOTE_NAME} release-${CONTOUR_RELEASE_VERSION_MAJOR
 git push ${CONTOUR_UPSTREAM_REMOTE_NAME} ${CONTOUR_RELEASE_VERSION}
 ```
 
-### Update Dependabot configuraion
+### Update Dependabot configuration
 
 Update the `.github/dependabot.yml` file to update the target branches for Dependabot scanning.
 The latest minor (N) and two previous minors should be scanned (N-1 and N-2).

--- a/site/content/resources/release-process.md
+++ b/site/content/resources/release-process.md
@@ -17,6 +17,7 @@ A minor release requires:
 - website updates
 - a release branch to be created
 - YAML to be customized
+- an update to dependabot config
 - a release tag to be created
 - a GitHub release with release notes
 - public communication
@@ -87,6 +88,11 @@ git push ${CONTOUR_UPSTREAM_REMOTE_NAME} release-${CONTOUR_RELEASE_VERSION_MAJOR
 ```bash
 git push ${CONTOUR_UPSTREAM_REMOTE_NAME} ${CONTOUR_RELEASE_VERSION}
 ```
+
+### Update Dependabot configuraion
+
+Update the `.github/dependabot.yml` file to update the target branches for Dependabot scanning.
+The latest minor (N) and two previous minors should be scanned (N-1 and N-2).
 
 ### Update quickstart YAML redirects
 


### PR DESCRIPTION
Add go and github action bumps for only patch versions on release branches

Also updates release process for minor releases to mention this config should be updated