### PR TITLE
remove disabled ingress-conformance run from CI

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -241,7 +241,8 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#contour-ci-notifications'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  # TODO: re-enable once Ingress v1 support is complete
+  # TODO: re-enable once Ingress v1 support is complete, also
+  # need to re-enable sonobuoy download in hack/actions/install-kubernetes-toolchain.sh
   # ingress-conformance:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -241,19 +241,6 @@ jobs:
           steps: ${{ toJson(steps) }}
           channel: '#contour-ci-notifications'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  # TODO: re-enable once Ingress v1 support is complete, also
-  # need to re-enable sonobuoy download in hack/actions/install-kubernetes-toolchain.sh
-  # ingress-conformance:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: add deps to path
-  #       run: |
-  #         ./hack/actions/install-kubernetes-toolchain.sh $GITHUB_WORKSPACE/bin
-  #         echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-  #     - name: ingress conformance tests
-  #       run: |
-  #         make check-ingress-conformance
   test-linux:
     needs:
       - lint

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -51,9 +51,10 @@ download \
 
 chmod +x "${DESTDIR}/kubectl"
 
-download \
-    "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERS}/sonobuoy_${SONOBUOY_VERS}_linux_amd64.tar.gz" \
-    "${DESTDIR}/sonobuoy.tgz"
+# TODO re-enable if/when Ingress conformance is enabled
+# download \
+#     "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERS}/sonobuoy_${SONOBUOY_VERS}_linux_amd64.tar.gz" \
+#     "${DESTDIR}/sonobuoy.tgz"
 
-tar -C "${DESTDIR}" -xf "${DESTDIR}/sonobuoy.tgz" sonobuoy
-rm "${DESTDIR}/sonobuoy.tgz"
+# tar -C "${DESTDIR}" -xf "${DESTDIR}/sonobuoy.tgz" sonobuoy
+# rm "${DESTDIR}/sonobuoy.tgz"

--- a/hack/actions/install-kubernetes-toolchain.sh
+++ b/hack/actions/install-kubernetes-toolchain.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 readonly KUBECTL_VERS="v1.28.0"
 readonly KIND_VERS="v0.20.0"
-readonly SONOBUOY_VERS="0.19.0"
 
 readonly PROGNAME=$(basename $0)
 readonly CURL=${CURL:-curl}
@@ -50,11 +49,3 @@ download \
     "${DESTDIR}/kubectl"
 
 chmod +x "${DESTDIR}/kubectl"
-
-# TODO re-enable if/when Ingress conformance is enabled
-# download \
-#     "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERS}/sonobuoy_${SONOBUOY_VERS}_linux_amd64.tar.gz" \
-#     "${DESTDIR}/sonobuoy.tgz"
-
-# tar -C "${DESTDIR}" -xf "${DESTDIR}/sonobuoy.tgz" sonobuoy
-# rm "${DESTDIR}/sonobuoy.tgz"


### PR DESCRIPTION
Upstream Ingress conformance is flaky/poorly maintained and
unlikely to reach a state where it can reliably be run in CI.