### PR TITLE
Promote upstream TLS changelog entry from minor to major

### DIFF
--- a/changelogs/unreleased/5828-KauzClay-major.md
+++ b/changelogs/unreleased/5828-KauzClay-major.md
@@ -1,0 +1,9 @@
+## Upstream TLS now supports TLS 1.3 and TLS parameters can be configured
+
+The default maximum TLS version for upstream connections is now 1.3, instead of the Envoy default of 1.2.
+
+In a similar way to how Contour users can configure Min/Max TLS version and
+Cipher Suites for Envoy's listeners, users can now specify the
+same information for upstream connections. In the ContourConfiguration, this is
+available under `spec.envoy.cluster.upstreamTLS`. The equivalent config file
+parameter is `cluster.upstream-tls`.

--- a/changelogs/unreleased/5828-KauzClay-minor.md
+++ b/changelogs/unreleased/5828-KauzClay-minor.md
@@ -1,8 +1,0 @@
-## Allow Configuration of Upstream TLS Options
-
-In a similar way to how Contour users can configure Min/Max TLS version and
-Cipher Suites for Envoy's listeners, this change allows users to specify the
-same information for upstream connections. In the ContourConfiguration, this is
-available under `spec.envoy.cluster.upstreamTLS`. The equivalent config file
-parameter is `cluster.upstream-tls` .This change also defaults the Max TLS
-version for upstream connections to 1.3, instead of the Envoy default of 1.2.


### PR DESCRIPTION
After #5828 was merged (Thank You @KauzClay!) it occurred to me that we could promote the change from `minor` to `major` category, to call out the maximum TLS protocol version update. All information was there already, but I think it could be good to highlight it as a major change, since users might observe some differences with their upstream services after upgrade, when TLS handshake selects TLSv1.3. In worst case users could even have some minor problems due to the gaps in Envoy's retry handling, described in [envoyproxy/envoy#9300](https://www.github.com/envoyproxy/envoy/issues/9300).

