### PR TITLE
change default xDS server to envoy

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -16,7 +16,7 @@ env:
   GO_VERSION: 1.22.0
 
 jobs:
-  e2e-envoy-xds:
+  e2e-contour-xds:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -43,7 +43,7 @@ jobs:
     - name: e2e tests
       env:
         CONTOUR_E2E_IMAGE: ghcr.io/projectcontour/contour:main
-        CONTOUR_E2E_XDS_SERVER_TYPE: envoy
+        CONTOUR_E2E_XDS_SERVER_TYPE: contour
       run: |
         make setup-kind-cluster run-e2e cleanup-kind
     - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0

--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -101,7 +101,7 @@ type FeatureFlags []string
 type XDSServerType string
 
 const (
-	// Use Contour's xDS server.
+	// Use Contour's xDS server (deprecated).
 	ContourServerType XDSServerType = "contour"
 	// Use the upstream `go-control-plane`-based xDS server.
 	EnvoyServerType XDSServerType = "envoy"
@@ -126,7 +126,7 @@ type GlobalCircuitBreakerDefaults struct {
 type XDSServerConfig struct {
 	// Defines the XDSServer to use for `contour serve`.
 	//
-	// Values: `contour` (default), `envoy`.
+	// Values: `envoy` (default), `contour (deprecated)`.
 	//
 	// Other values will produce an error.
 	// +optional

--- a/changelogs/unreleased/6146-skriss-deprecation.md
+++ b/changelogs/unreleased/6146-skriss-deprecation.md
@@ -1,0 +1,5 @@
+## Contour xDS server implementation is now deprecated
+
+As of this release, the `contour` xDS server implementation is now deprecated.
+Once the go-control-plane based `envoy` xDS server has had sufficient production bake time, the `contour` implementation will be removed from Contour.
+Notification of removal will occur at least one release in advance.

--- a/changelogs/unreleased/6146-skriss-major.md
+++ b/changelogs/unreleased/6146-skriss-major.md
@@ -2,7 +2,7 @@
 
 As of this release, Contour now uses the `envoy` xDS server implementation by default.
 This xDS server implementation is based on Envoy's [go-control-plane project](https://github.com/envoyproxy/go-control-plane) and will eventually be the only supported xDS server implementation in Contour.
-This change is expected to be transparent to users, and has been tested extensively.
+This change is expected to be transparent to users.
 
 ### I'm seeing issues after upgrading, how to I revert to the contour xDS server?
 

--- a/changelogs/unreleased/6146-skriss-major.md
+++ b/changelogs/unreleased/6146-skriss-major.md
@@ -1,0 +1,25 @@
+## Default xDS Server Implementation is now Envoy
+
+As of this release, Contour now uses the `envoy` xDS server implementation by default.
+This xDS server implementation is based on Envoy's [go-control-plane project](https://github.com/envoyproxy/go-control-plane) and will eventually be the only supported xDS server implementation in Contour.
+This change is expected to be transparent to users, and has been tested extensively.
+
+### I'm seeing issues after upgrading, how to I revert to the contour xDS server?
+
+If you encounter any issues, you can easily revert to the `contour` xDS server with the following configuration:
+
+(if using Contour config file)
+```yaml
+server:
+  xds-server-type: contour
+```
+
+(if using ContourConfiguration CRD
+```yaml
+...
+spec:
+  xdsServer:
+    type: contour
+```
+
+You will need to restart Contour for the changes to take effect.

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -379,7 +379,7 @@ func TestConvertServeContext(t *testing.T) {
 	defaultContourConfiguration := func() contour_v1alpha1.ContourConfigurationSpec {
 		return contour_v1alpha1.ContourConfigurationSpec{
 			XDSServer: &contour_v1alpha1.XDSServerConfig{
-				Type:    contour_v1alpha1.ContourServerType,
+				Type:    contour_v1alpha1.EnvoyServerType,
 				Address: "127.0.0.1",
 				Port:    8001,
 				TLS: &contour_v1alpha1.TLS{

--- a/examples/contour/01-contour-config.yaml
+++ b/examples/contour/01-contour-config.yaml
@@ -9,7 +9,7 @@ data:
     #
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
-    #   xds-server-type: contour
+    #   xds-server-type: envoy
     #
     # Specify the Gateway API configuration.
     # gateway:

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1141,7 +1141,7 @@ spec:
                   type:
                     description: |-
                       Defines the XDSServer to use for `contour serve`.
-                      Values: `contour` (default), `envoy`.
+                      Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
                     type: string
                 type: object
@@ -4828,7 +4828,7 @@ spec:
                       type:
                         description: |-
                           Defines the XDSServer to use for `contour serve`.
-                          Values: `contour` (default), `envoy`.
+                          Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
                         type: string
                     type: object

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -42,7 +42,7 @@ data:
     #
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
-    #   xds-server-type: contour
+    #   xds-server-type: envoy
     #
     # Specify the Gateway API configuration.
     # gateway:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1361,7 +1361,7 @@ spec:
                   type:
                     description: |-
                       Defines the XDSServer to use for `contour serve`.
-                      Values: `contour` (default), `envoy`.
+                      Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
                     type: string
                 type: object
@@ -5048,7 +5048,7 @@ spec:
                       type:
                         description: |-
                           Defines the XDSServer to use for `contour serve`.
-                          Values: `contour` (default), `envoy`.
+                          Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
                         type: string
                     type: object

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -1152,7 +1152,7 @@ spec:
                   type:
                     description: |-
                       Defines the XDSServer to use for `contour serve`.
-                      Values: `contour` (default), `envoy`.
+                      Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
                     type: string
                 type: object
@@ -4839,7 +4839,7 @@ spec:
                       type:
                         description: |-
                           Defines the XDSServer to use for `contour serve`.
-                          Values: `contour` (default), `envoy`.
+                          Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
                         type: string
                     type: object

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1177,7 +1177,7 @@ spec:
                   type:
                     description: |-
                       Defines the XDSServer to use for `contour serve`.
-                      Values: `contour` (default), `envoy`.
+                      Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
                     type: string
                 type: object
@@ -4864,7 +4864,7 @@ spec:
                       type:
                         description: |-
                           Defines the XDSServer to use for `contour serve`.
-                          Values: `contour` (default), `envoy`.
+                          Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
                         type: string
                     type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -42,7 +42,7 @@ data:
     #
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
-    #   xds-server-type: contour
+    #   xds-server-type: envoy
     #
     # Specify the Gateway API configuration.
     # gateway:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1361,7 +1361,7 @@ spec:
                   type:
                     description: |-
                       Defines the XDSServer to use for `contour serve`.
-                      Values: `contour` (default), `envoy`.
+                      Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
                     type: string
                 type: object
@@ -5048,7 +5048,7 @@ spec:
                       type:
                         description: |-
                           Defines the XDSServer to use for `contour serve`.
-                          Values: `contour` (default), `envoy`.
+                          Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
                         type: string
                     type: object

--- a/internal/contourconfig/contourconfiguration.go
+++ b/internal/contourconfig/contourconfiguration.go
@@ -41,7 +41,7 @@ func OverlayOnDefaults(spec contour_v1alpha1.ContourConfigurationSpec) (contour_
 func Defaults() contour_v1alpha1.ContourConfigurationSpec {
 	return contour_v1alpha1.ContourConfigurationSpec{
 		XDSServer: &contour_v1alpha1.XDSServerConfig{
-			Type:    contour_v1alpha1.ContourServerType,
+			Type:    contour_v1alpha1.EnvoyServerType,
 			Address: "0.0.0.0",
 			Port:    8001,
 			TLS: &contour_v1alpha1.TLS{

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -241,7 +241,7 @@ func (t ProtocolParameters) Validate() error {
 // ServerParameters holds the configuration for the Contour xDS server.
 type ServerParameters struct {
 	// Defines the XDSServer to use for `contour serve`.
-	// Defaults to "contour"
+	// Defaults to "envoy"
 	XDSServerType ServerType `yaml:"xds-server-type,omitempty"`
 }
 
@@ -1036,7 +1036,7 @@ func Defaults() Parameters {
 		InCluster:  false,
 		Kubeconfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		Server: ServerParameters{
-			XDSServerType: ContourServerType,
+			XDSServerType: EnvoyServerType,
 		},
 		IngressStatusAddress:       "",
 		AccessLogFormat:            DEFAULT_ACCESS_LOG_TYPE,

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -48,7 +48,7 @@ func TestParseDefaults(t *testing.T) {
 debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
-    xds-server-type: contour
+    xds-server-type: envoy
 accesslog-format: envoy
 json-fields:
     - '@timestamp'

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -9029,7 +9029,7 @@ XDSServerType
 <td>
 <em>(Optional)</em>
 <p>Defines the XDSServer to use for <code>contour serve</code>.</p>
-<p>Values: <code>contour</code> (default), <code>envoy</code>.</p>
+<p>Values: <code>envoy</code> (default), <code>contour (deprecated)</code>.</p>
 <p>Other values will produce an error.</p>
 </td>
 </tr>
@@ -9096,7 +9096,7 @@ TLS
 </tr>
 </thead>
 <tbody><tr><td><p>&#34;contour&#34;</p></td>
-<td><p>Use Contour&rsquo;s xDS server.</p>
+<td><p>Use Contour&rsquo;s xDS server (deprecated).</p>
 </td>
 </tr><tr><td><p>&#34;envoy&#34;</p></td>
 <td><p>Use the upstream <code>go-control-plane</code>-based xDS server.</p>

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -206,7 +206,7 @@ The server configuration block can be used to configure various settings for the
 
 | Field Name      | Type   | Default | Description                                                                   |
 | --------------- | ------ | ------- | ----------------------------------------------------------------------------- |
-| xds-server-type | string | envoy   | This field specifies the xDS Server to use. Options are `contour` or `envoy`. |
+| xds-server-type | string | envoy   | This field specifies the xDS Server to use. Options are `envoy` or `contour` (deprecated). |
 
 ### Gateway Configuration
 

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -206,7 +206,7 @@ The server configuration block can be used to configure various settings for the
 
 | Field Name      | Type   | Default | Description                                                                   |
 | --------------- | ------ | ------- | ----------------------------------------------------------------------------- |
-| xds-server-type | string | contour | This field specifies the xDS Server to use. Options are `contour` or `envoy`. |
+| xds-server-type | string | envoy   | This field specifies the xDS Server to use. Options are `contour` or `envoy`. |
 
 ### Gateway Configuration
 
@@ -316,7 +316,7 @@ data:
     #
     # server:
     #   determine which XDS Server implementation to utilize in Contour.
-    #   xds-server-type: contour
+    #   xds-server-type: envoy
     #
     # specify the gateway-api Gateway Contour should configure
     # gateway:

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -640,8 +640,8 @@ func DefaultContourConfiguration() *contour_v1alpha1.ContourConfiguration {
 }
 
 func XDSServerTypeFromEnv() contour_v1alpha1.XDSServerType {
-	// Default to contour if not provided.
-	serverType := contour_v1alpha1.ContourServerType
+	// Default to envoy if not provided.
+	serverType := contour_v1alpha1.EnvoyServerType
 	typeFromEnv, found := os.LookupEnv("CONTOUR_E2E_XDS_SERVER_TYPE")
 	if found {
 		serverType = contour_v1alpha1.XDSServerType(typeFromEnv)


### PR DESCRIPTION
The default xDS server implementation is
now `envoy`, i.e. the go-control-plane
implementation.

Updates #2134.

Signed-off-by: Steve Kriss <stephen.kriss@gmail.com>