### PR TITLE
Pin github actions using shas

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -15,8 +15,8 @@ jobs:
   e2e-envoy-xds:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -26,7 +26,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -40,7 +40,7 @@ jobs:
           CONTOUR_E2E_XDS_SERVER_TYPE: envoy
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -49,8 +49,8 @@ jobs:
   e2e-envoy-deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -74,7 +74,7 @@ jobs:
           CONTOUR_E2E_ENVOY_DEPLOYMENT_MODE: deployment
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -83,8 +83,8 @@ jobs:
   e2e-gateway-reconcile-controller:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -94,7 +94,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -109,7 +109,7 @@ jobs:
           CONTOUR_E2E_GATEWAY_RECONCILE_MODE: controller
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -118,8 +118,8 @@ jobs:
   e2e-ipv6:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -129,7 +129,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -146,7 +146,7 @@ jobs:
           make setup-kind-cluster
           export CONTOUR_E2E_LOCAL_HOST=$(ifconfig | grep inet6 | grep global | head -n1 | awk '{print $2}')
           make run-e2e cleanup-kind
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -155,8 +155,8 @@ jobs:
   e2e-endpoint-slices:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -166,7 +166,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -180,10 +180,9 @@ jobs:
           CONTOUR_E2E_USE_ENDPOINT_SLICES: true
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
           channel: '#contour-ci-notifications'
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-

--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -40,7 +40,7 @@ jobs:
           CONTOUR_E2E_XDS_SERVER_TYPE: envoy
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -74,7 +74,7 @@ jobs:
           CONTOUR_E2E_ENVOY_DEPLOYMENT_MODE: deployment
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -109,7 +109,7 @@ jobs:
           CONTOUR_E2E_GATEWAY_RECONCILE_MODE: controller
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -146,7 +146,7 @@ jobs:
           make setup-kind-cluster
           export CONTOUR_E2E_LOCAL_HOST=$(ifconfig | grep inet6 | grep global | head -n1 | awk '{print $2}')
           make run-e2e cleanup-kind
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -180,7 +180,7 @@ jobs:
           CONTOUR_E2E_USE_ENDPOINT_SLICES: true
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -40,7 +40,7 @@ jobs:
           CONTOUR_E2E_XDS_SERVER_TYPE: envoy
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -74,7 +74,7 @@ jobs:
           CONTOUR_E2E_ENVOY_DEPLOYMENT_MODE: deployment
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -109,7 +109,7 @@ jobs:
           CONTOUR_E2E_GATEWAY_RECONCILE_MODE: controller
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -146,7 +146,7 @@ jobs:
           make setup-kind-cluster
           export CONTOUR_E2E_LOCAL_HOST=$(ifconfig | grep inet6 | grep global | head -n1 | awk '{print $2}')
           make run-e2e cleanup-kind
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -180,7 +180,7 @@ jobs:
           CONTOUR_E2E_USE_ENDPOINT_SLICES: true
         run: |
           make setup-kind-cluster run-e2e cleanup-kind
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -11,13 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       with:
         version: latest
     - name: Log in to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -30,7 +30,7 @@ jobs:
         PUSH_IMAGE: "true"
       run: |
         make multiarch-build
-    - uses: act10ns/slack@v2
+    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -30,7 +30,7 @@ jobs:
         PUSH_IMAGE: "true"
       run: |
         make multiarch-build
-    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -30,7 +30,7 @@ jobs:
         PUSH_IMAGE: "true"
       run: |
         make multiarch-build
-    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -37,7 +37,7 @@ jobs:
         TAG_LATEST: "false"
       run: |
         ./hack/actions/build-and-push-release-images.sh
-    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -77,7 +77,7 @@ jobs:
         with:
           name: gateway-conformance-report
           path: gateway-conformance-report/projectcontour-contour-*.yaml
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -37,7 +37,7 @@ jobs:
         TAG_LATEST: "false"
       run: |
         ./hack/actions/build-and-push-release-images.sh
