### PR TITLE
Support gateway api BackendTLSPolicy

### DIFF
--- a/changelogs/unreleased/6119-flawedmatrix-major.md
+++ b/changelogs/unreleased/6119-flawedmatrix-major.md
@@ -1,0 +1,9 @@
+## Support for Gateway API BackendTLSPolicy
+
+The BackendTLSPolicy CRD can now be used with HTTPRoute to configure a Contour gateway to connect to a backend Service with TLS. This will give users the ability to use Gateway API to configure their routes to securely connect to backends that use TLS with Contour.
+
+The BackendTLSPolicy spec requires you to specify a `targetRef`, which can currently only be a Kubernetes Service within the same namespace as the BackendTLSPolicy. The targetRef is what Service should be watched to apply the BackendTLSPolicy to. A `SectionName` can also be configured to the port name of a Service to reference a specific section of the Service.
+
+The spec also requires you to specify `caCertRefs`, which can either be a ConfigMap or Secret with a `ca.crt` key in the data map containing a PEM-encoded TLS certificate. The CA certificates referenced will be configured to be used by the gateway to perform TLS to the backend Service. You will also need to specify a `Hostname`, which will be used to configure the SNI the gateway will use for the connection.
+
+See Gateway API's [GEP-1897](https://gateway-api.sigs.k8s.io/geps/gep-1897) for the proposal for BackendTLSPolicy.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -133,7 +133,7 @@ func registerServe(app *kingpin.Application) (*kingpin.CmdClause, *serveContext)
 	serve.Flag("debug", "Enable debug logging.").Short('d').BoolVar(&ctx.Config.Debug)
 	serve.Flag("debug-http-address", "Address the debug http endpoint will bind to.").PlaceHolder("<ipaddr>").StringVar(&ctx.debugAddr)
 	serve.Flag("debug-http-port", "Port the debug http endpoint will bind to.").PlaceHolder("<port>").IntVar(&ctx.debugPort)
-	serve.Flag("disable-feature", "Do not start an informer for the specified resources.").PlaceHolder("<extensionservices,tlsroutes,grpcroutes,tcproutes>").EnumsVar(&ctx.disabledFeatures, "extensionservices", "tlsroutes", "grpcroutes", "tcproutes")
+	serve.Flag("disable-feature", "Do not start an informer for the specified resources.").PlaceHolder("<extensionservices,tlsroutes,grpcroutes,tcproutes,backendtlspolicies>").EnumsVar(&ctx.disabledFeatures, "extensionservices", "tlsroutes", "grpcroutes", "tcproutes", "backendtlspolicies")
 	serve.Flag("disable-leader-election", "Disable leader election mechanism.").BoolVar(&ctx.LeaderElection.Disable)
 
 	serve.Flag("envoy-http-access-log", "Envoy HTTP access log.").PlaceHolder("/path/to/file").StringVar(&ctx.httpAccessLog)
@@ -258,6 +258,28 @@ func NewServer(log logrus.FieldLogger, ctx *serveContext) (*Server, error) {
 						secret.SetAnnotations(nil)
 
 						return secret, nil
+					},
+				},
+				&corev1.ConfigMap{}: {
+					Transform: func(obj any) (any, error) {
+						configMap, ok := obj.(*corev1.ConfigMap)
+						// TransformFunc should handle the tombstone of type cache.DeletedFinalStateUnknown
+						if !ok {
+							return obj, nil
+						}
+
+						// Keep ConfigMaps that have the ca.crt key because they may be necessary
+						if _, ok := configMap.Data[dag.CACertificateKey]; ok {
+							return obj, nil
+						}
+
+						// Other types of ConfigMaps will never be referred to, so we can remove all data.
+						// Last-applied-configuration annotation might contain a copy of the complete data.
+						configMap.Data = map[string]string{}
+						configMap.SetManagedFields(nil)
+						configMap.SetAnnotations(nil)
+
+						return configMap, nil
 					},
 				},
 			},
@@ -1053,9 +1075,10 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 
 		// Some features may be disabled.
 		features := map[string]struct{}{
-			"tlsroutes":  {},
-			"grpcroutes": {},
-			"tcproutes":  {},
+			"tlsroutes":          {},
+			"grpcroutes":         {},
+			"tcproutes":          {},
+			"backendtlspolicies": {},
 		}
 		for _, f := range s.ctx.disabledFeatures {
 			delete(features, f)
@@ -1084,6 +1107,18 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_api_v1alpha1.Conto
 		if _, enabled := features["tcproutes"]; enabled {
 			if err := controller.RegisterTCPRouteController(s.log.WithField("context", "tcproute-controller"), mgr, eventHandler); err != nil {
 				s.log.WithError(err).Fatal("failed to create tcproute-controller")
+			}
+		}
+
+		// Create and register the BackendTLSPolicy controller with the manager.
+		if _, enabled := features["backendtlspolicies"]; enabled {
+			// Inform on ConfigMap if BackendTLSPolicy is enabled
+			if err := s.informOnResource(&corev1.ConfigMap{}, eventHandler); err != nil {
+				s.log.WithError(err).WithField("resource", "configmaps").Fatal("failed to create informer")
+			}
+
+			if err := controller.RegisterBackendTLSPolicyController(s.log.WithField("context", "backendtlspolicy-controller"), mgr, eventHandler); err != nil {
+				s.log.WithError(err).Fatal("failed to create backendtlspolicy-controller")
 			}
 		}
 
@@ -1232,6 +1267,7 @@ func (s *Server) getDAGBuilder(dbc dagBuilderConfig) *dag.Builder {
 			PerConnectionBufferLimitBytes: dbc.perConnectionBufferLimitBytes,
 			SetSourceMetadataOnRoutes:     true,
 			GlobalCircuitBreakerDefaults:  dbc.globalCircuitBreakerDefaults,
+			UpstreamTLS:                   dbc.upstreamTLS,
 		})
 	}
 

--- a/examples/contour/02-role-contour.yaml
+++ b/examples/contour/02-role-contour.yaml
@@ -10,6 +10,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -29,6 +30,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -43,6 +45,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status

--- a/examples/gateway-provisioner/01-roles.yaml
+++ b/examples/gateway-provisioner/01-roles.yaml
@@ -10,6 +10,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -70,15 +71,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -93,19 +86,29 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gatewayclasses/status
-  - gateways/status
-  verbs:
-  - update
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
   - httproutes/status
   - tcproutes/status
   - tlsroutes/status
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
   verbs:
   - update
 - apiGroups:

