### PR TITLE
Set stream limits for HTTP2 protocol - CVE CVE-2023-44487

### DIFF
--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -486,6 +486,12 @@ func (b *httpConnectionManagerBuilder) Get() *envoy_listener_v3.Filter {
 			AcceptHttp_10:      true,
 			AllowChunkedLength: b.allowChunkedLength,
 		},
+		Http2ProtocolOptions: &envoy_core_v3.Http2ProtocolOptions{
+			MaxConcurrentStreams:        wrapperspb.UInt32(100),
+			HpackTableSize:              wrapperspb.UInt32(4096),
+			InitialStreamWindowSize:     wrapperspb.UInt32(65535),
+			InitialConnectionWindowSize: wrapperspb.UInt32(65535),
+		},
 
 		UseRemoteAddress:  wrapperspb.Bool(true),
 		XffNumTrustedHops: b.numTrustedHops,

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -36,8 +36,11 @@ func RuntimeLayers() []*envoy_service_runtime_v3.Runtime {
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"re2.max_program_size.error_level": {Kind: &structpb.Value_NumberValue{NumberValue: maxRegexProgramSizeError}},
-			"re2.max_program_size.warn_level":  {Kind: &structpb.Value_NumberValue{NumberValue: maxRegexProgramSizeWarn}},
+			"re2.max_program_size.error_level":                     structpb.NewNumberValue(maxRegexProgramSizeError),
+			"re2.max_program_size.warn_level":                      structpb.NewNumberValue(maxRegexProgramSizeWarn),
+			"overload.premature_reset_total_stream_count":          structpb.NewNumberValue(50),
+			"overload.premature_reset_min_stream_lifetime_seconds": structpb.NewNumberValue(1),
+			"http.max_requests_per_io_cycle":                       structpb.NewNumberValue(10),
 		},
 	}
 }


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/30055

1. Set `max_concurrent_stream=100` to limit streams per connection. Helps limit memory usage.
2. Set `http.max_requests_per_io_cycle=1` to limit requests processed in one IO cycle.
3. Set `overload.premature_reset_total_stream_count=50`. This kept low enough to reduce impact.
4. Set `overload.premature_reset_min_stream_lifetime_seconds=1`.