### PR TITLE
feature(httpproxy): Enhance retry policy

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1175,6 +1175,7 @@ type RetryPolicy struct {
 	// SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
 	// that allows it to choose a different host than the host where previous request
 	// has failed.
+	// +optional
 	SkipPreviousHost bool `json:"skipPreviousHost"`
 }
 

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1171,6 +1171,11 @@ type RetryPolicy struct {
 	// This field is only respected when you include `retriable-status-codes` in the `RetryOn` field.
 	// +optional
 	RetriableStatusCodes []uint32 `json:"retriableStatusCodes,omitempty"`
+
+	// SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
+	// that allows it to choose a different host than the host where previous request
+	// has failed.
+	SkipPreviousHost bool `json:"skipPreviousHost"`
 }
 
 // ReplacePrefix describes a path prefix replacement.

--- a/changelogs/unreleased/5947-davinci26-minor.md
+++ b/changelogs/unreleased/5947-davinci26-minor.md
@@ -1,0 +1,6 @@
+### feature(httpproxy): Enhance retry policy
+
+Enhances retry policy with retry_host_predicate which allows users to eject the failing host from Envoy retries.
+
+This pattern is described in https://www.envoyproxy.io/docs/envoy/latest/faq/load_balancing/transient_failures.html as a way to have more reliable retries.
+

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -6198,8 +6198,6 @@ spec:
                             Host Retry Predicate that allows it to choose a different
                             host than the host where previous request has failed.
                           type: boolean
-                      required:
-                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -6193,6 +6193,13 @@ spec:
                             - unavailable
                             type: string
                           type: array
+                        skipPreviousHost:
+                          description: SkipPreviousHost configures Envoy to use Previous
+                            Host Retry Predicate that allows it to choose a different
+                            host than the host where previous request has failed.
+                          type: boolean
+                      required:
+                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -6412,6 +6412,13 @@ spec:
                             - unavailable
                             type: string
                           type: array
+                        skipPreviousHost:
+                          description: SkipPreviousHost configures Envoy to use Previous
+                            Host Retry Predicate that allows it to choose a different
+                            host than the host where previous request has failed.
+                          type: boolean
+                      required:
+                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -6417,8 +6417,6 @@ spec:
                             Host Retry Predicate that allows it to choose a different
                             host than the host where previous request has failed.
                           type: boolean
-                      required:
-                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -6204,6 +6204,13 @@ spec:
                             - unavailable
                             type: string
                           type: array
+                        skipPreviousHost:
+                          description: SkipPreviousHost configures Envoy to use Previous
+                            Host Retry Predicate that allows it to choose a different
+                            host than the host where previous request has failed.
+                          type: boolean
+                      required:
+                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -6209,8 +6209,6 @@ spec:
                             Host Retry Predicate that allows it to choose a different
                             host than the host where previous request has failed.
                           type: boolean
-                      required:
-                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -6415,6 +6415,13 @@ spec:
                             - unavailable
                             type: string
                           type: array
+                        skipPreviousHost:
+                          description: SkipPreviousHost configures Envoy to use Previous
+                            Host Retry Predicate that allows it to choose a different
+                            host than the host where previous request has failed.
+                          type: boolean
+                      required:
+                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -6420,8 +6420,6 @@ spec:
                             Host Retry Predicate that allows it to choose a different
                             host than the host where previous request has failed.
                           type: boolean
-                      required:
-                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -6412,6 +6412,13 @@ spec:
                             - unavailable
                             type: string
                           type: array
+                        skipPreviousHost:
+                          description: SkipPreviousHost configures Envoy to use Previous
+                            Host Retry Predicate that allows it to choose a different
+                            host than the host where previous request has failed.
+                          type: boolean
+                      required:
+                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -6417,8 +6417,6 @@ spec:
                             Host Retry Predicate that allows it to choose a different
                             host than the host where previous request has failed.
                           type: boolean
