### PR TITLE
Adds `log-path` to the Contour cli

### DIFF
--- a/changelogs/unreleased/5813-davinci26-minor.md
+++ b/changelogs/unreleased/5813-davinci26-minor.md
@@ -1,0 +1,3 @@
+## Adds `log-path` to the Contour cli
+
+This change allows users to write the output of `Contour` to a file instead of stdout.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Log-format applies to log format of all sub-commands.
 	logFormat := app.Flag("log-format", "Log output format for Contour. Either text or json.").Default("text").Enum("text", "json")
-
+	logPath := app.Flag("log-path", "Log output path.").Default("").String()
 	bootstrap, bootstrapCtx := registerBootstrap(app)
 
 	certgenApp, certgenConfig := registerCertGen(app)
@@ -82,6 +82,14 @@ func main() {
 
 	args := os.Args[1:]
 	cmd := kingpin.MustParse(app.Parse(args))
+
+	if *logPath != "" {
+		f, err := os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			log.WithError(err).Fatalf("failed to open log file %s", *logPath)
+		}
+		log.Out = f
+	}
 
 	switch *logFormat {
 	case "text":

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Log-format applies to log format of all sub-commands.
 	logFormat := app.Flag("log-format", "Log output format for Contour. Either text or json.").Default("text").Enum("text", "json")
-	logPath := app.Flag("log-path", "Log output path. If not specified it defaults to standard error.").Default("").String()
+	logPath := app.Flag("log-path", "Log output path. If not specified it defaults to stderr.").Default("").String()
 	bootstrap, bootstrapCtx := registerBootstrap(app)
 
 	certgenApp, certgenConfig := registerCertGen(app)

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -45,7 +45,7 @@ func main() {
 
 	// Log-format applies to log format of all sub-commands.
 	logFormat := app.Flag("log-format", "Log output format for Contour. Either text or json.").Default("text").Enum("text", "json")
-	logPath := app.Flag("log-path", "Log output path.").Default("").String()
+	logPath := app.Flag("log-path", "Log output path. If not specified it defaults to standard error.").Default("").String()
 	bootstrap, bootstrapCtx := registerBootstrap(app)
 
 	certgenApp, certgenConfig := registerCertGen(app)


### PR DESCRIPTION
I am debugging a `shutdown` issue and getting logs from `shutdown` manager is generally tricky because `preStop` command logs don't appear in `kubectl logs` or generally anywhere unless there is an error. 

To debug this issue I use this PR in our local PR that adds a `log-path` parameter to contour and redirected the output of the preStop hook to `/proc/1/fd/1`. See this relevant [stackoverflow thread](https://stackoverflow.com/questions/46525317/how-to-monitor-executing-of-prestop-command)

If I found it useful I believe other people might so I pushed it here as well in case you believe it is generally helpful