### PR TITLE
feat(access-log): omit empty fields in Envoy logs

### DIFF
--- a/changelogs/unreleased/6077-abbas-gheydi-small.md
+++ b/changelogs/unreleased/6077-abbas-gheydi-small.md
@@ -1,0 +1,1 @@
+Access Log: Contour excludes empty fields in Envoy JSON based access logs by default.

--- a/internal/envoy/v3/accesslog.go
+++ b/internal/envoy/v3/accesslog.go
@@ -99,7 +99,8 @@ func FileAccessLogJSON(path string, fields contour_api_v1alpha1.AccessLogJSONFie
 						Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 							JsonFormat: jsonformat,
 						},
-						Formatters: extensionConfig(extensions),
+						OmitEmptyValues: true,
+						Formatters:      extensionConfig(extensions),
 					},
 				},
 			}),

--- a/internal/envoy/v3/accesslog_test.go
+++ b/internal/envoy/v3/accesslog_test.go
@@ -122,6 +122,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 							Path: "/dev/stdout",
 							AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 								LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+									OmitEmptyValues: true,
 									Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 										JsonFormat: &structpb.Struct{
 											Fields: map[string]*structpb.Value{
@@ -153,6 +154,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 							Path: "/dev/stdout",
 							AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 								LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+									OmitEmptyValues: true,
 									Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 										JsonFormat: &structpb.Struct{
 											Fields: map[string]*structpb.Value{
@@ -244,6 +246,7 @@ func TestAccessLogLevel(t *testing.T) {
 				Path: "/dev/stdout",
 				AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 					LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+						OmitEmptyValues: true,
 						Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 							JsonFormat: &structpb.Struct{
 								Fields: map[string]*structpb.Value{},

--- a/site/content/docs/main/config/access-logging.md
+++ b/site/content/docs/main/config/access-logging.md
@@ -78,7 +78,7 @@ See the [example config file][6] to see this used in context.
 
 #### Omitting Logs with Empty Values
 
-Contour now automatically omits empty fields in Envoy JSON access logs, enhancing clarity and delivering more concise and relevant log outputs by default.
+Contour automatically omits empty fields in Envoy JSON access logs, enhancing clarity and delivering more concise and relevant log outputs by default.
 
 #### Sample Configuration File
 

--- a/site/content/docs/main/config/access-logging.md
+++ b/site/content/docs/main/config/access-logging.md
@@ -76,6 +76,10 @@ Note that the `DYNAMIC_METADATA` and `FILTER_STATE` Envoy logging operators are 
 
 See the [example config file][6] to see this used in context.
 
+#### Omitting Logs with Empty Values
+
+Contour now automatically omits empty fields in Envoy JSON access logs, enhancing clarity and delivering more concise and relevant log outputs by default.
+
 #### Sample Configuration File
 
 Here is a sample config:


### PR DESCRIPTION
## Pull Request

### Description

This PR addresses the issue #6067 by implementing the feature to omit empty fields in Envoy logs for the access log.

### Changes Made

- Modified the access log to exclude empty fields in Envoy logs.

### Related Issue
#6067