### PR TITLE
provisioner: Set SupportedVersion condition on GatewayClass

### DIFF
--- a/changelogs/unreleased/6147-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6147-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Gateway API provisioner now checks `gateway.networking.k8s.io/bundle-version` annotation on Gateway CRDs and sets SupportedVersion status condition on GatewayClass if annotation value matches supported Gateway API version. Best-effort support is provided if version does not match.

--- a/examples/gateway-provisioner/01-roles.yaml
+++ b/examples/gateway-provisioner/01-roles.yaml
@@ -40,6 +40,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -19809,6 +19809,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -151,7 +151,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// setConditions.
 	statusConditions := map[string]metav1.Condition{}
 
-	statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion)] = r.getSupportedVersionCondition(ctx, *gatewayClass)
+	statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion)] = r.getSupportedVersionCondition(ctx)
 
 	ok, params, err := r.isValidParametersRef(ctx, gatewayClass.Spec.ParametersRef)
 	if err != nil {
@@ -291,6 +291,7 @@ func (r *gatewayClassReconciler) setConditions(ctx context.Context, gatewayClass
 		updatedConds = append(updatedConds, c)
 	}
 
+	// nolint:gocritic
 	gatewayClass.Status.Conditions = append(unchangedConds, updatedConds...)
 
 	if err := r.client.Status().Update(ctx, gatewayClass); err != nil {
@@ -299,7 +300,7 @@ func (r *gatewayClassReconciler) setConditions(ctx context.Context, gatewayClass
 	return nil
 }
 
-func (r *gatewayClassReconciler) getSupportedVersionCondition(ctx context.Context, gatewayClass gatewayapi_v1beta1.GatewayClass) metav1.Condition {
+func (r *gatewayClassReconciler) getSupportedVersionCondition(ctx context.Context) metav1.Condition {
 	cond := metav1.Condition{
 		Type: string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion),
 		// Assume false until we get to the happy case.

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiextensions_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const (
+	gatewayAPIBundleVersionAnnotation   = "gateway.networking.k8s.io/bundle-version"
+	gatewayAPICRDBundleSupportedVersion = "v1.0.0"
 )
 
 // gatewayClassReconciler reconciles GatewayClass objects.
@@ -141,19 +147,25 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	// Collect various status conditions here so we can update using
+	// setConditions.
+	statusConditions := map[string]metav1.Condition{}
+
+	statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion)] = r.getSupportedVersionCondition(ctx, *gatewayClass)
+
 	ok, params, err := r.isValidParametersRef(ctx, gatewayClass.Spec.ParametersRef)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error checking gateway class's parametersRef: %w", err)
 	}
 	if !ok {
-		if err := r.setAcceptedCondition(
-			ctx,
-			gatewayClass,
-			metav1.ConditionFalse,
-			gatewayapi_v1.GatewayClassReasonInvalidParameters,
-			"Invalid ParametersRef, must be a reference to an existing namespaced projectcontour.io/ContourDeployment resource",
-		); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set gateway class %s Accepted condition: %w", req, err)
+		statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusAccepted)] = metav1.Condition{
+			Type:    string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayapi_v1.GatewayClassReasonInvalidParameters),
+			Message: "Invalid ParametersRef, must be a reference to an existing namespaced projectcontour.io/ContourDeployment resource",
+		}
+		if err := r.setConditions(ctx, gatewayClass, statusConditions); err != nil {
+			return ctrl.Result{}, err
 		}
 
 		return ctrl.Result{}, nil
@@ -227,68 +239,100 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 
 		if len(invalidParamsMessages) > 0 {
-			if err := r.setAcceptedCondition(
-				ctx,
-				gatewayClass,
-				metav1.ConditionFalse,
-				gatewayapi_v1.GatewayClassReasonInvalidParameters,
-				strings.Join(invalidParamsMessages, "; "),
-			); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set gateway class %s Accepted condition: %w", req, err)
+			statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusAccepted)] = metav1.Condition{
+				Type:    string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gatewayapi_v1.GatewayClassReasonInvalidParameters),
+				Message: strings.Join(invalidParamsMessages, "; "),
+			}
+			if err := r.setConditions(ctx, gatewayClass, statusConditions); err != nil {
+				return ctrl.Result{}, err
 			}
 
 			return ctrl.Result{}, nil
 		}
 	}
 
