### PR TITLE
provisioner: fix envoy-max-heapsize not set

### DIFF
--- a/internal/provisioner/controller/gateway.go
+++ b/internal/provisioner/controller/gateway.go
@@ -361,6 +361,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				contourModel.Spec.EnvoyBaseID = envoyParams.BaseID
 			}
 
+			if envoyParams.OverloadMaxHeapSize > 0 {
+				contourModel.Spec.EnvoyMaxHeapSizeBytes = envoyParams.OverloadMaxHeapSize
+			}
+
 		}
 	}
 

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -1110,8 +1110,7 @@ func TestGatewayReconcile(t *testing.T) {
 				},
 				Spec: contourv1alpha1.ContourDeploymentSpec{
 					Envoy: &contourv1alpha1.EnvoySettings{
-						BaseID:              1,
-						OverloadMaxHeapSize: 10000000,
+						BaseID: 1,
 					},
 				},
 			},

--- a/internal/provisioner/controller/gateway_test.go
+++ b/internal/provisioner/controller/gateway_test.go
@@ -1110,7 +1110,8 @@ func TestGatewayReconcile(t *testing.T) {
 				},
 				Spec: contourv1alpha1.ContourDeploymentSpec{
 					Envoy: &contourv1alpha1.EnvoySettings{
-						BaseID: 1,
+						BaseID:              1,
+						OverloadMaxHeapSize: 10000000,
 					},
 				},
 			},
@@ -1124,6 +1125,56 @@ func TestGatewayReconcile(t *testing.T) {
 				}
 				require.NoError(t, r.client.Get(context.Background(), keyFor(ds), ds))
 				assert.Contains(t, ds.Spec.Template.Spec.Containers[1].Args, "--base-id 1")
+			},
+		},
+
+		"If ContourDeployment.Spec.Envoy.OverloadMaxHeapSize is specified, the envoy-initconfig container's arguments contain --overload-max-heap": {
+			gatewayClass: reconcilableGatewayClassWithParams("gatewayclass-1", controller),
+			gatewayClassParams: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-1-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Envoy: &contourv1alpha1.EnvoySettings{
+						OverloadMaxHeapSize: 10000000,
+					},
+				},
+			},
+			gateway: makeGateway(),
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1beta1.Gateway, reconcileErr error) {
+				ds := &appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "envoy-gateway-1",
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(ds), ds))
+				assert.Contains(t, ds.Spec.Template.Spec.InitContainers[0].Args, "--overload-max-heap=10000000")
+			},
+		},
+
+		"If ContourDeployment.Spec.Envoy.OverloadMaxHeapSize is not specified, the envoy-initconfig container's arguments contain --overload-max-heap=0": {
+			gatewayClass: reconcilableGatewayClassWithParams("gatewayclass-1", controller),
+			gatewayClassParams: &contourv1alpha1.ContourDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "projectcontour",
+					Name:      "gatewayclass-1-params",
+				},
+				Spec: contourv1alpha1.ContourDeploymentSpec{
+					Envoy: &contourv1alpha1.EnvoySettings{},
+				},
+			},
+			gateway: makeGateway(),
+			assertions: func(t *testing.T, r *gatewayReconciler, gw *gatewayv1beta1.Gateway, reconcileErr error) {
+				ds := &appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "gateway-1",
+						Name:      "envoy-gateway-1",
+					},
+				}
+				require.NoError(t, r.client.Get(context.Background(), keyFor(ds), ds))
+				assert.Contains(t, ds.Spec.Template.Spec.InitContainers[0].Args, "--overload-max-heap=0")
 			},
 		},
 

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -38,11 +38,12 @@ func Default(namespace, name string) *Contour {
 			Name:      name,
 		},
 		Spec: ContourSpec{
-			ContourReplicas:   2,
-			EnvoyWorkloadType: WorkloadTypeDaemonSet,
-			EnvoyReplicas:     2, // ignored if not provisioning Envoy as a deployment.
-			EnvoyLogLevel:     contourv1alpha1.InfoLog,
-			EnvoyBaseID:       0,
+			ContourReplicas:       2,
+			EnvoyWorkloadType:     WorkloadTypeDaemonSet,
+			EnvoyReplicas:         2, // ignored if not provisioning Envoy as a deployment.
+			EnvoyLogLevel:         contourv1alpha1.InfoLog,
+			EnvoyBaseID:           0,
+			EnvoyMaxHeapSizeBytes: 0,
 			NetworkPublishing: NetworkPublishing{
 				Envoy: EnvoyNetworkPublishing{
 					Type:                  LoadBalancerServicePublishingType,

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -290,6 +290,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
 	testLogLevelArg := "--log-level debug"
 	testBaseIDArg := "--base-id 1"
+	testEnvoyMaxHeapSize := "--overload-max-heap=8000000000"
 
 	resQutoa := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -315,6 +316,8 @@ func TestDesiredDaemonSet(t *testing.T) {
 	// Change the Envoy base id to test --base-id 1
 	cntr.Spec.EnvoyBaseID = 1
 
+	cntr.Spec.EnvoyMaxHeapSizeBytes = 8000000000
+
 	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
 	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)
 	checkContainerHasArg(t, container, testLogLevelArg)
@@ -330,6 +333,8 @@ func TestDesiredDaemonSet(t *testing.T) {
 	checkContainerHaveResourceRequirements(t, container)
 
 	checkContainerHasImage(t, container, testContourImage)
+	checkContainerHasArg(t, container, testEnvoyMaxHeapSize)
+
 	checkDaemonSetHasEnvVar(t, ds, EnvoyContainerName, envoyNsEnvVar)
 	checkDaemonSetHasEnvVar(t, ds, EnvoyContainerName, envoyPodEnvVar)
 	checkDaemonSetHasEnvVar(t, ds, envoyInitContainerName, envoyNsEnvVar)


### PR DESCRIPTION
There was a problem in the previous [PR](https://github.com/projectcontour/contour/pull/5699) ,The `OverloadMaxHeapSize` field in contourDeployment was not assigned correctly. This PR fixes this problem.  