### PR TITLE
test/e2e: NamespacedTest helper can create/delete multiple namespaces

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -286,10 +286,14 @@ type TestBody func()
 func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody, additionalNamespaces ...string) {
 	ginkgo.Context("with namespace: "+namespace, func() {
 		ginkgo.BeforeEach(func() {
-			f.CreateNamespace(namespace)
+			for _, ns := range append(additionalNamespaces, namespace) {
+				f.CreateNamespace(ns)
+			}
 		})
 		ginkgo.AfterEach(func() {
-			f.DeleteNamespace(namespace, false)
+			for _, ns := range append(additionalNamespaces, namespace) {
+				f.DeleteNamespace(ns, false)
+			}
 		})
 
 		body(namespace)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -283,7 +283,7 @@ type NamespacedGatewayTestBody func(ns string, gw types.NamespacedName)
 type NamespacedTestBody func(string)
 type TestBody func()
 
-func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody) {
+func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody, additionalNamespaces ...string) {
 	ginkgo.Context("with namespace: "+namespace, func() {
 		ginkgo.BeforeEach(func() {
 			f.CreateNamespace(namespace)


### PR DESCRIPTION
changed the function signature from func `(f *Framework) NamespacedTest(namespace string, body NamespacedTestBody)` to this
`func (f *Framework) NamespacedTest(namespace string, body NamespacedTestBody, additionalNamespaces ...string)`

Updates: #3837 