### PR TITLE
 internal/provisioner: add cmd line argument: --base-id for envoy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ BUILD_CGO_ENABLED ?= 0
 BUILD_GOPRIVATE ?= ""
 
 # Go module mirror to use.
-#BUILD_GOPROXY ?= https://proxy.golang.org
-BUILD_GOPROXY ?= https://goproxy.cn
+BUILD_GOPROXY ?= https://proxy.golang.org
 
 # Checksum db to use.
 BUILD_GOSUMDB ?= sum.golang.org
@@ -125,7 +124,7 @@ race:
 download: ## Download Go modules
 	go mod download
 
-multiarch-build2: ## Build and optionally push a multi-arch Contour container image to the Docker registry
+multiarch-build: ## Build and optionally push a multi-arch Contour container image to the Docker registry
 	@mkdir -p $(shell pwd)/image
 	docker buildx build $(IMAGE_RESULT_FLAG) \
 		--platform $(IMAGE_PLATFORMS) \
@@ -142,25 +141,6 @@ multiarch-build2: ## Build and optionally push a multi-arch Contour container im
 		$(DOCKER_BUILD_LABELS) \
 		$(IMAGE_TAGS) \
 		$(shell pwd)
-
-multiarch-build: ## Build and optionally push a multi-arch Contour container image to the Docker registry
-	docker buildx build \
-		--platform $(IMAGE_PLATFORMS) \
-		--build-arg "BUILD_GOPRIVATE=$(BUILD_GOPRIVATE)" \
-		--build-arg "BUILD_GOPROXY=$(BUILD_GOPROXY)" \
-		--build-arg "BUILD_GOSUMDB=$(BUILD_GOSUMDB)" \
-		--build-arg "BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE)" \
-		--build-arg "BUILD_VERSION=$(BUILD_VERSION)" \
-		--build-arg "BUILD_BRANCH=$(BUILD_BRANCH)" \
-		--build-arg "BUILD_SHA=$(BUILD_SHA)" \
-		--build-arg "BUILD_CGO_ENABLED=$(BUILD_CGO_ENABLED)" \
-		--build-arg "BUILD_EXTRA_GO_LDFLAGS=$(BUILD_EXTRA_GO_LDFLAGS)" \
-		--build-arg "BUILD_GOEXPERIMENT=$(BUILD_GOEXPERIMENT)" \
-		$(DOCKER_BUILD_LABELS) \
-        -t release-ci.daocloud.io/skoala/contour:v1.25.2-with-envoy-base-id  \
-        $(shell pwd) \
-        --push
-
 
 container: ## Build the Contour container image
 	docker build \
@@ -247,7 +227,7 @@ lint-flags:
 
 .PHONY: generate
 generate: ## Re-generate generated code and documentation
-generate: generate-rbac generate-crd-deepcopy generate-crd-yaml  generate-deployment generate-api-docs generate-metrics-docs generate-uml generate-go
+generate: generate-rbac generate-crd-deepcopy generate-crd-yaml generate-gateway-yaml generate-deployment generate-api-docs generate-metrics-docs generate-uml generate-go
 
 .PHONY: generate-rbac
 generate-rbac:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ BUILD_CGO_ENABLED ?= 0
 BUILD_GOPRIVATE ?= ""
 
 # Go module mirror to use.
-BUILD_GOPROXY ?= https://proxy.golang.org
+#BUILD_GOPROXY ?= https://proxy.golang.org
+BUILD_GOPROXY ?= https://goproxy.cn
 
 # Checksum db to use.
 BUILD_GOSUMDB ?= sum.golang.org
@@ -124,7 +125,7 @@ race:
 download: ## Download Go modules
 	go mod download
 
-multiarch-build: ## Build and optionally push a multi-arch Contour container image to the Docker registry
+multiarch-build2: ## Build and optionally push a multi-arch Contour container image to the Docker registry
 	@mkdir -p $(shell pwd)/image
 	docker buildx build $(IMAGE_RESULT_FLAG) \
 		--platform $(IMAGE_PLATFORMS) \
@@ -141,6 +142,25 @@ multiarch-build: ## Build and optionally push a multi-arch Contour container ima
 		$(DOCKER_BUILD_LABELS) \
 		$(IMAGE_TAGS) \
 		$(shell pwd)
