### PR TITLE
Add more debugging log on generating crd related code.

### DIFF
--- a/hack/actions/check-uncommitted-codegen.sh
+++ b/hack/actions/check-uncommitted-codegen.sh
@@ -24,5 +24,6 @@ if git status -s ${TARGETS[@]} 2>&1 | grep -E -q '^\s+[MADRCU]'
 then
 	echo Uncommitted changes in generated sources:
 	git status -s ${TARGETS[@]}
+	git diff
 	exit 1
 fi

--- a/hack/actions/check-uncommitted-codegen.sh
+++ b/hack/actions/check-uncommitted-codegen.sh
@@ -24,6 +24,6 @@ if git status -s ${TARGETS[@]} 2>&1 | grep -E -q '^\s+[MADRCU]'
 then
 	echo Uncommitted changes in generated sources:
 	git status -s ${TARGETS[@]}
-	git diff
+	git --no-pager diff
 	exit 1
 fi

--- a/hack/generate-crd-deepcopy.sh
+++ b/hack/generate-crd-deepcopy.sh
@@ -38,6 +38,9 @@ readonly HEADER=$(mktemp)
 
 boilerplate > "${HEADER}"
 
+exec echo "controller-gen version: "
+exec go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
+
 exec go run sigs.k8s.io/controller-tools/cmd/controller-gen \
     "object:headerFile=${HEADER}" \
     "paths=${PATHS}"

--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -15,6 +15,9 @@ trap 'rm -rf "$TEMPDIR"; exit' 0 1 2 15
 
 cd "${REPO}"
 
+echo "controller-gen version: "
+go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
+
 # Controller-gen seems to use an unstable sort for the order of output of the CRDs
 # so, output them to separate files, then concatenate those files.
 # That should give a stable sort.

--- a/hack/generate-rbac.sh
+++ b/hack/generate-rbac.sh
@@ -17,6 +17,9 @@ cat > "${REPO}/examples/contour/02-role-contour.yaml" <<EOF
 # files and re-render.
 EOF
 
+echo "controller-gen version: "
+go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
+
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
     rbac:roleName=contour \
     output:stdout \


### PR DESCRIPTION
Currently, the `check-uncommited-codegen` shows there are uncommited change, but not the details of the change. So add some command to help debug
1. print git diff if there is diff
2. print controller-gen version, since sometimes it could just because the controller-gen version is incorrect, then the generated output is different between remote job and local environment