-	if err := r.setAcceptedCondition(ctx, gatewayClass, metav1.ConditionTrue, gatewayapi_v1.GatewayClassReasonAccepted, "GatewayClass has been accepted by the controller"); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set gateway class %s Accepted condition: %w", req, err)
+	statusConditions[string(gatewayapi_v1.GatewayClassConditionStatusAccepted)] = metav1.Condition{
+		Type:    string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapi_v1.GatewayClassReasonAccepted),
+		Message: "GatewayClass has been accepted by the controller",
+	}
+	if err := r.setConditions(ctx, gatewayClass, statusConditions); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *gatewayClassReconciler) setAcceptedCondition(
-	ctx context.Context,
-	gatewayClass *gatewayapi_v1beta1.GatewayClass,
-	status metav1.ConditionStatus,
-	reason gatewayapi_v1beta1.GatewayClassConditionReason,
-	message string,
-) error {
-	currentAcceptedCondition := metav1.Condition{
-		Type:               string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
-		Status:             status,
-		ObservedGeneration: gatewayClass.Generation,
-		LastTransitionTime: metav1.Now(),
-		Reason:             string(reason),
-		Message:            message,
-	}
-	var newConds []metav1.Condition
-	for _, cond := range gatewayClass.Status.Conditions {
-		if cond.Type == string(gatewayapi_v1.GatewayClassConditionStatusAccepted) {
-			if cond.Status == status {
+func (r *gatewayClassReconciler) setConditions(ctx context.Context, gatewayClass *gatewayapi_v1beta1.GatewayClass, newConds map[string]metav1.Condition) error {
+	var unchangedConds, updatedConds []metav1.Condition
+	for _, existing := range gatewayClass.Status.Conditions {
+		if cond, ok := newConds[existing.Type]; ok {
+			if existing.Status == cond.Status {
 				// If status hasn't changed, don't change the condition, just
 				// update the generation.
-				currentAcceptedCondition = cond
-				currentAcceptedCondition.ObservedGeneration = gatewayClass.Generation
+				changed := existing
+				changed.ObservedGeneration = gatewayClass.Generation
+				updatedConds = append(updatedConds, changed)
+				delete(newConds, cond.Type)
 			}
-
-			continue
+		} else {
+			unchangedConds = append(unchangedConds, existing)
 		}
-
-		newConds = append(newConds, cond)
 	}
 
-	r.log.WithValues("gatewayclass-name", gatewayClass.Name).Info(fmt.Sprintf("setting gateway class's Accepted condition to %s", status))
+	transitionTime := metav1.Now()
+	for _, c := range newConds {
+		r.log.WithValues("gatewayclass-name", gatewayClass.Name).Info(fmt.Sprintf("setting gateway class's %s condition to %s", c.Type, c.Status))
+		c.ObservedGeneration = gatewayClass.Generation
+		c.LastTransitionTime = transitionTime
+		updatedConds = append(updatedConds, c)
+	}
 
-	// nolint:gocritic
-	gatewayClass.Status.Conditions = append(newConds, currentAcceptedCondition)
+	gatewayClass.Status.Conditions = append(unchangedConds, updatedConds...)
 
 	if err := r.client.Status().Update(ctx, gatewayClass); err != nil {
-		return fmt.Errorf("failed to set gatewayclass %s accepted condition: %w", gatewayClass.Name, err)
+		return fmt.Errorf("failed to update gateway class %s status: %w", gatewayClass.Name, err)
+	}
+	return nil
+}
+
+func (r *gatewayClassReconciler) getSupportedVersionCondition(ctx context.Context, gatewayClass gatewayapi_v1beta1.GatewayClass) metav1.Condition {
+	cond := metav1.Condition{
+		Type: string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion),
+		// Assume false until we get to the happy case.
+		Status: metav1.ConditionFalse,
+		Reason: string(gatewayapi_v1.GatewayClassReasonUnsupportedVersion),
+	}
+	gatewayClassCRD := &apiextensions_v1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatewayclasses." + gatewayapi_v1.GroupName,
+		},
+	}
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(gatewayClassCRD), gatewayClassCRD); err != nil {
+		errorMsg := "Error fetching gatewayclass CRD resource to validate supported version"
+		r.log.Error(err, errorMsg)
+		cond.Message = fmt.Sprintf("%s: %s. Resources will be reconciled with best-effort.", errorMsg, err)
+		return cond
 	}
 
-	return nil
+	version, ok := gatewayClassCRD.Annotations[gatewayAPIBundleVersionAnnotation]
+	if !ok {
+		cond.Message = fmt.Sprintf("Bundle version annotation %s not found. Resources will be reconciled with best-effort.", gatewayAPIBundleVersionAnnotation)
+		return cond
+	}
+	if version != gatewayAPICRDBundleSupportedVersion {
+		cond.Message = fmt.Sprintf("Gateway API CRD bundle version %s is not supported. Resources will be reconciled with best-effort.", version)
+		return cond
+	}
+
+	// No errors found, we can return true.
+	cond.Status = metav1.ConditionTrue
+	cond.Reason = string(gatewayapi_v1.GatewayClassReasonSupportedVersion)
+	cond.Message = fmt.Sprintf("Gateway API CRD bundle version %s is supported", gatewayAPICRDBundleSupportedVersion)
+	return cond
 }
 
 // isValidParametersRef returns true if the provided ParametersReference is

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -332,7 +332,7 @@ func (r *gatewayClassReconciler) getSupportedVersionCondition(ctx context.Contex
 	// No errors found, we can return true.
 	cond.Status = metav1.ConditionTrue
 	cond.Reason = string(gatewayapi_v1.GatewayClassReasonSupportedVersion)
-	cond.Message = fmt.Sprintf("Gateway API CRD bundle version %s is supported", gatewayAPICRDBundleSupportedVersion)
+	cond.Message = fmt.Sprintf("Gateway API CRD bundle version %s is supported.", gatewayAPICRDBundleSupportedVersion)
 	return cond
 }
 