+
+multiarch-build: ## Build and optionally push a multi-arch Contour container image to the Docker registry
+	docker buildx build \
+		--platform $(IMAGE_PLATFORMS) \
+		--build-arg "BUILD_GOPRIVATE=$(BUILD_GOPRIVATE)" \
+		--build-arg "BUILD_GOPROXY=$(BUILD_GOPROXY)" \
+		--build-arg "BUILD_GOSUMDB=$(BUILD_GOSUMDB)" \
+		--build-arg "BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE)" \
+		--build-arg "BUILD_VERSION=$(BUILD_VERSION)" \
+		--build-arg "BUILD_BRANCH=$(BUILD_BRANCH)" \
+		--build-arg "BUILD_SHA=$(BUILD_SHA)" \
+		--build-arg "BUILD_CGO_ENABLED=$(BUILD_CGO_ENABLED)" \
+		--build-arg "BUILD_EXTRA_GO_LDFLAGS=$(BUILD_EXTRA_GO_LDFLAGS)" \
+		--build-arg "BUILD_GOEXPERIMENT=$(BUILD_GOEXPERIMENT)" \
+		$(DOCKER_BUILD_LABELS) \
+        -t release-ci.daocloud.io/skoala/contour:v1.25.2-with-envoy-base-id  \
+        $(shell pwd) \
+        --push
+
 
 container: ## Build the Contour container image
 	docker build \
@@ -227,7 +247,7 @@ lint-flags:
 
 .PHONY: generate
 generate: ## Re-generate generated code and documentation
-generate: generate-rbac generate-crd-deepcopy generate-crd-yaml generate-gateway-yaml generate-deployment generate-api-docs generate-metrics-docs generate-uml generate-go
+generate: generate-rbac generate-crd-deepcopy generate-crd-yaml  generate-deployment generate-api-docs generate-metrics-docs generate-uml generate-go
 
 .PHONY: generate-rbac
 generate-rbac:

--- a/apis/projectcontour/v1alpha1/contourdeployment.go
+++ b/apis/projectcontour/v1alpha1/contourdeployment.go
@@ -206,6 +206,15 @@ type EnvoySettings struct {
 	// if `WorkloadType` is `DaemonSet`,it's must be nil
 	// +optional
 	Deployment *DeploymentSettings `json:"deployment,omitempty"`
+
+	// The base ID to use when allocating shared memory regions.
+	// if Envoy needs to be run multiple times on the same machine, each running Envoy will need a unique base ID
+	// so that the shared memory regions do not conflict.
+	// defaults to 0.
+	//
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	BaseID int32 `json:"baseID,omitempty"`
 }
 
 // WorkloadType is the type of Kubernetes workload to use for a component.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1432,6 +1432,14 @@ spec:
                   or Deployment), node placement constraints for the pods, and various
                   options for the Envoy service.
                 properties:
+                  baseID:
+                    description: The base ID to use when allocating shared memory
+                      regions. if Envoy needs to be run multiple times on the same
+                      machine, each running Envoy will need a unique base ID so that
+                      the shared memory regions do not conflict. defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   daemonSet:
                     description: DaemonSet describes the settings for running envoy
                       as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1645,6 +1645,14 @@ spec:
                   or Deployment), node placement constraints for the pods, and various
                   options for the Envoy service.
                 properties:
+                  baseID:
+                    description: The base ID to use when allocating shared memory
+                      regions. if Envoy needs to be run multiple times on the same
+                      machine, each running Envoy will need a unique base ID so that
+                      the shared memory regions do not conflict. defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   daemonSet:
                     description: DaemonSet describes the settings for running envoy
                       as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -1446,6 +1446,14 @@ spec:
                   or Deployment), node placement constraints for the pods, and various
                   options for the Envoy service.
                 properties:
+                  baseID:
+                    description: The base ID to use when allocating shared memory
+                      regions. if Envoy needs to be run multiple times on the same
+                      machine, each running Envoy will need a unique base ID so that
+                      the shared memory regions do not conflict. defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   daemonSet:
                     description: DaemonSet describes the settings for running envoy
                       as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1651,6 +1651,14 @@ spec:
                   or Deployment), node placement constraints for the pods, and various
                   options for the Envoy service.
                 properties:
