### PR TITLE
internal/envoy: use consistent HTTP filter names

### DIFF
--- a/changelogs/unreleased/6124-skriss-small.md
+++ b/changelogs/unreleased/6124-skriss-small.md
@@ -1,0 +1,1 @@
+Updates HTTP filter names to match between the HTTP connection manager and per-filter config on virtual hosts/routes, and to use canonical names.

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -153,6 +153,19 @@ func Listener(name, address string, port int, perConnectionBufferLimitBytes *uin
 	return l
 }
 
+const (
+	CORSFilterName            string = "envoy.filters.http.cors"
+	LocalRateLimitFilterName  string = "envoy.filters.http.local_ratelimit"
+	GlobalRateLimitFilterName string = "envoy.filters.http.ratelimit"
+	RBACFilterName            string = "envoy.filters.http.rbac"
+	ExtAuthzFilterName        string = "envoy.filters.http.ext_authz"
+	JWTAuthnFilterName        string = "envoy.filters.http.jwt_authn"
+	LuaFilterName             string = "envoy.filters.http.lua"
+	CompressorFilterName      string = "envoy.filters.http.compressor"
+	GRPCWebFilterName         string = "envoy.filters.http.grpc_web"
+	GRPCStatsFilterName       string = "envoy.filters.http.grpc_stats"
+)
+
 type httpConnectionManagerBuilder struct {
 	routeConfigName               string
 	metricsPrefix                 string
@@ -296,7 +309,7 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 	// identified by the TypeURL of each filter.
 	b.filters = append(b.filters,
 		&http.HttpFilter{
-			Name: "compressor",
+			Name: CompressorFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_compressor_v3.Compressor{
 					CompressorLibrary: &envoy_core_v3.TypedExtensionConfig{
@@ -323,13 +336,13 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 			},
 		},
 		&http.HttpFilter{
-			Name: "grpcweb",
+			Name: GRPCWebFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_grpc_web_v3.GrpcWeb{}),
 			},
 		},
 		&http.HttpFilter{
-			Name: "grpc_stats",
+			Name: GRPCStatsFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(
 					&envoy_config_filter_http_grpc_stats_v3.FilterConfig{
@@ -340,13 +353,13 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 			},
 		},
 		&http.HttpFilter{
-			Name: "cors",
+			Name: CORSFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_cors_v3.Cors{}),
 			},
 		},
 		&http.HttpFilter{
-			Name: "local_ratelimit",
+			Name: LocalRateLimitFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(
 					&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
@@ -358,7 +371,7 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 			},
 		},
 		&http.HttpFilter{
-			Name: "envoy.filters.http.lua",
+			Name: LuaFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&lua.Lua{
 					DefaultSourceCode: &envoy_core_v3.DataSource{
@@ -370,7 +383,7 @@ func (b *httpConnectionManagerBuilder) DefaultFilters() *httpConnectionManagerBu
 			},
 		},
 		&http.HttpFilter{
-			Name: "envoy.filters.http.rbac",
+			Name: RBACFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_rbac_v3.RBAC{}),
 			},