--- a/examples/gateway/00-crds.yaml
+++ b/examples/gateway/00-crds.yaml
@@ -1,3 +1,509 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Gateway API Experimental channel install
+#
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
+    gateway.networking.k8s.io/bundle-version: v1.0.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: BackendTLSPolicy provides a way to configure how a Gateway connects
+          to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              targetRef:
+                description: "TargetRef identifies an API object to apply the policy
+                  to. Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support. Note that
+                  this config applies to the entire referenced resource by default,
+                  but this default may change in the future to provide a more granular
+                  application of the policy. \n Support: Extended for Kubernetes Service
+                  \n Support: Implementation-specific for any other resource"
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  sectionName:
+                    description: "SectionName is the name of a section within the
+                      target resource. When unspecified, this targetRef targets the
+                      entire resource. In the following resources, SectionName is
+                      interpreted as the following: \n * Gateway: Listener Name *
+                      Service: Port Name \n If a SectionName is specified, but does
+                      not exist on the targeted object, the Policy must fail to attach,
+                      and the policy implementation should record a `ResolvedRefs`
+                      or similar Condition in the Policy's status."
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              tls:
+                description: TLS contains backend TLS policy configuration.
+                properties:
+                  caCertRefs:
+                    description: "CACertRefs contains one or more references to Kubernetes
+                      objects that contain a PEM-encoded TLS CA certificate bundle,
+                      which is used to validate a TLS handshake between the Gateway
+                      and backend Pod. \n If CACertRefs is empty or unspecified, then
+                      WellKnownCACerts must be specified. Only one of CACertRefs or
+                      WellKnownCACerts may be specified, not both. If CACertRefs is
+                      empty or unspecified, the configuration for WellKnownCACerts
+                      MUST be honored instead. \n References to a resource in a different
+                      namespace are invalid for the moment, although we will revisit
+                      this in the future. \n A single CACertRef to a Kubernetes ConfigMap
+                      kind has \"Core\" support. Implementations MAY choose to support
+                      attaching multiple certificates to a backend, but this behavior
+                      is implementation-specific. \n Support: Core - An optional single
+                      reference to a Kubernetes ConfigMap, with the CA certificate
+                      in a key named `ca.crt`. \n Support: Implementation-specific
+                      (More than one reference, or other kinds of resources)."
+                    items:
+                      description: "LocalObjectReference identifies an API object
+                        within the namespace of the referrer. The API object must
+                        be valid in the cluster; the Group and Kind must be registered
+                        in the cluster for this reference to be valid. \n References
+                        to objects with invalid Group and Kind are not valid, and
+                        must be rejected by the implementation, with appropriate Conditions
+                        set on the containing object."
+                      properties:
+                        group:
+                          description: Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io". When unspecified or empty
+                            string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: "Hostname is used for two purposes in the connection
+                      between Gateways and backends: \n 1. Hostname MUST be used as
+                      the SNI to connect to the backend (RFC 6066). 2. Hostname MUST
+                      be used for authentication and MUST match the certificate served
+                      by the matching backend. \n Support: Core"
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  wellKnownCACerts:
+                    description: "WellKnownCACerts specifies whether system CA certificates
+                      may be used in the TLS handshake between the gateway and backend
+                      pod. \n If WellKnownCACerts is unspecified or empty (\"\"),
+                      then CACertRefs must be specified with at least one entry for
+                      a valid configuration. Only one of CACertRefs or WellKnownCACerts
+                      may be specified, not both. \n Support: Core for \"System\""
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertRefs and WellKnownCACerts
+                  rule: '!(has(self.caCertRefs) && size(self.caCertRefs) > 0 && has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")'
+                - message: must specify either CACertRefs or WellKnownCACerts
+                  rule: (has(self.caCertRefs) && size(self.caCertRefs) > 0 || has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")
+            required:
+            - targetRef
+            - tls
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: "Ancestors is a list of ancestor resources (usually Gateways)
+                  that are associated with the policy, and the status of the policy
+                  with respect to each ancestor. When this policy attaches to a parent,
+                  the controller that manages the parent and the ancestors MUST add
+                  an entry to this list when the controller first sees the policy
+                  and SHOULD update the entry as appropriate when the relevant ancestor
+                  is modified. \n Note that choosing the relevant ancestor is left
+                  to the Policy designers; an important part of Policy design is designing
+                  the right object level at which to namespace this status. \n Note
+                  also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST use the ControllerName field to uniquely identify the entries
+                  in this list that they are responsible for. \n Note that to achieve
+                  this, the list of PolicyAncestorStatus structs MUST be treated as
+                  a map with a composite key, made up of the AncestorRef and ControllerName
+                  fields combined. \n A maximum of 16 ancestors will be represented
+                  in this list. An empty list means the Policy is not relevant for
+                  any ancestors. \n If this slice is full, implementations MUST NOT
+                  add further entries. Instead they MUST consider the policy unimplementable
+                  and signal that on any related resources such as the ancestor that
+                  would be referenced here. For example, if this list was full on
+                  BackendTLSPolicy, no additional Gateways would be able to reference
+                  the Service targeted by the BackendTLSPolicy."
+                items:
+                  description: "PolicyAncestorStatus describes the status of a route
+                    with respect to an associated Ancestor. \n Ancestors refer to
+                    objects that are either the Target of a policy or above it in
+                    terms of object hierarchy. For example, if a policy targets a
+                    Service, the Policy's Ancestors are, in order, the Service, the
+                    HTTPRoute, the Gateway, and the GatewayClass. Almost always, in
+                    this hierarchy, the Gateway will be the most useful object to
+                    place Policy status on, so we recommend that implementations SHOULD
+                    use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise. \n In the context of policy
+                    attachment, the Ancestor is used to distinguish which resource
+                    results in a distinct application of this policy. For example,
+                    if a policy targets a Service, it may have a distinct result per
+                    attached Gateway. \n Policies targeting the same resource may
+                    have different effects depending on the ancestors of those resources.
+                    For example, different Gateways targeting the same Service may
+                    have different capabilities, especially if they have different
+                    underlying implementations. \n For example, in BackendTLSPolicy,
+                    the Policy attaches to a Service that is used as a backend in
+                    a HTTPRoute that is itself attached to a Gateway. In this case,
+                    the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status. \n Note that a parent
+                    is also an ancestor, so for objects where the parent is the relevant
+                    object for status, this struct SHOULD still be used. \n This struct
+                    is intended to be used in a slice that's effectively a map, with
+                    a composite key made up of the AncestorRef and the ControllerName."
+                  properties:
+                    ancestorRef:
+                      description: AncestorRef corresponds with a ParentRef in the
+                        spec that this PolicyAncestorStatus struct describes the status
+                        of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n  ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route.  \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n  When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values.  \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -495,6 +1001,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2300,6 +2809,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4027,6 +4539,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -8986,6 +9501,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9272,6 +9790,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9910,6 +10431,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -10597,6 +11121,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -8861,6 +8861,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -8880,6 +8881,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -8894,6 +8896,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -8540,6 +8540,512 @@ spec:
       status: {}
 
 ---
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Gateway API Experimental channel install
+#
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
+    gateway.networking.k8s.io/bundle-version: v1.0.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: BackendTLSPolicy provides a way to configure how a Gateway connects
+          to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              targetRef:
+                description: "TargetRef identifies an API object to apply the policy
+                  to. Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support. Note that
+                  this config applies to the entire referenced resource by default,
+                  but this default may change in the future to provide a more granular
+                  application of the policy. \n Support: Extended for Kubernetes Service
+                  \n Support: Implementation-specific for any other resource"
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  sectionName:
+                    description: "SectionName is the name of a section within the
+                      target resource. When unspecified, this targetRef targets the
+                      entire resource. In the following resources, SectionName is
+                      interpreted as the following: \n * Gateway: Listener Name *
+                      Service: Port Name \n If a SectionName is specified, but does
+                      not exist on the targeted object, the Policy must fail to attach,
+                      and the policy implementation should record a `ResolvedRefs`
+                      or similar Condition in the Policy's status."
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              tls:
+                description: TLS contains backend TLS policy configuration.
+                properties:
+                  caCertRefs:
+                    description: "CACertRefs contains one or more references to Kubernetes
+                      objects that contain a PEM-encoded TLS CA certificate bundle,
+                      which is used to validate a TLS handshake between the Gateway
+                      and backend Pod. \n If CACertRefs is empty or unspecified, then
+                      WellKnownCACerts must be specified. Only one of CACertRefs or
+                      WellKnownCACerts may be specified, not both. If CACertRefs is
+                      empty or unspecified, the configuration for WellKnownCACerts
+                      MUST be honored instead. \n References to a resource in a different
+                      namespace are invalid for the moment, although we will revisit
+                      this in the future. \n A single CACertRef to a Kubernetes ConfigMap
+                      kind has \"Core\" support. Implementations MAY choose to support
+                      attaching multiple certificates to a backend, but this behavior
+                      is implementation-specific. \n Support: Core - An optional single
+                      reference to a Kubernetes ConfigMap, with the CA certificate
+                      in a key named `ca.crt`. \n Support: Implementation-specific
+                      (More than one reference, or other kinds of resources)."
+                    items:
+                      description: "LocalObjectReference identifies an API object
+                        within the namespace of the referrer. The API object must
+                        be valid in the cluster; the Group and Kind must be registered
+                        in the cluster for this reference to be valid. \n References
+                        to objects with invalid Group and Kind are not valid, and
+                        must be rejected by the implementation, with appropriate Conditions
+                        set on the containing object."
+                      properties:
+                        group:
+                          description: Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io". When unspecified or empty
+                            string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: "Hostname is used for two purposes in the connection
+                      between Gateways and backends: \n 1. Hostname MUST be used as
+                      the SNI to connect to the backend (RFC 6066). 2. Hostname MUST
+                      be used for authentication and MUST match the certificate served
+                      by the matching backend. \n Support: Core"
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  wellKnownCACerts:
+                    description: "WellKnownCACerts specifies whether system CA certificates
+                      may be used in the TLS handshake between the gateway and backend
+                      pod. \n If WellKnownCACerts is unspecified or empty (\"\"),
+                      then CACertRefs must be specified with at least one entry for
+                      a valid configuration. Only one of CACertRefs or WellKnownCACerts
+                      may be specified, not both. \n Support: Core for \"System\""
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertRefs and WellKnownCACerts
+                  rule: '!(has(self.caCertRefs) && size(self.caCertRefs) > 0 && has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")'
+                - message: must specify either CACertRefs or WellKnownCACerts
+                  rule: (has(self.caCertRefs) && size(self.caCertRefs) > 0 || has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")
+            required:
+            - targetRef
+            - tls
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: "Ancestors is a list of ancestor resources (usually Gateways)
+                  that are associated with the policy, and the status of the policy
+                  with respect to each ancestor. When this policy attaches to a parent,
+                  the controller that manages the parent and the ancestors MUST add
+                  an entry to this list when the controller first sees the policy
+                  and SHOULD update the entry as appropriate when the relevant ancestor
+                  is modified. \n Note that choosing the relevant ancestor is left
+                  to the Policy designers; an important part of Policy design is designing
+                  the right object level at which to namespace this status. \n Note
+                  also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST use the ControllerName field to uniquely identify the entries
+                  in this list that they are responsible for. \n Note that to achieve
+                  this, the list of PolicyAncestorStatus structs MUST be treated as
+                  a map with a composite key, made up of the AncestorRef and ControllerName
+                  fields combined. \n A maximum of 16 ancestors will be represented
+                  in this list. An empty list means the Policy is not relevant for
+                  any ancestors. \n If this slice is full, implementations MUST NOT
+                  add further entries. Instead they MUST consider the policy unimplementable
+                  and signal that on any related resources such as the ancestor that
+                  would be referenced here. For example, if this list was full on
+                  BackendTLSPolicy, no additional Gateways would be able to reference
+                  the Service targeted by the BackendTLSPolicy."
+                items:
+                  description: "PolicyAncestorStatus describes the status of a route
+                    with respect to an associated Ancestor. \n Ancestors refer to
+                    objects that are either the Target of a policy or above it in
+                    terms of object hierarchy. For example, if a policy targets a
+                    Service, the Policy's Ancestors are, in order, the Service, the
+                    HTTPRoute, the Gateway, and the GatewayClass. Almost always, in
+                    this hierarchy, the Gateway will be the most useful object to
+                    place Policy status on, so we recommend that implementations SHOULD
+                    use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise. \n In the context of policy
+                    attachment, the Ancestor is used to distinguish which resource
+                    results in a distinct application of this policy. For example,
+                    if a policy targets a Service, it may have a distinct result per
+                    attached Gateway. \n Policies targeting the same resource may
+                    have different effects depending on the ancestors of those resources.
+                    For example, different Gateways targeting the same Service may
+                    have different capabilities, especially if they have different
+                    underlying implementations. \n For example, in BackendTLSPolicy,
+                    the Policy attaches to a Service that is used as a backend in
+                    a HTTPRoute that is itself attached to a Gateway. In this case,
+                    the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status. \n Note that a parent
+                    is also an ancestor, so for objects where the parent is the relevant
+                    object for status, this struct SHOULD still be used. \n This struct
+                    is intended to be used in a slice that's effectively a map, with
+                    a composite key made up of the AncestorRef and the ControllerName."
+                  properties:
+                    ancestorRef:
+                      description: AncestorRef corresponds with a ParentRef in the
+                        spec that this PolicyAncestorStatus struct describes the status
+                        of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n  ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route.  \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n  When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values.  \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9037,6 +9543,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -10842,6 +11351,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12569,6 +13081,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17528,6 +18043,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17814,6 +18332,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -18452,6 +18973,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19139,6 +19663,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19801,6 +20328,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -19861,15 +20389,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gatewayclasses
-  - gateways
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -19884,19 +20404,29 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gatewayclasses/status
-  - gateways/status
-  verbs:
-  - update
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
   - httproutes/status
   - tcproutes/status
   - tlsroutes/status
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
   verbs:
   - update
 - apiGroups:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8864,6 +8864,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -8883,6 +8884,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -8897,6 +8899,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
@@ -9256,6 +9259,512 @@ spec:
         runAsGroup: 65534
 
 ---
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Gateway API Experimental channel install
+#
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2466
+    gateway.networking.k8s.io/bundle-version: v1.0.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: BackendTLSPolicy provides a way to configure how a Gateway connects
+          to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              targetRef:
+                description: "TargetRef identifies an API object to apply the policy
+                  to. Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support. Note that
+                  this config applies to the entire referenced resource by default,
+                  but this default may change in the future to provide a more granular
+                  application of the policy. \n Support: Extended for Kubernetes Service
+                  \n Support: Implementation-specific for any other resource"
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  sectionName:
+                    description: "SectionName is the name of a section within the
+                      target resource. When unspecified, this targetRef targets the
+                      entire resource. In the following resources, SectionName is
+                      interpreted as the following: \n * Gateway: Listener Name *
+                      Service: Port Name \n If a SectionName is specified, but does
+                      not exist on the targeted object, the Policy must fail to attach,
+                      and the policy implementation should record a `ResolvedRefs`
+                      or similar Condition in the Policy's status."
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              tls:
+                description: TLS contains backend TLS policy configuration.
+                properties:
+                  caCertRefs:
+                    description: "CACertRefs contains one or more references to Kubernetes
+                      objects that contain a PEM-encoded TLS CA certificate bundle,
+                      which is used to validate a TLS handshake between the Gateway
+                      and backend Pod. \n If CACertRefs is empty or unspecified, then
+                      WellKnownCACerts must be specified. Only one of CACertRefs or
+                      WellKnownCACerts may be specified, not both. If CACertRefs is
+                      empty or unspecified, the configuration for WellKnownCACerts
+                      MUST be honored instead. \n References to a resource in a different
+                      namespace are invalid for the moment, although we will revisit
+                      this in the future. \n A single CACertRef to a Kubernetes ConfigMap
+                      kind has \"Core\" support. Implementations MAY choose to support
+                      attaching multiple certificates to a backend, but this behavior
+                      is implementation-specific. \n Support: Core - An optional single
+                      reference to a Kubernetes ConfigMap, with the CA certificate
+                      in a key named `ca.crt`. \n Support: Implementation-specific
+                      (More than one reference, or other kinds of resources)."
+                    items:
+                      description: "LocalObjectReference identifies an API object
+                        within the namespace of the referrer. The API object must
+                        be valid in the cluster; the Group and Kind must be registered
+                        in the cluster for this reference to be valid. \n References
+                        to objects with invalid Group and Kind are not valid, and
+                        must be rejected by the implementation, with appropriate Conditions
+                        set on the containing object."
+                      properties:
+                        group:
+                          description: Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io". When unspecified or empty
+                            string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: "Hostname is used for two purposes in the connection
+                      between Gateways and backends: \n 1. Hostname MUST be used as
+                      the SNI to connect to the backend (RFC 6066). 2. Hostname MUST
+                      be used for authentication and MUST match the certificate served
+                      by the matching backend. \n Support: Core"
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  wellKnownCACerts:
+                    description: "WellKnownCACerts specifies whether system CA certificates
+                      may be used in the TLS handshake between the gateway and backend
+                      pod. \n If WellKnownCACerts is unspecified or empty (\"\"),
+                      then CACertRefs must be specified with at least one entry for
+                      a valid configuration. Only one of CACertRefs or WellKnownCACerts
+                      may be specified, not both. \n Support: Core for \"System\""
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertRefs and WellKnownCACerts
+                  rule: '!(has(self.caCertRefs) && size(self.caCertRefs) > 0 && has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")'
+                - message: must specify either CACertRefs or WellKnownCACerts
+                  rule: (has(self.caCertRefs) && size(self.caCertRefs) > 0 || has(self.wellKnownCACerts)
+                    && self.wellKnownCACerts != "")
+            required:
+            - targetRef
+            - tls
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: "Ancestors is a list of ancestor resources (usually Gateways)
+                  that are associated with the policy, and the status of the policy
+                  with respect to each ancestor. When this policy attaches to a parent,
+                  the controller that manages the parent and the ancestors MUST add
+                  an entry to this list when the controller first sees the policy
+                  and SHOULD update the entry as appropriate when the relevant ancestor
+                  is modified. \n Note that choosing the relevant ancestor is left
+                  to the Policy designers; an important part of Policy design is designing
+                  the right object level at which to namespace this status. \n Note
+                  also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST use the ControllerName field to uniquely identify the entries
+                  in this list that they are responsible for. \n Note that to achieve
+                  this, the list of PolicyAncestorStatus structs MUST be treated as
+                  a map with a composite key, made up of the AncestorRef and ControllerName
+                  fields combined. \n A maximum of 16 ancestors will be represented
+                  in this list. An empty list means the Policy is not relevant for
+                  any ancestors. \n If this slice is full, implementations MUST NOT
+                  add further entries. Instead they MUST consider the policy unimplementable
+                  and signal that on any related resources such as the ancestor that
+                  would be referenced here. For example, if this list was full on
+                  BackendTLSPolicy, no additional Gateways would be able to reference
+                  the Service targeted by the BackendTLSPolicy."
+                items:
+                  description: "PolicyAncestorStatus describes the status of a route
+                    with respect to an associated Ancestor. \n Ancestors refer to
+                    objects that are either the Target of a policy or above it in
+                    terms of object hierarchy. For example, if a policy targets a
+                    Service, the Policy's Ancestors are, in order, the Service, the
+                    HTTPRoute, the Gateway, and the GatewayClass. Almost always, in
+                    this hierarchy, the Gateway will be the most useful object to
+                    place Policy status on, so we recommend that implementations SHOULD
+                    use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise. \n In the context of policy
+                    attachment, the Ancestor is used to distinguish which resource
+                    results in a distinct application of this policy. For example,
+                    if a policy targets a Service, it may have a distinct result per
+                    attached Gateway. \n Policies targeting the same resource may
+                    have different effects depending on the ancestors of those resources.
+                    For example, different Gateways targeting the same Service may
+                    have different capabilities, especially if they have different
+                    underlying implementations. \n For example, in BackendTLSPolicy,
+                    the Policy attaches to a Service that is used as a backend in
+                    a HTTPRoute that is itself attached to a Gateway. In this case,
+                    the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status. \n Note that a parent
+                    is also an ancestor, so for objects where the parent is the relevant
+                    object for status, this struct SHOULD still be used. \n This struct
+                    is intended to be used in a slice that's effectively a map, with
+                    a composite key made up of the AncestorRef and the ControllerName."
+                  properties:
+                    ancestorRef:
+                      description: AncestorRef corresponds with a ParentRef in the
+                        spec that this PolicyAncestorStatus struct describes the status
+                        of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n There are
+                            two kinds of parent resources with \"Core\" support: \n
+                            * Gateway (Gateway conformance profile) * Service (Mesh
+                            conformance profile, experimental, ClusterIP Services
+                            only) \n Support for other resources is Implementation-Specific."
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n  ParentRefs from a Route to a Service in
+                            the same namespace are \"producer\" routes, which apply
+                            default routing rules to inbound connections from any
+                            namespace to the Service. \n ParentRefs from a Route to
+                            a Service in a different namespace are \"consumer\" routes,
+                            and these routing rules are only applied to outbound connections
+                            originating from the same namespace as the Route, for
+                            which the intended destination of the connections are
+                            a Service targeted as a ParentRef of the Route.  \n Support:
+                            Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n  When the parent resource is
+                            a Service, this targets a specific port in the Service
+                            spec. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected port must
+                            match both specified values.  \n Implementations MAY choose
+                            to support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n "
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. * Service: Port Name.
+                            When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services
+                            as Parents is part of experimental Mesh support and is
+                            not supported for any other purpose. \n Implementations
+                            MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9753,6 +10262,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -11558,6 +12070,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -13285,6 +13800,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -18244,6 +18762,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -18530,6 +19051,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19168,6 +19692,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19855,6 +20382,9 @@ status:
   conditions: null
   storedVersions: null
 ---
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -8861,6 +8861,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - endpoints
   - namespaces
   - secrets
@@ -8880,6 +8881,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies
   - gatewayclasses
   - gateways
   - grpcroutes
@@ -8894,6 +8896,7 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - backendtlspolicies/status
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status

--- a/hack/generate-gateway-yaml.sh
+++ b/hack/generate-gateway-yaml.sh
@@ -14,4 +14,4 @@ run::sed() {
 }
 
 
-kubectl kustomize -o examples/gateway/00-crds.yaml "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_API_VERSION}"
+wget -O examples/gateway/00-crds.yaml "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/experimental-install.yaml"

--- a/internal/controller/backendtlspolicy.go
+++ b/internal/controller/backendtlspolicy.go
@@ -1,0 +1,76 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type backendTLSPolicyReconciler struct {
+	client       client.Client
+	eventHandler cache.ResourceEventHandler
+	logrus.FieldLogger
+}
+
+// RegisterBackendTLSPolicyController creates the backendtlspolicy controller from mgr. The controller will be pre-configured
+// to watch for BackendTLSPolicy objects across all namespaces.
+func RegisterBackendTLSPolicyController(log logrus.FieldLogger, mgr manager.Manager, eventHandler cache.ResourceEventHandler) error {
+	r := &backendTLSPolicyReconciler{
+		client:       mgr.GetClient(),
+		eventHandler: eventHandler,
+		FieldLogger:  log,
+	}
+	c, err := controller.NewUnmanaged("backendtlspolicy-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+	if err := mgr.Add(&noLeaderElectionController{c}); err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind(mgr.GetCache(), &gatewayapi_v1alpha2.BackendTLSPolicy{}), &handler.EnqueueRequestForObject{})
+}
+
+func (r *backendTLSPolicyReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the BackendTLSPolicy from the cache.
+	backendTLSPolicy := &gatewayapi_v1alpha2.BackendTLSPolicy{}
+	err := r.client.Get(ctx, request.NamespacedName, backendTLSPolicy)
+	if errors.IsNotFound(err) {
+		r.eventHandler.OnDelete(&gatewayapi_v1alpha2.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      request.Name,
+				Namespace: request.Namespace,
+			},
+		})
+		return reconcile.Result{}, nil
+	}
+
+	// Pass the new changed object off to the eventHandler.
+	r.eventHandler.OnAdd(backendTLSPolicy, false)
+
+	return reconcile.Result{}, nil
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -45,6 +45,9 @@ func TestRegisterControllers(t *testing.T) {
 		"grpcroute controller": func(mockManager *mocks.Manager) error {
 			return controller.RegisterGRPCRouteController(fixture.NewTestLogger(t), mockManager, nil)
 		},
+		"backendtlspolicy controller": func(mockManager *mocks.Manager) error {
+			return controller.RegisterBackendTLSPolicyController(fixture.NewTestLogger(t), mockManager, nil)
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -526,6 +526,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
+	crossNSBackendHTTPRoute := makeHTTPRoute("basic", "default", "", gatewayapi_v1beta1.HTTPRouteRule{
+		Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+		BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
+			BackendRef: gatewayapi_v1beta1.BackendRef{
+				BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+					Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
+					Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+					Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
+					Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+				},
+				Weight: ref.To(int32(1)),
+			},
+		}},
+	})
+
 	tests := map[string]struct {
 		objs         []any
 		gatewayclass *gatewayapi_v1beta1.GatewayClass
@@ -587,24 +602,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPSameNamespace,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "different-ns-than-gateway",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "different-ns-than-gateway", "test.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(),
 		},
@@ -622,24 +620,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 				kuardServiceCustomNs,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "custom",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "custom", "test.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -664,24 +645,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 				},
 				kuardServiceCustomNs,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "custom",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "custom", "test.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(),
 		},
@@ -1052,24 +1016,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				basicHTTPRoute,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic-two",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"another.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic-two", "projectcontour", "another.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1149,35 +1096,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				blogService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io",
+					makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1),
+					makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/blog", "blogsvc", 80, 1),
+					gatewayapi_v1beta1.HTTPRouteRule{
+						Matches: append(
+							gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another"),
+							gatewayapi_v1beta1.HTTPRouteMatch{
+								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "X-Foo-Header", "some_value"),
+							},
+						),
+						BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}, {
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/blog"),
-							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
-						}, {
-							Matches: append(
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another"),
-								gatewayapi_v1beta1.HTTPRouteMatch{
-									Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "X-Foo-Header", "some_value"),
-								},
-							),
-							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
-						}},
-					},
-				},
+				),
 			},
 			want: listeners(
 				&Listener{
@@ -1253,21 +1184,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1283,24 +1200,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"*.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "*.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1319,24 +1219,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"192.168.122.1",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "192.168.122.1", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(),
 		},
@@ -1345,24 +1228,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io:80",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "default", "test.projectcontour.io:80", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(),
 		},
