### PR TITLE
Refactor bootstrap configuration to use dynamic runtime layers

### DIFF
--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -164,12 +164,6 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 		LayeredRuntime: &envoy_bootstrap_v3.LayeredRuntime{
 			Layers: []*envoy_bootstrap_v3.RuntimeLayer{
 				{
-					Name: "base",
-					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_StaticLayer{
-						StaticLayer: baseRuntimeLayer(),
-					},
-				},
-				{
 					Name: "dynamic",
 					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer_{
 						RtdsLayer: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer{


### PR DESCRIPTION
In contour/internal/envoy/v3/bootstrap.go, removed the static bootstrap runtime layer. Instead, this modifies the bootstrap configuration to use dynamic runtime layers, allowing for more flexibility and consolidation of the codebase.
#5845