### PR TITLE
release-1.26: test/e2e: add flake retries for HTTPS metrics test

### DIFF
--- a/test/e2e/infra/metrics_test.go
+++ b/test/e2e/infra/metrics_test.go
@@ -53,7 +53,8 @@ func testReady() {
 }
 
 func testEnvoyMetricsOverHTTPS() {
-	Specify("requests to metrics listener are served", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/5932
+	Specify("requests to metrics listener are served", FlakeAttempts(3), func() {
 		t := f.T()
 
 		// Port-forward seems to be flaky. Following sequence happens:


### PR DESCRIPTION
Updates #5932.