@@ -1371,24 +1237,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"*",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "default", "*", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(),
 		},
@@ -1398,21 +1247,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1428,30 +1263,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
-								{
-									BackendRef: gatewayapi_v1beta1.BackendRef{
-										BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-											Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
-											Name: "kuard",
-										},
-									},
+				makeHTTPRoute("basic", "default", "", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+									Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
+									Name: "kuard",
 								},
 							},
-						}},
+						},
 					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -1467,31 +1291,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 			},
 			want: listeners(&Listener{
 				Name: "http-80",
@@ -1505,31 +1305,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1557,31 +1333,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1610,31 +1362,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1664,31 +1392,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1718,31 +1422,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1772,31 +1452,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "default",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
-									},
-									Weight: ref.To(int32(1)),
-								},
-							}},
-						}},
-					},
-				},
+				crossNSBackendHTTPRoute,
 				&gatewayapi_v1beta1.ReferenceGrant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
@@ -1827,24 +1483,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchExact, "/blog"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchExact, "/blog", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1861,24 +1500,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchRegularExpression, "/bl+og"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchRegularExpression, "/bl+og", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -1896,39 +1518,26 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-							}, {
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/blog"),
-								},
-							}, {
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/tech"),
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io",
+					gatewayapi_v1beta1.HTTPRouteRule{
+						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+								Value: ref.To("/"),
+							},
+						}, {
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+								Value: ref.To("/blog"),
+							},
+						}, {
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+								Value: ref.To("/tech"),
+							},
 						}},
-					},
-				},
+						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					}),
 			},
 			want: listeners(
 				&Listener{
@@ -2380,24 +1989,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"*.*.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "*.*.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "blobsvc", 80, 1)),
 			},
 			want: listeners(),
 		},
@@ -2541,30 +2133,16 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "foo", "bar"),
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+						Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "foo", "bar"),
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2586,39 +2164,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
-							{
-								Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
-									{
-										Path: &gatewayapi_v1beta1.HTTPPathMatch{
-											Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-											Value: ref.To("/blog"),
-										},
-									}, {
-										Path: &gatewayapi_v1beta1.HTTPPathMatch{
-											Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-											Value: ref.To("/tech"),
-										},
-										Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "foo", "bar"),
-									},
-								},
-								BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
+						{
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+								Value: ref.To("/blog"),
 							},
+						}, {
+							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+								Value: ref.To("/tech"),
+							},
+							Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "foo", "bar"),
 						},
 					},
-				},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2644,26 +2206,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchRegularExpression, "foo", "^abc$"),
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchRegularExpression, "foo", "^abc$"),
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2685,31 +2233,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
+							{Name: "header-1", Value: "value-1"},
+							{Name: "header-2", Value: "value-2"},
+							{Name: "header-1", Value: "value-3"},
+							{Name: "HEADER-1", Value: "value-4"},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
-									{Name: "header-1", Value: "value-1"},
-									{Name: "header-2", Value: "value-2"},
-									{Name: "header-1", Value: "value-3"},
-									{Name: "HEADER-1", Value: "value-4"},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2732,30 +2266,16 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								Method: ref.To(gatewayapi_v1.HTTPMethodGet),
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+						Method: ref.To(gatewayapi_v1.HTTPMethodGet),
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2777,35 +2297,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Name:  "param-1",
+								Value: "value-1",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Name:  "param-1",
-										Value: "value-1",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2827,36 +2333,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-1",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-1",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2878,51 +2370,37 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-1",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-2",
+								Value: "value-2",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-3",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "Param-1",
+								Value: "value-4",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-1",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-2",
-										Value: "value-2",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-3",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "Param-1",
-										Value: "value-4",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -2946,51 +2424,37 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-1",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-2",
+								Value: "value-2",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-3",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+								Name:  "Param-1",
+								Value: "value-4",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-1",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-2",
-										Value: "value-2",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-3",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
-										Name:  "Param-1",
-										Value: "value-4",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3016,41 +2480,27 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
+								Name:  "param-1",
+								Value: "value-1",
+							},
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+								Name:  "param-1",
+								Value: "value-2",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
-										Name:  "param-1",
-										Value: "value-1",
-									},
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
-										Name:  "param-1",
-										Value: "value-2",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3074,36 +2524,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+							Value: ref.To("/"),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							{
+								Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+								Name:  "query-param-regex",
+								Value: "value-%d-[a-zA-Z0-9]",
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
-								},
-								QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
-									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
-										Name:  "query-param-regex",
-										Value: "value-%d-[a-zA-Z0-9]",
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3126,53 +2562,39 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{
-								{
-									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: "custom-header-add", Value: "foo-bar"},
-										},
-										Remove: []string{"x-remove"},
-									},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 								},
-								{
-									// Second instance of filter should be ignored.
-									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
-											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
-										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: "custom-header-add", Value: "ignored"},
-										},
-										Remove: []string{"x-remove-ignored"},
-									},
+								Add: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: "custom-header-add", Value: "foo-bar"},
 								},
