### PR TITLE
release-1.24: Bump Envoy to 1.25.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.25.9
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.25.10
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -34,7 +34,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.24.5",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.25.9",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.25.10",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.9
+        image: docker.io/envoyproxy/envoy:v1.25.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.25.9
+          image: docker.io/envoyproxy/envoy:v1.25.10
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -7413,7 +7413,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.25.9
+          image: docker.io/envoyproxy/envoy:v1.25.10
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -7406,7 +7406,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.9
+        image: docker.io/envoyproxy/envoy:v1.25.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -7400,7 +7400,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.25.9
+        image: docker.io/envoyproxy/envoy:v1.25.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
See release notes:
https://www.envoyproxy.io/docs/envoy/v1.25.10/version_history/v1.25/v1.25.10