--- a/internal/provisioner/rbac/rbac.go
+++ b/internal/provisioner/rbac/rbac.go
@@ -22,6 +22,7 @@ package rbac
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses;gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status;gateways/status,verbs=update
 // +kubebuilder:rbac:groups=projectcontour.io,resources=contourdeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // ---
 
 // RBAC for core Contour resources to be provisioned.

--- a/internal/provisioner/scheme.go
+++ b/internal/provisioner/scheme.go
@@ -15,6 +15,7 @@ package provisioner
 
 import (
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
+	apiextensions_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gateway_api_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -28,6 +29,7 @@ func CreateScheme() (*runtime.Scheme, error) {
 
 	b := runtime.SchemeBuilder{
 		clientgoscheme.AddToScheme,
+		apiextensions_v1.AddToScheme,
 		gateway_api_v1alpha2.AddToScheme,
 		gateway_api_v1beta1.AddToScheme,
 		contour_api_v1alpha1.AddToScheme,

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -138,6 +139,28 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("Gateway provisioner", func() {
+	Specify("GatewayClass status condition SupportedVersion is set to True", func() {
+		// This test will fail if we bump the Gateway API module and CRDs but
+		// forget to update the supported version we check for.
+		require.Eventually(f.T(), func() bool {
+			gc := &gatewayapi_v1beta1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "contour",
+				},
+			}
+			if err := f.Client.Get(context.TODO(), client.ObjectKeyFromObject(gc), gc); err != nil {
+				return false
+			}
+			for _, cond := range gc.Status.Conditions {
+				if cond.Type == string(gatewayapi_v1.GatewayClassConditionStatusSupportedVersion) &&
+					cond.Status == metav1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, f.RetryTimeout, f.RetryInterval)
+	})
+
 	f.NamespacedTest("provisioner-gatewayclass-params", func(namespace string) {
 		Specify("GatewayClass parameters are handled correctly", func() {
 			// Create GatewayClass with a reference to a nonexistent ContourDeployment,
@@ -228,6 +251,7 @@ var _ = Describe("Gateway provisioner", func() {
 			require.NoError(f.T(), f.DeleteGatewayClass(gatewayClass, false))
 		})
 	})
+
 	f.NamespacedTest("gateway-with-envoy-deployment", func(namespace string) {
 		Specify("A gateway with Envoy as a deployment can be provisioned and routes traffic correctly", func() {
 			gateway := &gatewayapi_v1beta1.Gateway{
@@ -296,6 +320,7 @@ var _ = Describe("Gateway provisioner", func() {
 			assert.Equal(f.T(), "echo", body.Service)
 		})
 	})
+
 	f.NamespacedTest("gateway-with-many-listeners", func(namespace string) {
 		Specify("A gateway with many Listeners for different protocols can be provisioned and routes correctly", func() {
 			f.Certs.CreateSelfSignedCert(namespace, "https-1-cert", "https-1-cert", "https-1.provisioner.projectcontour.io")


### PR DESCRIPTION
Based on Gateway API CRD bundle-version annotation

We will still reconcile the GatewayClass etc. but will set a status condition on the GatewayClass saying this support is best effort.

Fixes #5754