### PR TITLE
Add Accepted condition to BackendTLSPolicy

### DIFF
--- a/changelogs/unreleased/6151-christianang-small.md
+++ b/changelogs/unreleased/6151-christianang-small.md
@@ -1,0 +1,1 @@
+For Gateway API, add "Accepted" condition to BackendTLSPolicy. If the condition is true the BackendTLSPolicy was accepted by the Gateway and if false a reason will be stated on the policy as to why it wasn't accepted.

--- a/internal/status/backendtlspolicyconditions.go
+++ b/internal/status/backendtlspolicyconditions.go
@@ -1,0 +1,151 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// BackendTLSPolicyStatusUpdate represents an atomic update to a
+// BackendTLSPolicy's status.
+type BackendTLSPolicyStatusUpdate struct {
+	FullName               types.NamespacedName
+	PolicyAncestorStatuses []*gatewayapi_v1alpha2.PolicyAncestorStatus
+	GatewayRef             types.NamespacedName
+	GatewayController      gatewayapi_v1beta1.GatewayController
+	Resource               client.Object
+	Generation             int64
+	TransitionTime         metav1.Time
+}
+
+// BackendTLSPolicyAncestorStatusUpdate helps update a specific ancestor ref's
+// PolicyAncestorStatus.
+type BackendTLSPolicyAncestorStatusUpdate struct {
+	*BackendTLSPolicyStatusUpdate
+	ancestorRef gatewayapi_v1beta1.ParentReference
+}
+
+// StatusUpdateFor returns a BackendTLSPolicyAncestorStatusUpdate for the given
+// ancestor ref.
+func (b *BackendTLSPolicyStatusUpdate) StatusUpdateFor(ancestorRef gatewayapi_v1beta1.ParentReference) *BackendTLSPolicyAncestorStatusUpdate {
+	return &BackendTLSPolicyAncestorStatusUpdate{
+		BackendTLSPolicyStatusUpdate: b,
+		ancestorRef:                  ancestorRef,
+	}
+}
+
+// AddCondition adds a condition with the given properties to the
+// BackendTLSPolicyAncestorStatus.
+func (b *BackendTLSPolicyAncestorStatusUpdate) AddCondition(conditionType gatewayapi_v1alpha2.PolicyConditionType, status metav1.ConditionStatus, reason gatewayapi_v1alpha2.PolicyConditionReason, message string) metav1.Condition {
+	var pas *gatewayapi_v1alpha2.PolicyAncestorStatus
+
+	for _, v := range b.PolicyAncestorStatuses {
+		if v.AncestorRef == b.ancestorRef {
+			pas = v
+			break
+		}
+	}
+
+	if pas == nil {
+		pas = &gatewayapi_v1alpha2.PolicyAncestorStatus{
+			AncestorRef:    b.ancestorRef,
+			ControllerName: b.GatewayController,
+		}
+
+		b.PolicyAncestorStatuses = append(b.PolicyAncestorStatuses, pas)
+	}
+
+	idx := -1
+	for i, c := range pas.Conditions {
+		if c.Type == string(conditionType) {
+			idx = i
+			break
+		}
+	}
+
+	if idx > -1 {
+		message = pas.Conditions[idx].Message + ", " + message
+	}
+
+	cond := metav1.Condition{
+		Reason:             string(reason),
+		Status:             status,
+		Type:               string(conditionType),
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		ObservedGeneration: b.Generation,
+	}
+
+	if idx > -1 {
+		pas.Conditions[idx] = cond
+	} else {
+		pas.Conditions = append(pas.Conditions, cond)
+	}
+
+	return cond
+}
+
+// ConditionsForAncestorRef returns the list of conditions for a given ancestor
+// if it exists.
+func (b *BackendTLSPolicyStatusUpdate) ConditionsForAncestorRef(ancestorRef gatewayapi_v1beta1.ParentReference) []metav1.Condition {
+	for _, pas := range b.PolicyAncestorStatuses {
+		if pas.AncestorRef == ancestorRef {
+			return pas.Conditions
+		}
+	}
+
+	return nil
+}
+
+func (b *BackendTLSPolicyStatusUpdate) Mutate(obj client.Object) client.Object {
+	o, ok := obj.(*gatewayapi_v1alpha2.BackendTLSPolicy)
+	if !ok {
+		panic(fmt.Sprintf("Unsupported %T object %s/%s in status mutator",
+			obj, b.FullName.Namespace, b.FullName.Name,
+		))
+	}
+
+	var newPolicyAncestorStatuses []gatewayapi_v1alpha2.PolicyAncestorStatus
+	for _, pas := range b.PolicyAncestorStatuses {
+		for i := range pas.Conditions {
+			cond := &pas.Conditions[i]
+
+			cond.ObservedGeneration = b.Generation
+			cond.LastTransitionTime = b.TransitionTime
+		}
+
+		newPolicyAncestorStatuses = append(newPolicyAncestorStatuses, *pas)
+	}
+
+	btp := o.DeepCopy()
+
+	// Get all the PolicyAncestorStatuses that are for other Gateways.
+	for _, pas := range o.Status.Ancestors {
+		if !gatewayapi.IsRefToGateway(pas.AncestorRef, b.GatewayRef) {
+			newPolicyAncestorStatuses = append(newPolicyAncestorStatuses, pas)
+		}
+	}
+
+	btp.Status.Ancestors = newPolicyAncestorStatuses
+
+	return btp
+}

