### PR TITLE
update Gateway API conformance exclusions

### DIFF
--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -74,8 +74,16 @@ func TestGatewayConformance(t *testing.T) {
 			// See: https://github.com/envoyproxy/envoy/issues/17318
 			tests.HTTPRouteRedirectPortAndScheme.ShortName,
 
-			// Tests newly failing with Gateway API 1.0, to be addressed.
+			// Not implemented yet since it's functionally equivalent
+			// to Timeouts.Request, to be enabled once Gateway API
+			// supports retries.
+			// See: https://github.com/projectcontour/contour/issues/6000
 			tests.HTTPRouteTimeoutBackendRequest.ShortName,
+
+			// Contour supports the positive-case functionality,
+			// but there are some negative cases that aren't fully
+			// implemented plus complications with the test setup itself.
+			// See: https://github.com/projectcontour/contour/issues/5922
 			tests.GatewayStaticAddresses.ShortName,
 		},
 		ExemptFeatures: sets.New(

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -67,5 +67,5 @@ else
   # test/conformance/gatewayapi/gateway_conformance_test.go.
   go test -timeout=40m ./conformance -run TestConformance -gateway-class=contour -all-features \
     -exempt-features=Mesh \
-    -skip-tests=HTTPRouteRedirectPortAndScheme
+    -skip-tests=HTTPRouteRedirectPortAndScheme,HTTPRouteTimeoutBackendRequest,GatewayStaticAddresses
 fi


### PR DESCRIPTION
Adds comments for excluded Gateway API conformance tests and syncs run-gateway-conformance.sh with
gateway_conformance_test.go.

To merge after https://github.com/projectcontour/contour/pull/5961