### PR TITLE
Allow TLSv1.3 between Envoy and upstream service

### DIFF
--- a/changelogs/unreleased/5666-tsaarni-small.md
+++ b/changelogs/unreleased/5666-tsaarni-small.md
@@ -1,0 +1,1 @@
+Allow TLSv1.3 between Envoy and upstream services.

--- a/internal/envoy/v3/auth.go
+++ b/internal/envoy/v3/auth.go
@@ -38,6 +38,12 @@ func UpstreamTLSContext(peerValidationContext *dag.PeerValidationContext, sni st
 		CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 			AlpnProtocols:                  alpnProtocols,
 			TlsCertificateSdsSecretConfigs: clientSecretConfigs,
+			TlsParams: &envoy_v3_tls.TlsParameters{
+				// Envoy defaults to TLSv1.2 for both minimum and maximum protocol version, when acting as a client.
+				// Override the maximum to allow upstream server to use TLSv1.3.
+				// See https://github.com/envoyproxy/envoy/issues/9300 for further information.
+				TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+			},
 		},
 		Sni: sni,
 	}

--- a/internal/envoy/v3/auth_test.go
+++ b/internal/envoy/v3/auth_test.go
@@ -45,7 +45,11 @@ func TestUpstreamTLSContext(t *testing.T) {
 	}{
 		"no alpn, no validation": {
 			want: &envoy_v3_tls.UpstreamTlsContext{
-				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{},
+				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
+				},
 			},
 		},
 		"h2, no validation": {
@@ -53,6 +57,9 @@ func TestUpstreamTLSContext(t *testing.T) {
 			want: &envoy_v3_tls.UpstreamTlsContext{
 				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 					AlpnProtocols: []string{"h2c"},
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
 				},
 			},
 		},
@@ -61,7 +68,11 @@ func TestUpstreamTLSContext(t *testing.T) {
 				CACertificate: secret,
 			},
 			want: &envoy_v3_tls.UpstreamTlsContext{
-				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{},
+				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
+				},
 			},
 		},
 		"no alpn, missing ca": {
@@ -69,7 +80,11 @@ func TestUpstreamTLSContext(t *testing.T) {
 				SubjectName: "www.example.com",
 			},
 			want: &envoy_v3_tls.UpstreamTlsContext{
-				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{},
+				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
+				},
 			},
 		},
 		"no alpn, ca and altname": {
@@ -98,14 +113,21 @@ func TestUpstreamTLSContext(t *testing.T) {
 							},
 						},
 					},
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
 				},
 			},
 		},
 		"external name sni": {
 			externalName: "projectcontour.local",
 			want: &envoy_v3_tls.UpstreamTlsContext{
-				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{},
-				Sni:              "projectcontour.local",
+				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
+					TlsParams: &envoy_v3_tls.TlsParameters{
+						TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+					},
+				},
+				Sni: "projectcontour.local",
 			},
 		},
 	}

--- a/internal/featuretests/v3/extensionservice_test.go
+++ b/internal/featuretests/v3/extensionservice_test.go
@@ -54,6 +54,9 @@ func extBasic(t *testing.T, rh ResourceEventHandlerWrapper, c *Contour) {
 						&envoy_v3_tls.UpstreamTlsContext{
 							CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 								AlpnProtocols: []string{"h2"},
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
 							},
 							// Note there's no SNI in this scenario.
 						},
@@ -137,6 +140,9 @@ func extUpstreamValidation(t *testing.T, rh ResourceEventHandlerWrapper, c *Cont
 							},
 						},
 					},
+				},
+				TlsParams: &envoy_v3_tls.TlsParameters{
+					TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
 				},
 			},
 		},
@@ -273,6 +279,9 @@ func extIdleConnectionTimeout(t *testing.T, rh ResourceEventHandlerWrapper, c *C
 						&envoy_v3_tls.UpstreamTlsContext{
 							CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 								AlpnProtocols: []string{"h2"},
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
 							},
 						},
 					),