--- a/internal/status/backendtlspolicyconditions_test.go
+++ b/internal/status/backendtlspolicyconditions_test.go
@@ -1,0 +1,135 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+	"time"
+
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/internal/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestBackendTLSPolicyAddCondition(t *testing.T) {
+	backendTLSPolicyUpdate := BackendTLSPolicyStatusUpdate{
+		FullName:   k8s.NamespacedNameFrom("test/test"),
+		Generation: 7,
+	}
+
+	ancestorRef := gatewayapi.GatewayParentRef("projectcontour", "contour")
+
+	basUpdate := backendTLSPolicyUpdate.StatusUpdateFor(ancestorRef)
+
+	basUpdate.AddCondition(gatewayapi_v1alpha2.PolicyConditionAccepted, metav1.ConditionTrue, gatewayapi_v1alpha2.PolicyReasonAccepted, "Valid BackendTLSPolicy")
+
+	require.Len(t, backendTLSPolicyUpdate.ConditionsForAncestorRef(ancestorRef), 1)
+	got := backendTLSPolicyUpdate.ConditionsForAncestorRef(ancestorRef)[0]
+
+	assert.EqualValues(t, gatewayapi_v1alpha2.PolicyConditionAccepted, got.Type)
+	assert.EqualValues(t, metav1.ConditionTrue, got.Status)
+	assert.EqualValues(t, gatewayapi_v1alpha2.PolicyReasonAccepted, got.Reason)
+	assert.EqualValues(t, "Valid BackendTLSPolicy", got.Message)
+	assert.EqualValues(t, 7, got.ObservedGeneration)
+}
+
+func TestBackendTLSPolicyMutate(t *testing.T) {
+	testTransitionTime := v1.NewTime(time.Now())
+	var testGeneration int64 = 7
+
+	bsu := BackendTLSPolicyStatusUpdate{
+		FullName:       k8s.NamespacedNameFrom("test/test"),
+		Generation:     testGeneration,
+		TransitionTime: testTransitionTime,
+		PolicyAncestorStatuses: []*gatewayapi_v1alpha2.PolicyAncestorStatus{
+			{
+				AncestorRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(gatewayapi_v1alpha2.PolicyConditionAccepted),
+						Status:  contour_api_v1.ConditionTrue,
+						Reason:  string(gatewayapi_v1alpha2.PolicyReasonAccepted),
+						Message: "Accepted BackendTLSPolicy",
+					},
+				},
+			},
+		},
+	}
+
+	btp := &gatewayapi_v1alpha2.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Status: gatewayapi_v1alpha2.PolicyStatus{
+			Ancestors: []gatewayapi_v1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gatewayapi.GatewayParentRef("externalgateway", "some-gateway"),
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(gatewayapi_v1alpha2.PolicyConditionAccepted),
+							Status:  contour_api_v1.ConditionTrue,
+							Reason:  string(gatewayapi_v1alpha2.PolicyReasonAccepted),
+							Message: "This was added by some other gateway and should not be removed.",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	wantBackendTLSPolicy := &gatewayapi_v1alpha2.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Status: gatewayapi_v1alpha2.PolicyStatus{
+			Ancestors: []gatewayapi_v1alpha2.PolicyAncestorStatus{
+				{
+					AncestorRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+					Conditions: []metav1.Condition{
+						{
+							ObservedGeneration: testGeneration,
+							LastTransitionTime: testTransitionTime,
+							Type:               string(gatewayapi_v1alpha2.PolicyConditionAccepted),
+							Status:             contour_api_v1.ConditionTrue,
+							Reason:             string(gatewayapi_v1alpha2.PolicyReasonAccepted),
+							Message:            "Accepted BackendTLSPolicy",
+						},
+					},
+				},
+				{
+					AncestorRef: gatewayapi.GatewayParentRef("externalgateway", "some-gateway"),
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(gatewayapi_v1alpha2.PolicyConditionAccepted),
+							Status:  contour_api_v1.ConditionTrue,
+							Reason:  string(gatewayapi_v1alpha2.PolicyReasonAccepted),
+							Message: "This was added by some other gateway and should not be removed.",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	btp, ok := bsu.Mutate(btp).(*gatewayapi_v1alpha2.BackendTLSPolicy)
+	require.True(t, ok)
+	assert.Equal(t, wantBackendTLSPolicy, btp, 1)
+}

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -163,7 +163,8 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 			},
 		}
 
-		f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
+		_, ok := f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
+		assert.Truef(t, ok, "expected policy condition accepted on backend tls policy")
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -148,9 +148,17 @@ func TCPRouteAccepted(route *gatewayapi_v1alpha2.TCPRoute) bool {
 // BackendTLSPolicyAccepted returns true if the backend TLS policy has a .status.conditions
 // entry of "Accepted: true".
 func BackendTLSPolicyAccepted(btp *gatewayapi_v1alpha2.BackendTLSPolicy) bool {
-	// TODO (christianang): Right now this always returns true if a backendtlspolicy is
-	// provided since status conditions are not implemented yet for BackendTLSPolicy
-	return btp != nil
+	if btp == nil {
+		return false
+	}
+
+	for _, gw := range btp.Status.Ancestors {
+		if conditionExists(gw.Conditions, string(gatewayapi_v1alpha2.PolicyConditionAccepted), metav1.ConditionTrue) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func conditionExists(conditions []metav1.Condition, conditionType string, conditionStatus metav1.ConditionStatus) bool {


### PR DESCRIPTION
This PR adds the Accepted Condition to the BackendTLSPolicy.

The Status contains an array of Ancestor Policy Statuses. The Ancestor Ref will be set to the gateway similar to what happens on routes now.
If the BackendTLSPolicy is successfully applied to the Gateway for a given HTTPRoute and Backend Service the "Accepted" condition status will be set to true with the "Accepted" Reason.
If the BackendTLSPolicy is found, but is invalid due to any validation reasons (e.g unsupported certRefs, missing certs, malformed hostname, etc) the status will be set to false with the "Invalid" Reason.

Fixes #6137