-    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -77,7 +77,7 @@ jobs:
         with:
           name: gateway-conformance-report
           path: gateway-conformance-report/projectcontour-contour-*.yaml
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -20,13 +20,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       with:
         version: latest
     - name: Log in to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
         TAG_LATEST: "false"
       run: |
         ./hack/actions/build-and-push-release-images.sh
-    - uses: act10ns/slack@v2
+    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -47,8 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -58,7 +58,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -73,11 +73,11 @@ jobs:
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(git describe --tags)"
           make setup-kind-cluster run-gateway-conformance cleanup-kind
       - name: Upload gateway conformance report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: gateway-conformance-report
           path: gateway-conformance-report/projectcontour-contour-*.yaml
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         # * Module download cache
         # * Build cache (Linux)
@@ -32,20 +32,20 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ github.job }}-go-
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
       with:
         languages: go
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -20,17 +20,17 @@ jobs:
     name: Check release-note label set
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@4e9ef4ce8c697cf55716ecbf7f13a3d9e0b6ac6a # v5.1.0
         with:
           mode: minimum
           count: 1
           labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/deprecation, release-note/none-required"
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@4e9ef4ce8c697cf55716ecbf7f13a3d9e0b6ac6a # v5.1.0
         with:
           mode: maximum
           count: 1
           labels: "release-note/major, release-note/minor, release-note/small, release-note/docs, release-note/infra, release-note/none-required"
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@4e9ef4ce8c697cf55716ecbf7f13a3d9e0b6ac6a # v5.1.0
         with:
           mode: maximum
           count: 1
@@ -41,8 +41,8 @@ jobs:
       - check-label
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/cache@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         # * Module download cache
         # * Build cache (Linux)
@@ -52,7 +52,7 @@ jobs:
         key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-${{ github.job }}-go-
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: 'stable'
         cache: false

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -23,24 +23,24 @@ jobs:
 
     steps:
     - name: "Checkout code"
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         persist-credentials: false
 
     - name: "Run analysis"
-      uses: ossf/scorecard-action@v2.3.1
+      uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
       with:
         results_file: results.sarif
         results_format: sarif
         publish_results: true
 
     - name: "Upload artifact"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
       with:
         name: SARIF file
         path: results.sarif
 
     - name: "Upload to code-scanning"
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
       with:
         sarif_file: results.sarif

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -28,7 +28,7 @@ jobs:
           # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
           # is resolved
           args: --build-tags=e2e,conformance,gcp,oidc,none
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -47,7 +47,7 @@ jobs:
           ignore_words_file: './.codespell.ignorewords'
           check_filenames: true
           check_hidden: true
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -79,7 +79,7 @@ jobs:
         run: |
           make generate lint-yamllint lint-flags
           ./hack/actions/check-uncommitted-codegen.sh
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -107,7 +107,7 @@ jobs:
       with:
         name: image
         path: image/contour-*.tar
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -172,7 +172,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make e2e
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -235,7 +235,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make upgrade
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -276,7 +276,7 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: coverage.out
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -312,7 +312,7 @@ jobs:
         run: |
           make install
           make check-coverage
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -352,7 +352,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make gateway-conformance
-      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -107,7 +107,7 @@ jobs:
       with:
         name: image
         path: image/contour-*.tar
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -16,19 +16,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: v1.55.2
           # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
           # is resolved
           args: --build-tags=e2e,conformance,gcp,oidc,none
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -39,15 +39,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2.0
+        uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461 # v2.0
         with:
           skip: .git,*.png,*.woff,*.woff2,*.eot,*.ttf,*.jpg,*.ico,*.svg,./site/themes/contour/static/fonts/README.md,./vendor,./site/public,./hack/actions/check-changefile-exists.go,go.mod,go.sum
           ignore_words_file: './.codespell.ignorewords'
           check_filenames: true
           check_hidden: true
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -56,8 +56,8 @@ jobs:
   codegen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -67,7 +67,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -79,7 +79,7 @@ jobs:
         run: |
           make generate lint-yamllint lint-flags
           ./hack/actions/check-uncommitted-codegen.sh
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -92,9 +92,9 @@ jobs:
       - codegen
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       with:
         version: latest
     - name: Build image