@@ -366,6 +375,9 @@ func extInvalidLoadBalancerPolicy(t *testing.T, rh ResourceEventHandlerWrapper, 
 						&envoy_v3_tls.UpstreamTlsContext{
 							CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 								AlpnProtocols: []string{"h2"},
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
 							},
 						},
 					),
@@ -399,6 +411,9 @@ func extInvalidLoadBalancerPolicy(t *testing.T, rh ResourceEventHandlerWrapper, 
 						&envoy_v3_tls.UpstreamTlsContext{
 							CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
 								AlpnProtocols: []string{"h2"},
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
 							},
 						},
 					),

--- a/internal/featuretests/v3/jwtverification_test.go
+++ b/internal/featuretests/v3/jwtverification_test.go
@@ -24,6 +24,7 @@ import (
 	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_jwt_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_v3_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -213,8 +214,12 @@ func TestJWTVerification(t *testing.T) {
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
 						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
-							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
-							Sni:              "jwt.example.com",
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
+							},
+							Sni: "jwt.example.com",
 						}),
 					},
 				},
@@ -698,8 +703,12 @@ func TestJWTVerification(t *testing.T) {
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
 						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
-							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
-							Sni:              "jwt.example.com",
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
+							},
+							Sni: "jwt.example.com",
 						}),
 					},
 				},
@@ -872,6 +881,9 @@ func TestJWTVerification(t *testing.T) {
 										},
 									},
 								},
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
 							},
 							Sni: "jwt.example.com",
 						}),
@@ -1016,8 +1028,12 @@ func TestJWTVerification(t *testing.T) {
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
 						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
-							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
-							Sni:              "jwt.example.com",
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
+							},
+							Sni: "jwt.example.com",
 						}),
 					},
 				},
@@ -1162,8 +1178,12 @@ func TestJWTVerification(t *testing.T) {
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
 						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
-							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
-							Sni:              "jwt.example.com",
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
+							},
+							Sni: "jwt.example.com",
 						}),
 					},
 				},
@@ -1383,8 +1403,12 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 					Name: "envoy.transport_sockets.tls",
 					ConfigType: &envoy_core_v3.TransportSocket_TypedConfig{
 						TypedConfig: protobuf.MustMarshalAny(&envoy_tls_v3.UpstreamTlsContext{
-							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{},
-							Sni:              "jwt.example.com",
+							CommonTlsContext: &envoy_tls_v3.CommonTlsContext{
+								TlsParams: &envoy_v3_tls.TlsParameters{
+									TlsMaximumProtocolVersion: envoy_v3_tls.TlsParameters_TLSv1_3,
+								},
+							},
+							Sni: "jwt.example.com",
 						}),
 					},
 				},


### PR DESCRIPTION
Envoy currently defaults to min/max TLSv1.2 for upstream connections. This change sets maximum to TLSv1.3 to allow both TLSv1.2 and TLSv1.3 between Envoy and the upstream service. The upstream service is responsible for picking one of the protocol versions.

The suggested change does not make the upstream min/max TLS version configurable via Contour. If we need min/max as configurable, then we can consider adding new field(s) either inside `httpproxy.spec.routes.services.validation`, which is existing struct with TLS related parameters, but the name implies it is only for validation parameters, or we could introduce new structure `httpproxy.spec.routes.services.tls`, and include other TLS parameters as well, such as the ones discussed in https://github.com/projectcontour/contour/issues/5127.

There are some implications from the suggested change that the users will be able to observe:  

When an upstream service using TLSv1.3 does not accept the client certificate that Envoy presents, the TLS alert message about authentication failure is not propagated to downstream client. See https://github.com/envoyproxy/envoy/issues/9300 for further information. 

Secondly, Envoy will not retry connection attempt after authentication failure, when TLSv1.3 is used (not 100% sure if it does for TLSv1.2 but it is implied in the Envoy issue). This should be OK since upstream service consists of replicas of single deployment and all pods are expected to share their configuration, including the authentication parameters. Therefore, authentication would fail towards another replica as well.

Fixes #5501

Signed-off-by: Tero Saarni <tero.saarni@est.tech>