+								Remove: []string{"x-remove"},
 							},
-						}},
+						},
+						{
+							// Second instance of filter should be ignored.
+							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+								},
+								Add: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: "custom-header-add", Value: "ignored"},
+								},
+								Remove: []string{"x-remove-ignored"},
+							},
+						},
 					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3201,21 +2623,133 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
+							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
+								},
+								Add: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: "custom-header-add", Value: "foo-bar"},
+								},
+								Remove: []string{"x-remove"},
+							},
+						},
+						{
+							// Second instance of filter should be ignored.
+							Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
+							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+								},
+								Add: []gatewayapi_v1beta1.HTTPHeader{
+									{Name: "custom-header-add", Value: "ignored"},
+								},
+								Remove: []string{"x-remove-ignored"},
+							},
+						},
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				}),
+			},
+			want: listeners(
+				&Listener{
+					Name: "http-80",
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixString("/"),
+							Clusters:           clustersWeight(service(kuardService)),
+							ResponseHeadersPolicy: &HeadersPolicy{
+								Set: map[string]string{
+									"Custom-Header-Set": "foo-bar", // Verify the header key is canonicalized.
+									"Host":              "bar.com", // Host header isn't significant in a response so it can be set.
+								},
+								Add: map[string]string{
+									"Custom-Header-Add": "foo-bar", // Verify the header key is canonicalized.
+								},
+								Remove: []string{"X-Remove"}, // Verify the header key is canonicalized.
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
+					)),
+				},
+			),
+		},
+		"HTTP backend with request header modifier": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []any{
+				kuardService,
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
+								Weight:                 ref.To(int32(1)),
+							},
+							Filters: []gatewayapi_v1.HTTPRouteFilter{
+								{
+									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "foo-bar"},
+										},
+										Remove: []string{"x-remove"},
+									},
+								},
+								{
+									// Second instance of filter should be ignored.
+									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
+											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
+										},
+										Add: []gatewayapi_v1beta1.HTTPHeader{
+											{Name: "custom-header-add", Value: "ignored"},
+										},
+										Remove: []string{"x-remove-ignored"},
+									},
+								},
+							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					},
+				}),
+			},
+			want: listeners(
+				&Listener{
+					Name: "http-80",
+					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
+						&Route{
+							PathMatchCondition: prefixString("/"),
+							Clusters:           clusterHeaders(map[string]string{"Custom-Header-Set": "foo-bar"}, map[string]string{"Custom-Header-Add": "foo-bar"}, []string{"X-Remove"}, "bar.com", nil, nil, nil, service(kuardService)),
+						},
+					)),
+				},
+			),
+		},
+		"HTTP backend with response header modifier": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []any{
+				kuardService,
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
+								Weight:                 ref.To(int32(1)),
+							},
 							Filters: []gatewayapi_v1.HTTPRouteFilter{
 								{
 									Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
@@ -3245,163 +2779,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 									},
 								},
 							},
-						}},
+						},
 					},
-				},
-			},
-			want: listeners(
-				&Listener{
-					Name: "http-80",
-					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
-						&Route{
-							PathMatchCondition: prefixString("/"),
-							Clusters:           clustersWeight(service(kuardService)),
-							ResponseHeadersPolicy: &HeadersPolicy{
-								Set: map[string]string{
-									"Custom-Header-Set": "foo-bar", // Verify the header key is canonicalized.
-									"Host":              "bar.com", // Host header isn't significant in a response so it can be set.
-								},
-								Add: map[string]string{
-									"Custom-Header-Add": "foo-bar", // Verify the header key is canonicalized.
-								},
-								Remove: []string{"X-Remove"}, // Verify the header key is canonicalized.
-							},
-						},
-					)),
-				},
-			),
-		},
-		"HTTP backend with request header modifier": {
-			gatewayclass: validClass,
-			gateway:      gatewayHTTPAllNamespaces,
-			objs: []any{
-				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
-								{
-									BackendRef: gatewayapi_v1beta1.BackendRef{
-										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-										Weight:                 ref.To(int32(1)),
-									},
-									Filters: []gatewayapi_v1.HTTPRouteFilter{
-										{
-											Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "custom-header-add", Value: "foo-bar"},
-												},
-												Remove: []string{"x-remove"},
-											},
-										},
-										{
-											// Second instance of filter should be ignored.
-											Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "custom-header-add", Value: "ignored"},
-												},
-												Remove: []string{"x-remove-ignored"},
-											},
-										},
-									},
-								},
-							},
-						}},
-					},
-				},
-			},
-			want: listeners(
-				&Listener{
-					Name: "http-80",
-					VirtualHosts: virtualhosts(virtualhost("test.projectcontour.io",
-						&Route{
-							PathMatchCondition: prefixString("/"),
-							Clusters:           clusterHeaders(map[string]string{"Custom-Header-Set": "foo-bar"}, map[string]string{"Custom-Header-Add": "foo-bar"}, []string{"X-Remove"}, "bar.com", nil, nil, nil, service(kuardService)),
-						},
-					)),
-				},
-			),
-		},
-		"HTTP backend with response header modifier": {
-			gatewayclass: validClass,
-			gateway:      gatewayHTTPAllNamespaces,
-			objs: []any{
-				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
-								{
-									BackendRef: gatewayapi_v1beta1.BackendRef{
-										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-										Weight:                 ref.To(int32(1)),
-									},
-									Filters: []gatewayapi_v1.HTTPRouteFilter{
-										{
-											Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-											ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "custom-header-add", Value: "foo-bar"},
-												},
-												Remove: []string{"x-remove"},
-											},
-										},
-										{
-											// Second instance of filter should be ignored.
-											Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-											ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "custom-header-add", Value: "ignored"},
-												},
-												Remove: []string{"x-remove-ignored"},
-											},
-										},
-									},
-								},
-							},
-						}},
-					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3420,38 +2800,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
-							{
-								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-								BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-								Filters: []gatewayapi_v1.HTTPRouteFilter{{
-									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
-											{Name: "!invalid-header-add", Value: "foo-bar"},
-										},
-									},
-								}},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+						RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+							Set: []gatewayapi_v1beta1.HTTPHeader{
+								{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+								{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
+							},
+							Add: []gatewayapi_v1beta1.HTTPHeader{
+								{Name: "!invalid-header-add", Value: "foo-bar"},
 							},
 						},
-					},
-				},
+					}},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3475,45 +2839,29 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
-							{
-								Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-								BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
-									{
-										BackendRef: gatewayapi_v1beta1.BackendRef{
-											BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-											Weight:                 ref.To(int32(1)),
-										},
-										Filters: []gatewayapi_v1.HTTPRouteFilter{{
-											Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-											RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "!invalid-header-add", Value: "foo-bar"},
-												},
-											},
-										}},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
+								Weight:                 ref.To(int32(1)),
+							},
+							Filters: []gatewayapi_v1.HTTPRouteFilter{{
+								Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+									Set: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+										{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
+									},
+									Add: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: "!invalid-header-add", Value: "foo-bar"},
 									},
 								},
-							},
+							}},
 						},
 					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3532,45 +2880,29 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
-							{
-								Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-								BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
-									{
-										BackendRef: gatewayapi_v1beta1.BackendRef{
-											BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
-											Weight:                 ref.To(int32(1)),
-										},
-										Filters: []gatewayapi_v1.HTTPRouteFilter{{
-											Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-											ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-												Set: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
-													{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
-												},
-												Add: []gatewayapi_v1beta1.HTTPHeader{
-													{Name: "!invalid-header-add", Value: "foo-bar"},
-												},
-											},
-										}},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
+								Weight:                 ref.To(int32(1)),
+							},
+							Filters: []gatewayapi_v1.HTTPRouteFilter{{
+								Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
+								ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+									Set: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
+										{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
+									},
+									Add: []gatewayapi_v1beta1.HTTPHeader{
+										{Name: "!invalid-header-add", Value: "foo-bar"},
 									},
 								},
-							},
+							}},
 						},
 					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3589,32 +2921,18 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+							Scheme:     ref.To("https"),
+							Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
+							Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
+							StatusCode: ref.To(301),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Scheme:     ref.To("https"),
-									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
-									Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
-									StatusCode: ref.To(301),
-								},
-							}},
-						}},
-					},
-				},
+					}},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3638,35 +2956,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: append(
+						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
+					),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+							Scheme:     ref.To("https"),
+							Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
+							Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
+							StatusCode: ref.To(301),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: append(
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
-							),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Scheme:     ref.To("https"),
-									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
-									Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
-									StatusCode: ref.To(301),
-								},
-							}},
-						}},
-					},
-				},
+					}},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3699,33 +3003,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ref.To("/replacement"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
-										ReplacePrefixMatch: ref.To("/replacement"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3748,33 +3038,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ref.To("/"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
-										ReplacePrefixMatch: ref.To("/"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3797,33 +3073,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
+						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:            gatewayapi_v1.FullPathHTTPPathModifier,
+								ReplaceFullPath: ref.To("/replacement"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:            gatewayapi_v1.FullPathHTTPPathModifier,
-										ReplaceFullPath: ref.To("/replacement"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3847,30 +3109,16 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				kuardService2,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
-								},
-							}},
-						}},
-					},
-				},
+					}},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3887,38 +3135,24 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{
-								{
-									Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-									RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-										BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
-									},
-								},
-								{
-									Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-									RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-										BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
-									},
-								},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 							},
-						}},
+						},
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
+							},
+						},
 					},
-				},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3934,33 +3168,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				kuardService2,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: append(
+						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
+					),
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: append(
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-								gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
-							),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
-								},
-							}},
-						}},
-					},
-				},
+					}},
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -3977,33 +3197,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ref.To("/replacement"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
-										ReplacePrefixMatch: ref.To("/replacement"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4025,33 +3231,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: ref.To("/"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
-										ReplacePrefixMatch: ref.To("/"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4073,33 +3265,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+								Type:            gatewayapi_v1.FullPathHTTPPathModifier,
+								ReplaceFullPath: ref.To("/replacement"),
+							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-									Path: &gatewayapi_v1beta1.HTTPPathModifier{
-										Type:            gatewayapi_v1.FullPathHTTPPathModifier,
-										ReplaceFullPath: ref.To("/replacement"),
-									},
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4121,30 +3299,16 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{{
+						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+							Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("rewritten.com")),
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{{
-								Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-								URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-									Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("rewritten.com")),
-								},
-							}},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+					}},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4164,43 +3328,29 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"test.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
-							Filters: []gatewayapi_v1.HTTPRouteFilter{
-								{
-									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
-											{
-												Name:  "Host",
-												Value: "requestheader.rewritten.com",
-											},
-										},
-									},
-								},
-								{
-									Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-									URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-										Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("url.rewritten.com")),
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
+					Filters: []gatewayapi_v1.HTTPRouteFilter{
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
+							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1beta1.HTTPHeader{
+									{
+										Name:  "Host",
+										Value: "requestheader.rewritten.com",
 									},
 								},
 							},
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
+						},
+						{
+							Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
+							URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
+								Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("url.rewritten.com")),
+							},
+						},
 					},
-				},
+					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4224,7 +3374,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("5s", ""),
+				makeHTTPRouteWithTimeouts("5s", ""),
 			},
 			want: listeners(
 				&Listener{
@@ -4248,7 +3398,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("5s", "5s"),
+				makeHTTPRouteWithTimeouts("5s", "5s"),
 			},
 			want: listeners(),
 		},
@@ -4258,7 +3408,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("", "5s"),
+				makeHTTPRouteWithTimeouts("", "5s"),
 			},
 			want: listeners(),
 		},
@@ -4267,7 +3417,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("invalid", ""),
+				makeHTTPRouteWithTimeouts("invalid", ""),
 			},
 			want: listeners(),
 		},
