### PR TITLE
Minor fixes to Gateway API conformance on release tag

### DIFF
--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -71,7 +71,7 @@ jobs:
           GENERATE_GATEWAY_CONFORMANCE_REPORT: "true"
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(git describe --tags)"
-          make gateway-conformance
+          make setup-kind-cluster run-gateway-conformance cleanup-kind
       - name: Upload gateway conformance report
         uses: actions/upload-artifact@v3
         with:

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -116,6 +116,11 @@ func TestGatewayConformance(t *testing.T) {
 
 		report, err := cSuite.Report()
 		require.NoError(t, err, "failed generating conformance report")
+
+		if gwAPIVersion := os.Getenv("GATEWAY_API_VERSION"); gwAPIVersion != "" {
+			report.GatewayAPIVersion = gwAPIVersion
+		}
+
 		rawReport, err := yaml.Marshal(report)
 		require.NoError(t, err)
 		t.Logf("Conformance report:\n%s", string(rawReport))


### PR DESCRIPTION
- Don't build/load contour image to kind as we should be using the image we just pushed
- Fill in Gateway API version from our environment var