### PR TITLE
Add instructions for docker-mac-net-connect and installation instructions to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,35 @@ This section describes how to build Contour from source.
 
     The easiest way to experiment with Contour is to build it in a container and run it locally in [kind](https://kind.sigs.k8s.io/) cluster.
 
-2. Install tools: `git`, `make`, [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/), `kubectl`, `jq` and `yq`
+    On Mac, you can follow instructions to download and install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+    On Linux, you can follow one of the installation methods provided by [Docker](https://docs.docker.com/desktop/install/linux-install/).
+
+2. Install tools: `git`, `make`, `gcc` (used by `go test -race`), [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/), `kubectl`, `jq` and `yq`
+
+    On Mac, the easiest, and recommended way, to get `git` and `make` is to install Xcode command line tools. To install Xcode command line tools run:
+
+    ```bash
+    xcode-select --install
+    ```
+
+    For some of the other tools, the recommended way is to use [homebrew](https://brew.sh/) to install them. Once brew is installed you can run:
+
+    ```bash
+    brew install kind kubectl jq yq
+    ```
+
+    On Ubuntu Linux, some of the above tools can be downloaded via the package manager:
+
+    ```bash
+    apt-get install build-essential git jq
+    ```
+
+    Reference the documentation of the various tools for installation instructions for your platform:
+
+    * kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
+    * kind: https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries
+    * yq: https://github.com/mikefarah/yq?tab=readme-ov-file#install
 
 3. Install Go
 
@@ -27,8 +55,17 @@ This section describes how to build Contour from source.
     Contour generally uses the most recent minor [Go version][1].
     Look in the `Makefile` (search for the `BUILD_BASE_IMAGE` variable) to find the specific version being used.
 
+    For installation instructions for Golang see: https://go.dev/doc/install
+
+    On Mac with homebrew, you can install Golang with:
+
+    ```bash
+    brew install go
+    ```
+
 4. (Optional for MacOS) [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect) to connect directly to Docker-for-Mac containers via IP address.
 
+    See installation instructions [here](https://github.com/chipmk/docker-mac-net-connect?tab=readme-ov-file#installation)
 
 ### Fetch the source
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ This section describes how to build Contour from source.
     Contour generally uses the most recent minor [Go version][1].
     Look in the `Makefile` (search for the `BUILD_BASE_IMAGE` variable) to find the specific version being used.
 
+4. (Optional for MacOS) [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect) to connect directly to Docker-for-Mac containers via IP address.
 
 
 ### Fetch the source
@@ -87,6 +88,16 @@ To remove the Kind cluster and all resources, run:
 ```shell
 make cleanup-kind
 ```
+
+#### MacOS
+
+Both `install-contour-working` and `install-provisioner-working` configure [MetalLB](https://metallb.universe.tf/) to setup a local LoadBalancer Service that can be accessed on the Docker network.
+On Linux, you are able to directly reach IPs on the Docker network, but on MacOS the docker network is not directly accessible on the host.
+
+As a workaround to this problem, [Docker Mac Net Connect](https://github.com/chipmk/docker-mac-net-connect) can be installed to setup a tunnel between your host and the Docker Desktop Linux VM (see [here](https://github.com/chipmk/docker-mac-net-connect?tab=readme-ov-file#how-does-it-work) for more info on how this works).
+To setup follow the [readme installation instructions](https://github.com/chipmk/docker-mac-net-connect?tab=readme-ov-file#installation).
+
+Once it is setup, you are able to create the kind cluster using the above instructions. If you have issues with connecting to the MetalLB IP try to restart the Docker Engine or make sure there is an HTTProxy deployed on your kind cluster so the Contour listener is created.
 
 ### Pre-submit checks
 


### PR DESCRIPTION
Docker Mac Net Connect allows you to connect directly to Docker-for-Mac containers using their ip address instead of binding ports.

This also adds more helpful instructions for installation of tools, either tells them the recommended way to install the tool or links to the installation instructions of the specific tool.

Fixes #5294
Fixes #5269