+                  baseID:
+                    description: The base ID to use when allocating shared memory
+                      regions. if Envoy needs to be run multiple times on the same
+                      machine, each running Envoy will need a unique base ID so that
+                      the shared memory regions do not conflict. defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   daemonSet:
                     description: DaemonSet describes the settings for running envoy
                       as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1645,6 +1645,14 @@ spec:
                   or Deployment), node placement constraints for the pods, and various
                   options for the Envoy service.
                 properties:
+                  baseID:
+                    description: The base ID to use when allocating shared memory
+                      regions. if Envoy needs to be run multiple times on the same
+                      machine, each running Envoy will need a unique base ID so that
+                      the shared memory regions do not conflict. defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   daemonSet:
                     description: DaemonSet describes the settings for running envoy
                       as a `DaemonSet`. if `WorkloadType` is `Deployment`,it's must

--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -357,6 +357,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				contourModel.Spec.EnvoyDaemonSetUpdateStrategy = *envoyParams.DaemonSet.UpdateStrategy
 			}
 
+			if envoyParams.BaseID > 0 {
+				contourModel.Spec.EnvoyBaseID = envoyParams.BaseID
+			}
+
 		}
 	}
 

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -42,6 +42,7 @@ func Default(namespace, name string) *Contour {
 			EnvoyWorkloadType: WorkloadTypeDaemonSet,
 			EnvoyReplicas:     2, // ignored if not provisioning Envoy as a deployment.
 			EnvoyLogLevel:     contourv1alpha1.InfoLog,
+			EnvoyBaseID:       0,
 			NetworkPublishing: NetworkPublishing{
 				Envoy: EnvoyNetworkPublishing{
 					Type:                  LoadBalancerServicePublishingType,
@@ -224,6 +225,12 @@ type ContourSpec struct {
 	// EnvoyLogLevel sets the log level for Envoy
 	// Allowed values are "trace", "debug", "info", "warn", "error", "critical", "off".
 	EnvoyLogLevel contourv1alpha1.LogLevel
+
+	// The base ID to use when allocating shared memory regions.
+	// if Envoy needs to be run multiple times on the same machine, each running Envoy will need a unique base ID
+	// so that the shared memory regions do not conflict.
+	// defaults to 0.
+	EnvoyBaseID int32
 }
 
 // WorkloadType is the type of Kubernetes workload to use for a component.

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -209,6 +209,7 @@ func desiredContainers(contour *model.Contour, contourImage, envoyImage string) 
 				fmt.Sprintf("--service-cluster $(%s)", envoyNsEnvVar),
 				fmt.Sprintf("--service-node $(%s)", envoyPodEnvVar),
 				fmt.Sprintf("--log-level %s", contour.Spec.EnvoyLogLevel),
+				fmt.Sprintf("--base-id %d", contour.Spec.EnvoyBaseID),
 			},
 			Env: []corev1.EnvVar{
 				{

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -289,6 +289,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
 	testLogLevelArg := "--log-level debug"
+	testBaseIDArg := "--base-id 1"
 
 	resQutoa := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -311,10 +312,13 @@ func TestDesiredDaemonSet(t *testing.T) {
 			},
 		},
 	}
+	// Change the Envoy base id to test --base-id 1
+	cntr.Spec.EnvoyBaseID = 1
 
 	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
 	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)
 	checkContainerHasArg(t, container, testLogLevelArg)
+	checkContainerHasArg(t, container, testBaseIDArg)
 	checkContainerHasImage(t, container, testEnvoyImage)
 	checkContainerHasReadinessPort(t, container, 8002)
 

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -7035,6 +7035,22 @@ DeploymentSettings
 if <code>WorkloadType</code> is <code>DaemonSet</code>,it&rsquo;s must be nil</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>baseID</code>
+<br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The base ID to use when allocating shared memory regions.
+if Envoy needs to be run multiple times on the same machine, each running Envoy will need a unique base ID
+so that the shared memory regions do not conflict.
+defaults to 0.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1alpha1.EnvoyTLS">EnvoyTLS


### PR DESCRIPTION
Signed-off-by: Gang Liu [gang.liu@daocloud.io](mailto:gang.liu@daocloud.io)

With my use case, the pod for contour will be injected istio sidecar, but the both envoy instances( one for contour & one for istio) will use the default base id: 0, so this leads to the shared memory regions conflict, so add the (optional)  cmd line argument: --base-id to solve this.