### PR TITLE
Fix Gateway Status Addresses Updater with multiple Ingress entries.

### DIFF
--- a/changelogs/unreleased/5651-Jean-Daniel-small.md
+++ b/changelogs/unreleased/5651-Jean-Daniel-small.md
@@ -1,0 +1,1 @@
+Gateway provisioner: Expose all Envoy service IPs and Hostname in `Gateway.Status.Addresses`. Only the first IP was exposed before, even for dual-stack service.

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -180,27 +180,7 @@ func (s *StatusAddressUpdater) OnAdd(obj any, isInInitialList bool) {
 				}
 
 				dco := gateway.DeepCopy()
-
-				if len(loadBalancerStatus.Ingress) == 0 {
-					return dco
-				}
-
-				if ip := loadBalancerStatus.Ingress[0].IP; len(ip) > 0 {
-					dco.Status.Addresses = []gatewayapi_v1beta1.GatewayAddress{
-						{
-							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
-							Value: ip,
-						},
-					}
-				} else if hostname := loadBalancerStatus.Ingress[0].Hostname; len(hostname) > 0 {
-					dco.Status.Addresses = []gatewayapi_v1beta1.GatewayAddress{
-						{
-							Type:  ref.To(gatewayapi_v1beta1.HostnameAddressType),
-							Value: hostname,
-						},
-					}
-				}
-
+				dco.Status.Addresses = lbStatusToGatewayAddresses(loadBalancerStatus)
 				return dco
 			}),
 		))
@@ -304,4 +284,25 @@ func coreToNetworkingLBStatus(lbs v1.LoadBalancerStatus) networking_v1.IngressLo
 	return networking_v1.IngressLoadBalancerStatus{
 		Ingress: ingress,
 	}
+}
+
+func lbStatusToGatewayAddresses(lbs v1.LoadBalancerStatus) []gatewayapi_v1beta1.GatewayAddress {
+	addrs := []gatewayapi_v1beta1.GatewayAddress{}
+
+	for _, lbi := range lbs.Ingress {
+		if len(lbi.IP) > 0 {
+			addrs = append(addrs, gatewayapi_v1beta1.GatewayAddress{
+				Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+				Value: lbi.IP,
+			})
+		}
+		if len(lbi.Hostname) > 0 {
+			addrs = append(addrs, gatewayapi_v1beta1.GatewayAddress{
+				Type:  ref.To(gatewayapi_v1beta1.HostnameAddressType),
+				Value: lbi.Hostname,
+			})
+		}
+	}
+
+	return addrs
 }

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -359,6 +359,9 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 			{
 				IP: "127.0.0.1",
 			},
+			{
+				IP: "fe80::1",
+			},
 		},
 	}
 
@@ -416,6 +419,10 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 						{
 							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
 							Value: ipLBStatus.Ingress[0].IP,
+						},
+						{
+							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Value: ipLBStatus.Ingress[1].IP,
 						},
 					},
 				},
@@ -580,6 +587,10 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 						{
 							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
 							Value: ipLBStatus.Ingress[0].IP,
+						},
+						{
+							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Value: ipLBStatus.Ingress[1].IP,
 						},
 					},
 				},


### PR DESCRIPTION
That field is used by other components like k8s external-dns, and should contains all information provided by the envoy service load balancer status.

It also fixes the `Gateway.Status.Addresses` field update when all Ingress entries are remove from the envoy service.

Fixes #5650