@@ -761,7 +774,7 @@ end
 	`
 
 	return &http.HttpFilter{
-		Name: "envoy.filters.http.lua",
+		Name: LuaFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&lua.Lua{
 				DefaultSourceCode: &envoy_core_v3.DataSource{
@@ -805,7 +818,7 @@ func FilterExternalAuthz(externalAuthorization *dag.ExternalAuthorization) *http
 	}
 
 	return &http.HttpFilter{
-		Name: "envoy.filters.http.ext_authz",
+		Name: ExtAuthzFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&authConfig),
 		},
@@ -863,7 +876,7 @@ func FilterJWTAuthN(jwtProviders []dag.JWTProvider) *http.HttpFilter {
 	}
 
 	return &http.HttpFilter{
-		Name: "envoy.filters.http.jwt_authn",
+		Name: JWTAuthnFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&jwtConfig),
 		},

--- a/internal/envoy/v3/listener_test.go
+++ b/internal/envoy/v3/listener_test.go
@@ -567,7 +567,7 @@ func TestDownstreamTLSContext(t *testing.T) {
 func TestHTTPConnectionManager(t *testing.T) {
 	defaultHTTPFilters := []*http.HttpFilter{
 		{
-			Name: "compressor",
+			Name: CompressorFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_compressor_v3.Compressor{
 					CompressorLibrary: &envoy_core_v3.TypedExtensionConfig{
@@ -584,12 +584,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 				}),
 			},
 		}, {
-			Name: "grpcweb",
+			Name: GRPCWebFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_grpc_web_v3.GrpcWeb{}),
 			},
 		}, {
-			Name: "grpc_stats",
+			Name: GRPCStatsFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(
 					&envoy_config_filter_http_grpc_stats_v3.FilterConfig{
@@ -599,12 +599,12 @@ func TestHTTPConnectionManager(t *testing.T) {
 				),
 			},
 		}, {
-			Name: "cors",
+			Name: CORSFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_cors_v3.Cors{}),
 			},
 		}, {
-			Name: "local_ratelimit",
+			Name: LocalRateLimitFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(
 					&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
@@ -613,7 +613,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 				),
 			},
 		}, {
-			Name: "envoy.filters.http.lua",
+			Name: LuaFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&lua.Lua{
 					DefaultSourceCode: &envoy_core_v3.DataSource{
@@ -624,7 +624,7 @@ func TestHTTPConnectionManager(t *testing.T) {
 				}),
 			},
 		}, {
-			Name: "envoy.filters.http.rbac",
+			Name: RBACFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(&envoy_rbac_v3.RBAC{}),
 			},
@@ -1744,20 +1744,20 @@ func TestAddFilter(t *testing.T) {
 		},
 	}
 	grpcWebFilter := &http.HttpFilter{
-		Name: "grpcweb",
+		Name: GRPCWebFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&envoy_grpc_web_v3.GrpcWeb{}),
 		},
 	}
 	corsFilter := &http.HttpFilter{
-		Name: "cors",
+		Name: CORSFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&envoy_cors_v3.Cors{}),
 		},
 	}
 
 	grpcStatsFilter := &http.HttpFilter{
-		Name: "grpc_stats",
+		Name: GRPCStatsFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(
 				&envoy_config_filter_http_grpc_stats_v3.FilterConfig{
@@ -1768,7 +1768,7 @@ func TestAddFilter(t *testing.T) {
 		},
 	}
 	luaFilter := &http.HttpFilter{
-		Name: "envoy.filters.http.lua",
+		Name: LuaFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&lua.Lua{
 				DefaultSourceCode: &envoy_core_v3.DataSource{
@@ -1780,14 +1780,14 @@ func TestAddFilter(t *testing.T) {
 		},
 	}
 	rbacFilter := &http.HttpFilter{
-		Name: "envoy.filters.http.rbac",
+		Name: RBACFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&envoy_rbac_v3.RBAC{}),
 		},
 	}
 
 	localRateLimitFilter := &http.HttpFilter{
-		Name: "local_ratelimit",
+		Name: LocalRateLimitFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
@@ -1798,7 +1798,7 @@ func TestAddFilter(t *testing.T) {
 	}
 
 	compressFilter := &http.HttpFilter{
-		Name: "compressor",
+		Name: CompressorFilterName,
 		ConfigType: &http.HttpFilter_TypedConfig{
 			TypedConfig: protobuf.MustMarshalAny(&envoy_compressor_v3.Compressor{
 				CompressorLibrary: &envoy_core_v3.TypedExtensionConfig{

--- a/internal/envoy/v3/route_test.go
+++ b/internal/envoy/v3/route_test.go
@@ -1254,7 +1254,7 @@ func TestCORSVirtualHost(t *testing.T) {
 				Name:    "www.example.com",
 				Domains: []string{"www.example.com"},
 				TypedPerFilterConfig: map[string]*anypb.Any{
-					"envoy.filters.http.cors": protobuf.MustMarshalAny(&envoy_cors_v3.CorsPolicy{
+					CORSFilterName: protobuf.MustMarshalAny(&envoy_cors_v3.CorsPolicy{
 						AllowOriginStringMatch: []*matcher.StringMatcher{
 							{
 								MatchPattern: &matcher.StringMatcher_Exact{

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -266,7 +266,7 @@ func authzOverrideDisabled(t *testing.T, rh ResourceEventHandlerWrapper, c *Cont
 	// same authorization enablement as the root proxy, and
 	// the other path should have the opposite enablement.
 
-	disabledConfig := withFilterConfig("envoy.filters.http.ext_authz",
+	disabledConfig := withFilterConfig(envoy_v3.ExtAuthzFilterName,
 		&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 			Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_Disabled{
 				Disabled: true,
@@ -390,7 +390,7 @@ func authzMergeRouteContext(t *testing.T, rh ResourceEventHandlerWrapper, c *Con
 					&envoy_route_v3.Route{
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/app-server/80/da39a3ee5e"),
-						TypedPerFilterConfig: withFilterConfig("envoy.filters.http.ext_authz",
+						TypedPerFilterConfig: withFilterConfig(envoy_v3.ExtAuthzFilterName,
 							&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 								Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
 									CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -514,7 +514,7 @@ func authzFilterFor(
 		AddFilter(envoy_v3.FilterMisdirectedRequests(vhost)).
 		DefaultFilters().
 		AddFilter(&http.HttpFilter{
-			Name: "envoy.filters.http.ext_authz",
+			Name: envoy_v3.ExtAuthzFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(authz),
 			},
@@ -533,7 +533,7 @@ func jwtAuthnFilterFor(
 		AddFilter(envoy_v3.FilterMisdirectedRequests(vhost)).
 		DefaultFilters().
 		AddFilter(&http.HttpFilter{
-			Name: "envoy.filters.http.jwt_authn",
+			Name: envoy_v3.JWTAuthnFilterName,
 			ConfigType: &http.HttpFilter_TypedConfig{
 				TypedConfig: protobuf.MustMarshalAny(jwt),
 			},

--- a/internal/featuretests/v3/global_authorization_test.go
+++ b/internal/featuretests/v3/global_authorization_test.go
@@ -254,7 +254,7 @@ func globalExternalAuthorizationWithMergedAuthPolicy(t *testing.T, rh ResourceEv
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(
+							envoy_v3.ExtAuthzFilterName: protobuf.MustMarshalAny(
 								&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
 										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{
@@ -355,7 +355,7 @@ func globalExternalAuthorizationWithMergedAuthPolicyTLS(t *testing.T, rh Resourc
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(
+							envoy_v3.ExtAuthzFilterName: protobuf.MustMarshalAny(
 								&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
 										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{

--- a/internal/featuretests/v3/ipfilter_test.go
+++ b/internal/featuretests/v3/ipfilter_test.go
@@ -69,7 +69,7 @@ func TestIPFilterPolicy(t *testing.T) {
 					Match:  routePrefix("/"),
 					Action: routeCluster("default/backend/80/da39a3ee5e"),
 				},
-			), withFilterConfig("envoy.filters.http.rbac", &envoy_rbac_v3.RBACPerRoute{Rbac: &envoy_rbac_v3.RBAC{
+			), withFilterConfig(envoy_v3.RBACFilterName, &envoy_rbac_v3.RBACPerRoute{Rbac: &envoy_rbac_v3.RBAC{
 				Rules: &envoy_config_rbac_v3.RBAC{
 					Action: envoy_config_rbac_v3.RBAC_ALLOW,
 					Policies: map[string]*envoy_config_rbac_v3.Policy{
@@ -131,7 +131,7 @@ func TestIPFilterPolicy(t *testing.T) {
 				&envoy_route_v3.Route{
 					Match:  routePrefix("/"),
 					Action: routeCluster("default/backend/80/da39a3ee5e"),
-					TypedPerFilterConfig: withFilterConfig("envoy.filters.http.rbac", &envoy_rbac_v3.RBACPerRoute{
+					TypedPerFilterConfig: withFilterConfig(envoy_v3.RBACFilterName, &envoy_rbac_v3.RBACPerRoute{
 						Rbac: &envoy_rbac_v3.RBAC{
 							Rules: &envoy_config_rbac_v3.RBAC{
 								Action: envoy_config_rbac_v3.RBAC_DENY,
@@ -156,7 +156,7 @@ func TestIPFilterPolicy(t *testing.T) {
 						},
 					}),
 				},
-			), withFilterConfig("envoy.filters.http.rbac", &envoy_rbac_v3.RBACPerRoute{Rbac: &envoy_rbac_v3.RBAC{
+			), withFilterConfig(envoy_v3.RBACFilterName, &envoy_rbac_v3.RBACPerRoute{Rbac: &envoy_rbac_v3.RBAC{
 				Rules: &envoy_config_rbac_v3.RBAC{
 					Action: envoy_config_rbac_v3.RBAC_ALLOW,
 					Policies: map[string]*envoy_config_rbac_v3.Policy{

--- a/internal/featuretests/v3/jwtverification_test.go
+++ b/internal/featuretests/v3/jwtverification_test.go
@@ -221,7 +221,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -329,7 +329,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -437,7 +437,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -563,7 +563,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-2"},
 							}),
 						},
@@ -706,7 +706,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -874,7 +874,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1019,7 +1019,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1164,7 +1164,7 @@ func TestJWTVerification(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1378,7 +1378,7 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1496,7 +1496,7 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1614,7 +1614,7 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-1"},
 							}),
 						},
@@ -1750,7 +1750,7 @@ func TestJWTVerification_Inclusion(t *testing.T) {
 						Match:  routePrefix("/"),
 						Action: routeCluster("default/s1/80/da39a3ee5e"),
 						TypedPerFilterConfig: map[string]*anypb.Any{
-							"envoy.filters.http.jwt_authn": protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
+							envoy_v3.JWTAuthnFilterName: protobuf.MustMarshalAny(&envoy_jwt_v3.PerRouteConfig{
 								RequirementSpecifier: &envoy_jwt_v3.PerRouteConfig_RequirementName{RequirementName: "provider-2"},
 							}),
 						},

--- a/internal/featuretests/v3/localratelimit_test.go
+++ b/internal/featuretests/v3/localratelimit_test.go
@@ -139,7 +139,7 @@ func vhostRateLimitDefined(t *testing.T, rh ResourceEventHandlerWrapper, c *Cont
 			Match:  routePrefix("/"),
 			Action: routeCluster("default/s1/80/da39a3ee5e"),
 		})
-	vhost.TypedPerFilterConfig = withFilterConfig("envoy.filters.http.local_ratelimit",
+	vhost.TypedPerFilterConfig = withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 		&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 			StatPrefix: "vhost.foo.com",
 			TokenBucket: &envoy_type_v3.TokenBucket{
@@ -230,7 +230,7 @@ func routeRateLimitsDefined(t *testing.T, rh ResourceEventHandlerWrapper, c *Con
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s2"),
 			Action: routeCluster("default/s2/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{
@@ -255,7 +255,7 @@ func routeRateLimitsDefined(t *testing.T, rh ResourceEventHandlerWrapper, c *Con
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s1"),
 			Action: routeCluster("default/s1/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{
@@ -355,7 +355,7 @@ func vhostAndRouteRateLimitsDefined(t *testing.T, rh ResourceEventHandlerWrapper
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s2"),
 			Action: routeCluster("default/s2/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{
@@ -380,7 +380,7 @@ func vhostAndRouteRateLimitsDefined(t *testing.T, rh ResourceEventHandlerWrapper
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s1"),
 			Action: routeCluster("default/s1/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{
@@ -404,7 +404,7 @@ func vhostAndRouteRateLimitsDefined(t *testing.T, rh ResourceEventHandlerWrapper
 		},
 	)
 
-	vhost.TypedPerFilterConfig = withFilterConfig("envoy.filters.http.local_ratelimit",
+	vhost.TypedPerFilterConfig = withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 		&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 			StatPrefix: "vhost.foo.com",
 			TokenBucket: &envoy_type_v3.TokenBucket{
@@ -474,7 +474,7 @@ func customResponseCode(t *testing.T, rh ResourceEventHandlerWrapper, c *Contour
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s1"),
 			Action: routeCluster("default/s1/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{
@@ -560,7 +560,7 @@ func customResponseHeaders(t *testing.T, rh ResourceEventHandlerWrapper, c *Cont
 		&envoy_route_v3.Route{
 			Match:  routePrefix("/s1"),
 			Action: routeCluster("default/s1/80/da39a3ee5e"),
-			TypedPerFilterConfig: withFilterConfig("envoy.filters.http.local_ratelimit",
+			TypedPerFilterConfig: withFilterConfig(envoy_v3.LocalRateLimitFilterName,
 				&envoy_config_filter_http_local_ratelimit_v3.LocalRateLimit{
 					StatPrefix: "vhost.foo.com",
 					TokenBucket: &envoy_type_v3.TokenBucket{

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -3517,7 +3517,7 @@ func TestRouteVisit_GlobalExternalAuthorization(t *testing.T) {
 							Match:  routePrefix("/"),
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 							TypedPerFilterConfig: map[string]*anypb.Any{
-								"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
+								envoy_v3.ExtAuthzFilterName: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
 										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{
 											ContextExtensions: map[string]string{
@@ -3583,7 +3583,7 @@ func TestRouteVisit_GlobalExternalAuthorization(t *testing.T) {
 							Match:  routePrefix("/"),
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 							TypedPerFilterConfig: map[string]*anypb.Any{
-								"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
+								envoy_v3.ExtAuthzFilterName: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_Disabled{
 										Disabled: true,
 									},
@@ -3671,7 +3671,7 @@ func TestRouteVisit_GlobalExternalAuthorization(t *testing.T) {
 							Match:  routePrefix("/"),
 							Action: routecluster("default/backend/80/da39a3ee5e"),
 							TypedPerFilterConfig: map[string]*anypb.Any{
-								"envoy.filters.http.ext_authz": protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
+								envoy_v3.ExtAuthzFilterName: protobuf.MustMarshalAny(&envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute{
 									Override: &envoy_config_filter_http_ext_authz_v3.ExtAuthzPerRoute_CheckSettings{
 										CheckSettings: &envoy_config_filter_http_ext_authz_v3.CheckSettings{
 											ContextExtensions: map[string]string{


### PR DESCRIPTION
Use the same names for HTTP filters when they
are added to an HTTP connection manager and
when they are configured with per-filter config
on virtual hosts or routes. Extracts a set of
constants for filter names to ensure they remain
in sync.

This addresses a change in Envoy behavior in Envoy 1.29.
See https://github.com/envoyproxy/envoy/issues/29461 for
more detail.