### PR TITLE
Bump Envoy to v1.27.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.27.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.27.2
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/5821-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5821-sunjayBhatia-small.md
@@ -1,1 +1,0 @@
-Updates Envoy to v1.27.1. See the [release notes here](https://www.envoyproxy.io/docs/envoy/v1.27.1/version_history/v1.27/v1.27.1).

--- a/changelogs/unreleased/5863-sunjayBhatia-small.md
+++ b/changelogs/unreleased/5863-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.27.2. See the release notes for v1.27.1 [here](https://www.envoyproxy.io/docs/envoy/v1.27.1/version_history/v1.27/v1.27.1) and v1.27.2 [here](https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/v1.27/v1.27.2).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.27.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.27.2",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.27.1
+        image: docker.io/envoyproxy/envoy:v1.27.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.27.1
+          image: docker.io/envoyproxy/envoy:v1.27.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -8736,7 +8736,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.27.1
+          image: docker.io/envoyproxy/envoy:v1.27.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8726,7 +8726,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.27.1
+        image: docker.io/envoyproxy/envoy:v1.27.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -8723,7 +8723,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.27.1
+        image: docker.io/envoyproxy/envoy:v1.27.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Operator Version | Gateway API Version |
 | --------------- | :------------------- | ------------------- | ---------------- | --------------------|
-| main            | [1.27.1][42]         | 1.28, 1.27, 1.26    | N/A              | v1alpha2, v1beta1   |
+| main            | [1.27.2][42]         | 1.28, 1.27, 1.26    | N/A              | v1alpha2, v1beta1   |
 | 1.26.0          | [1.27.0][41]         | 1.28, 1.27, 1.26    | N/A              | v1alpha2, v1beta1   |
 | 1.25.2          | [1.26.4][40]         | 1.27, 1.26, 1.25    | N/A              | v1alpha2, v1beta1   |
 | 1.25.1          | [1.26.4][40]         | 1.27, 1.26, 1.25    | N/A              | v1alpha2, v1beta1   |
@@ -166,7 +166,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [39]: https://www.envoyproxy.io/docs/envoy/v1.25.9/version_history/v1.25/v1.25.9
 [40]: https://www.envoyproxy.io/docs/envoy/v1.26.4/version_history/v1.26/v1.26.4
 [41]: https://www.envoyproxy.io/docs/envoy/v1.27.0/version_history/v1.27/v1.27.0
-[42]: https://www.envoyproxy.io/docs/envoy/v1.27.1/version_history/v1.27/v1.27.1
+[42]: https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/v1.27/v1.27.2
 
 [50]: https://github.com/projectcontour/contour-operator
 [51]: https://github.com/projectcontour/contour-operator/releases/tag/v1.11.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.27.1"
+      envoy: "1.27.2"
       kubernetes:
         - "1.28"
         - "1.27"


### PR DESCRIPTION
See release notes:
https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/v1.27/v1.27.2