### PR TITLE
Add flag to golangci-lint to show line number if there is error

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -32,7 +32,7 @@ jobs:
         version: v1.55.2
         # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
         # is resolved
-        args: --build-tags=e2e,conformance,gcp,oidc,none --out-${NO_FUTURE}format=colored-line-number
+        args: --build-tags=e2e,conformance,gcp,oidc,none --out-format=colored-line-number
     - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -32,7 +32,7 @@ jobs:
         version: v1.55.2
         # TODO: re-enable linting tools package once https://github.com/projectcontour/contour/issues/5077
         # is resolved
-        args: --build-tags=e2e,conformance,gcp,oidc,none
+        args: --build-tags=e2e,conformance,gcp,oidc,none --out-${NO_FUTURE}format=colored-line-number
     - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
       with:
         status: ${{ job.status }}

--- a/changelogs/unreleased/6095-lubronzhan-small.md
+++ b/changelogs/unreleased/6095-lubronzhan-small.md
@@ -1,1 +1,0 @@
-Updates to Go 1.21.6. See the [Go release notes](https://go.dev/doc/devel/release#go1.21.minor) for more information.

--- a/changelogs/unreleased/6095-lubronzhan-small.md
+++ b/changelogs/unreleased/6095-lubronzhan-small.md
@@ -1,0 +1,1 @@
+Updates to Go 1.21.6. See the [Go release notes](https://go.dev/doc/devel/release#go1.21.minor) for more information.


### PR DESCRIPTION
Fix https://github.com/projectcontour/contour/issues/6095
Example run after adding the change in my PR
https://github.com/projectcontour/contour/pull/6073
[projectcontour/contour/actions/runs/7551166827/job/20557981226?pr=6073](https://github.com/projectcontour/contour/actions/runs/7551166827/job/20557981226?pr=6073)
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.55.2-linux-amd64/golangci-lint run --out-format=github-actions --build-tags=e2e,conformance,gcp,oidc,none --out-${NO_FUTURE}format=colored-line-number] in [] ...
  Error: internal/provisioner/objects/rbac/role/role.go:100:45: unused-parameter: parameter 'namespace' seems to be unused, consider removing or renaming it as _ (revive)
  func desiredRoleForContourInNamespace(name, namespace string, contour *model.Contour) *rbacv1.Role {
                                              ^
  Error: internal/provisioner/objects/rbac/role/role.go:117:121: updateRoleIfNeeded - result 0 (*k8s.io/api/rbac/v1.Role) is never used (unparam)
  func updateRoleIfNeeded(ctx context.Context, cli client.Client, contour *model.Contour, current, desired *rbacv1.Role) (*rbacv1.Role, error) {
                                                                                                                          ^
  Error: issues found

```