@@ -103,11 +103,11 @@ jobs:
       run: |
         make multiarch-build
     - name: Upload image
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
       with:
         name: image
         path: image/contour-*.tar
-    - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -140,13 +140,13 @@ jobs:
             use_config_crd: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: image
           path: image
-      - uses: actions/cache@v3
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -156,7 +156,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -172,7 +172,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make e2e
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -198,17 +198,17 @@ jobs:
           - kubernetes_version: "kubernetes:n-2"
             node_image: "docker.io/kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           # Fetch history for all tags and branches so we can figure out most
           # recent release tag.
           fetch-depth: 0
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: image
           path: image
-      - uses: actions/cache@v3
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -218,7 +218,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -235,7 +235,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make upgrade
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -248,8 +248,8 @@ jobs:
       - codegen
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -259,7 +259,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -273,10 +273,10 @@ jobs:
           make check-coverage
       - name: codeCoverage
         if: ${{ success() }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: coverage.out
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -289,8 +289,8 @@ jobs:
       - codegen
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Windows)
@@ -300,7 +300,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -312,7 +312,7 @@ jobs:
         run: |
           make install
           make check-coverage
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -322,13 +322,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-image]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: image
           path: image
-      - uses: actions/cache@v3
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
           # * Module download cache
           # * Build cache (Linux)
@@ -338,7 +338,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-${{ github.job }}-go-
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -352,7 +352,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make gateway-conformance
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -28,7 +28,7 @@ jobs:
           # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
           # is resolved
           args: --build-tags=e2e,conformance,gcp,oidc,none
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -47,7 +47,7 @@ jobs:
           ignore_words_file: './.codespell.ignorewords'
           check_filenames: true
           check_hidden: true
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -79,7 +79,7 @@ jobs:
         run: |
           make generate lint-yamllint lint-flags
           ./hack/actions/check-uncommitted-codegen.sh
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -107,7 +107,7 @@ jobs:
       with:
         name: image
         path: image/contour-*.tar
-    - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+    - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}
         steps: ${{ toJson(steps) }}
@@ -172,7 +172,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make e2e
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -235,7 +235,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make upgrade
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -276,7 +276,7 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: coverage.out
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -312,7 +312,7 @@ jobs:
         run: |
           make install
           make check-coverage
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
@@ -352,7 +352,7 @@ jobs:
         run: |
           export CONTOUR_E2E_IMAGE="ghcr.io/projectcontour/contour:$(ls ./image/contour-*.tar | sed -E 's/.*contour-(.*).tar/\1/')"
           make gateway-conformance
-      - uses: act10ns/slack@c97e3fd72786369b169158fff23a3bd2f418cb14 # v2
+      - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
         with:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}

--- a/.github/workflows/request-reviews.yaml
+++ b/.github/workflows/request-reviews.yaml
@@ -8,7 +8,7 @@ jobs:
   request-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: necojackarc/auto-request-review@v0.12.0
+      - uses: necojackarc/auto-request-review@6a51cebffe2c084705d9a7b394abd802e0119633 # v0.12.0
         with:
           token: ${{ secrets.PAT_FOR_AUTO_REQUEST_REVIEW }}
           config: .github/reviewers.yaml

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         exempt-all-milestones: true

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -18,10 +18,10 @@ jobs:
         - release-1.25
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ matrix.branch }}
-      - uses: aquasecurity/trivy-action@0.16.0
+      - uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601 # 0.16.0
         with:
           scanners: vuln
           scan-type: 'fs'
@@ -29,6 +29,6 @@ jobs:
           output: 'trivy-results.sarif'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Dependabot should be able to update these and preserve the tag in the comment, as per: https://github.com/dependabot/dependabot-core/pull/5951

Workflows updated with: https://app.stepsecurity.io/secureworkflow