-                      required:
-                      - skipPreviousHost
                       type: object
                     services:
                       description: Services are the services to proxy traffic.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -6923,8 +6923,9 @@ func TestDAGInsert(t *testing.T) {
 					Prefix: "/",
 				}},
 				RetryPolicy: &contour_api_v1.RetryPolicy{
-					NumRetries:    6,
-					PerTryTimeout: "10s",
+					NumRetries:       6,
+					PerTryTimeout:    "10s",
+					SkipPreviousHost: true,
 				},
 				Services: []contour_api_v1.Service{{
 					Name: "kuard",
@@ -10549,9 +10550,10 @@ func TestDAGInsert(t *testing.T) {
 							PathMatchCondition: prefixString("/"),
 							Clusters:           clustermap(s1),
 							RetryPolicy: &RetryPolicy{
-								RetryOn:       "5xx",
-								NumRetries:    6,
-								PerTryTimeout: timeout.DurationSetting(10 * time.Second),
+								RetryOn:          "5xx",
+								NumRetries:       6,
+								PerTryTimeout:    timeout.DurationSetting(10 * time.Second),
+								SkipPreviousHost: true,
 							},
 						}),
 					),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -433,8 +433,7 @@ type RetryPolicy struct {
 	// SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
 	// that allows it to choose a different host than the host where previous request
 	// has failed.
-	// +optional
-	SkipPreviousHost bool `json:"SkipPreviousHost,omitempty"`
+	SkipPreviousHost bool
 }
 
 // PathRewritePolicy defines a policy for rewriting the path of

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -429,6 +429,12 @@ type RetryPolicy struct {
 	// PerTryTimeout specifies the timeout per retry attempt.
 	// Ignored if RetryOn is blank.
 	PerTryTimeout timeout.Setting
+
+	// SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
+	// that allows it to choose a different host than the host where previous request
+	// has failed.
+	// +optional
+	SkipPreviousHost bool `json:"SkipPreviousHost,omitempty"`
 }
 
 // PathRewritePolicy defines a policy for rewriting the path of

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -106,6 +106,7 @@ func retryPolicy(rp *contour_api_v1.RetryPolicy) *RetryPolicy {
 		RetriableStatusCodes: rp.RetriableStatusCodes,
 		NumRetries:           uint32(numRetries),
 		PerTryTimeout:        perTryTimeout,
+		SkipPreviousHost:     rp.SkipPreviousHost,
 	}
 }
 

--- a/internal/dag/policy_test.go
+++ b/internal/dag/policy_test.go
@@ -130,8 +130,9 @@ func TestRetryPolicy(t *testing.T) {
 		"empty policy": {
 			rp: &contour_api_v1.RetryPolicy{},
 			want: &RetryPolicy{
-				RetryOn:    "5xx",
-				NumRetries: 1,
+				RetryOn:          "5xx",
+				NumRetries:       1,
+				SkipPreviousHost: false,
 			},
 		},
 		"explicitly zero retries": {
@@ -180,6 +181,16 @@ func TestRetryPolicy(t *testing.T) {
 				RetryOn:              "5xx",
 				RetriableStatusCodes: []uint32{502, 503, 504},
 				NumRetries:           1,
+			},
+		},
+		"retry skip previous host": {
+			rp: &contour_api_v1.RetryPolicy{
+				SkipPreviousHost: true,
+			},
+			want: &RetryPolicy{
+				NumRetries:       1,
+				RetryOn:          "5xx",
+				SkipPreviousHost: true,
 			},
 		},
 	}

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -535,6 +535,15 @@ func retryPolicy(r *dag.Route) *envoy_route_v3.RetryPolicy {
 	}
 	rp.PerTryTimeout = envoy.Timeout(r.RetryPolicy.PerTryTimeout)
 
+	if r.RetryPolicy.SkipPreviousHost {
+		rp.RetryHostPredicate = []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
+			{
+				Name:       "envoy.retry_host_predicates.previous_hosts",
+				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+			},
+		}
+	}
+
 	return rp
 }
 

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -33,6 +33,7 @@ import (
 	envoy_rbac_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	envoy_internal_redirect_previous_routes_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/internal_redirect/previous_routes/v3"
 	envoy_internal_redirect_safe_cross_scheme_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/internal_redirect/safe_cross_scheme/v3"
+	envoy_prev_hosts_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/envoy"
@@ -538,8 +539,10 @@ func retryPolicy(r *dag.Route) *envoy_route_v3.RetryPolicy {
 	if r.RetryPolicy.SkipPreviousHost {
 		rp.RetryHostPredicate = []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
 			{
-				Name:       "envoy.retry_host_predicates.previous_hosts",
-				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+				Name: "envoy.retry_host_predicates.previous_hosts",
+				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_prev_hosts_v3.PreviousHostsPredicate{}),
+				},
 			},
 		}
 	}

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -323,6 +323,33 @@ func TestRouteRoute(t *testing.T) {
 				},
 			},
 		},
