### PR TITLE
Use necojackarc/auto-request-review action to request reviews from non-maintainers

### DIFF
--- a/.github/reviewers.yaml
+++ b/.github/reviewers.yaml
@@ -1,0 +1,8 @@
+reviewers:
+  defaults:
+    - team:projectcontour/maintainers
+    - team:projectcontour/reviewers
+
+options:
+  ignore_draft: true
+  number_of_reviewers: 2

--- a/.github/reviewers.yaml
+++ b/.github/reviewers.yaml
@@ -1,7 +1,7 @@
 reviewers:
   defaults:
-    - team:projectcontour/maintainers
-    - team:projectcontour/reviewers
+    - team:maintainers
+    - team:contour-reviewers
 
 options:
   ignore_draft: true

--- a/.github/reviewers.yaml
+++ b/.github/reviewers.yaml
@@ -1,8 +1,7 @@
 reviewers:
   defaults:
-    - team:maintainers
-    - team:contour-reviewers
+  - team:contour-reviewers
 
 options:
   ignore_draft: true
-  number_of_reviewers: 2
+  number_of_reviewers: 1

--- a/.github/workflows/request-reviews.yaml
+++ b/.github/workflows/request-reviews.yaml
@@ -1,7 +1,7 @@
 name: Request Reviews
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:

--- a/.github/workflows/request-reviews.yaml
+++ b/.github/workflows/request-reviews.yaml
@@ -1,0 +1,14 @@
+name: Request Reviews
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  request-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: necojackarc/auto-request-review@v0.12.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yaml

--- a/.github/workflows/request-reviews.yaml
+++ b/.github/workflows/request-reviews.yaml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: necojackarc/auto-request-review@v0.12.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_FOR_AUTO_REQUEST_REVIEW }}
           config: .github/reviewers.yaml


### PR DESCRIPTION
CODEOWNERS only allows requesting reviews from users/teams with owner permission on the repo

Use this action which should not require the reviewers github team to have owner permissions