@@ -4282,23 +3432,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				tlsService,
 				configMapCert1,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4365,23 +3499,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				tlsService,
 				cert1,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4449,23 +3567,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				tlsService,
 				cert1,
 				cert2,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4539,23 +3641,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				tlsAndNonTLSService,
 				cert1,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tls-basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/tls"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlsandnontlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("tls-basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/tls", "tlsandnontlssvc", 443, 1)),
 				&gatewayapi_v1beta1.HTTPRoute{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "non-tls-basic",
@@ -4661,23 +3747,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			objs: []any{
 				tlsService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4732,23 +3802,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			objs: []any{
 				tlsService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4803,23 +3857,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			},
 			objs: []any{
 				tlsService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("tlssvc", 443, 1),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "tlssvc", 443, 1)),
 				&gatewayapi_v1alpha2.BackendTLSPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "basic",
@@ -4872,25 +3910,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("kuard", 8080, 5),
-								gatewayapi.HTTPBackendRef("kuard2", 8080, 10),
-								gatewayapi.HTTPBackendRef("kuard3", 8080, 15),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRefs(
+						gatewayapi.HTTPBackendRef("kuard", 8080, 5),
+						gatewayapi.HTTPBackendRef("kuard2", 8080, 10),
+						gatewayapi.HTTPBackendRef("kuard3", 8080, 15),
+					),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -4936,25 +3963,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRefs(
-								gatewayapi.HTTPBackendRef("kuard", 8080, 5),
-								gatewayapi.HTTPBackendRef("kuard2", 8080, 0),
-								gatewayapi.HTTPBackendRef("kuard3", 8080, 15),
-							),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1beta1.HTTPRouteRule{
+					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+					BackendRefs: gatewayapi.HTTPBackendRefs(
+						gatewayapi.HTTPBackendRef("kuard", 8080, 5),
+						gatewayapi.HTTPBackendRef("kuard2", 8080, 0),
+						gatewayapi.HTTPBackendRef("kuard3", 8080, 15),
+					),
+				}),
 			},
 			want: listeners(
 				&Listener{
@@ -5000,21 +4016,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 0),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 0)),
 			},
 			want: listeners(
 				&Listener{
@@ -5754,21 +4756,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPWithHostname,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchExact, "/blog"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchExact, "/blog", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -5785,24 +4773,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPWithWildcardHostname,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "basic",
-						Namespace: "projectcontour",
-					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
-						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
-							"http.projectcontour.io",
-						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchExact, "/blog"),
-							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
-						}},
-					},
-				},
+				makeHTTPRoute("basic", "projectcontour", "http.projectcontour.io", makeHTTPRouteRule(gatewayapi_v1.PathMatchExact, "/blog", "kuard", 8080, 1)),
 			},
 			want: listeners(
 				&Listener{
@@ -17031,7 +16002,7 @@ func makeHTTPRouteTimeouts(request, backendRequest string) *gatewayapi_v1.HTTPRo
 	return httpRouteTimeouts
 }
 
-func makeHTTPRoute(request, backendRequest string) *gatewayapi_v1beta1.HTTPRoute {
+func makeHTTPRouteWithTimeouts(request, backendRequest string) *gatewayapi_v1beta1.HTTPRoute {
 	return &gatewayapi_v1beta1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "basic",
@@ -17050,5 +16021,38 @@ func makeHTTPRoute(request, backendRequest string) *gatewayapi_v1beta1.HTTPRoute
 				Timeouts:    makeHTTPRouteTimeouts(request, backendRequest),
 			}},
 		},
+	}
+}
+
+func makeHTTPRoute(name, namespace, hostname string, firstRule gatewayapi_v1beta1.HTTPRouteRule, additionalRules ...gatewayapi_v1beta1.HTTPRouteRule) *gatewayapi_v1beta1.HTTPRoute {
+	rules := []gatewayapi_v1beta1.HTTPRouteRule{firstRule}
+	if len(additionalRules) > 0 {
+		rules = append(rules, additionalRules...)
+	}
+	var hostnames []gatewayapi_v1beta1.Hostname
+	if hostname != "" {
+		hostnames = []gatewayapi_v1beta1.Hostname{
+			gatewayapi_v1beta1.Hostname(hostname),
+		}
+	}
+	return &gatewayapi_v1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+			},
+			Hostnames: hostnames,
+			Rules:     rules,
+		},
+	}
+}
+
+func makeHTTPRouteRule(pathType gatewayapi_v1beta1.PathMatchType, pathValue, serviceName string, port int, weight int32) gatewayapi_v1beta1.HTTPRouteRule {
+	return gatewayapi_v1beta1.HTTPRouteRule{
+		Matches:     gatewayapi.HTTPRouteMatch(pathType, pathValue),
+		BackendRefs: gatewayapi.HTTPBackendRef(serviceName, port, weight),
 	}
 }

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -31,8 +31,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -357,6 +359,91 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Type: v1.SecretTypeOpaque,
 				Data: map[string][]byte{
 					CACertificateKey: []byte(fixture.CERTIFICATE),
+				},
+			},
+			want: true,
+		},
+		"insert certificate secret referenced by BackendTLSPolicy": {
+			pre: []any{
+				&gatewayapi_v1alpha2.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-btp",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+							CACertRefs: []gatewayapi_v1alpha2.LocalObjectReference{
+								{
+									Kind: "Secret",
+									Name: "ca",
+								},
+							},
+						},
+					},
+				},
+			},
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					CACertificateKey: []byte(fixture.CERTIFICATE),
+				},
+			},
+			want: true,
+		},
+		"insert certificate configmap not referenced": {
+			obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					CACertificateKey: fixture.CERTIFICATE,
+				},
+			},
+			want: false,
+		},
+		"insert generic configmap not referenced": {
+			obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"not-ca.crt": fixture.CERTIFICATE,
+				},
+			},
+			want: false,
+		},
+		"insert certificate configmap referenced by BackendTLSPolicy": {
+			pre: []any{
+				&gatewayapi_v1alpha2.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-btp",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+							CACertRefs: []gatewayapi_v1alpha2.LocalObjectReference{
+								{
+									Kind: "ConfigMap",
+									Name: "ca",
+								},
+							},
+						},
+					},
+				},
+			},
+			obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					CACertificateKey: fixture.CERTIFICATE,
 				},
 			},
 			want: true,
@@ -1035,6 +1122,48 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			},
 			want: true,
 		},
+		"insert backendtlspolicy targeting backend Service": {
+			pre: []any{
+				&gatewayapi_v1beta1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httproute",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
+								gatewayapi.GatewayParentRef("projectcontour", "contour"),
+							},
+						},
+						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+							BackendRefs: gatewayapi.HTTPBackendRef("service", 80, 1),
+						}},
+					},
+				},
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "service",
+						Namespace: "default",
+					},
+				},
+			},
+			obj: &gatewayapi_v1alpha2.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendtlspolicy",
+					Namespace: "default",
+				},
+				Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+					TargetRef: gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName{
+						PolicyTargetReference: gatewayapi_v1alpha2.PolicyTargetReference{
+							Kind: "Service",
+							Name: "service",
+						},
+					},
+					TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{},
+				},
+			},
+			want: true,
+		},
 
 		// SPECIFIC GATEWAY TESTS
 		"specific gateway configured, insert gatewayclass, no gateway cached": {
@@ -1192,6 +1321,24 @@ func TestKubernetesCacheRemove(t *testing.T) {
 					Namespace: "default",
 				},
 				Type: v1.SecretTypeTLS,
+			},
+			want: false,
+		},
+		"remove configmap": {
+			cache: cache(&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					CACertificateKey: fixture.CERTIFICATE,
+				},
+			}),
+			obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap",
+					Namespace: "default",
+				},
 			},
 			want: false,
 		},
@@ -1650,6 +1797,98 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			obj: &gatewayapi_v1beta1.ReferenceGrant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "referencegrant",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove gateway-api BackendTLSPolicy": {
+			cache: cache(&gatewayapi_v1alpha2.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendtlspolicy",
+					Namespace: "default",
+				},
+			}),
+			obj: &gatewayapi_v1alpha2.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backendtlspolicy",
+					Namespace: "default",
+				},
+			},
+			want: true,
+		},
+		"remove secret that is referenced by gateway-api BackendTLSPolicy": {
+			cache: cache(
+				&gatewayapi_v1alpha2.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backendtlspolicy",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+							CACertRefs: []v1beta1.LocalObjectReference{
+								{
+									Kind: "Secret",
+									Name: "ca",
+								},
+							},
+						},
+					},
+				},
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ca",
+						Namespace: "default",
+					},
+					Type: v1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						CACertificateKey: []byte(fixture.CERTIFICATE),
+					},
+				},
+			),
+			obj: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Type: v1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					CACertificateKey: []byte(fixture.CERTIFICATE),
+				},
+			},
+			want: true,
+		},
+		"remove configmap that is referenced by gateway-api BackendTLSPolicy": {
+			cache: cache(
+				&gatewayapi_v1alpha2.BackendTLSPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "backendtlspolicy",
+						Namespace: "default",
+					},
+					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+							CACertRefs: []v1beta1.LocalObjectReference{
+								{
+									Kind: "ConfigMap",
+									Name: "configmap",
+								},
+							},
+						},
+					},
+				},
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						CACertificateKey: fixture.CERTIFICATE,
+					},
+				},
+			),
+			obj: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap",
 					Namespace: "default",
 				},
 			},
