### PR TITLE
test/e2e: Add race detection in e2e tests

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onsi/gomega/gexec"
@@ -696,6 +697,7 @@ func localAddress() string {
 }
 
 func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile string) error {
+	defer os.RemoveAll(configFile)
 
 	// Look for the ENV variable to tell if this test run should use
 	// the ContourConfiguration file or the ContourConfiguration CRD.
@@ -714,8 +716,11 @@ func (d *Deployment) StopLocalContour(contourCmd *gexec.Session, configFile stri
 
 	// Default timeout of 1s produces test flakes,
 	// a minute should be more than enough to avoid them.
-	contourCmd.Terminate().Wait(time.Minute)
-	return os.RemoveAll(configFile)
+	logs := contourCmd.Terminate().Wait(time.Minute).Err.Contents()
+	if strings.Contains(string(logs), "DATA RACE") {
+		return errors.New("Detected data race, see log output above to diagnose")
+	}
+	return nil
 }
 
 // Convenience method for deploying the pieces of the deployment needed for

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -199,7 +199,7 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 		}
 
 		var err error
-		contourBin, err = gexec.Build("github.com/projectcontour/contour/cmd/contour")
+		contourBin, err = gexec.Build("github.com/projectcontour/contour/cmd/contour", "-race")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Compile contour binary with -race flag and look for "DATA RACE" in stderr. Fails test if found.