### PR TITLE
Remove static base runtime layer from bootstrap

### DIFF
--- a/changelogs/unreleased/6063-lubronzhan-small.md
+++ b/changelogs/unreleased/6063-lubronzhan-small.md
@@ -1,0 +1,1 @@
+Remove static base runtime layer from bootstrap

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -164,12 +164,6 @@ func bootstrapConfig(c *envoy.BootstrapConfig) *envoy_bootstrap_v3.Bootstrap {
 		LayeredRuntime: &envoy_bootstrap_v3.LayeredRuntime{
 			Layers: []*envoy_bootstrap_v3.RuntimeLayer{
 				{
-					Name: "base",
-					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_StaticLayer{
-						StaticLayer: baseRuntimeLayer(),
-					},
-				},
-				{
 					Name: "dynamic",
 					LayerSpecifier: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer_{
 						RtdsLayer: &envoy_bootstrap_v3.RuntimeLayer_RtdsLayer{

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -183,13 +183,6 @@ func TestBootstrap(t *testing.T) {
   "layered_runtime": {
     "layers": [
       {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
-      {
         "name": "dynamic",
         "rtds_layer": {
           "name": "dynamic",
@@ -369,13 +362,6 @@ func TestBootstrap(t *testing.T) {
   "layered_runtime": {
     "layers": [
       {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
-      {
         "name": "dynamic",
         "rtds_layer": {
           "name": "dynamic",
@@ -554,13 +540,6 @@ func TestBootstrap(t *testing.T) {
   },
   "layered_runtime": {
     "layers": [
-      {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
       {
         "name": "dynamic",
         "rtds_layer": {
@@ -742,13 +721,6 @@ func TestBootstrap(t *testing.T) {
   "layered_runtime": {
     "layers": [
       {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
-      {
         "name": "dynamic",
         "rtds_layer": {
           "name": "dynamic",
@@ -929,13 +901,6 @@ func TestBootstrap(t *testing.T) {
   "layered_runtime": {
     "layers": [
       {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
-      {
         "name": "dynamic",
         "rtds_layer": {
           "name": "dynamic",
@@ -1115,13 +1080,6 @@ func TestBootstrap(t *testing.T) {
   },
   "layered_runtime": {
     "layers": [
-      {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
       {
         "name": "dynamic",
         "rtds_layer": {
@@ -1304,13 +1262,6 @@ func TestBootstrap(t *testing.T) {
   },
   "layered_runtime": {
     "layers": [
-      {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
       {
         "name": "dynamic",
         "rtds_layer": {
@@ -1528,13 +1479,6 @@ func TestBootstrap(t *testing.T) {
   "layered_runtime": {
     "layers": [
       {
-        "name": "base",
-        "static_layer": {
-          "re2.max_program_size.error_level": 1048576,
-          "re2.max_program_size.warn_level": 1000
-        }
-      },
-      {
         "name": "dynamic",
         "rtds_layer": {
           "name": "dynamic",
@@ -1749,13 +1693,6 @@ func TestBootstrap(t *testing.T) {
         "layered_runtime": {
           "layers": [
             {
-              "name": "base",
-              "static_layer": {
-                "re2.max_program_size.error_level": 1048576,
-                "re2.max_program_size.warn_level": 1000
-              }
-            },
-            {
               "name": "dynamic",
               "rtds_layer": {
                 "name": "dynamic",
@@ -1964,13 +1901,6 @@ func TestBootstrap(t *testing.T) {
         },
         "layered_runtime": {
           "layers": [
-            {
-              "name": "base",
-              "static_layer": {
-                "re2.max_program_size.error_level": 1048576,
-                "re2.max_program_size.warn_level": 1000
-              }
-            },
             {
               "name": "dynamic",
               "rtds_layer": {


### PR DESCRIPTION
Right now dynamic runtime layer is available, they add the same config, so the static layer could be removed
Fix https://github.com/projectcontour/contour/issues/5845
