### PR TITLE
gw-api: Support multiple RequestMirror filters per rule in GW API

### DIFF
--- a/changelogs/unreleased/5652-LiorLieberman-minor.md
+++ b/changelogs/unreleased/5652-LiorLieberman-minor.md
@@ -1,0 +1,6 @@
+## Adding support for multiple gateway-api RequestMirror filters within the same HTTP or GRPC rule 
+
+Currently, Contour supports a single RequestMirror filter per rule in HTTPRoute or GRPCRoute.
+Envoy however, supports more than one mirror backend using [request_mirror_policies](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-routeaction)
+
+This PR adds support for multiple gateway-api RequestMirror filters within the same HTTP or GRPC rule.

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -202,8 +202,10 @@ func (d *DAG) GetClusters() []*Cluster {
 			for _, route := range vhost.Routes {
 				res = append(res, route.Clusters...)
 
-				if route.MirrorPolicy != nil && route.MirrorPolicy.Cluster != nil {
-					res = append(res, route.MirrorPolicy.Cluster)
+				for _, mp := range route.MirrorPolicies {
+					if mp.Cluster != nil {
+						res = append(res, mp.Cluster)
+					}
 				}
 			}
 		}
@@ -212,8 +214,10 @@ func (d *DAG) GetClusters() []*Cluster {
 			for _, route := range vhost.Routes {
 				res = append(res, route.Clusters...)
 
-				if route.MirrorPolicy != nil && route.MirrorPolicy.Cluster != nil {
-					res = append(res, route.MirrorPolicy.Cluster)
+				for _, mp := range route.MirrorPolicies {
+					if mp.Cluster != nil {
+						res = append(res, mp.Cluster)
+					}
 				}
 			}
 

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -291,7 +291,36 @@ func TestGetServiceClusters(t *testing.T) {
 			},
 		},
 	}
+
+	dagWithMirror := &DAG{
+		Listeners: map[string]*Listener{
+			"http-1": {
+				VirtualHosts: []*VirtualHost{
+					{
+						Routes: map[string]*Route{
+							"foo": {
+								Clusters: []*Cluster{
+									{Upstream: &Service{ExternalName: "bar.com"}},
+									{Upstream: &Service{}},
+								},
+								MirrorPolicies: []*MirrorPolicy{
+									{
+										Cluster: &Cluster{
+											Upstream: &Service{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	// We should only get one cluster since the other is for an ExternalName
 	// service.
 	assert.Len(t, d.GetServiceClusters(), 1)
+
+	// We should get one two clusters since we have mirrorPolicies.
+	assert.Len(t, dagWithMirror.GetServiceClusters(), 2)
 }

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -291,6 +291,9 @@ func TestGetServiceClusters(t *testing.T) {
 			},
 		},
 	}
+	// We should only get one cluster since the other is for an ExternalName
+	// service.
+	assert.Len(t, d.GetServiceClusters(), 1)
 
 	dagWithMirror := &DAG{
 		Listeners: map[string]*Listener{
@@ -300,7 +303,6 @@ func TestGetServiceClusters(t *testing.T) {
 						Routes: map[string]*Route{
 							"foo": {
 								Clusters: []*Cluster{
-									{Upstream: &Service{ExternalName: "bar.com"}},
 									{Upstream: &Service{}},
 								},
 								MirrorPolicies: []*MirrorPolicy{
@@ -317,10 +319,6 @@ func TestGetServiceClusters(t *testing.T) {
 			},
 		},
 	}
-	// We should only get one cluster since the other is for an ExternalName
-	// service.
-	assert.Len(t, d.GetServiceClusters(), 1)
-
-	// We should get one two clusters since we have mirrorPolicies.
+	// We should get two clusters since we have mirrorPolicies.
 	assert.Len(t, dagWithMirror.GetServiceClusters(), 2)
 }

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -319,8 +319,8 @@ type Route struct {
 	// Indicates that during forwarding, the matched prefix (or path) should be swapped with this value
 	PathRewritePolicy *PathRewritePolicy
 
-	// Mirror Policy defines the mirroring policy for this Route.
-	MirrorPolicy *MirrorPolicy
+	// MirrorPolicies is a list defining the mirroring policies for this Route.
+	MirrorPolicies []*MirrorPolicy
 
 	// RequestHeadersPolicy defines how headers are managed during forwarding
 	RequestHeadersPolicy *HeadersPolicy

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1129,8 +1129,9 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(route *gatewayapi_v1be
 			urlRewriteHostname   string
 		)
 
-		// Per Gateway API docs: "Specifying a core filter multiple times
-		// has unspecified or implementation-specific conformance." Contour
+		// Per Gateway API docs: "Specifying the same filter multiple times is
+		// not supported unless explicitly indicated in the filter." For filters
+		// that can't be used multiple times within the same rule, Contour
 		// chooses to use the first instance of each filter type and ignore
 		// subsequent instances.
 		for _, filter := range rule.Filters {
@@ -1406,8 +1407,9 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 			mirrorPolicies                            []*MirrorPolicy
 		)
 
-		// Per Gateway API docs: "Specifying a core filter multiple times
-		// has unspecified or implementation-specific conformance." Contour
+		// Per Gateway API docs: "Specifying the same filter multiple times is
+		// not supported unless explicitly indicated in the filter." For filters
+		// that can't be used multiple times within the same rule, Contour
 		// chooses to use the first instance of each filter type and ignore
 		// subsequent instances.
 		for _, filter := range rule.Filters {
@@ -1890,8 +1892,9 @@ func (p *GatewayAPIProcessor) httpClusters(routeNamespace string, backendRefs []
 		var clusterRequestHeaderPolicy *HeadersPolicy
 		var clusterResponseHeaderPolicy *HeadersPolicy
 
-		// Per Gateway API docs: "Specifying a core filter multiple times
-		// has unspecified or implementation-specific conformance." Contour
+		// Per Gateway API docs: "Specifying the same filter multiple times is
+		// not supported unless explicitly indicated in the filter." For filters
+		// that can't be used multiple times within the same rule, Contour
 		// chooses to use the first instance of each filter type and ignore
 		// subsequent instances.
 		for _, filter := range backendRef.Filters {
@@ -1973,8 +1976,9 @@ func (p *GatewayAPIProcessor) grpcClusters(routeNamespace string, backendRefs []
 
 		var clusterRequestHeaderPolicy, clusterResponseHeaderPolicy *HeadersPolicy
 
-		// Per Gateway API docs: "Specifying a core filter multiple times
-		// has unspecified or implementation-specific conformance." Contour
+		// Per Gateway API docs: "Specifying the same filter multiple times is
+		// not supported unless explicitly indicated in the filter." For filters
+		// that can't be used multiple times within the same rule, Contour
 		// chooses to use the first instance of each filter type and ignore
 		// subsequent instances.
 		for _, filter := range backendRef.Filters {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1433,8 +1433,7 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1al
 					routeAccessor.AddCondition(gatewayapi_v1beta1.RouteConditionResolvedRefs, metav1.ConditionFalse, status.ReasonDegraded, fmt.Sprintf("%s on response headers", err))
 				}
 			case gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror:
-				// If more than one, we only take the first RequestMirror filter.
-				if filter.RequestMirror == nil || len(mirrorPolicies) > 0 {
+				if filter.RequestMirror == nil {
 					continue
 				}
 

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1013,7 +1013,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				MaxRequestsPerConnection:      p.MaxRequestsPerConnection,
 				PerConnectionBufferLimitBytes: p.PerConnectionBufferLimitBytes,
 			}
-			if service.Mirror && len(r.MirrorPolicies) != 0 {
+			if service.Mirror && len(r.MirrorPolicies) > 0 {
 				validCond.AddError(contour_api_v1.ConditionTypeServiceError, "OnlyOneMirror",
 					"only one service per route may be nominated as mirror")
 				return nil

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1013,7 +1013,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				MaxRequestsPerConnection:      p.MaxRequestsPerConnection,
 				PerConnectionBufferLimitBytes: p.PerConnectionBufferLimitBytes,
 			}
-			if service.Mirror && r.MirrorPolicy != nil {
+			if service.Mirror && len(r.MirrorPolicies) != 0 {
 				validCond.AddError(contour_api_v1.ConditionTypeServiceError, "OnlyOneMirror",
 					"only one service per route may be nominated as mirror")
 				return nil
@@ -1024,15 +1024,15 @@ func (p *HTTPProxyProcessor) computeRoutes(
 				// EDGE CASE: This means that explicitly setting Weight to 0 will also result in 100%
 				// mirroring. The Mirror field must be set to false or removed to disable the mirror.
 				if service.Weight == 0 {
-					r.MirrorPolicy = &MirrorPolicy{
+					r.MirrorPolicies = []*MirrorPolicy{{
 						Cluster: c,
 						Weight:  100,
-					}
+					}}
 				} else {
-					r.MirrorPolicy = &MirrorPolicy{
+					r.MirrorPolicies = []*MirrorPolicy{{
 						Cluster: c,
 						Weight:  service.Weight,
-					}
+					}}
 				}
 			} else {
 				r.Clusters = append(r.Clusters, c)

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -7803,7 +7803,6 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// Invalid filters still result in an attached route.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", gatewayapi_v1beta1.HTTPProtocolType, 1),
 	})
 
@@ -10578,7 +10577,6 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 				},
 			},
 		}},
-		// Invalid filters still result in an attached route.
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", gatewayapi_v1beta1.HTTPProtocolType, 1),
 	})
 

--- a/internal/debug/dot.go
+++ b/internal/debug/dot.go
@@ -69,8 +69,10 @@ func collectDag(b DagBuilder) (nodeCollection, edgeCollection) {
 				nodes[route] = true
 
 				clusters := route.Clusters
-				if route.MirrorPolicy != nil && route.MirrorPolicy.Cluster != nil {
-					clusters = append(clusters, route.MirrorPolicy.Cluster)
+				for _, mp := range route.MirrorPolicies {
+					if mp.Cluster != nil {
+						clusters = append(clusters, mp.Cluster)
+					}
 				}
 				for _, cluster := range clusters {
 					edges[pair{route, cluster}] = true
@@ -93,8 +95,10 @@ func collectDag(b DagBuilder) (nodeCollection, edgeCollection) {
 				nodes[route] = true
 
 				clusters := route.Clusters
-				if route.MirrorPolicy != nil && route.MirrorPolicy.Cluster != nil {
-					clusters = append(clusters, route.MirrorPolicy.Cluster)
+				for _, mp := range route.MirrorPolicies {
+					if mp.Cluster != nil {
+						clusters = append(clusters, mp.Cluster)
+					}
 				}
 				for _, cluster := range clusters {
 					edges[pair{route, cluster}] = true

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -491,19 +491,23 @@ func hashPolicy(requestHashPolicies []dag.RequestHashPolicy) []*envoy_route_v3.R
 }
 
 func mirrorPolicy(r *dag.Route) []*envoy_route_v3.RouteAction_RequestMirrorPolicy {
-	if r.MirrorPolicy == nil {
+	if len(r.MirrorPolicies) == 0 {
 		return nil
 	}
 
-	return []*envoy_route_v3.RouteAction_RequestMirrorPolicy{{
-		Cluster: envoy.Clustername(r.MirrorPolicy.Cluster),
-		RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
-			DefaultValue: &envoy_type_v3.FractionalPercent{
-				Numerator:   uint32(r.MirrorPolicy.Weight),
-				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+	mirrorPolicies := []*envoy_route_v3.RouteAction_RequestMirrorPolicy{}
+	for _, mp := range r.MirrorPolicies {
+		mirrorPolicies = append(mirrorPolicies, &envoy_route_v3.RouteAction_RequestMirrorPolicy{
+			Cluster: envoy.Clustername(mp.Cluster),
+			RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+				DefaultValue: &envoy_type_v3.FractionalPercent{
+					Numerator:   uint32(mp.Weight),
+					Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+				},
 			},
-		},
-	}}
+		})
+	}
+	return mirrorPolicies
 }
 
 func retryPolicy(r *dag.Route) *envoy_route_v3.RetryPolicy {

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -679,7 +679,6 @@ func TestRouteRoute(t *testing.T) {
 			},
 		},
 
-		//TODO(liorlieberman) add multiple mirror test
 		"mirror": {
 			route: &dag.Route{
 				Clusters: []*dag.Cluster{{

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -43,6 +43,8 @@ import (
 func TestRouteRoute(t *testing.T) {
 	s1 := fixture.NewService("kuard").
 		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
+	s2 := fixture.NewService("kuard2").
+		WithPorts(v1.ServicePort{Name: "http", Port: 8080, TargetPort: intstr.FromInt(8080)})
 	c1 := &dag.Cluster{
 		Upstream: &dag.Service{
 			Weighted: dag.WeightedService{
@@ -719,6 +721,75 @@ func TestRouteRoute(t *testing.T) {
 								Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
 							},
 						}}},
+				},
+			},
+		},
+		"two mirrors": {
+			route: &dag.Route{
+				Clusters: []*dag.Cluster{{
+					Upstream: &dag.Service{
+						Weighted: dag.WeightedService{
+							Weight:           1,
+							ServiceName:      s1.Name,
+							ServiceNamespace: s1.Namespace,
+							ServicePort:      s1.Spec.Ports[0],
+						},
+					},
+					Weight: 90,
+				}},
+				MirrorPolicies: []*dag.MirrorPolicy{
+					{
+						Cluster: &dag.Cluster{
+							Upstream: &dag.Service{
+								Weighted: dag.WeightedService{
+									Weight:           1,
+									ServiceName:      s1.Name,
+									ServiceNamespace: s1.Namespace,
+									ServicePort:      s1.Spec.Ports[0],
+								},
+							},
+						},
+						Weight: 100,
+					},
+					{
+						Cluster: &dag.Cluster{
+							Upstream: &dag.Service{
+								Weighted: dag.WeightedService{
+									Weight:           1,
+									ServiceName:      s2.Name,
+									ServiceNamespace: s2.Namespace,
+									ServicePort:      s2.Spec.Ports[0],
+								},
+							},
+						},
+						Weight: 100,
+					},
+				}},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RequestMirrorPolicies: []*envoy_route_v3.RouteAction_RequestMirrorPolicy{
+						{
+							Cluster: "default/kuard/8080/da39a3ee5e",
+							RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+								DefaultValue: &envoy_type_v3.FractionalPercent{
+									Numerator:   100,
+									Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+								},
+							},
+						},
+						{
+							Cluster: "default/kuard2/8080/da39a3ee5e",
+							RuntimeFraction: &envoy_core_v3.RuntimeFractionalPercent{
+								DefaultValue: &envoy_type_v3.FractionalPercent{
+									Numerator:   100,
+									Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -677,6 +677,7 @@ func TestRouteRoute(t *testing.T) {
 			},
 		},
 
+		//TODO(liorlieberman) add multiple mirror test
 		"mirror": {
 			route: &dag.Route{
 				Clusters: []*dag.Cluster{{
@@ -690,20 +691,21 @@ func TestRouteRoute(t *testing.T) {
 					},
 					Weight: 90,
 				}},
-				MirrorPolicy: &dag.MirrorPolicy{
-					Cluster: &dag.Cluster{
-						Upstream: &dag.Service{
-							Weighted: dag.WeightedService{
-								Weight:           1,
-								ServiceName:      s1.Name,
-								ServiceNamespace: s1.Namespace,
-								ServicePort:      s1.Spec.Ports[0],
+				MirrorPolicies: []*dag.MirrorPolicy{
+					{
+						Cluster: &dag.Cluster{
+							Upstream: &dag.Service{
+								Weighted: dag.WeightedService{
+									Weight:           1,
+									ServiceName:      s1.Name,
+									ServiceNamespace: s1.Namespace,
+									ServicePort:      s1.Spec.Ports[0],
+								},
 							},
 						},
+						Weight: 100,
 					},
-					Weight: 100,
-				},
-			},
+				}},
 			want: &envoy_route_v3.Route_Route{
 				Route: &envoy_route_v3.RouteAction{
 					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{


### PR DESCRIPTION
Adding support for multiple RequestMirror filters per rule in GW API. both GRPC and HTTP

Fixes: https://github.com/projectcontour/contour/issues/4566

ref: https://github.com/kubernetes-sigs/gateway-api/pull/2199



