### PR TITLE
Inspect loadbalancer address from Envoy ingress objects

### DIFF
--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -239,6 +239,12 @@ type EnvoyConfig struct {
 	// +optional
 	Service *NamespacedName `json:"service,omitempty"`
 
+	// Ingress holds Envoy service parameters for setting Ingress status.
+	//
+	// Contour's default is { namespace: "projectcontour", name: "envoy" }.
+	// +optional
+	Ingress *NamespacedName `json:"ingress,omitempty"`
+
 	// Defines the HTTP Listener for Envoy.
 	//
 	// Contour's default is { address: "0.0.0.0", port: 8080, accessLog: "/dev/stdout" }.

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -239,11 +239,15 @@ type EnvoyConfig struct {
 	// +optional
 	Service *NamespacedName `json:"service,omitempty"`
 
-	// Ingress holds Envoy service parameters for setting Ingress status.
+	// LoadBalancer specifies how Contour should set the ingress status address.
+	// If provided, the value can be in one of the formats:
+	//   - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+	//   - service:<namespace>/<name>: Contour will use the address of the designated service.
+	//   - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
 	//
-	// Contour's default is { namespace: "projectcontour", name: "envoy" }.
+	// Contour's default is an empty string.
 	// +optional
-	Ingress *NamespacedName `json:"ingress,omitempty"`
+	LoadBalancer string `json:"loadBalancer,omitempty"`
 
 	// Defines the HTTP Listener for Envoy.
 	//

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -146,8 +147,6 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests.").PlaceHolder("<port>").IntVar(&ctx.httpsPort)
 	serve.Flag("envoy-service-name", "Name of the Envoy service to inspect for Ingress status details.").PlaceHolder("<name>").StringVar(&ctx.Config.EnvoyServiceName)
 	serve.Flag("envoy-service-namespace", "Envoy Service Namespace.").PlaceHolder("<namespace>").StringVar(&ctx.Config.EnvoyServiceNamespace)
-	serve.Flag("envoy-ingress-name", "Name of the Envoy ingress to inspect for Ingress status details.").PlaceHolder("<name>").StringVar(&ctx.Config.EnvoyIngressName)
-	serve.Flag("envoy-ingress-namespace", "Envoy Ingress Namespace.").PlaceHolder("<namespace>").StringVar(&ctx.Config.EnvoyIngressNamespace)
 
 	serve.Flag("health-address", "Address the health HTTP endpoint will bind to.").PlaceHolder("<ipaddr>").StringVar(&ctx.healthAddr)
 	serve.Flag("health-port", "Port the health HTTP endpoint will bind to.").PlaceHolder("<port>").IntVar(&ctx.healthPort)
@@ -169,6 +168,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("leader-election-resource-name", "The name of the resource (Lease) leader election will lease.").Default("leader-elect").StringVar(&ctx.LeaderElection.Name)
 	serve.Flag("leader-election-resource-namespace", "The namespace of the resource (Lease) leader election will lease.").Default(config.GetenvOr("CONTOUR_NAMESPACE", "projectcontour")).StringVar(&ctx.LeaderElection.Namespace)
 	serve.Flag("leader-election-retry-period", "The interval which Contour will attempt to acquire leadership lease.").Default("2s").DurationVar(&ctx.LeaderElection.RetryPeriod)
+
+	serve.Flag("load-balancer-status", "Address to set or the source to inspect for ingress status.").PlaceHolder("<kind:namespace/name|address>").StringVar(&ctx.Config.LoadBalancerStatus)
 
 	serve.Flag("root-namespaces", "Restrict contour to searching these namespaces for root ingress routes.").PlaceHolder("<ns,ns>").StringVar(&ctx.rootNamespaces)
 
@@ -675,63 +676,8 @@ func (s *Server) doServe() error {
 	}
 
 	// Set up ingress load balancer status writer.
-	lbsw := &loadBalancerStatusWriter{
-		log:               s.log.WithField("context", "loadBalancerStatusWriter"),
-		cache:             s.mgr.GetCache(),
-		lbStatus:          make(chan core_v1.LoadBalancerStatus, 1),
-		ingressClassNames: ingressClassNames,
-		gatewayRef:        gatewayRef,
-		statusUpdater:     sh.Writer(),
-		statusAddress:     contourConfiguration.Ingress.StatusAddress,
-		serviceName:       contourConfiguration.Envoy.Service.Name,
-		serviceNamespace:  contourConfiguration.Envoy.Service.Namespace,
-	}
-	if err := s.mgr.Add(lbsw); err != nil {
+	if err := s.setupIngressLoadBalancerStatusWriter(contourConfiguration, ingressClassNames, gatewayRef, sh.Writer()); err != nil {
 		return err
-	}
-
-	// Register an informer to watch envoy's service if we haven't been given static details.
-	if lbAddress := contourConfiguration.Ingress.StatusAddress; len(lbAddress) > 0 {
-		s.log.WithField("loadbalancer-address", lbAddress).Info("Using supplied information for Ingress status")
-		lbsw.lbStatus <- parseStatusFlag(lbAddress)
-	} else {
-		serviceHandler := &k8s.ServiceStatusLoadBalancerWatcher{
-			ServiceName: contourConfiguration.Envoy.Service.Name,
-			LBStatus:    lbsw.lbStatus,
-			Log:         s.log.WithField("context", "serviceStatusLoadBalancerWatcher"),
-		}
-
-		var handler cache.ResourceEventHandler = serviceHandler
-		if contourConfiguration.Envoy.Service.Namespace != "" {
-			handler = k8s.NewNamespaceFilter([]string{contourConfiguration.Envoy.Service.Namespace}, handler)
-		}
-
-		if err := s.informOnResource(&corev1.Service{}, handler); err != nil {
-			s.log.WithError(err).WithField("resource", "services").Fatal("failed to create informer")
-		}
-
-		ingressHandler := &k8s.IngressStatusLoadBalancerWatcher{
-			ServiceName: contourConfiguration.Envoy.Service.Name,
-			LBStatus:    lbsw.lbStatus,
-			Log:         s.log.WithField("context", "ingressStatusLoadBalancerWatcher"),
-		}
-
-		var ingressEventHandler cache.ResourceEventHandler = ingressHandler
-		if contourConfiguration.Envoy.Ingress.Namespace != "" {
-			handler = k8s.NewNamespaceFilter([]string{contourConfiguration.Envoy.Ingress.Namespace}, handler)
-		}
-
-		if err := informOnResource(&networking_v1.Ingress{}, ingressEventHandler, s.mgr.GetCache()); err != nil {
-			s.log.WithError(err).WithField("resource", "ingresses").Fatal("failed to create ingresses informer")
-		}
-
-		s.log.WithField("envoy-service-name", contourConfiguration.Envoy.Service.Name).
-			WithField("envoy-service-namespace", contourConfiguration.Envoy.Service.Namespace).
-			Info("Watching Service for Ingress status")
-
-		s.log.WithField("envoy-ingress-name", contourConfiguration.Envoy.Ingress.Name).
-			WithField("envoy-ingress-namespace", contourConfiguration.Envoy.Ingress.Namespace).
-			Info("Watching Ingress for Ingress status")
 	}
 
 	xdsServer := &xdsServer{
@@ -755,6 +701,136 @@ func (s *Server) doServe() error {
 
 	// GO!
 	return s.mgr.Start(signals.SetupSignalHandler())
+}
+
+func (s *Server) setupIngressLoadBalancerStatusWriter(
+	contourConfiguration contour_v1alpha1.ContourConfigurationSpec,
+	ingressClassNames []string,
+	gatewayRef *types.NamespacedName,
+	statusUpdater k8s.StatusUpdater,
+) error {
+	lbsw := &loadBalancerStatusWriter{
+		log:               s.log.WithField("context", "loadBalancerStatusWriter"),
+		cache:             s.mgr.GetCache(),
+		lbStatus:          make(chan core_v1.LoadBalancerStatus, 1),
+		ingressClassNames: ingressClassNames,
+		gatewayRef:        gatewayRef,
+		statusUpdater:     statusUpdater,
+		statusAddress:     contourConfiguration.Ingress.StatusAddress,
+		serviceName:       contourConfiguration.Envoy.Service.Name,
+		serviceNamespace:  contourConfiguration.Envoy.Service.Namespace,
+	}
+	if err := s.mgr.Add(lbsw); err != nil {
+		return err
+	}
+
+	elbs := &envoyLoadBalancerStatus{}
+	if lbAddress := contourConfiguration.Ingress.StatusAddress; len(lbAddress) > 0 {
+		elbs.Kind = "hostname"
+		elbs.FQDNs = lbAddress
+	} else if contourConfiguration.Envoy.LoadBalancer != "" {
+		status, err := parseEnvoyLoadBalancerStatus(contourConfiguration.Envoy.LoadBalancer)
+		if err != nil {
+			return err
+		}
+		elbs = status
+	} else {
+		elbs.Kind = "service"
+		elbs.Namespace = contourConfiguration.Envoy.Service.Namespace
+		elbs.Name = contourConfiguration.Envoy.Service.Name
+	}
+	switch strings.ToLower(elbs.Kind) {
+	case "hostname":
+		s.log.WithField("loadbalancer-fqdns", lbAddress).Info("Using supplied hostname for Ingress status")
+		lbsw.lbStatus <- parseStatusFlag(elbs.FQDNs)
+	case "service":
+		// Register an informer to watch supplied service
+		serviceHandler := &k8s.ServiceStatusLoadBalancerWatcher{
+			ServiceName: elbs.Name,
+			LBStatus:    lbsw.lbStatus,
+			Log:         s.log.WithField("context", "serviceStatusLoadBalancerWatcher"),
+		}
+
+		var handler cache.ResourceEventHandler = serviceHandler
+		if elbs.Namespace != "" {
+			handler = k8s.NewNamespaceFilter([]string{elbs.Namespace}, handler)
+		}
+
+		if err := s.informOnResource(&core_v1.Service{}, handler); err != nil {
+			s.log.WithError(err).WithField("resource", "services").Fatal("failed to create services informer")
+		}
+		s.log.Infof("Watching %s for Ingress status", elbs)
+	case "ingress":
+		// Register an informer to watch supplied ingress
+		ingressHandler := &k8s.IngressStatusLoadBalancerWatcher{
+			IngressName: elbs.Name,
+			LBStatus:    lbsw.lbStatus,
+			Log:         s.log.WithField("context", "ingressStatusLoadBalancerWatcher"),
+		}
+
+		var handler cache.ResourceEventHandler = ingressHandler
+		if elbs.Namespace != "" {
+			handler = k8s.NewNamespaceFilter([]string{elbs.Namespace}, handler)
+		}
+
+		if err := s.informOnResource(&networking_v1.Ingress{}, handler); err != nil {
+			s.log.WithError(err).WithField("resource", "ingresses").Fatal("failed to create ingresses informer")
+		}
+		s.log.Infof("Watching %s for Ingress status", elbs)
+	default:
+		return fmt.Errorf("unsupported ingress kind: %s", elbs.Kind)
+	}
+
+	return nil
+}
+
+type envoyLoadBalancerStatus struct {
+	Kind  string
+	FQDNs string
+	config.NamespacedName
+}
+
+func (elbs *envoyLoadBalancerStatus) String() string {
+	if elbs.Kind == "hostname" {
+		return fmt.Sprintf("%s:%s", elbs.Kind, elbs.FQDNs)
+	}
+	return fmt.Sprintf("%s:%s/%s", elbs.Kind, elbs.Namespace, elbs.Name)
+}
+
+func parseEnvoyLoadBalancerStatus(s string) (*envoyLoadBalancerStatus, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid load-balancer-status: %s", s)
+	}
+
+	if parts[1] == "" {
+		return nil, fmt.Errorf("invalid load-balancer-status: empty object reference")
+	}
+
+	elbs := envoyLoadBalancerStatus{}
+
+	elbs.Kind = strings.ToLower(parts[0])
+	switch elbs.Kind {
+	case "ingress", "service":
+		parts = strings.Split(parts[1], "/")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid load-balancer-status: %s is not in the format of <namespace>/<name>", s)
+		}
+
+		if parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid load-balancer-status: <namespace> or <name> is empty")
+		}
+		elbs.Namespace = parts[0]
+		elbs.Name = parts[1]
+	case "hostname":
+		elbs.FQDNs = parts[1]
+	case "":
+		return nil, fmt.Errorf("invalid load-balancer-status: kind is empty")
+	default:
+		return nil, fmt.Errorf("invalid load-balancer-status: unsupported kind: %s", elbs.Kind)
+	}
+
+	return &elbs, nil
 }
 
 func (s *Server) getExtensionSvcConfig(name, namespace string) (xdscache_v3.ExtensionServiceConfig, error) {

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -146,6 +146,8 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("envoy-service-https-port", "Kubernetes Service port for HTTPS requests.").PlaceHolder("<port>").IntVar(&ctx.httpsPort)
 	serve.Flag("envoy-service-name", "Name of the Envoy service to inspect for Ingress status details.").PlaceHolder("<name>").StringVar(&ctx.Config.EnvoyServiceName)
 	serve.Flag("envoy-service-namespace", "Envoy Service Namespace.").PlaceHolder("<namespace>").StringVar(&ctx.Config.EnvoyServiceNamespace)
+	serve.Flag("envoy-ingress-name", "Name of the Envoy ingress to inspect for Ingress status details.").PlaceHolder("<name>").StringVar(&ctx.Config.EnvoyIngressName)
+	serve.Flag("envoy-ingress-namespace", "Envoy Ingress Namespace.").PlaceHolder("<namespace>").StringVar(&ctx.Config.EnvoyIngressNamespace)
 
 	serve.Flag("health-address", "Address the health HTTP endpoint will bind to.").PlaceHolder("<ipaddr>").StringVar(&ctx.healthAddr)
 	serve.Flag("health-port", "Port the health HTTP endpoint will bind to.").PlaceHolder("<port>").IntVar(&ctx.healthPort)
@@ -686,6 +688,50 @@ func (s *Server) doServe() error {
 	}
 	if err := s.mgr.Add(lbsw); err != nil {
 		return err
+	}
+
+	// Register an informer to watch envoy's service if we haven't been given static details.
+	if lbAddress := contourConfiguration.Ingress.StatusAddress; len(lbAddress) > 0 {
+		s.log.WithField("loadbalancer-address", lbAddress).Info("Using supplied information for Ingress status")
+		lbsw.lbStatus <- parseStatusFlag(lbAddress)
+	} else {
+		serviceHandler := &k8s.ServiceStatusLoadBalancerWatcher{
+			ServiceName: contourConfiguration.Envoy.Service.Name,
+			LBStatus:    lbsw.lbStatus,
+			Log:         s.log.WithField("context", "serviceStatusLoadBalancerWatcher"),
+		}
+
+		var handler cache.ResourceEventHandler = serviceHandler
+		if contourConfiguration.Envoy.Service.Namespace != "" {
+			handler = k8s.NewNamespaceFilter([]string{contourConfiguration.Envoy.Service.Namespace}, handler)
+		}
+
+		if err := s.informOnResource(&corev1.Service{}, handler); err != nil {
+			s.log.WithError(err).WithField("resource", "services").Fatal("failed to create informer")
+		}
+
+		ingressHandler := &k8s.IngressStatusLoadBalancerWatcher{
+			ServiceName: contourConfiguration.Envoy.Service.Name,
+			LBStatus:    lbsw.lbStatus,
+			Log:         s.log.WithField("context", "ingressStatusLoadBalancerWatcher"),
+		}
+
+		var ingressEventHandler cache.ResourceEventHandler = ingressHandler
+		if contourConfiguration.Envoy.Ingress.Namespace != "" {
+			handler = k8s.NewNamespaceFilter([]string{contourConfiguration.Envoy.Ingress.Namespace}, handler)
+		}
+
+		if err := informOnResource(&networking_v1.Ingress{}, ingressEventHandler, s.mgr.GetCache()); err != nil {
+			s.log.WithError(err).WithField("resource", "ingresses").Fatal("failed to create ingresses informer")
+		}
+
+		s.log.WithField("envoy-service-name", contourConfiguration.Envoy.Service.Name).
+			WithField("envoy-service-namespace", contourConfiguration.Envoy.Service.Namespace).
+			Info("Watching Service for Ingress status")
+
+		s.log.WithField("envoy-ingress-name", contourConfiguration.Envoy.Ingress.Name).
+			WithField("envoy-ingress-namespace", contourConfiguration.Envoy.Ingress.Namespace).
+			Info("Watching Ingress for Ingress status")
 	}
 
 	xdsServer := &xdsServer{

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -571,6 +571,10 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_v1alpha1.Co
 				Name:      ctx.Config.EnvoyServiceName,
 				Namespace: ctx.Config.EnvoyServiceNamespace,
 			},
+			Ingress: &contour_v1alpha1.NamespacedName{
+				Name:      ctx.Config.EnvoyIngressName,
+				Namespace: ctx.Config.EnvoyIngressNamespace,
+			},
 			HTTPListener: &contour_v1alpha1.EnvoyListener{
 				Address:   ctx.httpAddr,
 				Port:      ctx.httpPort,

--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -571,10 +571,6 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_v1alpha1.Co
 				Name:      ctx.Config.EnvoyServiceName,
 				Namespace: ctx.Config.EnvoyServiceNamespace,
 			},
-			Ingress: &contour_v1alpha1.NamespacedName{
-				Name:      ctx.Config.EnvoyIngressName,
-				Namespace: ctx.Config.EnvoyIngressNamespace,
-			},
 			HTTPListener: &contour_v1alpha1.EnvoyListener{
 				Address:   ctx.httpAddr,
 				Port:      ctx.httpPort,
@@ -616,6 +612,7 @@ func (ctx *serveContext) convertToContourConfigurationSpec() contour_v1alpha1.Co
 				EnvoyStripTrailingHostDot: &ctx.Config.Network.EnvoyStripTrailingHostDot,
 			},
 			OMEnforcedHealth: envoyOMEnforcedHealthListenerConfig,
+			LoadBalancer:     ctx.Config.LoadBalancerStatus,
 		},
 		Gateway: gatewayConfig,
 		HTTPProxy: &contour_v1alpha1.HTTPProxyConfig{

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -460,6 +460,15 @@ spec:
                           Contour's default is false.
                         type: boolean
                     type: object
+                  loadBalancer:
+                    description: |-
+                      LoadBalancer specifies how Contour should set the ingress status address.
+                      If provided, the value can be in one of the formats:
+                        - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                        - service:<namespace>/<name>: Contour will use the address of the designated service.
+                        - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                      Contour's default is an empty string.
+                    type: string
                   logging:
                     description: Logging defines how Envoy's logs can be configured.
                     properties:
@@ -4323,6 +4332,15 @@ spec:
                               Contour's default is false.
                             type: boolean
                         type: object
+                      loadBalancer:
+                        description: |-
+                          LoadBalancer specifies how Contour should set the ingress status address.
+                          If provided, the value can be in one of the formats:
+                            - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                            - service:<namespace>/<name>: Contour will use the address of the designated service.
+                            - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                          Contour's default is an empty string.
+                        type: string
                       logging:
                         description: Logging defines how Envoy's logs can be configured.
                         properties:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -679,6 +679,15 @@ spec:
                           Contour's default is false.
                         type: boolean
                     type: object
+                  loadBalancer:
+                    description: |-
+                      LoadBalancer specifies how Contour should set the ingress status address.
+                      If provided, the value can be in one of the formats:
+                        - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                        - service:<namespace>/<name>: Contour will use the address of the designated service.
+                        - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                      Contour's default is an empty string.
+                    type: string
                   logging:
                     description: Logging defines how Envoy's logs can be configured.
                     properties:
@@ -4542,6 +4551,15 @@ spec:
                               Contour's default is false.
                             type: boolean
                         type: object
+                      loadBalancer:
+                        description: |-
+                          LoadBalancer specifies how Contour should set the ingress status address.
+                          If provided, the value can be in one of the formats:
+                            - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                            - service:<namespace>/<name>: Contour will use the address of the designated service.
+                            - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                          Contour's default is an empty string.
+                        type: string
                       logging:
                         description: Logging defines how Envoy's logs can be configured.
                         properties:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -471,6 +471,15 @@ spec:
                           Contour's default is false.
                         type: boolean
                     type: object
+                  loadBalancer:
+                    description: |-
+                      LoadBalancer specifies how Contour should set the ingress status address.
+                      If provided, the value can be in one of the formats:
+                        - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                        - service:<namespace>/<name>: Contour will use the address of the designated service.
+                        - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                      Contour's default is an empty string.
+                    type: string
                   logging:
                     description: Logging defines how Envoy's logs can be configured.
                     properties:
@@ -4334,6 +4343,15 @@ spec:
                               Contour's default is false.
                             type: boolean
                         type: object
+                      loadBalancer:
+                        description: |-
+                          LoadBalancer specifies how Contour should set the ingress status address.
+                          If provided, the value can be in one of the formats:
+                            - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                            - service:<namespace>/<name>: Contour will use the address of the designated service.
+                            - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                          Contour's default is an empty string.
+                        type: string
                       logging:
                         description: Logging defines how Envoy's logs can be configured.
                         properties:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -496,6 +496,15 @@ spec:
                           Contour's default is false.
                         type: boolean
                     type: object
+                  loadBalancer:
+                    description: |-
+                      LoadBalancer specifies how Contour should set the ingress status address.
+                      If provided, the value can be in one of the formats:
+                        - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                        - service:<namespace>/<name>: Contour will use the address of the designated service.
+                        - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                      Contour's default is an empty string.
+                    type: string
                   logging:
                     description: Logging defines how Envoy's logs can be configured.
                     properties:
@@ -4359,6 +4368,15 @@ spec:
                               Contour's default is false.
                             type: boolean
                         type: object
+                      loadBalancer:
+                        description: |-
+                          LoadBalancer specifies how Contour should set the ingress status address.
+                          If provided, the value can be in one of the formats:
+                            - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                            - service:<namespace>/<name>: Contour will use the address of the designated service.
+                            - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                          Contour's default is an empty string.
+                        type: string
                       logging:
                         description: Logging defines how Envoy's logs can be configured.
                         properties:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -679,6 +679,15 @@ spec:
                           Contour's default is false.
                         type: boolean
                     type: object
+                  loadBalancer:
+                    description: |-
+                      LoadBalancer specifies how Contour should set the ingress status address.
+                      If provided, the value can be in one of the formats:
+                        - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                        - service:<namespace>/<name>: Contour will use the address of the designated service.
+                        - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                      Contour's default is an empty string.
+                    type: string
                   logging:
                     description: Logging defines how Envoy's logs can be configured.
                     properties:
@@ -4542,6 +4551,15 @@ spec:
                               Contour's default is false.
                             type: boolean
                         type: object
+                      loadBalancer:
+                        description: |-
+                          LoadBalancer specifies how Contour should set the ingress status address.
+                          If provided, the value can be in one of the formats:
+                            - address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+                            - service:<namespace>/<name>: Contour will use the address of the designated service.
+                            - ingress:<namespace>/<name>: Contour will use the address of the designated ingress.
+                          Contour's default is an empty string.
+                        type: string
                       logging:
                         description: Logging defines how Envoy's logs can be configured.
                         properties:

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -280,3 +280,63 @@ func lbStatusToGatewayAddresses(lbs core_v1.LoadBalancerStatus) []gatewayapi_v1.
 
 	return addrs
 }
+
+// IngressStatusLoadBalancerWatcher implements ResourceEventHandler and
+// watches for changes to the status.loadbalancer field
+// Note that we specifically *don't* inspect inside the struct, as sending empty values
+// is desirable to clear the status.
+type IngressStatusLoadBalancerWatcher struct {
+	IngressName string
+	LBStatus    chan networking_v1.IngressLoadBalancerStatus
+	Log         logrus.FieldLogger
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnAdd(obj interface{}) {
+	ingress, ok := obj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.Log.WithField("name", ingress.Name).
+		WithField("namespace", ingress.Namespace).
+		Debug("received new service address")
+
+	s.notify(ingress.Status.LoadBalancer)
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnUpdate(oldObj, newObj interface{}) {
+	ingress, ok := newObj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.Log.WithField("name", ingress.Name).
+		WithField("namespace", ingress.Namespace).
+		Debug("received new service address")
+
+	s.notify(ingress.Status.LoadBalancer)
+}
+
+func (s *IngressStatusLoadBalancerWatcher) OnDelete(obj interface{}) {
+	ingress, ok := obj.(*networking_v1.Ingress)
+	if !ok {
+		// not a service
+		return
+	}
+	if ingress.Name != s.IngressName {
+		return
+	}
+	s.notify(networking_v1.IngressLoadBalancerStatus{
+		Ingress: nil,
+	})
+}
+
+func (s *IngressStatusLoadBalancerWatcher) notify(lbstatus networking_v1.IngressLoadBalancerStatus) {
+	s.LBStatus <- lbstatus
+}

--- a/internal/provisioner/model/names.go
+++ b/internal/provisioner/model/names.go
@@ -32,6 +32,11 @@ func (c *Contour) EnvoyServiceName() string {
 	return "envoy-" + c.Name
 }
 
+// EnvoyIngressName returns the name of the Envoy Ingress resource.
+func (c *Contour) EnvoyIngressName() string {
+	return "envoy-" + c.Name
+}
+
 // ContourDeploymentName returns the name of the Contour Deployment resource.
 func (c *Contour) ContourDeploymentName() string {
 	return "contour-" + c.Name

--- a/internal/provisioner/objects/contourconfig/contourconfig.go
+++ b/internal/provisioner/objects/contourconfig/contourconfig.go
@@ -73,6 +73,10 @@ func setGatewayConfig(config *contour_v1alpha1.ContourConfiguration, contour *mo
 		Namespace: contour.Namespace,
 		Name:      contour.EnvoyServiceName(),
 	}
+	config.Spec.Envoy.Ingress = &contour_api_v1alpha1.NamespacedName{
+		Namespace: contour.Namespace,
+		Name:      contour.EnvoyIngressName(),
+	}
 }
 
 // EnsureContourConfigDeleted deletes a ContourConfig for the provided contour, if the configured owner labels exist.

--- a/internal/provisioner/objects/contourconfig/contourconfig.go
+++ b/internal/provisioner/objects/contourconfig/contourconfig.go
@@ -73,10 +73,6 @@ func setGatewayConfig(config *contour_v1alpha1.ContourConfiguration, contour *mo
 		Namespace: contour.Namespace,
 		Name:      contour.EnvoyServiceName(),
 	}
-	config.Spec.Envoy.Ingress = &contour_api_v1alpha1.NamespacedName{
-		Namespace: contour.Namespace,
-		Name:      contour.EnvoyIngressName(),
-	}
 }
 
 // EnsureContourConfigDeleted deletes a ContourConfig for the provided contour, if the configured owner labels exist.

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -95,6 +95,7 @@ func DesiredDeployment(contour *model.Contour, image string) *apps_v1.Deployment
 		fmt.Sprintf("--contour-config-name=%s", contour.ContourConfigurationName()),
 		fmt.Sprintf("--leader-election-resource-name=%s", contour.LeaderElectionLeaseName()),
 		fmt.Sprintf("--envoy-service-name=%s", contour.EnvoyServiceName()),
+		fmt.Sprintf("--envoy-ingress-name=%s", contour.EnvoyIngressName()),
 		fmt.Sprintf("--kubernetes-debug=%d", contour.Spec.KubernetesLogLevel),
 	}
 

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -667,11 +667,9 @@ type Parameters struct {
 	// Name of the envoy service to inspect for Ingress status details.
 	EnvoyServiceName string `yaml:"envoy-service-name,omitempty"`
 
-	// Namespace of the envoy ingress to inspect for Ingress status details.
-	EnvoyIngressNamespace string `yaml:"envoy-ingress-namespace,omitempty"`
-
-	// Name of the envoy ingress to inspect for Ingress status details.
-	EnvoyIngressName string `yaml:"envoy-ingress-name,omitempty"`
+	// Identifier of ingress object for load balancer address in the format of
+	// (ingress|service):<namespace>/<name>, or hostname:fqdn1[,fqdn2].
+	LoadBalancerStatus string `yaml:"load-balancer-status,omitempty"`
 
 	// DefaultHTTPVersions defines the default set of HTTPS
 	// versions the proxy should accept. HTTP versions are
@@ -1099,8 +1097,6 @@ func Defaults() Parameters {
 		},
 		EnvoyServiceName:      "envoy",
 		EnvoyServiceNamespace: contourNamespace,
-		EnvoyIngressName:      "envoy",
-		EnvoyIngressNamespace: contourNamespace,
 		DefaultHTTPVersions:   []HTTPVersionType{},
 		Cluster: ClusterParameters{
 			DNSLookupFamily: AutoClusterDNSFamily,

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -667,6 +667,12 @@ type Parameters struct {
 	// Name of the envoy service to inspect for Ingress status details.
 	EnvoyServiceName string `yaml:"envoy-service-name,omitempty"`
 
+	// Namespace of the envoy ingress to inspect for Ingress status details.
+	EnvoyIngressNamespace string `yaml:"envoy-ingress-namespace,omitempty"`
+
+	// Name of the envoy ingress to inspect for Ingress status details.
+	EnvoyIngressName string `yaml:"envoy-ingress-name,omitempty"`
+
 	// DefaultHTTPVersions defines the default set of HTTPS
 	// versions the proxy should accept. HTTP versions are
 	// strings of the form "HTTP/xx". Supported versions are
@@ -1093,6 +1099,8 @@ func Defaults() Parameters {
 		},
 		EnvoyServiceName:      "envoy",
 		EnvoyServiceNamespace: contourNamespace,
+		EnvoyIngressName:      "envoy",
+		EnvoyIngressNamespace: contourNamespace,
 		DefaultHTTPVersions:   []HTTPVersionType{},
 		Cluster: ClusterParameters{
 			DNSLookupFamily: AutoClusterDNSFamily,

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -6714,6 +6714,24 @@ NamespacedName
 </tr>
 <tr>
 <td style="white-space:nowrap">
+<code>loadBalancer</code>
+<br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LoadBalancer specifies how Contour should set the ingress status address.
+If provided, the value can be in one of the formats:
+- address:<address,...>: Contour will use the provided comma separated list of addresses directly. The address can be a fully qualified domain name or an IP address.
+- service:<namespace>/<name>: Contour will use the address of the designated service.
+- ingress:<namespace>/<name>: Contour will use the address of the designated ingress.</p>
+<p>Contour&rsquo;s default is an empty string.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>http</code>
 <br>
 <em>

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -16,52 +16,53 @@ The `contour serve` command is the main command which is used to watch for Kuber
 There are a number of flags that can be passed to this command which further configures how Contour operates.
 Many of these flags are mirrored in the [Contour Configuration File](#configuration-file).
 
-| Flag Name                                                       | Description                                                                             |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `--config-path`                                                 | Path to base configuration                                                              |
-| `--contour-config-name`                                         | Name of the ContourConfiguration resource to use                                        |
-| `--incluster`                                                   | Use in cluster configuration                                                            |
-| `--kubeconfig=</path/to/file>`                                  | Path to kubeconfig (if not in running inside a cluster)                                 |
-| `--xds-address=<ipaddr>`                                        | xDS gRPC API address                                                                    |
-| `--xds-port=<port>`                                             | xDS gRPC API port                                                                       |
-| `--stats-address=<ipaddr>`                                      | Envoy /stats interface address                                                          |
-| `--stats-port=<port>`                                           | Envoy /stats interface port                                                             |
-| `--debug-http-address=<address>`                                | Address the debug http endpoint will bind to.                                           |
-| `--debug-http-port=<port>`                                      | Port the debug http endpoint will bind to                                               |
-| `--http-address=<ipaddr>`                                       | Address the metrics HTTP endpoint will bind to                                          |
-| `--http-port=<port>`                                            | Port the metrics HTTP endpoint will bind to.                                            |
-| `--health-address=<ipaddr>`                                     | Address the health HTTP endpoint will bind to                                           |
-| `--health-port=<port>`                                          | Port the health HTTP endpoint will bind to                                              |
-| `--contour-cafile=</path/to/file\|CONTOUR_CERT_FILE>`           | CA bundle file name for serving gRPC with TLS                                           |
-| `--contour-cert-file=</path/to/file\|CONTOUR_CERT_FILE>`        | Contour certificate file name for serving gRPC over TLS                                 |
-| `--contour-key-file=</path/to/file\|CONTOUR_KEY_FILE>`          | Contour key file name for serving gRPC over TLS                                         |
-| `--insecure`                                                    | Allow serving without TLS secured gRPC                                                  |
-| `--root-namespaces=<ns,ns>`                                     | Restrict contour to searching these namespaces for root ingress routes                  |
-| `--watch-namespaces=<ns,ns>`                                    | Restrict contour to searching these namespaces for all resources                        |
-| `--ingress-class-name=<name>`                                   | Contour IngressClass name (comma-separated list allowed)                                |
-| `--ingress-status-address=<address>`                            | Address to set in Ingress object status                                                 |
-| `--envoy-http-access-log=</path/to/file>`                       | Envoy HTTP access log                                                                   |
-| `--envoy-https-access-log=</path/to/file>`                      | Envoy HTTPS access log                                                                  |
-| `--envoy-service-http-address=<ipaddr>`                         | Kubernetes Service address for HTTP requests                                            |
-| `--envoy-service-https-address=<ipaddr>`                        | Kubernetes Service address for HTTPS requests                                           |
-| `--envoy-service-http-port=<port>`                              | Kubernetes Service port for HTTP requests                                               |
-| `--envoy-service-https-port=<port>`                             | Kubernetes Service port for HTTPS requests                                              |
-| `--envoy-service-name=<name>`                                   | Name of the Envoy service to inspect for Ingress status details.                        |
-| `--envoy-service-namespace=<namespace>`                         | Envoy Service Namespace                                                                 |
-| `--use-proxy-protocol`                                          | Use PROXY protocol for all listeners                                                    |
-| `--accesslog-format=<envoy\|json>`                              | Format for Envoy access logs                                                            |
-| `--disable-leader-election`                                     | Disable leader election mechanism                                                       |
-| `--disable-feature=<extensionservices\|tlsroutes\|grpcroutes>`  | Do not start an informer for the specified resources. Flag can be given multiple times. |
-| `--leader-election-lease-duration`                              | The duration of the leadership lease.                                                   |
-| `--leader-election-renew-deadline`                              | The duration leader will retry refreshing leadership before giving up.                  |
-| `--leader-election-retry-period`                                | The interval which Contour will attempt to acquire leadership lease.                    |
-| `--leader-election-resource-name`                               | The name of the resource (Lease) leader election will lease.                            |
-| `--leader-election-resource-namespace`                          | The namespace of the resource (Lease) leader election will lease.                       |
-| `-d, --debug`                                                   | Enable debug logging                                                                    |
-| `--kubernetes-debug=<log level>`                                | Enable Kubernetes client debug logging                                                  |
-| `--log-format=<text\|json>`                                     | Log output format for Contour. Either text (default) or json.                           |
-| `--kubernetes-client-qps=<qps>`                                 | QPS allowed for the Kubernetes client.                                                  |
-| `--kubernetes-client-burst=<burst>`                             | Burst allowed for the Kubernetes client.                                                |
+| Flag Name                                                      | Description                                                                                           |
+|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `--config-path`                                                | Path to base configuration                                                                            |
+| `--contour-config-name`                                        | Name of the ContourConfiguration resource to use                                                      |
+| `--incluster`                                                  | Use in cluster configuration                                                                          |
+| `--kubeconfig=</path/to/file>`                                 | Path to kubeconfig (if not in running inside a cluster)                                               |
+| `--xds-address=<ipaddr>`                                       | xDS gRPC API address                                                                                  |
+| `--xds-port=<port>`                                            | xDS gRPC API port                                                                                     |
+| `--stats-address=<ipaddr>`                                     | Envoy /stats interface address                                                                        |
+| `--stats-port=<port>`                                          | Envoy /stats interface port                                                                           |
+| `--debug-http-address=<address>`                               | Address the debug http endpoint will bind to.                                                         |
+| `--debug-http-port=<port>`                                     | Port the debug http endpoint will bind to                                                             |
+| `--http-address=<ipaddr>`                                      | Address the metrics HTTP endpoint will bind to                                                        |
+| `--http-port=<port>`                                           | Port the metrics HTTP endpoint will bind to.                                                          |
+| `--health-address=<ipaddr>`                                    | Address the health HTTP endpoint will bind to                                                         |
+| `--health-port=<port>`                                         | Port the health HTTP endpoint will bind to                                                            |
+| `--contour-cafile=</path/to/file\|CONTOUR_CERT_FILE>`          | CA bundle file name for serving gRPC with TLS                                                         |
+| `--contour-cert-file=</path/to/file\|CONTOUR_CERT_FILE>`       | Contour certificate file name for serving gRPC over TLS                                               |
+| `--contour-key-file=</path/to/file\|CONTOUR_KEY_FILE>`         | Contour key file name for serving gRPC over TLS                                                       |
+| `--insecure`                                                   | Allow serving without TLS secured gRPC                                                                |
+| `--root-namespaces=<ns,ns>`                                    | Restrict contour to searching these namespaces for root ingress routes                                |
+| `--watch-namespaces=<ns,ns>`                                   | Restrict contour to searching these namespaces for all resources                                      |
+| `--ingress-class-name=<name>`                                  | Contour IngressClass name (comma-separated list allowed)                                              |
+| `--ingress-status-address=<address>`                           | Address to set in Ingress object status                                                               |
+| `--envoy-http-access-log=</path/to/file>`                      | Envoy HTTP access log                                                                                 |
+| `--envoy-https-access-log=</path/to/file>`                     | Envoy HTTPS access log                                                                                |
+| `--envoy-service-http-address=<ipaddr>`                        | Kubernetes Service address for HTTP requests                                                          |
+| `--envoy-service-https-address=<ipaddr>`                       | Kubernetes Service address for HTTPS requests                                                         |
+| `--envoy-service-http-port=<port>`                             | Kubernetes Service port for HTTP requests                                                             |
+| `--envoy-service-https-port=<port>`                            | Kubernetes Service port for HTTPS requests                                                            |
+| `--envoy-service-name=<name>`                                  | Name of the Envoy service to inspect for Ingress status details.                                      |
+| `--envoy-service-namespace=<namespace>`                        | Envoy Service Namespace                                                                               |
+| `--use-proxy-protocol`                                         | Use PROXY protocol for all listeners                                                                  |
+| `--accesslog-format=<envoy\|json>`                             | Format for Envoy access logs                                                                          |
+| `--disable-leader-election`                                    | Disable leader election mechanism                                                                     |
+| `--disable-feature=<extensionservices\|tlsroutes\|grpcroutes>` | Do not start an informer for the specified resources. Flag can be given multiple times.               |
+| `--leader-election-lease-duration`                             | The duration of the leadership lease.                                                                 |
+| `--leader-election-renew-deadline`                             | The duration leader will retry refreshing leadership before giving up.                                |
+| `--leader-election-retry-period`                               | The interval which Contour will attempt to acquire leadership lease.                                  |
+| `--leader-election-resource-name`                              | The name of the resource (Lease) leader election will lease.                                          |
+| `--leader-election-resource-namespace`                         | The namespace of the resource (Lease) leader election will lease.                                     |
+| `--load-balancer-status=<kind:namespace/name\|addresses>       | Address to set (kind=hostname) or the source to inspect for ingress status (kind=service or ingress). |
+| `-d, --debug`                                                  | Enable debug logging                                                                                  |
+| `--kubernetes-debug=<log level>`                               | Enable Kubernetes client debug logging                                                                |
+| `--log-format=<text\|json>`                                    | Log output format for Contour. Either text (default) or json.                                         |
+| `--kubernetes-client-qps=<qps>`                                | QPS allowed for the Kubernetes client.                                                                |
+| `--kubernetes-client-burst=<burst>`                            | Burst allowed for the Kubernetes client.                                                              |
 
 ## Configuration File
 


### PR DESCRIPTION
Contour sets load balancer address in Ingress/HTTPProxy object's status. The load balancer address is extracted from Envoy `Service` object's status. This doesn't work in configuration that Envoy `Service` is of type `ClusterIP` and an Envoy `Ingress` object is used for inbound. This patch adds support for inspecting the Envoy `Ingress` object for setting load balancer address.

A new  flag `--load-balancer-status` is introduced as suggested by @tsaarni  in https://github.com/projectcontour/contour/pull/5083#issuecomment-1700491125

Flag `--load-balancer-status` takes value in one of below formats:

1. `hostname:fqdn1[,fqdn2]`:  This provides the same functionality as `--ingress-status-address`.
2. `sevice:namespace/name`: same as flags `envoy-service-name` and `envoy-service-namespace` combined.
3. `ingress:namespace/name`: new feature for getting address from Ingress objects.

Since the new flag covers functionality of some existing flags, if both `--load-balancer-status` and `--ingress-status-address` or `envoy-service-name/namespace` are specified, only value of `--load-balancer-status` is used and a warning message is logged.

This is based on [kahirokunn](https://github.com/kahirokunn)'s PR https://github.com/projectcontour/contour/pull/5083 .

Fixes #4952 