+		"retry skip previous host": {
+			route: &dag.Route{
+				RetryPolicy: &dag.RetryPolicy{
+					RetryOn:              "retriable-status-codes",
+					RetriableStatusCodes: []uint32{503},
+					SkipPreviousHost:     true,
+				},
+				Clusters: []*dag.Cluster{c1},
+			},
+			want: &envoy_route_v3.Route_Route{
+				Route: &envoy_route_v3.RouteAction{
+					ClusterSpecifier: &envoy_route_v3.RouteAction_Cluster{
+						Cluster: "default/kuard/8080/da39a3ee5e",
+					},
+					RetryPolicy: &envoy_route_v3.RetryPolicy{
+						RetryOn:              "retriable-status-codes",
+						RetriableStatusCodes: []uint32{503},
+						RetryHostPredicate: []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
+							{
+								Name:       "envoy.retry_host_predicates.previous_hosts",
+								ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+							},
+						},
+					},
+				},
+			},
+		},
 		"timeout 90s": {
 			route: &dag.Route{
 				TimeoutPolicy: dag.RouteTimeoutPolicy{

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -27,6 +27,7 @@ import (
 	envoy_rbac_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	envoy_internal_redirect_previous_routes_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/internal_redirect/previous_routes/v3"
 	envoy_internal_redirect_safe_cross_scheme_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/internal_redirect/safe_cross_scheme/v3"
+	envoy_prev_hosts_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -342,8 +343,10 @@ func TestRouteRoute(t *testing.T) {
 						RetriableStatusCodes: []uint32{503},
 						RetryHostPredicate: []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
 							{
-								Name:       "envoy.retry_host_predicates.previous_hosts",
-								ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+								Name: "envoy.retry_host_predicates.previous_hosts",
+								ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{
+									TypedConfig: protobuf.MustMarshalAny(&envoy_prev_hosts_v3.PreviousHostsPredicate{}),
+								},
 							},
 						},
 					},

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -302,7 +302,7 @@ func withPrefixRewrite(route *envoy_route_v3.Route_Route, replacement string) *e
 	return route
 }
 
-func withRetryPolicy(route *envoy_route_v3.Route_Route, retryOn string, numRetries uint32, perTryTimeout time.Duration) *envoy_route_v3.Route_Route {
+func withRetryPolicy(route *envoy_route_v3.Route_Route, retryOn string, numRetries uint32, perTryTimeout time.Duration, skipPreviousHost bool) *envoy_route_v3.Route_Route {
 	route.Route.RetryPolicy = &envoy_route_v3.RetryPolicy{
 		RetryOn: retryOn,
 	}
@@ -311,6 +311,15 @@ func withRetryPolicy(route *envoy_route_v3.Route_Route, retryOn string, numRetri
 	}
 	if perTryTimeout > 0 {
 		route.Route.RetryPolicy.PerTryTimeout = durationpb.New(perTryTimeout)
+	}
+
+	if skipPreviousHost {
+		route.Route.RetryPolicy.RetryHostPredicate = []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
+			{
+				Name:       "envoy.retry_host_predicates.previous_hosts",
+				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+			},
+		}
 	}
 	return route
 }

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -30,8 +30,10 @@ import (
 	envoy_jwt_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tcp_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	envoy_prev_hosts_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/dag"
@@ -316,8 +318,10 @@ func withRetryPolicy(route *envoy_route_v3.Route_Route, retryOn string, numRetri
 	if skipPreviousHost {
 		route.Route.RetryPolicy.RetryHostPredicate = []*envoy_route_v3.RetryPolicy_RetryHostPredicate{
 			{
-				Name:       "envoy.retry_host_predicates.previous_hosts",
-				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{},
+				Name: "envoy.retry_host_predicates.previous_hosts",
+				ConfigType: &envoy_route_v3.RetryPolicy_RetryHostPredicate_TypedConfig{
+					TypedConfig: protobuf.MustMarshalAny(&envoy_prev_hosts_v3.PreviousHostsPredicate{}),
+				},
 			},
 		}
 	}

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3528,6 +3528,7 @@ bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
 that allows it to choose a different host than the host where previous request
 has failed.</p>

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3519,6 +3519,20 @@ Ignored if NumRetries is not supplied.</p>
 <p>This field is only respected when you include <code>retriable-status-codes</code> in the <code>RetryOn</code> field.</p>
 </td>
 </tr>
+<tr>
+<td style="white-space:nowrap">
+<code>skipPreviousHost</code>
+<br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>SkipPreviousHost configures Envoy to use Previous Host Retry Predicate
+that allows it to choose a different host than the host where previous request
+has failed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="projectcontour.io/v1.Route">Route

--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -309,6 +309,7 @@ spec:
     retryPolicy:
       count: 3
       perTryTimeout: 150ms
+      skipPreviousHost: true
     services:
     - name: s1
       port: 80
@@ -340,6 +341,8 @@ Example input values: "300ms", "5s", "1m".
 
 - `retryPolicy.perTryTimeout` specifies the timeout per retry. If this field is greater than the request timeout, it is ignored. This parameter is optional.
   If left unspecified, `timeoutPolicy.request` will be used.
+
+- `retryPolicy.skipPreviousHost` which configures Envoy to use the Previous Host Retry Predicate that allows it to choose a different host than the host where previous request has failed. If left unspecified it defaults to `false`.
 
 ## Load Balancing Strategy
 


### PR DESCRIPTION
Enhances retry policy with `retry_host_predicate` which allows users to eject the failing host from Envoy retries.

This pattern is described in https://www.envoyproxy.io/docs/envoy/latest/faq/load_balancing/transient_failures.html as a way to have more reliable retries.