@@ -2693,9 +2932,11 @@ func TestLookupUpstreamValidation(t *testing.T) {
 
 	pvc := func(subjectNames []string) *PeerValidationContext {
 		return &PeerValidationContext{
-			CACertificate: &Secret{
-				Object:        secret(),
-				ValidCASecret: &SecretValidationStatus{},
+			CACertificates: []*Secret{
+				{
+					Object:        secret(),
+					ValidCASecret: &SecretValidationStatus{},
+				},
 			},
 			SubjectNames: subjectNames,
 		}
@@ -2747,6 +2988,265 @@ func TestLookupUpstreamValidation(t *testing.T) {
 			default:
 				require.NoError(t, gotErr)
 				assert.Equal(t, tc.wantPvc, gotPvc)
+			}
+		})
+	}
+}
+
+func TestLookupBackendTLSPolicyByTargetRef(t *testing.T) {
+	targetRef := func(group, kind, name string, namespace, sectionName *string) gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName {
+		var ns *gatewayapi_v1alpha2.Namespace
+		if namespace != nil {
+			ns = ptr.To(gatewayapi_v1alpha2.Namespace(*namespace))
+		}
+		var sn *gatewayapi_v1alpha2.SectionName
+		if sectionName != nil {
+			sn = ptr.To(gatewayapi_v1alpha2.SectionName(*sectionName))
+		}
+		return gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName{
+			PolicyTargetReference: gatewayapi_v1alpha2.PolicyTargetReference{
+				Group:     gatewayapi_v1alpha2.Group(group),
+				Kind:      gatewayapi_v1alpha2.Kind(kind),
+				Name:      gatewayapi_v1alpha2.ObjectName(name),
+				Namespace: ns,
+			},
+			SectionName: sn,
+		}
+	}
+
+	backendTLSPolicy := func(name, namespace, serviceName string, targetNamespace, sectionName *string) *gatewayapi_v1alpha2.BackendTLSPolicy {
+		return &gatewayapi_v1alpha2.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+				TargetRef: targetRef("", "Service", serviceName, targetNamespace, sectionName),
+				TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+					CACertRefs: []gatewayapi_v1beta1.LocalObjectReference{
+						{
+							Group: "",
+							Kind:  "Secret",
+							Name:  "ca",
+						},
+					},
+					Hostname: "example.com",
+				},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		targetRef          gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName
+		backendTLSPolicies []*gatewayapi_v1alpha2.BackendTLSPolicy
+		want               *gatewayapi_v1alpha2.BackendTLSPolicy
+		wantFound          bool
+	}{
+		"finds the BackendTLSPolicy with the matching targetRef": {
+			targetRef: targetRef("", "Service", "backend-service", nil, nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "", "backend-service-with-section-name", nil, ptr.To("https")),
+				backendTLSPolicy("btp2", "", "backend-service-with-section-name", nil, ptr.To("https2")),
+			},
+			want:      backendTLSPolicy("btp", "", "backend-service", nil, nil),
+			wantFound: true,
+		},
+		"finds the BackendTLSPolicy matching targetRef with section name": {
+			targetRef: targetRef("", "Service", "backend-service-with-section-name", nil, ptr.To("https2")),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "", "backend-service-with-section-name", nil, ptr.To("https")),
+				backendTLSPolicy("btp2", "", "backend-service-with-section-name", nil, ptr.To("https2")),
+			},
+			want:      backendTLSPolicy("btp2", "", "backend-service-with-section-name", nil, ptr.To("https2")),
+			wantFound: true,
+		},
+		"finds the fallback BackendTLSPolicy matching targetRef but not section name": {
+			targetRef: targetRef("", "Service", "backend-service-with-fallback", nil, ptr.To("https2")),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "", "backend-service-with-fallback", nil, nil),
+				backendTLSPolicy("btp2", "", "backend-service-with-fallback", nil, ptr.To("https")),
+			},
+			want:      backendTLSPolicy("btp1", "", "backend-service-with-fallback", nil, nil),
+			wantFound: true,
+		},
+		"finds the fallback BackendTLSPolicy matching targetRef with section name": {
+			targetRef: targetRef("", "Service", "backend-service-with-fallback", nil, ptr.To("https")),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "", "backend-service-with-fallback", nil, nil),
+				backendTLSPolicy("btp2", "", "backend-service-with-fallback", nil, ptr.To("https")),
+			},
+			want:      backendTLSPolicy("btp2", "", "backend-service-with-fallback", nil, ptr.To("https")),
+			wantFound: true,
+		},
+		"finds the BackendTLSPolicy matching namespace": {
+			targetRef: targetRef("", "Service", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "other-ns", "backend-service-with-other-ns", ptr.To("other-ns"), nil),
+				backendTLSPolicy("btp2", "some-ns", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			},
+			want:      backendTLSPolicy("btp2", "some-ns", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			wantFound: true,
+		},
+		"finds the BackendTLSPolicy matching namespace even if backendtlspolicy targetRef namespace is empty": {
+			targetRef: targetRef("", "Service", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "other-ns", "backend-service-with-other-ns", nil, nil),
+				backendTLSPolicy("btp2", "some-ns", "backend-service-with-ns", nil, nil),
+			},
+			want:      backendTLSPolicy("btp2", "some-ns", "backend-service-with-ns", nil, nil),
+			wantFound: true,
+		},
+		"finds the BackendTLSPolicy in default namespace": {
+			targetRef: targetRef("", "Service", "backend-service", nil, nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "default", "backend-service", nil, nil),
+			},
+			want:      backendTLSPolicy("btp", "default", "backend-service", nil, nil),
+			wantFound: true,
+		},
+		"does not find the BackendTLSPolicy if the target namespace doesn't match the policy namespace": {
+			targetRef: targetRef("", "Service", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+				backendTLSPolicy("btp1", "some-ns", "backend-service-with-ns", ptr.To("wrong-ns"), nil),
+				backendTLSPolicy("btp2", "wrong-ns", "backend-service-with-ns", ptr.To("some-ns"), nil),
+			},
+			wantFound: false,
+		},
+		"does not find the BackendTLSPolicy if the namespace does not match": {
+			targetRef: targetRef("", "Service", "backend-service", ptr.To("not-default"), nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+			},
+			wantFound: false,
+		},
+		"does not find the BackendTLSPolicy if the service name does not match": {
+			targetRef: targetRef("", "Service", "other-service", nil, nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+			},
+			wantFound: false,
+		},
+		"does not find the BackendTLSPolicy if the GroupKind does not match": {
+			targetRef: targetRef("example.api", "ExampleService", "backend-service", nil, nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+			},
+			wantFound: false,
+		},
+		"does not find the BackendTLSPolicy if the group does not match": {
+			targetRef: targetRef("core", "Service", "backend-service", ptr.To("not-default"), nil),
+			backendTLSPolicies: []*gatewayapi_v1alpha2.BackendTLSPolicy{
+				backendTLSPolicy("btp", "", "backend-service", nil, nil),
+			},
+			wantFound: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := KubernetesCache{
+				FieldLogger: fixture.NewTestLogger(t),
+			}
+
+			for _, backendTLSPolicy := range tc.backendTLSPolicies {
+				cache.Insert(backendTLSPolicy)
+			}
+
+			gotBTP, gotFound := cache.LookupBackendTLSPolicyByTargetRef(tc.targetRef)
+
+			if tc.wantFound {
+				assert.True(t, gotFound)
+				assert.Equal(t, tc.want, gotBTP)
+			} else {
+				assert.False(t, gotFound)
+				assert.Nil(t, gotBTP)
+			}
+		})
+	}
+}
+
+func TestLookupCAConfigMap(t *testing.T) {
+	cache := func(objs ...any) *KubernetesCache {
+		cache := KubernetesCache{
+			FieldLogger: fixture.NewTestLogger(t),
+		}
+		for _, o := range objs {
+			cache.Insert(o)
+		}
+		return &cache
+	}
+
+	configmap := func(name, namespace, data string) *v1.ConfigMap {
+		return &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				CACertificateKey: data,
+			},
+		}
+	}
+
+	secret := func(name, namespace, data string) *Secret {
+		return &Secret{
+			Object: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Type: v1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					CACertificateKey: []byte(data),
+				},
+			},
+			ValidCASecret: &SecretValidationStatus{
+				Error: nil,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		cache      *KubernetesCache
+		meta       types.NamespacedName
+		wantSecret *Secret
+		wantErr    error
+	}{
+		"finds configmap by namespacedname and returns it as dag secret": {
+			cache: cache(
+				configmap("ca", "default", fixture.CA_CERT),
+				configmap("another-ca", "default", fixture.EC_CERTIFICATE),
+			),
+			meta:       types.NamespacedName{Namespace: "default", Name: "ca"},
+			wantSecret: secret("ca", "default", fixture.CA_CERT),
+		},
+		"returns an error if configmap secret is not a valid cert": {
+			cache: cache(
+				configmap("ca", "default", "invalid-ca-data"),
+			),
+			meta:    types.NamespacedName{Namespace: "default", Name: "ca"},
+			wantErr: errors.New("invalid CA certificate bundle: failed to locate certificate"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotSecret, gotErr := tc.cache.LookupCAConfigMap(tc.meta)
+
+			switch {
+			case tc.wantErr != nil:
+				require.Error(t, gotErr)
+				require.EqualError(t, tc.wantErr, gotErr.Error())
+			default:
+				require.NoError(t, gotErr)
+				assert.Equal(t, tc.wantSecret, gotSecret)
 			}
 		})
 	}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -668,7 +668,7 @@ type ClientCertificateDetails struct {
 type PeerValidationContext struct {
 	// CACertificate holds a reference to the Secret containing the CA to be used to
 	// verify the upstream connection.
-	CACertificate *Secret
+	CACertificates []*Secret
 	// SubjectNames holds optional subject names which Envoy will check against the
 	// certificate presented by the upstream. The first entry must match the value of SubjectName
 	SubjectNames []string
@@ -691,11 +691,18 @@ type PeerValidationContext struct {
 
 // GetCACertificate returns the CA certificate from PeerValidationContext.
 func (pvc *PeerValidationContext) GetCACertificate() []byte {
-	if pvc == nil || pvc.CACertificate == nil {
+	if pvc == nil || len(pvc.CACertificates) == 0 {
 		// No validation required.
 		return nil
 	}
-	return pvc.CACertificate.Object.Data[CACertificateKey]
+	var certs []byte
+	for _, cert := range pvc.CACertificates {
+		if cert == nil {
+			continue
+		}
+		certs = append(certs, cert.Object.Data[CACertificateKey]...)
+	}
+	return certs
 }
 
 // GetSubjectName returns the SubjectNames from PeerValidationContext.

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -76,10 +76,12 @@ func TestSecureVirtualHostValid(t *testing.T) {
 
 func TestPeerValidationContext(t *testing.T) {
 	pvc1 := PeerValidationContext{
-		CACertificate: &Secret{
-			Object: &v1.Secret{
-				Data: map[string][]byte{
-					CACertificateKey: []byte("cacert"),
+		CACertificates: []*Secret{
+			{
+				Object: &v1.Secret{
+					Data: map[string][]byte{
+						CACertificateKey: []byte("cacert"),
+					},
 				},
 			},
 		},
@@ -87,13 +89,45 @@ func TestPeerValidationContext(t *testing.T) {
 	}
 	pvc2 := PeerValidationContext{}
 	var pvc3 *PeerValidationContext
+	pvc4 := PeerValidationContext{
+		CACertificates: []*Secret{
+			{
+				Object: &v1.Secret{
+					Data: map[string][]byte{
+						CACertificateKey: []byte("-cacert-"),
+					},
+				},
+			},
+			{
+				Object: &v1.Secret{
+					Data: map[string][]byte{
+						CACertificateKey: []byte("-cacert2-"),
+					},
+				},
+			},
+			{
+				Object: &v1.Secret{
+					Data: map[string][]byte{},
+				},
+			},
+			nil,
+		},
+		SubjectNames: []string{"subject"},
+	}
+	pvc5 := PeerValidationContext{
+		CACertificates: []*Secret{},
+	}
 
-	assert.Equal(t, "subject", pvc1.GetSubjectNames()[0])
+	assert.ElementsMatch(t, []string{"subject"}, pvc1.GetSubjectNames())
 	assert.Equal(t, []byte("cacert"), pvc1.GetCACertificate())
 	assert.Equal(t, []string(nil), pvc2.GetSubjectNames())
 	assert.Equal(t, []byte(nil), pvc2.GetCACertificate())
 	assert.Equal(t, []string(nil), pvc3.GetSubjectNames())
 	assert.Equal(t, []byte(nil), pvc3.GetCACertificate())
+	assert.ElementsMatch(t, []string{"subject"}, pvc4.GetSubjectNames())
+	assert.Equal(t, []byte("-cacert--cacert2-"), pvc4.GetCACertificate())
+	assert.Equal(t, []string(nil), pvc5.GetSubjectNames())
+	assert.Equal(t, []byte(nil), pvc5.GetCACertificate())
 }
 
 func TestObserverFunc(t *testing.T) {

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -340,7 +340,9 @@ func (p *HTTPProxyProcessor) computeHTTPProxy(proxy *contour_api_v1.HTTPProxy) {
 						}
 						return
 					}
-					dv.CACertificate = cacert
+					dv.CACertificates = []*Secret{
+						cacert,
+					}
 				} else if !tls.ClientValidation.SkipClientCertValidation {
 					validCond.AddErrorf(contour_api_v1.ConditionTypeTLSError, "ClientValidationInvalid",
 						"Spec.VirtualHost.TLS client validation is invalid: CA Secret must be specified")

--- a/internal/envoy/cluster.go
+++ b/internal/envoy/cluster.go
@@ -47,8 +47,12 @@ func Clustername(cluster *dag.Cluster) string {
 		buf += hc.Path
 	}
 	if uv := cluster.UpstreamValidation; uv != nil {
-		buf += uv.CACertificate.Object.ObjectMeta.Name
-		buf += uv.SubjectNames[0]
+		if len(uv.CACertificates) > 0 {
+			buf += uv.CACertificates[0].Object.ObjectMeta.Name
+		}
+		if len(uv.SubjectNames) > 0 {
+			buf += uv.SubjectNames[0]
+		}
 	}
 	buf += cluster.Protocol + cluster.SNI
 	if !cluster.TimeoutPolicy.IdleConnectionTimeout.UseDefault() {

--- a/internal/envoy/v3/auth_test.go
+++ b/internal/envoy/v3/auth_test.go
@@ -59,7 +59,9 @@ func TestUpstreamTLSContext(t *testing.T) {
 		},
 		"no alpn, missing altname": {
 			validation: &dag.PeerValidationContext{
-				CACertificate: secret,
+				CACertificates: []*dag.Secret{
+					secret,
+				},
 			},
 			want: &envoy_v3_tls.UpstreamTlsContext{
 				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{},
@@ -75,8 +77,10 @@ func TestUpstreamTLSContext(t *testing.T) {
 		},
 		"no alpn, ca and altname": {
 			validation: &dag.PeerValidationContext{
-				CACertificate: secret,
-				SubjectNames:  []string{"www.example.com"},
+				CACertificates: []*dag.Secret{
+					secret,
+				},
+				SubjectNames: []string{"www.example.com"},
 			},
 			want: &envoy_v3_tls.UpstreamTlsContext{
 				CommonTlsContext: &envoy_v3_tls.CommonTlsContext{
@@ -125,7 +129,9 @@ func TestUpstreamTLSContext(t *testing.T) {
 		},
 		"multiple subjectnames": {
 			validation: &dag.PeerValidationContext{
-				CACertificate: secret,
+				CACertificates: []*dag.Secret{
+					secret,
+				},
 				SubjectNames: []string{
 					"foo.com",
 					"bar.com",

--- a/internal/envoy/v3/cluster_test.go
+++ b/internal/envoy/v3/cluster_test.go
@@ -299,8 +299,10 @@ func TestCluster(t *testing.T) {
 				Upstream: service(s1, "tls"),
 				Protocol: "tls",
 				UpstreamValidation: &dag.PeerValidationContext{
-					CACertificate: secret,
-					SubjectNames:  []string{"foo.bar.io"},
+					CACertificates: []*dag.Secret{
+						secret,
+					},
+					SubjectNames: []string{"foo.bar.io"},
 				},
 			},
 			want: &envoy_cluster_v3.Cluster{
@@ -314,8 +316,10 @@ func TestCluster(t *testing.T) {
 				TransportSocket: UpstreamTLSTransportSocket(
 					UpstreamTLSContext(
 						&dag.PeerValidationContext{
-							CACertificate: secret,
-							SubjectNames:  []string{"foo.bar.io"},
+							CACertificates: []*dag.Secret{
+								secret,
+							},
+							SubjectNames: []string{"foo.bar.io"},
 						},
 						"",
 						nil,
@@ -328,8 +332,10 @@ func TestCluster(t *testing.T) {
 				Upstream: service(s1, "tls"),
 				Protocol: "tls",
 				UpstreamValidation: &dag.PeerValidationContext{
-					CACertificate: secret,
-					SubjectNames:  []string{"foo.bar.io"},
+					CACertificates: []*dag.Secret{
+						secret,
+					},
+					SubjectNames: []string{"foo.bar.io"},
 				},
 				UpstreamTLS: &dag.UpstreamTLS{
 					MinimumProtocolVersion: "1.3",
@@ -347,8 +353,10 @@ func TestCluster(t *testing.T) {
 				TransportSocket: UpstreamTLSTransportSocket(
 					UpstreamTLSContext(
 						&dag.PeerValidationContext{
-							CACertificate: secret,
-							SubjectNames:  []string{"foo.bar.io"},
+							CACertificates: []*dag.Secret{
+								secret,
+							},
+							SubjectNames: []string{"foo.bar.io"},
 						},
 						"",
 						nil,
@@ -935,10 +943,12 @@ func TestDNSNameCluster(t *testing.T) {
 				Port:            443,
 				DNSLookupFamily: "auto",
 				UpstreamValidation: &dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: &v1.Secret{
-							Data: map[string][]byte{
-								"ca.crt": []byte("ca-cert"),
+					CACertificates: []*dag.Secret{
+						{
+							Object: &v1.Secret{
+								Data: map[string][]byte{
+									"ca.crt": []byte("ca-cert"),
+								},
 							},
 						},
 					},
@@ -966,10 +976,12 @@ func TestDNSNameCluster(t *testing.T) {
 					},
 				},
 				TransportSocket: UpstreamTLSTransportSocket(UpstreamTLSContext(&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: &v1.Secret{
-							Data: map[string][]byte{
-								"ca.crt": []byte("ca-cert"),
+					CACertificates: []*dag.Secret{
+						{
+							Object: &v1.Secret{
+								Data: map[string][]byte{
+									"ca.crt": []byte("ca-cert"),
+								},
 							},
 						},
 					},
@@ -1093,14 +1105,16 @@ func TestClustername(t *testing.T) {
 		},
 		LoadBalancerPolicy: "Random",
 		UpstreamValidation: &dag.PeerValidationContext{
-			CACertificate: &dag.Secret{
-				Object: &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "secret",
-						Namespace: "default",
-					},
-					Data: map[string][]byte{
-						dag.CACertificateKey: []byte("somethingsecret"),
+			CACertificates: []*dag.Secret{
+				{
+					Object: &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							dag.CACertificateKey: []byte("somethingsecret"),
+						},
 					},
 				},
 			},

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -302,14 +302,16 @@ func TestDownstreamTLSContext(t *testing.T) {
 	}
 
 	peerValidationContext := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},
@@ -317,14 +319,16 @@ func TestDownstreamTLSContext(t *testing.T) {
 
 	// Negative test case: downstream validation should not contain subjectname.
 	peerValidationContextWithSubjectName := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},
@@ -340,14 +344,16 @@ func TestDownstreamTLSContext(t *testing.T) {
 		},
 	}
 	peerValidationContextSkipClientCertValidationWithCA := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},
@@ -364,28 +370,32 @@ func TestDownstreamTLSContext(t *testing.T) {
 		},
 	}
 	peerValidationContextOptionalClientCertValidationWithCA := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},
 		OptionalClientCertificate: true,
 	}
 	peerValidationContextWithCRLCheck := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},
@@ -417,14 +427,16 @@ func TestDownstreamTLSContext(t *testing.T) {
 	}
 
 	peerValidationContextWithCRLCheckOnlyLeaf := &dag.PeerValidationContext{
-		CACertificate: &dag.Secret{
-			Object: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					dag.CACertificateKey: ca,
+		CACertificates: []*dag.Secret{
+			{
+				Object: &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						dag.CACertificateKey: ca,
+					},
 				},
 			},
 		},

--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -207,8 +207,8 @@ func TestBackendClientAuthenticationWithExtensionService(t *testing.T) {
 	tlsSocket := envoy_v3.UpstreamTLSTransportSocket(
 		envoy_v3.UpstreamTLSContext(
 			&dag.PeerValidationContext{
-				CACertificate: &dag.Secret{Object: featuretests.CASecret(t, "secret", &featuretests.CACertificate)},
-				SubjectNames:  []string{"subjname"},
+				CACertificates: []*dag.Secret{{Object: featuretests.CASecret(t, "secret", &featuretests.CACertificate)}},
+				SubjectNames:   []string{"subjname"},
 			},
 			"subjname",
 			&dag.Secret{Object: clientSecret},

--- a/internal/featuretests/v3/downstreamvalidation_test.go
+++ b/internal/featuretests/v3/downstreamvalidation_test.go
@@ -72,8 +72,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			filterchaintls("example.com", serverTLSSecret,
 				httpsFilterFor("example.com"),
 				&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 				},
 				"h2", "http/1.1",
@@ -171,8 +173,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 				httpsFilterFor("example.com"),
 				&dag.PeerValidationContext{
 					SkipClientCertValidation: true,
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 				},
 				"h2", "http/1.1",
@@ -224,8 +228,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			filterchaintls("example.com", serverTLSSecret,
 				httpsFilterFor("example.com"),
 				&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 					CRL: &dag.Secret{
 						Object: crlSecret,
@@ -276,8 +282,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			filterchaintls("example.com", serverTLSSecret,
 				httpsFilterFor("example.com"),
 				&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 					CRL: &dag.Secret{
 						Object: crlSecret,
@@ -328,8 +336,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 			filterchaintls("example.com", serverTLSSecret,
 				httpsFilterFor("example.com"),
 				&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 					OptionalClientCertificate: true,
 				},
@@ -389,8 +399,10 @@ func TestDownstreamTLSCertificateValidation(t *testing.T) {
 					URI:     true,
 				}),
 				&dag.PeerValidationContext{
-					CACertificate: &dag.Secret{
-						Object: clientCASecret,
+					CACertificates: []*dag.Secret{
+						{
+							Object: clientCASecret,
+						},
 					},
 				},
 				"h2", "http/1.1",

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -190,16 +190,16 @@ func tlsCluster(c *envoy_cluster_v3.Cluster, ca *v1.Secret, subjectName, sni str
 	}
 
 	// Secret for validation is optional.
-	var s *dag.Secret
+	var s []*dag.Secret
 	if ca != nil {
-		s = &dag.Secret{Object: ca}
+		s = []*dag.Secret{{Object: ca}}
 	}
 
 	c.TransportSocket = envoy_v3.UpstreamTLSTransportSocket(
 		envoy_v3.UpstreamTLSContext(
 			&dag.PeerValidationContext{
-				CACertificate: s,
-				SubjectNames:  []string{subjectName},
+				CACertificates: s,
+				SubjectNames:   []string{subjectName},
 			},
 			sni,
 			secret,

--- a/internal/featuretests/v3/upstreamtls_test.go
+++ b/internal/featuretests/v3/upstreamtls_test.go
@@ -28,12 +28,16 @@ import (
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
 	"github.com/projectcontour/contour/internal/fixture"
+	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestUpstreamTLSWithHTTPProxy(t *testing.T) {
@@ -221,5 +225,120 @@ func TestUpstreamTLSWithExtensionService(t *testing.T) {
 				&envoy_cluster_v3.Cluster{TransportSocket: tlsSocket},
 			),
 		),
+	})
+}
+
+func TestUpstreamTLSWithHTTPRoute(t *testing.T) {
+	rh, c, done := setup(t, func(b *dag.Builder) {
+		for _, processor := range b.Processors {
+			if gatewayAPIProcessor, ok := processor.(*dag.GatewayAPIProcessor); ok {
+				gatewayAPIProcessor.UpstreamTLS = &dag.UpstreamTLS{
+					MinimumProtocolVersion: "1.2",
+					MaximumProtocolVersion: "1.2",
+				}
+			}
+		}
+	})
+	defer done()
+
+	sec1 := featuretests.TLSSecret(t, "sec1", &featuretests.ClientCertificate)
+	sec2 := featuretests.CASecret(t, "sec2", &featuretests.CACertificate)
+	rh.OnAdd(sec1)
+	rh.OnAdd(sec2)
+
+	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: fixture.ObjectMeta("test-gc"),
+		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+			ControllerName: "projectcontour.io/contour",
+		},
+		Status: gatewayapi_v1beta1.GatewayClassStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	})
+
+	gateway := &gatewayapi_v1beta1.Gateway{
+		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
+		Spec: gatewayapi_v1beta1.GatewaySpec{
+			Listeners: []gatewayapi_v1beta1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayapi_v1.HTTPProtocolType,
+				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						From: ref.To(gatewayapi_v1.NamespacesFromAll),
+					},
+				},
+			}},
+		},
+	}
+	rh.OnAdd(gateway)
+
+	svc := fixture.NewService("backend").
+		WithPorts(v1.ServicePort{Name: "http", Port: 443})
+	rh.OnAdd(svc)
+
+	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authenticated",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+				},
+			},
+			Hostnames: []gatewayapi_v1beta1.Hostname{
+				"test.projectcontour.io",
+			},
+			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+				BackendRefs: gatewayapi.HTTPBackendRef("backend", 443, 1),
+			}},
+		},
+	})
+
+	rh.OnAdd(&gatewayapi_v1alpha2.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "authenticated",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+			TargetRef: gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName{
+				PolicyTargetReference: gatewayapi_v1alpha2.PolicyTargetReference{
+					Kind: "Service",
+					Name: "backend",
+				},
+			},
+			TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+				CACertRefs: []gatewayapi_v1alpha2.LocalObjectReference{{
+					Kind: "Secret",
+					Name: gatewayapi_v1.ObjectName(sec2.Name),
+				}},
+				Hostname: "subjname",
+			},
+		},
+	})
+
+	c.Request(clusterType).Equals(&envoy_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			tlsCluster(
+				cluster("default/backend/443/867941ed65", "default/backend/http", "default_backend_443"),
+				sec2,
+				"subjname",
+				"",
+				nil,
+				&dag.UpstreamTLS{
+					MinimumProtocolVersion: "1.2",
+					MaximumProtocolVersion: "1.2",
+				}),
+		),
+		TypeUrl: clusterType,
 	})
 }

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -116,7 +116,8 @@ func IsObjectEqual(oldObj, newObj client.Object) (bool, error) {
 		*gatewayapi_v1beta1.HTTPRoute,
 		*gatewayapi_v1alpha2.TLSRoute,
 		*gatewayapi_v1alpha2.GRPCRoute,
-		*gatewayapi_v1alpha2.TCPRoute:
+		*gatewayapi_v1alpha2.TCPRoute,
+		*gatewayapi_v1alpha2.BackendTLSPolicy:
 		return isGenerationEqual(oldObj, newObj), nil
 
 	// Slow path: compare the content of the objects.
@@ -126,6 +127,10 @@ func IsObjectEqual(oldObj, newObj client.Object) (bool, error) {
 			apiequality.Semantic.DeepEqual(oldObj.GetAnnotations(), newObj.GetAnnotations()), nil
 	case *v1.Secret:
 		if newObj, ok := newObj.(*v1.Secret); ok {
+			return reflect.DeepEqual(oldObj.Data, newObj.Data), nil
+		}
+	case *v1.ConfigMap:
+		if newObj, ok := newObj.(*v1.ConfigMap); ok {
 			return reflect.DeepEqual(oldObj.Data, newObj.Data), nil
 		}
 	case *v1.Service:

--- a/internal/k8s/helpers_test.go
+++ b/internal/k8s/helpers_test.go
@@ -49,6 +49,16 @@ func TestIsObjectEqual(t *testing.T) {
 			equals:   true,
 		},
 		{
+			name:     "ConfigMap with content change",
+			filename: "testdata/configmap-content-change.yaml",
+			equals:   false,
+		},
+		{
+			name:     "ConfigMap with metadata change",
+			filename: "testdata/configmap-metadata-change.yaml",
+			equals:   true,
+		},
+		{
 			name:     "Service with status change",
 			filename: "testdata/service-status-change.yaml",
 			equals:   false,
@@ -135,16 +145,20 @@ func TestIsEqualForResourceVersion(t *testing.T) {
 	assert.True(t, got)
 }
 
-// TestIsEqualFallback compares with ConfigMap objects, which are not supported.
+// TestIsEqualFallback compares with ServiceAccount objects, which are not supported.
 func TestIsEqualFallback(t *testing.T) {
-	oldObj := &v1.ConfigMap{
+	oldObj := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test",
 			Namespace:       "default",
 			ResourceVersion: "123",
 		},
-		Data: map[string]string{
-			"foo": "bar",
+		Secrets: []v1.ObjectReference{
+			{
+				Kind:      "Secret",
+				Name:      "test",
+				Namespace: "default",
+			},
 		},
 	}
 

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -19,10 +19,10 @@ package k8s
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies;tlscertificatedelegations;extensionservices;contourconfigurations,verbs=get;list;watch
 // +kubebuilder:rbac:groups="projectcontour.io",resources=httpproxies/status;extensionservices/status;contourconfigurations/status,verbs=create;get;update
 
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;grpcroutes;tcproutes;referencegrants,verbs=get;list;watch
-// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;grpcroutes/status;tcproutes/status,verbs=update
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses;gateways;httproutes;tlsroutes;grpcroutes;tcproutes;referencegrants;backendtlspolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups="gateway.networking.k8s.io",resources=gatewayclasses/status;gateways/status;httproutes/status;tlsroutes/status;grpcroutes/status;tcproutes/status;backendtlspolicies/status,verbs=update
 
-// +kubebuilder:rbac:groups="",resources=secrets;endpoints;services;namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets;endpoints;services;namespaces;configmaps,verbs=get;list;watch
 
 // Add RBAC policy to support leader election.
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;get;update,namespace=projectcontour

--- a/internal/k8s/testdata/configmap-content-change.yaml
+++ b/internal/k8s/testdata/configmap-content-change.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+  file: aGVsbG8=
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"aGVsbG8="},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-configmap","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-configmap
+  namespace: default
+  resourceVersion: "62125"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+---
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-configmap","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-configmap
+  namespace: default
+  resourceVersion: "62159"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3

--- a/internal/k8s/testdata/configmap-metadata-change.yaml
+++ b/internal/k8s/testdata/configmap-metadata-change.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-configmap","namespace":"default"}}
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  name: my-configmap
+  namespace: default
+  resourceVersion: "62159"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3
+---
+apiVersion: v1
+data:
+  file: d29ybGQ=
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"file":"d29ybGQ="},"kind":"ConfigMap","metadata":{"annotations":{},"creationTimestamp":null,"name":"my-configmap","namespace":"default"}}
+    my-annotation: foo
+  creationTimestamp: "2023-02-09T10:43:43Z"
+  labels:
+    my-label: bar
+  name: my-configmap
+  namespace: default
+  resourceVersion: "72965"
+  uid: b6e2da92-1b70-4c76-aac7-a2169e9b49b3

--- a/internal/provisioner/objects/rbac/util/util.go
+++ b/internal/provisioner/objects/rbac/util/util.go
@@ -43,15 +43,15 @@ func PolicyRuleFor(apiGroup string, verbs []string, resources ...string) rbacv1.
 func NamespacedResourcePolicyRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		// Core Contour-watched resources.
-		PolicyRuleFor(corev1.GroupName, getListWatch, "secrets", "endpoints", "services"),
+		PolicyRuleFor(corev1.GroupName, getListWatch, "secrets", "endpoints", "services", "configmaps"),
 
 		// Discovery Contour-watched resources.
 		PolicyRuleFor(discoveryv1.GroupName, getListWatch, "endpointslices"),
 
 		// Gateway API resources.
 		// Note, ReferenceGrant does not currently have a .status field so it's omitted from the status rule.
-		PolicyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gateways", "httproutes", "tlsroutes", "grpcroutes", "tcproutes", "referencegrants"),
-		PolicyRuleFor(gatewayv1alpha2.GroupName, update, "gateways/status", "httproutes/status", "tlsroutes/status", "grpcroutes/status", "tcproutes/status"),
+		PolicyRuleFor(gatewayv1alpha2.GroupName, getListWatch, "gateways", "httproutes", "tlsroutes", "grpcroutes", "tcproutes", "referencegrants", "backendtlspolicies"),
+		PolicyRuleFor(gatewayv1alpha2.GroupName, update, "gateways/status", "httproutes/status", "tlsroutes/status", "grpcroutes/status", "tcproutes/status", "backendtlspolicies/status"),
 
 		// Ingress resources.
 		PolicyRuleFor(networkingv1.GroupName, getListWatch, "ingresses"),

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -389,6 +389,12 @@ func (f *Framework) CreateTCPRouteAndWaitFor(route *gatewayapi_v1alpha2.TCPRoute
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
+// CreateBackendTLSPolicy creates the provided BackendTLSPolicy in the Kubernetes API
+// and then waits for the specified condition to be true.
+func (f *Framework) CreateBackendTLSPolicyAndWaitFor(route *gatewayapi_v1alpha2.BackendTLSPolicy, condition func(*gatewayapi_v1alpha2.BackendTLSPolicy) bool) (*gatewayapi_v1alpha2.BackendTLSPolicy, bool) {
+	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
+}
+
 // CreateNamespace creates a namespace with the given name in the
 // Kubernetes API or fails the test if it encounters an error.
 func (f *Framework) CreateNamespace(name string) {

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -1,0 +1,188 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
+	Specify("Creates a BackendTLSPolicy configures an HTTPRoute to use TLS to a backend service", func() {
+		protocolVersion := "TLSv1.3"
+		t := f.T()
+
+		// Top level issuer.
+		selfSignedIssuer := &certmanagerv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "selfsigned",
+			},
+			Spec: certmanagerv1.IssuerSpec{
+				IssuerConfig: certmanagerv1.IssuerConfig{
+					SelfSigned: &certmanagerv1.SelfSignedIssuer{},
+				},
+			},
+		}
+		require.NoError(f.T(), f.Client.Create(context.TODO(), selfSignedIssuer))
+
+		// CA to sign backend certs with.
+		caCertificate := &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "ca-cert",
+			},
+			Spec: certmanagerv1.CertificateSpec{
+				IsCA: true,
+				Usages: []certmanagerv1.KeyUsage{
+					certmanagerv1.UsageSigning,
+					certmanagerv1.UsageCertSign,
+				},
+				CommonName: "ca-cert",
+				SecretName: "ca-cert",
+				IssuerRef: certmanagermetav1.ObjectReference{
+					Name: "selfsigned",
+				},
+			},
+		}
+		require.NoError(f.T(), f.Client.Create(context.TODO(), caCertificate))
+
+		// Issuer based on CA to generate new certs with.
+		basedOnCAIssuer := &certmanagerv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "ca-issuer",
+			},
+			Spec: certmanagerv1.IssuerSpec{
+				IssuerConfig: certmanagerv1.IssuerConfig{
+					CA: &certmanagerv1.CAIssuer{
+						SecretName: "ca-cert",
+					},
+				},
+			},
+		}
+		require.NoError(f.T(), f.Client.Create(context.TODO(), basedOnCAIssuer))
+
+		// Backend server cert signed by CA.
+		backendServerCert := &certmanagerv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "backend-server-cert",
+			},
+			Spec: certmanagerv1.CertificateSpec{
+				Usages: []certmanagerv1.KeyUsage{
+					certmanagerv1.UsageServerAuth,
+				},
+				CommonName: "echo-secure",
+				DNSNames:   []string{"echo-secure"},
+				SecretName: "backend-server-cert",
+				IssuerRef: certmanagermetav1.ObjectReference{
+					Name: "ca-issuer",
+				},
+			},
+		}
+
+		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
+		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", func(deployment *appsv1.Deployment, service *corev1.Service) {
+			delete(service.Annotations, "projectcontour.io/upstream-protocol.tls")
+		})
+
+		route := &gatewayapi_v1beta1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "http-route-1",
+			},
+			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1beta1.Hostname{"backend-tls-policy.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					{
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-secure", 443, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+
+		backendTLSPolicy := &gatewayapi_v1alpha2.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "echo-secure-backend-tls-policy",
+				Namespace: namespace,
+			},
+			Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+				TargetRef: gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName{
+					PolicyTargetReference: gatewayapi_v1alpha2.PolicyTargetReference{
+						Group: "",
+						Kind:  "Service",
+						Name:  "echo-secure",
+					},
+				},
+				TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+					CACertRefs: []gatewayapi_v1.LocalObjectReference{
+						{
+							Group: "",
+							Kind:  "Secret",
+							Name:  "backend-server-cert",
+						},
+					},
+					Hostname: "echo-secure",
+				},
+			},
+		}
+
+		f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
+
+		type responseTLSDetails struct {
+			TLS struct {
+				Version string
+			}
+		}
+
+		// Ensure http (insecure) request routes to echo-secure.
+		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
+			Host:      "backend-tls-policy.projectcontour.io",
+			Condition: e2e.HasStatusCode(200),
+		})
+		require.NotNil(t, res)
+		assert.Truef(t, ok, "expected 200 response code, got %d", res.StatusCode)
+		assert.Equal(t, "echo-secure", f.GetEchoResponseBody(res.Body).Service)
+
+		// Get cert presented to backend app.
+		tlsInfo := new(responseTLSDetails)
+		require.NoError(f.T(), json.Unmarshal(res.Body, tlsInfo))
+		assert.Equal(f.T(), tlsInfo.TLS.Version, protocolVersion)
+	})
+}

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -207,6 +207,8 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-host-rewrite", testWithHTTPGateway(testHostRewrite))
 
 		f.NamespacedTest("gateway-request-redirect-rule", testWithHTTPGateway(testRequestRedirectRule))
+
+		f.NamespacedTest("gateway-backend-tls-policy", testWithHTTPGateway(testBackendTLSPolicy))
 	})
 
 	Describe("Gateway with one HTTP listener and one HTTPS listener", func() {

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -145,6 +145,14 @@ func TCPRouteAccepted(route *gatewayapi_v1alpha2.TCPRoute) bool {
 	return false
 }
 
+// BackendTLSPolicyAccepted returns true if the backend TLS policy has a .status.conditions
+// entry of "Accepted: true".
+func BackendTLSPolicyAccepted(btp *gatewayapi_v1alpha2.BackendTLSPolicy) bool {
+	// TODO (christianang): Right now this always returns true if a backendtlspolicy is
+	// provided since status conditions are not implemented yet for BackendTLSPolicy
+	return btp != nil
+}
+
 func conditionExists(conditions []metav1.Condition, conditionType string, conditionStatus metav1.ConditionStatus) bool {
 	for _, cond := range conditions {
 		if cond.Type == conditionType && cond.Status == conditionStatus {

--- a/test/e2e/httpproxy/backend_tls_protocol_version_test.go
+++ b/test/e2e/httpproxy/backend_tls_protocol_version_test.go
@@ -50,7 +50,7 @@ func testBackendTLSProtocolVersion(namespace, protocolVersion string) {
 			},
 		}
 		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
-		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure")
+		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		p := &contourv1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -53,7 +53,7 @@ func testBackendTLS(namespace string) {
 			},
 		}
 		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
-		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure")
+		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		p := &contourv1.HTTPProxy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/httpproxy/external_name_test.go
+++ b/test/e2e/httpproxy/external_name_test.go
@@ -101,7 +101,7 @@ func testExternalNameServiceTLS(namespace string) {
 
 		f.Certs.CreateSelfSignedCert(namespace, "backend-server-cert", "backend-server-cert", "echo")
 
-		f.Fixtures.EchoSecure.Deploy(namespace, "echo-tls")
+		f.Fixtures.EchoSecure.Deploy(namespace, "echo-tls", nil)
 
 		externalNameService := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/ingress/backend_tls_test.go
+++ b/test/e2e/ingress/backend_tls_test.go
@@ -53,7 +53,7 @@ func testBackendTLS(namespace string) {
 			},
 		}
 		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
-		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure")
+		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		i := &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The BackendTLSPolicy will allow a user to connect an httproute to a backend service with TLS.

Implements #5929

- Only implements BackendTLSPolicy for HTTPRoute
- Only allows Services for spec.targetRef
- Allows ConfigMap or Secret for spec.TLS.CACertRefs
- Adds backendtlspolicies to the ClusterRole for Contour
- Adds configmaps to the ClusterRole for Contour
- Controller reconciles on BackendTLSPolicy and ConfigMaps now
- BackendTLSPolicy spec.targetRef can specify SectionName to be port name of a service to target a particular section of the service.

In the interest of keeping this size of this change relatively small, we opted not to implement all of the GEP (https://gateway-api.sigs.k8s.io/geps/gep-1897/)

Specifically, we have not yet implemented BackendTLSPolicy for TLSRoute or GRPCRoute, precedence handling for BackendTLSPolicy (described here: https://gateway-api.sigs.k8s.io/geps/gep-713/#conflict-resolution), displaying status conditions on the BackendTLSPolicy, among others we may have missed.

We have also opted not to implement `wellKnownCACerts` since it was an implementation-specific detail of the GEP (https://github.com/kubernetes-sigs/gateway-api/issues/2726) and right now support for System certs was not supported anywhere in Contour.