### PR TITLE
internal/dag: default Listener ResolvedRefs to true

### DIFF
--- a/changelogs/unreleased/5804-skriss-small.md
+++ b/changelogs/unreleased/5804-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: set Listeners' `ResolvedRefs` condition to `true` by default.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5137,20 +5137,7 @@ func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v
 					Name:           gatewayapi_v1beta1.SectionName(listenerName),
 					AttachedRoutes: int32(attachedRoutes),
 					SupportedKinds: supportedKinds,
-					Conditions: []metav1.Condition{
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-							Message: "Valid listener",
-						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
-					},
+					Conditions:     listenerValidConditions(),
 				},
 			},
 		},
@@ -6340,12 +6327,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -6497,12 +6479,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -6598,12 +6575,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -6699,12 +6671,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -6800,12 +6767,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -6902,12 +6864,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -7135,20 +7092,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 					"listener-2": {
 						Name:           gatewayapi_v1beta1.SectionName("listener-2"),
@@ -7163,20 +7107,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 				},
 			},
@@ -7277,20 +7208,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 					"listener-2": {
 						Name:           gatewayapi_v1beta1.SectionName("listener-2"),
@@ -7305,20 +7223,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 				},
 			},
@@ -7408,20 +7313,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 				},
 			},
@@ -7511,20 +7403,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 				},
 			},
@@ -7678,20 +7557,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								Kind:  "GRPCRoute",
 							},
 						},
-						Conditions: []metav1.Condition{
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-								Message: "Valid listener",
-							},
-							{
-								Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-								Status:  metav1.ConditionTrue,
-								Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-								Message: "Listener accepted",
-							},
-						},
+						Conditions: listenerValidConditions(),
 					},
 				},
 			},
@@ -8420,20 +8286,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Kind:  "GRPCRoute",
 						},
 					},
-					Conditions: []metav1.Condition{
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
-							Message: "Valid listener",
-						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
-					},
+					Conditions: listenerValidConditions(),
 				},
 			},
 		}},
@@ -8487,12 +8340,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -8550,12 +8398,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -8613,12 +8456,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -8691,12 +8529,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -8765,12 +8598,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -8831,6 +8659,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  string(gatewayapi_v1beta1.ListenerReasonUnsupportedProtocol),
 							Message: "Listener protocol \"invalid\" is unsupported, must be one of HTTP, HTTPS, TLS, TCP or projectcontour.io/https",
 						},
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -8888,12 +8717,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.TLS is required when protocol is \"HTTPS\".",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -8951,12 +8776,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.TLS is required when protocol is \"TLS\".",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9020,12 +8841,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.TLS.CertificateRefs cannot be defined when Listener.TLS.Mode is \"Passthrough\".",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9086,12 +8903,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  string(gatewayapi_v1beta1.ListenerReasonInvalid),
 							Message: "Listener.TLS.CertificateRefs must contain exactly one entry",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9152,12 +8965,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.TLS.Mode must be \"Terminate\" when protocol is \"HTTPS\".",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9217,12 +9026,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.AllowedRoutes.Namespaces.Selector is required when Listener.AllowedRoutes.Namespaces.From is set to \"Selector\".",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9288,12 +9093,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Error parsing Listener.AllowedRoutes.Namespaces.Selector: values: Invalid value: []string{\"error\"}: values set must be empty for exists and does not exist.",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9353,12 +9154,8 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Listener.AllowedRoutes.Namespaces.Selector must specify at least one MatchLabel or MatchExpression.",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -9978,17 +9775,13 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					},
 					Conditions: []metav1.Condition{
 						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
-						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
 							Status:  metav1.ConditionFalse,
 							Reason:  "Invalid",
 							Message: `Listener.TLS.Mode must be "Terminate" or "Passthrough".`,
 						},
+						listenerAcceptedCondition(),
+						listenerResolvedRefsCondition(),
 					},
 				},
 			},
@@ -11049,12 +10842,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 							Reason:  "Invalid",
 							Message: "Invalid listener, see other listener conditions for details",
 						},
-						{
-							Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
-							Status:  metav1.ConditionTrue,
-							Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
-							Message: "Listener accepted",
-						},
+						listenerAcceptedCondition(),
 						{
 							Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
 							Status:  metav1.ConditionFalse,
@@ -11217,5 +11005,40 @@ func routeAcceptedTCPRouteCondition() metav1.Condition {
 		Status:  contour_api_v1.ConditionTrue,
 		Reason:  string(gatewayapi_v1beta1.RouteReasonAccepted),
 		Message: "Accepted TCPRoute",
+	}
+}
+
+func listenerProgrammedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayapi_v1beta1.ListenerConditionProgrammed),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapi_v1beta1.ListenerReasonProgrammed),
+		Message: "Valid listener",
+	}
+}
+
+func listenerAcceptedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayapi_v1beta1.ListenerConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapi_v1beta1.ListenerReasonAccepted),
+		Message: "Listener accepted",
+	}
+}
+
+func listenerResolvedRefsCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayapi_v1beta1.ListenerConditionResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapi_v1beta1.ListenerReasonResolvedRefs),
+		Message: "Listener references resolved",
+	}
+}
+
+func listenerValidConditions() []metav1.Condition {
+	return []metav1.Condition{
+		listenerProgrammedCondition(),
+		listenerAcceptedCondition(),
+		listenerResolvedRefsCondition(),
 	}
 }

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -60,7 +60,7 @@ else
   git checkout "${GATEWAY_API_VERSION}"
   # Keep the list of skipped features in sync with
   # test/conformance/gatewayapi/gateway_conformance_test.go.
-  go test -timeout=40m ./conformance -gateway-class=contour -all-features \
+  go test -timeout=40m ./conformance -run TestConformance -gateway-class=contour -all-features \
     -exempt-features=Mesh \
     -skip-tests=HTTPRouteRedirectPortAndScheme
 fi


### PR DESCRIPTION
Sets Gateway Listeners' ResolvedRefs condition
to true by default, to meet conformance.

Closes #5648.

Ran Gateway API main branch conformance manually, confirmed it fails without this change and passes with it.