### PR TITLE
Inform on and use Gateway API v1 types where possible

### DIFF
--- a/changelogs/unreleased/6153-sunjayBhatia-major.md
+++ b/changelogs/unreleased/6153-sunjayBhatia-major.md
@@ -1,0 +1,5 @@
+## Gateway API: Inform on v1 types
+
+Contour no longer informs on v1beta1 resources that have graduated to v1.
+This includes the "core" resources GatewayClass, Gateway, and HTTPRoute.
+This means that users should ensure they have updated CRDs to Gateway API v1.0.0 or newer, which introduced the v1 version with compatibility with v1beta1.

--- a/cmd/contour/ingressstatus.go
+++ b/cmd/contour/ingressstatus.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -91,7 +91,7 @@ func (isw *loadBalancerStatusWriter) Start(ctx context.Context) error {
 	// Only create Gateway informer if a controller or specific gateway was provided,
 	// otherwise the API may not exist in the cluster.
 	if len(isw.gatewayControllerName) > 0 || isw.gatewayRef != nil {
-		resources = append(resources, &gatewayapi_v1beta1.Gateway{})
+		resources = append(resources, &gatewayapi_v1.Gateway{})
 	}
 
 	for _, r := range resources {
@@ -142,7 +142,7 @@ func (isw *loadBalancerStatusWriter) Start(ctx context.Context) error {
 			// Only list Gateways if a controller or specific gateway was configured,
 			// otherwise the API may not exist in the cluster.
 			if len(isw.gatewayControllerName) > 0 || isw.gatewayRef != nil {
-				var gatewayList gatewayapi_v1beta1.GatewayList
+				var gatewayList gatewayapi_v1.GatewayList
 				if err := isw.cache.List(context.Background(), &gatewayList); err != nil {
 					isw.log.WithError(err).WithField("kind", "Gateway").Error("failed to list objects")
 				} else {

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	controller_runtime_metrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	controller_runtime_metrics_server "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -1040,12 +1041,12 @@ func (s *Server) setupGatewayAPI(contourConfiguration contour_v1alpha1.ContourCo
 		// to process, we just need informers to get events.
 		case contourConfiguration.Gateway.GatewayRef != nil:
 			// Inform on GatewayClasses.
-			if err := s.informOnResource(&gatewayapi_v1beta1.GatewayClass{}, eventHandler); err != nil {
+			if err := s.informOnResource(&gatewayapi_v1.GatewayClass{}, eventHandler); err != nil {
 				s.log.WithError(err).WithField("resource", "gatewayclasses").Fatal("failed to create informer")
 			}
 
 			// Inform on Gateways.
-			if err := s.informOnResource(&gatewayapi_v1beta1.Gateway{}, eventHandler); err != nil {
+			if err := s.informOnResource(&gatewayapi_v1.Gateway{}, eventHandler); err != nil {
 				s.log.WithError(err).WithField("resource", "gateways").Fatal("failed to create informer")
 			}
 		// Otherwise, run the GatewayClass and Gateway controllers to determine

--- a/internal/controller/httproute.go
+++ b/internal/controller/httproute.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type httpRouteReconciler struct {
@@ -51,15 +51,15 @@ func RegisterHTTPRouteController(log logrus.FieldLogger, mgr manager.Manager, ev
 		return err
 	}
 
-	return c.Watch(source.Kind(mgr.GetCache(), &gatewayapi_v1beta1.HTTPRoute{}), &handler.EnqueueRequestForObject{})
+	return c.Watch(source.Kind(mgr.GetCache(), &gatewayapi_v1.HTTPRoute{}), &handler.EnqueueRequestForObject{})
 }
 
 func (r *httpRouteReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the HTTPRoute from the cache.
-	httpRoute := &gatewayapi_v1beta1.HTTPRoute{}
+	httpRoute := &gatewayapi_v1.HTTPRoute{}
 	err := r.client.Get(ctx, request.NamespacedName, httpRoute)
 	if errors.IsNotFound(err) {
-		r.eventHandler.OnDelete(&gatewayapi_v1beta1.HTTPRoute{
+		r.eventHandler.OnDelete(&gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      request.Name,
 				Namespace: request.Namespace,

--- a/internal/dag/builder.go
+++ b/internal/dag/builder.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/metrics"
@@ -61,7 +61,7 @@ func (b *Builder) Build() *DAG {
 	if b.Source.gateway != nil {
 		gatewayNSName = k8s.NamespacedNameOf(b.Source.gateway)
 	}
-	var gatewayController gatewayapi_v1beta1.GatewayController
+	var gatewayController gatewayapi_v1.GatewayController
 	if b.Source.gatewayclass != nil {
 		gatewayController = b.Source.gatewayclass.Spec.ControllerName
 	}

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -112,15 +112,15 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	validClass := &gatewayapi_v1beta1.GatewayClass{
+	validClass := &gatewayapi_v1.GatewayClass{
 		TypeMeta: meta_v1.TypeMeta{},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "test-validClass",
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -130,19 +130,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPAllNamespaces := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPAllNamespaces := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "http",
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -150,19 +150,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPSameNamespace := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPSameNamespace := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "http",
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromSame),
 					},
 				},
@@ -170,18 +170,18 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPNamespaceSelector := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPNamespaceSelector := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 						Selector: &meta_v1.LabelSelector{
 							MatchLabels: map[string]string{
@@ -199,22 +199,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	hostname := gatewayapi_v1beta1.Hostname("gateway.projectcontour.io")
-	wildcardHostname := gatewayapi_v1beta1.Hostname("*.projectcontour.io")
+	hostname := gatewayapi_v1.Hostname("gateway.projectcontour.io")
+	wildcardHostname := gatewayapi_v1.Hostname("*.projectcontour.io")
 
-	gatewayHTTPWithHostname := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPWithHostname := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     80,
 				Hostname: &hostname,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -222,19 +222,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPWithWildcardHostname := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPWithWildcardHostname := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     80,
 				Hostname: &wildcardHostname,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -242,25 +242,25 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPWithAddresses := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPWithAddresses := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Addresses: []gatewayapi_v1beta1.GatewayAddress{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Addresses: []gatewayapi_v1.GatewayAddress{
 				{
-					Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+					Type:  ref.To(gatewayapi_v1.IPAddressType),
 					Value: "1.2.3.4",
 				},
 			},
-			Listeners: []gatewayapi_v1beta1.Listener{{
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "http",
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -268,21 +268,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayTLSPassthroughAllNamespaces := &gatewayapi_v1beta1.Gateway{
+	gatewayTLSPassthroughAllNamespaces := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -290,21 +290,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayTLSPassthroughSameNamespace := &gatewayapi_v1beta1.Gateway{
+	gatewayTLSPassthroughSameNamespace := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromSame),
 					},
 				},
@@ -312,21 +312,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayTLSPassthroughNamespaceSelector := &gatewayapi_v1beta1.Gateway{
+	gatewayTLSPassthroughNamespaceSelector := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 						Selector: &meta_v1.LabelSelector{
 							MatchLabels: map[string]string{"matching-label-key": "matching-label-value"},
@@ -386,25 +386,25 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		Data: secretdata(fixture.CERTIFICATE, fixture.RSA_PRIVATE_KEY),
 	}
 
-	gatewayTLSTerminateCertInDifferentNamespace := &gatewayapi_v1beta1.Gateway{
+	gatewayTLSTerminateCertInDifferentNamespace := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "https",
 				Port:     443,
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-					CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 						gatewayapi.CertificateRef(sec2.Name, sec2.Namespace),
 					},
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -412,23 +412,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPSAllNamespaces := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPSAllNamespaces := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-					CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
+					CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 						gatewayapi.CertificateRef(sec1.Name, sec1.Namespace),
 					},
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -436,20 +436,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	gatewayHTTPAndHTTPS := &gatewayapi_v1beta1.Gateway{
+	gatewayHTTPAndHTTPS := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "http-listener",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -458,13 +458,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					Name:     "https-listener",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef(sec1.Name, sec1.Namespace),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -473,19 +473,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	basicHTTPRoute := &gatewayapi_v1beta1.HTTPRoute{
+	basicHTTPRoute := &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 			}},
@@ -527,15 +527,15 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 	}
 
-	crossNSBackendHTTPRoute := makeHTTPRoute("basic", "default", "", gatewayapi_v1beta1.HTTPRouteRule{
+	crossNSBackendHTTPRoute := makeHTTPRoute("basic", "default", "", gatewayapi_v1.HTTPRouteRule{
 		Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-		BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{{
-			BackendRef: gatewayapi_v1beta1.BackendRef{
-				BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-					Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-					Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-					Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-					Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+		BackendRefs: []gatewayapi_v1.HTTPBackendRef{{
+			BackendRef: gatewayapi_v1.BackendRef{
+				BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+					Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+					Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
+					Name:      gatewayapi_v1.ObjectName(kuardService.Name),
+					Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 				},
 				Weight: ref.To(int32(1)),
 			},
@@ -544,8 +544,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 
 	tests := map[string]struct {
 		objs         []any
-		gatewayclass *gatewayapi_v1beta1.GatewayClass
-		gateway      *gatewayapi_v1beta1.Gateway
+		gatewayclass *gatewayapi_v1.GatewayClass
+		gateway      *gatewayapi_v1.Gateway
 		upstreamTLS  *UpstreamTLS
 		want         []*Listener
 	}{
@@ -656,22 +656,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
 								gatewayapi.GatewayParentRef("projectcontour", "some-other-gateway"),
 								gatewayapi.GatewayParentRef("projectcontour", "some-other-gateway-2"),
 							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
+						Hostnames: []gatewayapi_v1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
@@ -889,23 +889,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 
 		"TLS Listener with TLS.Mode=Passthrough is invalid if certificateRef is specified": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.TLSProtocolType,
-						TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+						TLS: &gatewayapi_v1.GatewayTLSConfig{
 							Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
-							CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+							CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 								gatewayapi.CertificateRef(sec1.Name, sec1.Namespace),
 							},
 						},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -920,21 +920,21 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"TLS Listener with TLS.Mode=Terminate is invalid if certificateRef is not specified": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(validClass.Name),
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(validClass.Name),
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.TLSProtocolType,
-						TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+						TLS: &gatewayapi_v1.GatewayTLSConfig{
 							Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
 						},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -950,17 +950,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"TLS Listener with TLS not defined is invalid": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.TLSProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -975,20 +975,20 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"TLSRoute with invalid listener protocol of HTTP": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+						TLS: &gatewayapi_v1.GatewayTLSConfig{
 							Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 						},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -1031,23 +1031,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"insert gateway with selector kind that doesn't match": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
-							Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							Kinds: []gatewayapi_v1.RouteGroupKind{
 								{
-									Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-									Kind:  gatewayapi_v1beta1.Kind("INVALID-KIND"),
+									Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+									Kind:  gatewayapi_v1.Kind("INVALID-KIND"),
 								},
 							},
 						},
@@ -1062,23 +1062,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"insert gateway with selector group that doesn't match": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
-							Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							Kinds: []gatewayapi_v1.RouteGroupKind{
 								{
-									Group: ref.To(gatewayapi_v1beta1.Group("invalid-group-name")),
-									Kind:  gatewayapi_v1beta1.Kind("HTTPRoute"),
+									Group: ref.To(gatewayapi_v1.Group("invalid-group-name")),
+									Kind:  gatewayapi_v1.Kind("HTTPRoute"),
 								},
 							},
 						},
@@ -1100,10 +1100,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io",
 					makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/", "kuard", 8080, 1),
 					makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/blog", "blogsvc", 80, 1),
-					gatewayapi_v1beta1.HTTPRouteRule{
+					gatewayapi_v1.HTTPRouteRule{
 						Matches: append(
 							gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another"),
-							gatewayapi_v1beta1.HTTPRouteMatch{
+							gatewayapi_v1.HTTPRouteMatch{
 								Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchExact, "X-Foo-Header", "some_value"),
 							},
 						),
@@ -1146,22 +1146,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
+						Hostnames: []gatewayapi_v1.Hostname{
 							"test.projectcontour.io",
 							"test2.projectcontour.io",
 							"test3.projectcontour.io",
 							"test4.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
@@ -1264,13 +1264,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
-				makeHTTPRoute("basic", "default", "", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "default", "", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+					BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 						{
-							BackendRef: gatewayapi_v1beta1.BackendRef{
-								BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-									Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
+							BackendRef: gatewayapi_v1.BackendRef{
+								BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+									Kind: ref.To(gatewayapi_v1.Kind("Service")),
 									Name: "kuard",
 								},
 							},
@@ -1314,7 +1314,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "default",
 						}},
@@ -1342,13 +1342,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "default",
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Service",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName(kuardService.Name)),
+							Name: ref.To(gatewayapi_v1.ObjectName(kuardService.Name)),
 						}},
 					},
 				},
@@ -1371,7 +1371,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "default",
 						}},
@@ -1401,7 +1401,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "default",
 						}},
@@ -1431,7 +1431,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "some-other-namespace", // would need to be "default" to be valid
 						}},
@@ -1461,13 +1461,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute",
 							Namespace: "default",
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Service",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName("some-other-service")), // would need to be "kuard" to be valid.
+							Name: ref.To(gatewayapi_v1.ObjectName("some-other-service")), // would need to be "kuard" to be valid.
 						}},
 					},
 				},
@@ -1520,19 +1520,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io",
-					gatewayapi_v1beta1.HTTPRouteRule{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					gatewayapi_v1.HTTPRouteRule{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
 						}, {
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/blog"),
 							},
 						}, {
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/tech"),
 							},
@@ -1554,22 +1554,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"insert basic single route, single hostname, gateway with TLS, HTTP protocol is ignored": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     443,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-							CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						TLS: &gatewayapi_v1.GatewayTLSConfig{
+							CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 								gatewayapi.CertificateRef(sec1.Name, sec1.Namespace),
 							},
 						},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -1597,17 +1597,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"insert basic single route, single hostname, gateway with TLS, HTTPS protocol missing certificateRef": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     443,
 						Protocol: gatewayapi_v1.HTTPSProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -1701,26 +1701,26 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"TLS Listener Gateway CertificateRef must be type core.Secret": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     443,
 						Protocol: gatewayapi_v1.HTTPSProtocolType,
-						TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-							CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						TLS: &gatewayapi_v1.GatewayTLSConfig{
+							CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 								{
-									Group: ref.To(gatewayapi_v1beta1.Group("custom")),
-									Kind:  ref.To(gatewayapi_v1beta1.Kind("shhhh")),
-									Name:  gatewayapi_v1beta1.ObjectName(sec1.Name),
+									Group: ref.To(gatewayapi_v1.Group("custom")),
+									Kind:  ref.To(gatewayapi_v1.Kind("shhhh")),
+									Name:  gatewayapi_v1.ObjectName(sec1.Name),
 								},
 							},
 						},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -1736,18 +1736,18 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"TLS Listener Gateway CertificateRef must be specified": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     443,
 						Protocol: gatewayapi_v1.HTTPSProtocolType,
-						TLS:      &gatewayapi_v1beta1.GatewayTLSConfig{},
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						TLS:      &gatewayapi_v1.GatewayTLSConfig{},
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -1775,9 +1775,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
@@ -1824,13 +1824,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName(sec2.Name)),
+							Name: ref.To(gatewayapi_v1.ObjectName(sec2.Name)),
 						}},
 					},
 				},
@@ -1864,9 +1864,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
@@ -1890,9 +1890,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace("wrong-namespace"),
+							Namespace: gatewayapi_v1.Namespace("wrong-namespace"),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
@@ -1916,9 +1916,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "WrongKind",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
@@ -1942,9 +1942,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "WrongKind",
@@ -1968,13 +1968,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "Gateway",
-							Namespace: gatewayapi_v1beta1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
+							Namespace: gatewayapi_v1.Namespace(gatewayTLSTerminateCertInDifferentNamespace.Namespace),
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Secret",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName("wrong-name")),
+							Name: ref.To(gatewayapi_v1.ObjectName("wrong-name")),
 						}},
 					},
 				},
@@ -1996,17 +1996,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"Invalid listener protocol type (TCP)": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.TCPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -2018,17 +2018,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"Invalid listener protocol type (UDP)": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: gatewayapi_v1.UDPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -2040,17 +2040,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 		},
 		"Invalid listener protocol type (custom)": {
 			gatewayclass: validClass,
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					Listeners: []gatewayapi_v1beta1.Listener{{
+				Spec: gatewayapi_v1.GatewaySpec{
+					Listeners: []gatewayapi_v1.Listener{{
 						Port:     80,
 						Protocol: "projectcontour.io/HTTPUDP",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
@@ -2067,41 +2067,41 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				sec1,
 				kuardService,
 				blogService,
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
 								gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http-listener", 0),
 							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
+						Hostnames: []gatewayapi_v1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						}},
 					},
 				},
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "basictls",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
 								gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "https-listener", 0),
 							},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
+						Hostnames: []gatewayapi_v1.Hostname{
 							"test.projectcontour.io",
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("blogsvc", 80, 1),
 						}},
@@ -2134,9 +2134,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
@@ -2165,15 +2165,15 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{
 						{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/blog"),
 							},
 						}, {
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/tech"),
 							},
@@ -2207,8 +2207,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
 						Headers: gatewayapi.HTTPHeaderMatch(gatewayapi_v1.HeaderMatchRegularExpression, "foo", "^abc$"),
 					}},
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -2234,9 +2234,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Headers: []gatewayapi_v1.HTTPHeaderMatch{
 							{Name: "header-1", Value: "value-1"},
 							{Name: "header-2", Value: "value-2"},
 							{Name: "header-1", Value: "value-3"},
@@ -2267,9 +2267,9 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
@@ -2298,13 +2298,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Name:  "param-1",
 								Value: "value-1",
@@ -2334,13 +2334,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
 								Name:  "param-1",
@@ -2371,13 +2371,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
 								Name:  "param-1",
@@ -2425,13 +2425,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
 								Name:  "param-1",
@@ -2481,13 +2481,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
 								Name:  "param-1",
@@ -2525,13 +2525,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
-					Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-						Path: &gatewayapi_v1beta1.HTTPPathMatch{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
+					Matches: []gatewayapi_v1.HTTPRouteMatch{{
+						Path: &gatewayapi_v1.HTTPPathMatch{
 							Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 							Value: ref.To("/"),
 						},
-						QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+						QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 							{
 								Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
 								Name:  "query-param-regex",
@@ -2563,18 +2563,18 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 								},
-								Add: []gatewayapi_v1beta1.HTTPHeader{
+								Add: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom-header-add", Value: "foo-bar"},
 								},
 								Remove: []string{"x-remove"},
@@ -2583,12 +2583,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						{
 							// Second instance of filter should be ignored.
 							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
 									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
 								},
-								Add: []gatewayapi_v1beta1.HTTPHeader{
+								Add: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom-header-add", Value: "ignored"},
 								},
 								Remove: []string{"x-remove-ignored"},
@@ -2624,18 +2624,18 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 								},
-								Add: []gatewayapi_v1beta1.HTTPHeader{
+								Add: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom-header-add", Value: "foo-bar"},
 								},
 								Remove: []string{"x-remove"},
@@ -2644,12 +2644,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						{
 							// Second instance of filter should be ignored.
 							Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
 									{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
 								},
-								Add: []gatewayapi_v1beta1.HTTPHeader{
+								Add: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom-header-add", Value: "ignored"},
 								},
 								Remove: []string{"x-remove-ignored"},
@@ -2685,23 +2685,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+					BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 						{
-							BackendRef: gatewayapi_v1beta1.BackendRef{
+							BackendRef: gatewayapi_v1.BackendRef{
 								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								Weight:                 ref.To(int32(1)),
 							},
 							Filters: []gatewayapi_v1.HTTPRouteFilter{
 								{
 									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
+										Add: []gatewayapi_v1.HTTPHeader{
 											{Name: "custom-header-add", Value: "foo-bar"},
 										},
 										Remove: []string{"x-remove"},
@@ -2710,12 +2710,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								{
 									// Second instance of filter should be ignored.
 									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
 											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
 										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
+										Add: []gatewayapi_v1.HTTPHeader{
 											{Name: "custom-header-add", Value: "ignored"},
 										},
 										Remove: []string{"x-remove-ignored"},
@@ -2743,23 +2743,23 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+					BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 						{
-							BackendRef: gatewayapi_v1beta1.BackendRef{
+							BackendRef: gatewayapi_v1.BackendRef{
 								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								Weight:                 ref.To(int32(1)),
 							},
 							Filters: []gatewayapi_v1.HTTPRouteFilter{
 								{
 									Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
+										Add: []gatewayapi_v1.HTTPHeader{
 											{Name: "custom-header-add", Value: "foo-bar"},
 										},
 										Remove: []string{"x-remove"},
@@ -2768,12 +2768,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								{
 									// Second instance of filter should be ignored.
 									Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "ignored"},
 											{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar-ignored.com"},
 										},
-										Add: []gatewayapi_v1beta1.HTTPHeader{
+										Add: []gatewayapi_v1.HTTPHeader{
 											{Name: "custom-header-add", Value: "ignored"},
 										},
 										Remove: []string{"x-remove-ignored"},
@@ -2801,17 +2801,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-						RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-							Set: []gatewayapi_v1beta1.HTTPHeader{
+						RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+							Set: []gatewayapi_v1.HTTPHeader{
 								{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 								{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 							},
-							Add: []gatewayapi_v1beta1.HTTPHeader{
+							Add: []gatewayapi_v1.HTTPHeader{
 								{Name: "!invalid-header-add", Value: "foo-bar"},
 							},
 						},
@@ -2840,22 +2840,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+					BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 						{
-							BackendRef: gatewayapi_v1beta1.BackendRef{
+							BackendRef: gatewayapi_v1.BackendRef{
 								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								Weight:                 ref.To(int32(1)),
 							},
 							Filters: []gatewayapi_v1.HTTPRouteFilter{{
 								Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-									Set: []gatewayapi_v1beta1.HTTPHeader{
+								RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+									Set: []gatewayapi_v1.HTTPHeader{
 										{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 										{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 									},
-									Add: []gatewayapi_v1beta1.HTTPHeader{
+									Add: []gatewayapi_v1.HTTPHeader{
 										{Name: "!invalid-header-add", Value: "foo-bar"},
 									},
 								},
@@ -2881,22 +2881,22 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-					BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+					BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 						{
-							BackendRef: gatewayapi_v1beta1.BackendRef{
+							BackendRef: gatewayapi_v1.BackendRef{
 								BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								Weight:                 ref.To(int32(1)),
 							},
 							Filters: []gatewayapi_v1.HTTPRouteFilter{{
 								Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-								ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-									Set: []gatewayapi_v1beta1.HTTPHeader{
+								ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+									Set: []gatewayapi_v1.HTTPHeader{
 										{Name: gatewayapi_v1.HTTPHeaderName("custom-header-set"), Value: "foo-bar"},
 										{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "bar.com"},
 									},
-									Add: []gatewayapi_v1beta1.HTTPHeader{
+									Add: []gatewayapi_v1.HTTPHeader{
 										{Name: "!invalid-header-add", Value: "foo-bar"},
 									},
 								},
@@ -2922,14 +2922,14 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+						RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
 							Scheme:     ref.To("https"),
-							Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
-							Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
+							Hostname:   ref.To(gatewayapi_v1.PreciseHostname("envoyproxy.io")),
+							Port:       ref.To(gatewayapi_v1.PortNumber(443)),
 							StatusCode: ref.To(301),
 						},
 					}},
@@ -2957,17 +2957,17 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: append(
 						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
 					),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
+						RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
 							Scheme:     ref.To("https"),
-							Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
-							Port:       ref.To(gatewayapi_v1beta1.PortNumber(443)),
+							Hostname:   ref.To(gatewayapi_v1.PreciseHostname("envoyproxy.io")),
+							Port:       ref.To(gatewayapi_v1.PortNumber(443)),
 							StatusCode: ref.To(301),
 						},
 					}},
@@ -3004,12 +3004,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
 								ReplacePrefixMatch: ref.To("/replacement"),
 							},
@@ -3039,12 +3039,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
 								ReplacePrefixMatch: ref.To("/"),
 							},
@@ -3074,12 +3074,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:            gatewayapi_v1.FullPathHTTPPathModifier,
 								ReplaceFullPath: ref.To("/replacement"),
 							},
@@ -3110,12 +3110,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				kuardService2,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-						RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+						RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 							BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 						},
 					}},
@@ -3136,19 +3136,19 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 							},
 						},
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
 							},
 						},
@@ -3169,7 +3169,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			objs: []any{
 				kuardService,
 				kuardService2,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: append(
 						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/another-match")...,
@@ -3177,7 +3177,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-						RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+						RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 							BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 						},
 					}},
@@ -3198,12 +3198,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
 								ReplacePrefixMatch: ref.To("/replacement"),
 							},
@@ -3232,12 +3232,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:               gatewayapi_v1.PrefixMatchHTTPPathModifier,
 								ReplacePrefixMatch: ref.To("/"),
 							},
@@ -3266,12 +3266,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-							Path: &gatewayapi_v1beta1.HTTPPathModifier{
+						URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+							Path: &gatewayapi_v1.HTTPPathModifier{
 								Type:            gatewayapi_v1.FullPathHTTPPathModifier,
 								ReplaceFullPath: ref.To("/replacement"),
 							},
@@ -3300,12 +3300,12 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{{
 						Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-						URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-							Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("rewritten.com")),
+						URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+							Hostname: ref.To(gatewayapi_v1.PreciseHostname("rewritten.com")),
 						},
 					}},
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -3329,13 +3329,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 			gateway:      gatewayHTTPAllNamespaces,
 			objs: []any{
 				kuardService,
-				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "test.projectcontour.io", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 					Filters: []gatewayapi_v1.HTTPRouteFilter{
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{
 										Name:  "Host",
 										Value: "requestheader.rewritten.com",
@@ -3345,8 +3345,8 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						},
 						{
 							Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-							URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-								Hostname: ref.To(gatewayapi_v1beta1.PreciseHostname("url.rewritten.com")),
+							URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+								Hostname: ref.To(gatewayapi_v1.PreciseHostname("url.rewritten.com")),
 							},
 						},
 					},
@@ -3643,16 +3643,16 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				tlsAndNonTLSService,
 				cert1,
 				makeHTTPRoute("tls-basic", "projectcontour", "", makeHTTPRouteRule(gatewayapi_v1.PathMatchPathPrefix, "/tls", "tlsandnontlssvc", 443, 1)),
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "non-tls-basic",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/non-tls"),
 							BackendRefs: gatewayapi.HTTPBackendRefs(
 								gatewayapi.HTTPBackendRef("tlsandnontlssvc", 80, 1),
@@ -3911,7 +3911,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRefs(
 						gatewayapi.HTTPBackendRef("kuard", 8080, 5),
@@ -3964,7 +3964,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				kuardService,
 				kuardService2,
 				kuardService3,
-				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1beta1.HTTPRouteRule{
+				makeHTTPRoute("basic", "projectcontour", "", gatewayapi_v1.HTTPRouteRule{
 					Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRefs(
 						gatewayapi.HTTPBackendRef("kuard", 8080, 5),
@@ -4115,10 +4115,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4133,7 +4133,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "default",
 						}},
@@ -4178,10 +4178,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4196,13 +4196,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "default",
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Service",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName(kuardService.Name)),
+							Name: ref.To(gatewayapi_v1.ObjectName(kuardService.Name)),
 						}},
 					},
 				},
@@ -4242,10 +4242,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4260,7 +4260,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "HTTPRoute", // would need to be TLSRoute to be valid
 							Namespace: "default",
 						}},
@@ -4291,10 +4291,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4309,7 +4309,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "default",
 						}},
@@ -4340,10 +4340,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4358,7 +4358,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "some-other-namespace", // would have to be "default" to be valid
 						}},
@@ -4389,10 +4389,10 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 								{
 									BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -4407,13 +4407,13 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 					},
 					Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 						From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-							Group:     gatewayapi_v1beta1.GroupName,
+							Group:     gatewayapi_v1.GroupName,
 							Kind:      "TLSRoute",
 							Namespace: "default",
 						}},
 						To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 							Kind: "Service",
-							Name: ref.To(gatewayapi_v1beta1.ObjectName("some-other-service")), // would have to be "kuard" to be valid
+							Name: ref.To(gatewayapi_v1.ObjectName("some-other-service")), // would have to be "kuard" to be valid
 						}},
 					},
 				},
@@ -5319,7 +5319,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 						},
-						Hostnames: []gatewayapi_v1beta1.Hostname{
+						Hostnames: []gatewayapi_v1.Hostname{
 							"test.projectcontour.io",
 						},
 						Rules: []gatewayapi_v1alpha2.GRPCRouteRule{
@@ -5476,7 +5476,7 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 							}},
 							BackendRefs: []gatewayapi_v1alpha2.GRPCBackendRef{{
 								BackendRef: gatewayapi_v1alpha2.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
+									BackendObjectReference: gatewayapi_v1.BackendObjectReference{
 										Kind:      ref.To(gatewayapi_v1alpha2.Kind("Service")),
 										Namespace: ref.To(gatewayapi_v1alpha2.Namespace(kuardService.Namespace)),
 										Name:      gatewayapi_v1alpha2.ObjectName(kuardService.Name),
@@ -13919,25 +13919,25 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		gateway *gatewayapi_v1beta1.Gateway
+		gateway *gatewayapi_v1.Gateway
 		objs    []any
 		want    []*Listener
 	}{
 		"HTTPProxy attached to HTTP-only Gateway": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -13984,20 +13984,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"HTTPProxy attached to Gateway with multiple HTTP listeners": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14006,8 +14006,8 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "http-2",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     81,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14047,20 +14047,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			want: nil,
 		},
 		"HTTPProxy attached to Gateway with HTTP and HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14069,12 +14069,12 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 							},
 						},
@@ -14120,20 +14120,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"HTTPProxy with TLS attached to Gateway with HTTP and HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14142,12 +14142,12 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 							},
 						},
@@ -14203,20 +14203,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"HTTPProxy with TLS attached to Gateway with HTTP and HTTPS listener using projectcontour.io/https protocol": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14225,8 +14225,8 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi.ContourHTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14283,20 +14283,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"HTTPProxy with TLS attached to Gateway with no HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14341,20 +14341,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 		},
 
 		"Ingress attached to HTTP-only Gateway": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14397,20 +14397,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"Ingress attached to Gateway with multiple HTTP listeners": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14419,8 +14419,8 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "http-2",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     81,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14456,20 +14456,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			want: nil,
 		},
 		"Ingress attached to Gateway with HTTP and HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14478,12 +14478,12 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 							},
 						},
@@ -14525,20 +14525,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"Ingress with TLS attached to Gateway with HTTP and HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14547,12 +14547,12 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 							},
 						},
@@ -14607,20 +14607,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"Ingress with TLS attached to Gateway with HTTP and HTTPS listener using projectcontour.io/https protocol": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14629,8 +14629,8 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 							Name:     "https-1",
 							Protocol: gatewayapi.ContourHTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14686,20 +14686,20 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 			),
 		},
 		"Ingress with TLS (with HTTP not allowed) attached to Gateway with no HTTPS listener": {
-			gateway: &gatewayapi_v1beta1.Gateway{
+			gateway: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -14748,11 +14748,11 @@ func TestGatewayWithHTTPProxyAndIngress(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			gc := &gatewayapi_v1beta1.GatewayClass{
+			gc := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour-gc",
 				},
-				Spec: gatewayapi_v1beta1.GatewayClassSpec{
+				Spec: gatewayapi_v1.GatewayClassSpec{
 					ControllerName: "projectcontour.io/gateway-controller",
 				},
 			}
@@ -16003,20 +16003,20 @@ func makeHTTPRouteTimeouts(request, backendRequest string) *gatewayapi_v1.HTTPRo
 	return httpRouteTimeouts
 }
 
-func makeHTTPRouteWithTimeouts(request, backendRequest string) *gatewayapi_v1beta1.HTTPRoute {
-	return &gatewayapi_v1beta1.HTTPRoute{
+func makeHTTPRouteWithTimeouts(request, backendRequest string) *gatewayapi_v1.HTTPRoute {
+	return &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 				Timeouts:    makeHTTPRouteTimeouts(request, backendRequest),
@@ -16025,25 +16025,25 @@ func makeHTTPRouteWithTimeouts(request, backendRequest string) *gatewayapi_v1bet
 	}
 }
 
-func makeHTTPRoute(name, namespace, hostname string, firstRule gatewayapi_v1beta1.HTTPRouteRule, additionalRules ...gatewayapi_v1beta1.HTTPRouteRule) *gatewayapi_v1beta1.HTTPRoute {
-	rules := []gatewayapi_v1beta1.HTTPRouteRule{firstRule}
+func makeHTTPRoute(name, namespace, hostname string, firstRule gatewayapi_v1.HTTPRouteRule, additionalRules ...gatewayapi_v1.HTTPRouteRule) *gatewayapi_v1.HTTPRoute {
+	rules := []gatewayapi_v1.HTTPRouteRule{firstRule}
 	if len(additionalRules) > 0 {
 		rules = append(rules, additionalRules...)
 	}
-	var hostnames []gatewayapi_v1beta1.Hostname
+	var hostnames []gatewayapi_v1.Hostname
 	if hostname != "" {
-		hostnames = []gatewayapi_v1beta1.Hostname{
-			gatewayapi_v1beta1.Hostname(hostname),
+		hostnames = []gatewayapi_v1.Hostname{
+			gatewayapi_v1.Hostname(hostname),
 		}
 	}
-	return &gatewayapi_v1beta1.HTTPRoute{
+	return &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 			},
 			Hostnames: hostnames,
 			Rules:     rules,
@@ -16051,8 +16051,8 @@ func makeHTTPRoute(name, namespace, hostname string, firstRule gatewayapi_v1beta
 	}
 }
 
-func makeHTTPRouteRule(pathType gatewayapi_v1beta1.PathMatchType, pathValue, serviceName string, port int, weight int32) gatewayapi_v1beta1.HTTPRouteRule {
-	return gatewayapi_v1beta1.HTTPRouteRule{
+func makeHTTPRouteRule(pathType gatewayapi_v1.PathMatchType, pathValue, serviceName string, port int, weight int32) gatewayapi_v1.HTTPRouteRule {
+	return gatewayapi_v1.HTTPRouteRule{
 		Matches:     gatewayapi.HTTPRouteMatch(pathType, pathValue),
 		BackendRefs: gatewayapi.HTTPBackendRef(serviceName, port, weight),
 	}

--- a/internal/dag/cache_test.go
+++ b/internal/dag/cache_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -948,7 +949,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		// invalid gatewayclass test case is unneeded since the controller
 		// uses a predicate to filter events before they're given to the EventHandler.
 		"insert valid gatewayclass": {
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour",
 				},
@@ -956,7 +957,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert gateway-api Gateway": {
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
@@ -965,7 +966,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 			want: true,
 		},
 		"insert gateway-api HTTPRoute, no reference to Gateway": {
-			obj: &gatewayapi_v1beta1.HTTPRoute{
+			obj: &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
@@ -975,21 +976,21 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert gateway-api HTTPRoute, has reference to Gateway": {
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.HTTPRoute{
+			obj: &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{
 							gatewayapi.GatewayParentRef("gateway-namespace", "gateway-name"),
 						},
 					},
@@ -1008,7 +1009,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert gateway-api TLSRoute, has reference to Gateway": {
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
@@ -1041,7 +1042,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert gateway-api GRPCRoute, has reference to Gateway": {
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
@@ -1074,7 +1075,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert gateway-api TCPRoute, has reference to Gateway": {
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
@@ -1124,18 +1125,18 @@ func TestKubernetesCacheInsert(t *testing.T) {
 		},
 		"insert backendtlspolicy targeting backend Service": {
 			pre: []any{
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "httproute",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
 						CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 							ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 								gatewayapi.GatewayParentRef("projectcontour", "contour"),
 							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+						Rules: []gatewayapi_v1.HTTPRouteRule{{
 							BackendRefs: gatewayapi.HTTPBackendRef("service", 80, 1),
 						}},
 					},
@@ -1171,7 +1172,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Namespace: "gateway-namespace",
 				Name:      "gateway-name",
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "gatewayclass-1",
 				},
@@ -1184,17 +1185,17 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Name:      "gateway-name",
 			},
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						GatewayClassName: gatewayapi_v1beta1.ObjectName("some-other-gatewayclass"),
+					Spec: gatewayapi_v1.GatewaySpec{
+						GatewayClassName: gatewayapi_v1.ObjectName("some-other-gatewayclass"),
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "gatewayclass-1",
 				},
@@ -1207,17 +1208,17 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Name:      "gateway-name",
 			},
 			pre: []any{
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						GatewayClassName: gatewayapi_v1beta1.ObjectName("gatewayclass-1"),
+					Spec: gatewayapi_v1.GatewaySpec{
+						GatewayClassName: gatewayapi_v1.ObjectName("gatewayclass-1"),
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "gatewayclass-1",
 				},
@@ -1229,7 +1230,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Namespace: "gateway-namespace",
 				Name:      "gateway-name",
 			},
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "gateway-namespace",
 					Name:      "some-other-gateway-name",
@@ -1242,7 +1243,7 @@ func TestKubernetesCacheInsert(t *testing.T) {
 				Namespace: "gateway-namespace",
 				Name:      "gateway-name",
 			},
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "gateway-namespace",
 					Name:      "gateway-name",
@@ -1531,12 +1532,12 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove gatewayclass": {
-			cache: cache(&gatewayapi_v1beta1.GatewayClass{
+			cache: cache(&gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour",
 				},
 			}),
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour",
 				},
@@ -1544,13 +1545,13 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api Gateway": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
 				},
 			}),
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "contour",
 					Namespace: "projectcontour",
@@ -1559,20 +1560,20 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api HTTPRoute with no parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "Gateway",
 					Namespace: "default",
 				},
 			},
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "httproute",
 						Namespace: "default",
 					},
 				},
 			),
-			obj: &gatewayapi_v1beta1.HTTPRoute{
+			obj: &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
@@ -1581,34 +1582,34 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove gateway-api HTTPRoute with parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "gateway",
 					Namespace: "default",
 				},
 			},
-				&gatewayapi_v1beta1.HTTPRoute{
+				&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "httproute",
 						Namespace: "default",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
 								gatewayapi.GatewayParentRef("default", "gateway"),
 							},
 						},
 					},
 				},
 			),
-			obj: &gatewayapi_v1beta1.HTTPRoute{
+			obj: &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{
 							gatewayapi.GatewayParentRef("default", "gateway"),
 						},
 					},
@@ -1617,7 +1618,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api TLSRoute with no parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "Gateway",
 					Namespace: "default",
@@ -1638,7 +1639,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove gateway-api TLSRoute with parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "gateway",
 					Namespace: "default",
@@ -1674,7 +1675,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api GRPCRoute with no parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "Gateway",
 					Namespace: "default",
@@ -1695,7 +1696,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove gateway-api GRPCRoute with parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "gateway",
 					Namespace: "default",
@@ -1731,7 +1732,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: true,
 		},
 		"remove gateway-api TCPRoute with no parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "Gateway",
 					Namespace: "default",
@@ -1752,7 +1753,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			want: false,
 		},
 		"remove gateway-api TCPRoute with parentRef": {
-			cache: cache(&gatewayapi_v1beta1.Gateway{
+			cache: cache(&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "gateway",
 					Namespace: "default",
@@ -1826,7 +1827,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
 						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
-							CACertRefs: []gatewayapi_v1beta1.LocalObjectReference{
+							CACertRefs: []gatewayapi_v1.LocalObjectReference{
 								{
 									Kind: "Secret",
 									Name: "ca",
@@ -1867,7 +1868,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 					},
 					Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
 						TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
-							CACertRefs: []gatewayapi_v1beta1.LocalObjectReference{
+							CACertRefs: []gatewayapi_v1.LocalObjectReference{
 								{
 									Kind: "ConfigMap",
 									Name: "configmap",
@@ -1912,7 +1913,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "gatewayclass-1",
 				},
@@ -1922,13 +1923,13 @@ func TestKubernetesCacheRemove(t *testing.T) {
 		"specific gateway configured, remove gatewayclass, non-matching name": {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
-				gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+				gatewayclass: &gatewayapi_v1.GatewayClass{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: "gatewayclass-1",
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "some-other-gatewayclass",
 				},
@@ -1938,13 +1939,13 @@ func TestKubernetesCacheRemove(t *testing.T) {
 		"specific gateway configured, remove gatewayclass, matching name": {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
-				gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+				gatewayclass: &gatewayapi_v1.GatewayClass{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name: "gatewayclass-1",
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.GatewayClass{
+			obj: &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "gatewayclass-1",
 				},
@@ -1955,7 +1956,7 @@ func TestKubernetesCacheRemove(t *testing.T) {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
 			},
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "gateway-namespace",
 					Name:      "gateway-name",
@@ -1966,14 +1967,14 @@ func TestKubernetesCacheRemove(t *testing.T) {
 		"specific gateway configured, remove gateway, non-matching namespace/name": {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
-				gateway: &gatewayapi_v1beta1.Gateway{
+				gateway: &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "gateway-namespace",
 					Name:      "some-other-gateway",
@@ -1984,14 +1985,14 @@ func TestKubernetesCacheRemove(t *testing.T) {
 		"specific gateway configured, remove gateway, matching namespace/name": {
 			cache: &KubernetesCache{
 				ConfiguredGatewayToCache: &types.NamespacedName{Namespace: "gateway-namespace", Name: "gateway-name"},
-				gateway: &gatewayapi_v1beta1.Gateway{
+				gateway: &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: "gateway-namespace",
 						Name:      "gateway-name",
 					},
 				},
 			},
-			obj: &gatewayapi_v1beta1.Gateway{
+			obj: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "gateway-namespace",
 					Name:      "gateway-name",
@@ -2212,14 +2213,14 @@ func TestServiceTriggersRebuild(t *testing.T) {
 		}
 	}
 
-	httpRoute := func(namespace, name string) *gatewayapi_v1beta1.HTTPRoute {
-		return &gatewayapi_v1beta1.HTTPRoute{
+	httpRoute := func(namespace, name string) *gatewayapi_v1.HTTPRoute {
+		return &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Rules: []gatewayapi_v1.HTTPRouteRule{{
 					BackendRefs: gatewayapi.HTTPBackendRef(name, 80, 1),
 				}},
 			},
@@ -2637,13 +2638,13 @@ func TestSecretTriggersRebuild(t *testing.T) {
 		},
 		"gateway does not define TLS on listener, does not trigger rebuild": {
 			cache: cache(
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
 							TLS: nil,
 						}},
 					},
@@ -2654,14 +2655,14 @@ func TestSecretTriggersRebuild(t *testing.T) {
 		},
 		"gateway does not define TLS.CertificateRef on listener, does not trigger rebuild": {
 			cache: cache(
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								CertificateRefs: nil,
 							},
 						}},
@@ -2673,15 +2674,15 @@ func TestSecretTriggersRebuild(t *testing.T) {
 		},
 		"gateway listener references secret, triggers rebuild (core Group)": {
 			cache: cache(
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert", ""),
 								},
 							},
@@ -2694,15 +2695,15 @@ func TestSecretTriggersRebuild(t *testing.T) {
 		},
 		"gateway listener references secret, triggers rebuild (v1 Group)": {
 			cache: cache(
-				&gatewayapi_v1beta1.Gateway{
+				&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert", ""),
 								},
 							},
@@ -2745,19 +2746,19 @@ func TestRouteTriggersRebuild(t *testing.T) {
 		return &cache
 	}
 
-	httpRoute := func(namespace, name, parentRefNamespace, parentRefName string) *gatewayapi_v1beta1.HTTPRoute {
-		return &gatewayapi_v1beta1.HTTPRoute{
+	httpRoute := func(namespace, name, parentRefNamespace, parentRefName string) *gatewayapi_v1.HTTPRoute {
+		return &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(parentRefNamespace, parentRefName),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Rules: []gatewayapi_v1.HTTPRouteRule{{
 					BackendRefs: gatewayapi.HTTPBackendRef(name, 80, 1),
 				}},
 			},
@@ -2783,8 +2784,8 @@ func TestRouteTriggersRebuild(t *testing.T) {
 		}
 	}
 
-	gateway := func(namespace, name string) *gatewayapi_v1beta1.Gateway {
-		return &gatewayapi_v1beta1.Gateway{
+	gateway := func(namespace, name string) *gatewayapi_v1.Gateway {
+		return &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
@@ -2794,7 +2795,7 @@ func TestRouteTriggersRebuild(t *testing.T) {
 
 	tests := map[string]struct {
 		cache     *KubernetesCache
-		httproute *gatewayapi_v1beta1.HTTPRoute
+		httproute *gatewayapi_v1.HTTPRoute
 		tlsroute  *gatewayapi_v1alpha2.TLSRoute
 		want      bool
 	}{
@@ -2807,13 +2808,13 @@ func TestRouteTriggersRebuild(t *testing.T) {
 			cache: cache(
 				gateway("default", "gateway"),
 			),
-			httproute: &gatewayapi_v1beta1.HTTPRoute{
+			httproute: &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "httproute",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						BackendRefs: gatewayapi.HTTPBackendRef("httproute", 80, 1),
 					}},
 				},
@@ -3023,7 +3024,7 @@ func TestLookupBackendTLSPolicyByTargetRef(t *testing.T) {
 			Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
 				TargetRef: targetRef("", "Service", serviceName, targetNamespace, sectionName),
 				TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
-					CACertRefs: []gatewayapi_v1beta1.LocalObjectReference{
+					CACertRefs: []gatewayapi_v1.LocalObjectReference{
 						{
 							Group: "",
 							Kind:  "Secret",

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/fixture"
 	"github.com/projectcontour/contour/internal/gatewayapi"
@@ -35,13 +34,13 @@ import (
 func TestComputeHosts(t *testing.T) {
 	tests := map[string]struct {
 		listenerHost string
-		hostnames    []gatewayapi_v1beta1.Hostname
+		hostnames    []gatewayapi_v1.Hostname
 		want         sets.Set[string]
 		wantError    []error
 	}{
 		"single host": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
 			want:      sets.New("test.projectcontour.io"),
@@ -49,7 +48,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"single DNS label hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"projectcontour",
 			},
 			want:      sets.New("projectcontour"),
@@ -57,7 +56,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"multiple hosts": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 				"test1.projectcontour.io",
 				"test2.projectcontour.io",
@@ -73,13 +72,13 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"no host": {
 			listenerHost: "",
-			hostnames:    []gatewayapi_v1beta1.Hostname{},
+			hostnames:    []gatewayapi_v1.Hostname{},
 			want:         sets.New("*"),
 			wantError:    []error(nil),
 		},
 		"IP in host": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"1.2.3.4",
 			},
 			want: nil,
@@ -89,7 +88,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"valid wildcard hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.New("*.projectcontour.io"),
@@ -97,7 +96,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid wildcard hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.*.projectcontour.io",
 			},
 			want: nil,
@@ -107,7 +106,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid wildcard hostname *": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*",
 			},
 			want:      nil,
@@ -115,7 +114,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"invalid hostname": {
 			listenerHost: "",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"#projectcontour.io",
 			},
 			want: nil,
@@ -125,7 +124,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host do not exactly match": {
 			listenerHost: "listener.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      nil,
@@ -133,7 +132,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host exactly match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      sets.New("http.projectcontour.io"),
@@ -141,7 +140,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & multi hostnames host exactly match one host": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"http.projectcontour.io",
 				"http2.projectcontour.io",
 				"http3.projectcontour.io",
@@ -151,7 +150,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host match wildcard host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"http.projectcontour.io",
 			},
 			want:      sets.New("http.projectcontour.io"),
@@ -159,7 +158,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostnames host do not match wildcard host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"http.example.com",
 			},
 			want:      nil,
@@ -167,7 +166,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostnames host do not match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.New("http.projectcontour.io"),
@@ -175,7 +174,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostname and matching hostname match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 				"http.projectcontour.io",
 			},
@@ -184,7 +183,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & wildcard hostname and non-matching hostname don't match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 				"not.matching.io",
 			},
@@ -193,7 +192,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host wildcard & wildcard hostnames host match": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.New("*.projectcontour.io"),
@@ -201,13 +200,13 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener host & hostname not defined match": {
 			listenerHost: "http.projectcontour.io",
-			hostnames:    []gatewayapi_v1beta1.Hostname{},
+			hostnames:    []gatewayapi_v1.Hostname{},
 			want:         sets.New("http.projectcontour.io"),
 			wantError:    nil,
 		},
 		"listener host with many labels matches hostnames wildcard host": {
 			listenerHost: "very.many.labels.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"*.projectcontour.io",
 			},
 			want:      sets.New("very.many.labels.projectcontour.io"),
@@ -215,7 +214,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener wildcard host matches hostnames with many labels host": {
 			listenerHost: "*.projectcontour.io",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"very.many.labels.projectcontour.io",
 			},
 			want:      sets.New("very.many.labels.projectcontour.io"),
@@ -223,7 +222,7 @@ func TestComputeHosts(t *testing.T) {
 		},
 		"listener wildcard host doesn't match bare hostname": {
 			listenerHost: "*.foo",
-			hostnames: []gatewayapi_v1beta1.Hostname{
+			hostnames: []gatewayapi_v1.Hostname{
 				"foo",
 			},
 			want:      nil,
@@ -246,7 +245,7 @@ func TestComputeHosts(t *testing.T) {
 
 func TestNamespaceMatches(t *testing.T) {
 	tests := map[string]struct {
-		namespaces *gatewayapi_v1beta1.RouteNamespaces
+		namespaces *gatewayapi_v1.RouteNamespaces
 		namespace  string
 		valid      bool
 	}{
@@ -256,35 +255,35 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:      true,
 		},
 		"nil From matches all": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: nil,
 			},
 			namespace: "projectcontour",
 			valid:     true,
 		},
 		"From.NamespacesFromAll matches all": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromAll),
 			},
 			namespace: "projectcontour",
 			valid:     true,
 		},
 		"From.NamespacesFromSame matches": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSame),
 			},
 			namespace: "projectcontour",
 			valid:     true,
 		},
 		"From.NamespacesFromSame doesn't match": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSame),
 			},
 			namespace: "custom",
 			valid:     false,
 		},
 		"From.NamespacesFromSelector matches labels, same ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -296,7 +295,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     true,
 		},
 		"From.NamespacesFromSelector matches labels, different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -308,7 +307,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     true,
 		},
 		"From.NamespacesFromSelector doesn't matches labels, different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -320,7 +319,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     false,
 		},
 		"From.NamespacesFromSelector matches expression 'In', different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -334,7 +333,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     true,
 		},
 		"From.NamespacesFromSelector matches expression 'DoesNotExist', different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -347,7 +346,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     true,
 		},
 		"From.NamespacesFromSelector doesn't match expression 'DoesNotExist', different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -360,7 +359,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     false,
 		},
 		"From.NamespacesFromSelector matches expression 'Exists', different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -373,7 +372,7 @@ func TestNamespaceMatches(t *testing.T) {
 			valid:     false,
 		},
 		"From.NamespacesFromSelector doesn't match expression 'Exists', different ns as gateway": {
-			namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+			namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 				Selector: &meta_v1.LabelSelector{
 					MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -392,7 +391,7 @@ func TestNamespaceMatches(t *testing.T) {
 			processor := &GatewayAPIProcessor{
 				FieldLogger: fixture.NewTestLogger(t),
 				source: &KubernetesCache{
-					gateway: &gatewayapi_v1beta1.Gateway{
+					gateway: &gatewayapi_v1.Gateway{
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name:      "contour",
 							Namespace: "projectcontour",
@@ -444,7 +443,7 @@ func TestNamespaceMatches(t *testing.T) {
 
 func TestGetListenersForRouteParentRef(t *testing.T) {
 	tests := map[string]struct {
-		routeParentRef gatewayapi_v1beta1.ParentReference
+		routeParentRef gatewayapi_v1.ParentReference
 		routeNamespace string
 		routeKind      string
 		listeners      []*listenerInfo
@@ -456,27 +455,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -488,26 +487,26 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 			},
 			want: nil,
@@ -518,27 +517,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -550,26 +549,26 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 			},
 			want: nil,
@@ -581,27 +580,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -613,27 +612,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -645,26 +644,26 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 				},
 			},
 			want: nil,
@@ -675,27 +674,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "HTTPRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"TLSRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"TLSRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -707,27 +706,27 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			routeKind:      "GRPCRoute",
 			listeners: []*listenerInfo{
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-1",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"GRPCRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"GRPCRoute"},
 					ready:        true,
 				},
 				{
-					listener: gatewayapi_v1beta1.Listener{
+					listener: gatewayapi_v1.Listener{
 						Name: "http-2",
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSame),
 							},
 						},
 					},
-					allowedKinds: []gatewayapi_v1beta1.Kind{"HTTPRoute"},
+					allowedKinds: []gatewayapi_v1.Kind{"HTTPRoute"},
 					ready:        true,
 				},
 			},
@@ -740,7 +739,7 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			processor := &GatewayAPIProcessor{
 				FieldLogger: fixture.NewTestLogger(t),
 				source: &KubernetesCache{
-					gateway: &gatewayapi_v1beta1.Gateway{
+					gateway: &gatewayapi_v1.Gateway{
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name:      "contour",
 							Namespace: "projectcontour",
@@ -755,7 +754,7 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 			got := processor.getListenersForRouteParentRef(
 				tc.routeParentRef,
 				tc.routeNamespace,
-				gatewayapi_v1beta1.Kind(tc.routeKind),
+				gatewayapi_v1.Kind(tc.routeKind),
 				tc.listeners,
 				map[string]int{},
 				rpsu)

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -238,14 +237,14 @@ func extractHostRewriteHeaderValue(s string) string {
 
 // headersPolicyGatewayAPI builds a *HeaderPolicy for the supplied HTTPHeaderFilter.
 // TODO: Take care about the order of operators once https://github.com/kubernetes-sigs/gateway-api/issues/480 was solved.
-func headersPolicyGatewayAPI(hf *gatewayapi_v1beta1.HTTPHeaderFilter, headerPolicyType string) (*HeadersPolicy, error) {
+func headersPolicyGatewayAPI(hf *gatewayapi_v1.HTTPHeaderFilter, headerPolicyType string) (*HeadersPolicy, error) {
 	var (
 		remove      = sets.NewString()
 		hostRewrite = ""
 		errlist     = []error{}
 	)
 
-	addOrSetHeader := func(headers []gatewayapi_v1beta1.HTTPHeader, op string) map[string]string {
+	addOrSetHeader := func(headers []gatewayapi_v1.HTTPHeader, op string) map[string]string {
 		m := make(map[string]string, len(headers))
 
 		for _, header := range headers {

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -4755,20 +4755,20 @@ func TestDAGStatus(t *testing.T) {
 
 	run(t, "HTTPProxy cannot attach to a Gateway with >1 HTTP Listener", testcase{
 		objs: []any{
-			&gatewayapi_v1beta1.Gateway{
+			&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -4777,8 +4777,8 @@ func TestDAGStatus(t *testing.T) {
 							Name:     "http-2",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     81,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -4834,24 +4834,24 @@ func TestDAGStatus(t *testing.T) {
 
 	run(t, "HTTPProxy cannot attach to a Gateway with no HTTP Listener", testcase{
 		objs: []any{
-			&gatewayapi_v1beta1.Gateway{
+			&gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour-gc",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 							},
 						},
@@ -5167,36 +5167,36 @@ func TestDAGStatus(t *testing.T) {
 	})
 }
 
-func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v1beta1.ProtocolType, attachedRoutes int) []*status.GatewayStatusUpdate {
-	var supportedKinds []gatewayapi_v1beta1.RouteGroupKind
+func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v1.ProtocolType, attachedRoutes int) []*status.GatewayStatusUpdate {
+	var supportedKinds []gatewayapi_v1.RouteGroupKind
 
 	switch listenerProtocol {
 	case gatewayapi_v1.HTTPProtocolType, gatewayapi_v1.HTTPSProtocolType:
 		supportedKinds = append(supportedKinds,
-			gatewayapi_v1beta1.RouteGroupKind{
-				Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			gatewayapi_v1.RouteGroupKind{
+				Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 				Kind:  KindHTTPRoute,
 			},
-			gatewayapi_v1beta1.RouteGroupKind{
-				Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			gatewayapi_v1.RouteGroupKind{
+				Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 				Kind:  KindGRPCRoute,
 			},
 		)
 	case gatewayapi_v1.TLSProtocolType:
 		supportedKinds = append(supportedKinds,
-			gatewayapi_v1beta1.RouteGroupKind{
-				Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			gatewayapi_v1.RouteGroupKind{
+				Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 				Kind:  KindTLSRoute,
 			},
-			gatewayapi_v1beta1.RouteGroupKind{
-				Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			gatewayapi_v1.RouteGroupKind{
+				Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 				Kind:  KindTCPRoute,
 			},
 		)
 	case gatewayapi_v1.TCPProtocolType:
 		supportedKinds = append(supportedKinds,
-			gatewayapi_v1beta1.RouteGroupKind{
-				Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+			gatewayapi_v1.RouteGroupKind{
+				Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 				Kind:  KindTCPRoute,
 			},
 		)
@@ -5214,9 +5214,9 @@ func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v
 					Message: status.MessageValidGateway,
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				listenerName: {
-					Name:           gatewayapi_v1beta1.SectionName(listenerName),
+					Name:           gatewayapi_v1.SectionName(listenerName),
 					AttachedRoutes: int32(attachedRoutes),
 					SupportedKinds: supportedKinds,
 					Conditions:     listenerValidConditions(),
@@ -5229,7 +5229,7 @@ func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v
 func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	type testcase struct {
 		objs                    []any
-		gateway                 *gatewayapi_v1beta1.Gateway
+		gateway                 *gatewayapi_v1.Gateway
 		wantRouteConditions     []*status.RouteStatusUpdate
 		wantGatewayStatusUpdate []*status.GatewayStatusUpdate
 	}
@@ -5242,15 +5242,15 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
-					gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+					gatewayclass: &gatewayapi_v1.GatewayClass{
 						TypeMeta: meta_v1.TypeMeta{},
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name: "test-gc",
 						},
-						Spec: gatewayapi_v1beta1.GatewayClassSpec{
+						Spec: gatewayapi_v1.GatewayClassSpec{
 							ControllerName: "projectcontour.io/contour",
 						},
-						Status: gatewayapi_v1beta1.GatewayClassStatus{
+						Status: gatewayapi_v1.GatewayClassStatus{
 							Conditions: []meta_v1.Condition{
 								{
 									Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -5275,18 +5275,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 			// Set a default gateway if not defined by a test
 			if tc.gateway == nil {
-				builder.Source.gateway = &gatewayapi_v1beta1.Gateway{
+				builder.Source.gateway = &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
 							Name:     "http",
 							Port:     80,
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -5396,19 +5396,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "simple httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
@@ -5417,7 +5417,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5433,28 +5433,28 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "simple httproute with backendref namespace matching route's explicitly specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace(kuardService.Namespace)),
-										Name:      gatewayapi_v1beta1.ObjectName(kuardService.Name),
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+								BackendRef: gatewayapi_v1.BackendRef{
+									BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace(kuardService.Namespace)),
+										Name:      gatewayapi_v1.ObjectName(kuardService.Name),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 									Weight: ref.To(int32(1)),
 								},
@@ -5466,7 +5466,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{{
 				ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				Conditions: []meta_v1.Condition{
 					routeResolvedRefsCondition(),
@@ -5480,37 +5480,37 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "multiple httproutes", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic-2",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
@@ -5520,7 +5520,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteStatusUpdate{
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 						Conditions: []meta_v1.Condition{
@@ -5532,7 +5532,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic-2"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 						Conditions: []meta_v1.Condition{
@@ -5549,21 +5549,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "prefix path match not starting with '/' for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("doesnt-start-with-slash"),
 							},
@@ -5575,7 +5575,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5596,21 +5596,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "exact path match not starting with '/' for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchExact),
 								Value: ref.To("doesnt-start-with-slash"),
 							},
@@ -5622,7 +5622,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5644,19 +5644,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "regular expression path match with invalid value for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchRegularExpression, "invalid-regex???"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
@@ -5665,7 +5665,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5687,21 +5687,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "prefix path match with consecutive '/' characters for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/foo///bar"),
 							},
@@ -5713,7 +5713,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5735,21 +5735,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "exact path match with consecutive '/' characters for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchExact),
 								Value: ref.To("//foo/bar"),
 							},
@@ -5761,7 +5761,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5783,22 +5783,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "invalid path match type for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
-								Type:  ref.To(gatewayapi_v1beta1.PathMatchType("UNKNOWN")), // <---- unknown type to break the test
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
+								Type:  ref.To(gatewayapi_v1.PathMatchType("UNKNOWN")), // <---- unknown type to break the test
 								Value: ref.To("/"),
 							},
 						}},
@@ -5809,7 +5809,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5825,27 +5825,27 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "invalid header match type not supported for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
-							Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
+							Headers: []gatewayapi_v1.HTTPHeaderMatch{
 								{
-									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
+									Type:  ref.To(gatewayapi_v1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
 									Name:  gatewayapi_v1.HTTPHeaderName("foo"),
 									Value: "bar",
 								},
@@ -5858,7 +5858,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5874,25 +5874,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "regular expression header match with invalid value for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
-							Headers: []gatewayapi_v1beta1.HTTPHeaderMatch{
+							Headers: []gatewayapi_v1.HTTPHeaderMatch{
 								{
 									Type:  ref.To(gatewayapi_v1.HeaderMatchRegularExpression),
 									Name:  gatewayapi_v1.HTTPHeaderName("foo"),
@@ -5907,7 +5907,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5923,25 +5923,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "regular expression query param match with valid value for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
-							QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 								{
 									Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
 									Name:  "param-1",
@@ -5956,7 +5956,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -5977,25 +5977,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "regular expression query param match with invalid value for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
-							QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 								{
 									Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
 									Name:  "param-1",
@@ -6010,7 +6010,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6026,27 +6026,27 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "query param match with invalid type for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
-							QueryParams: []gatewayapi_v1beta1.HTTPQueryParamMatch{
+							QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 								{
-									Type:  ref.To(gatewayapi_v1beta1.QueryParamMatchType("Invalid")),
+									Type:  ref.To(gatewayapi_v1.QueryParamMatchType("Invalid")),
 									Name:  "param-1",
 									Value: "invalid query param type",
 								},
@@ -6059,7 +6059,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6075,26 +6075,26 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.name not specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Port: ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+								BackendRef: gatewayapi_v1.BackendRef{
+									BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+										Kind: ref.To(gatewayapi_v1.Kind("Service")),
+										Port: ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 								},
 							},
@@ -6105,7 +6105,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6121,29 +6121,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "spec.rules.backendRef.serviceName invalid on two matches", testcase{
 		objs: []any{
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
 						}},
 						BackendRefs: gatewayapi.HTTPBackendRef("invalid-one", 8080, 1),
 					}, {
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/blog"),
 							},
@@ -6155,7 +6155,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6172,25 +6172,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.port not specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
+								BackendRef: gatewayapi_v1.BackendRef{
+									BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+										Kind: ref.To(gatewayapi_v1.Kind("Service")),
 										Name: "kuard",
 									},
 								},
@@ -6202,7 +6202,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6219,19 +6219,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRefs not specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					}},
 				},
@@ -6239,7 +6239,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6255,28 +6255,28 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.backendRef.namespace does not match route", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
-									BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-										Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-										Namespace: ref.To(gatewayapi_v1beta1.Namespace("some-other-namespace")),
+								BackendRef: gatewayapi_v1.BackendRef{
+									BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+										Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+										Namespace: ref.To(gatewayapi_v1.Namespace("some-other-namespace")),
 										Name:      "service",
-										Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+										Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 									},
 								},
 							},
@@ -6287,7 +6287,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -6305,25 +6305,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	// BEGIN TLS CertificateRef + ReferenceGrant tests
 	run(t, "Gateway references TLS cert in different namespace, with valid ReferenceGrant", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6346,9 +6346,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("projectcontour"),
+						Namespace: gatewayapi_v1.Namespace("projectcontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
@@ -6360,25 +6360,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with no ReferenceGrant", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6406,16 +6406,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6440,25 +6440,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with valid ReferenceGrant (secret-specific)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6481,13 +6481,13 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("projectcontour"),
+						Namespace: gatewayapi_v1.Namespace("projectcontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
-						Name: ref.To(gatewayapi_v1beta1.ObjectName("secret")),
+						Name: ref.To(gatewayapi_v1.ObjectName("secret")),
 					}},
 				},
 			},
@@ -6496,25 +6496,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (policy in wrong namespace)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6537,9 +6537,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("projectcontour"),
+						Namespace: gatewayapi_v1.Namespace("projectcontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
@@ -6558,16 +6558,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6592,25 +6592,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From namespace)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6633,9 +6633,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("wrong-namespace"),
+						Namespace: gatewayapi_v1.Namespace("wrong-namespace"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
@@ -6654,16 +6654,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6688,25 +6688,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong From kind)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6729,9 +6729,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "WrongKind",
-						Namespace: gatewayapi_v1beta1.Namespace("projectontour"),
+						Namespace: gatewayapi_v1.Namespace("projectontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
@@ -6750,16 +6750,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6784,25 +6784,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong To kind)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6825,9 +6825,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("projectcontour"),
+						Namespace: gatewayapi_v1.Namespace("projectcontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "WrongKind",
@@ -6846,16 +6846,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6880,25 +6880,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "Gateway references TLS cert in different namespace, with invalid ReferenceGrant (wrong secret name)", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				GatewayClassName: gatewayapi_v1beta1.ObjectName("projectcontour.io/contour"),
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				GatewayClassName: gatewayapi_v1.ObjectName("projectcontour.io/contour"),
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("secret", "tls-cert-namespace"),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -6921,13 +6921,13 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				},
 				Spec: gatewayapi_v1beta1.ReferenceGrantSpec{
 					From: []gatewayapi_v1beta1.ReferenceGrantFrom{{
-						Group:     gatewayapi_v1beta1.GroupName,
+						Group:     gatewayapi_v1.GroupName,
 						Kind:      "Gateway",
-						Namespace: gatewayapi_v1beta1.Namespace("projectcontour"),
+						Namespace: gatewayapi_v1.Namespace("projectcontour"),
 					}},
 					To: []gatewayapi_v1beta1.ReferenceGrantTo{{
 						Kind: "Secret",
-						Name: ref.To(gatewayapi_v1beta1.ObjectName("wrong-name")),
+						Name: ref.To(gatewayapi_v1.ObjectName("wrong-name")),
 					}},
 				},
 			},
@@ -6943,16 +6943,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -6981,19 +6981,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid wildcard", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"*.*.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					}},
 				},
@@ -7001,7 +7001,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7024,19 +7024,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid hostname", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"#projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					}},
 				},
@@ -7044,7 +7044,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7067,19 +7067,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "spec.rules.hostname: invalid hostname, ip address", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"1.2.3.4",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					}},
 				},
@@ -7087,7 +7087,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7108,58 +7108,58 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "two HTTP listeners, route's hostname intersects with one of them", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 					{
 						Name:     "listener-2",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("specific.hostname.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("specific.hostname.io")),
 					},
 				},
 			},
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7181,32 +7181,32 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: status.MessageValidGateway,
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(1),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: listenerValidConditions(),
 					},
 					"listener-2": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-2"),
+						Name:           gatewayapi_v1.SectionName("listener-2"),
 						AttachedRoutes: int32(1),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
@@ -7220,58 +7220,58 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "two HTTP listeners, route's hostname intersects with neither of them", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.randomdomain.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.randomdomain.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 					{
 						Name:     "listener-2",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("specific.hostname.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("specific.hostname.io")),
 					},
 				},
 			},
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7298,32 +7298,32 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: status.MessageValidGateway,
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(1),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
 						Conditions: listenerValidConditions(),
 					},
 					"listener-2": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-2"),
+						Name:           gatewayapi_v1.SectionName("listener-2"),
 						AttachedRoutes: int32(1),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
@@ -7337,47 +7337,47 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTP listener, route's parent ref sectionname does not match", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 0)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 0)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 				},
 			},
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 0),
 					Conditions: []meta_v1.Condition{
@@ -7404,17 +7404,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: status.MessageValidGateway,
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(0),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
@@ -7428,47 +7428,47 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTP listener, route's parent ref port does not match", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "", 443)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "", 443)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 				},
 			},
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "", 443),
 					Conditions: []meta_v1.Condition{
@@ -7495,17 +7495,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: status.MessageValidGateway,
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(0),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
@@ -7519,72 +7519,72 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTP listener, route's parent ref section name and port both must match", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 80)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 80)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic-2",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 443)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 443)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic-3",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 				},
 			},
@@ -7592,7 +7592,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteStatusUpdate{
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "nonexistent", 80),
 						Conditions: []meta_v1.Condition{
@@ -7609,7 +7609,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic-2"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 443),
 						Conditions: []meta_v1.Condition{
@@ -7626,7 +7626,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic-3"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80),
 						Conditions: []meta_v1.Condition{
@@ -7649,17 +7649,17 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: status.MessageValidGateway,
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(1),
-						SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+						SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "HTTPRoute",
 							},
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+								Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 								Kind:  "GRPCRoute",
 							},
 						},
@@ -7673,40 +7673,40 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTPRoute: backendrefs still validated when route not accepted", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 81)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 81)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("invalid", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromAll),
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 				},
 			},
@@ -7714,7 +7714,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantRouteConditions: []*status.RouteStatusUpdate{
 			{
 				FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-				RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 					{
 						ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 81),
 						Conditions: []meta_v1.Condition{
@@ -7743,30 +7743,30 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			kuardService,
 			kuardService2,
 			kuardService3,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{
 							{
 								Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 								},
 							}, {
 								Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
 								},
 							},
@@ -7777,7 +7777,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7794,28 +7794,28 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []any{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
-									Group: ref.To(gatewayapi_v1beta1.Group("")),
-									Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
-									Port:  ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1.BackendObjectReference{
+									Group: ref.To(gatewayapi_v1.Group("")),
+									Kind:  ref.To(gatewayapi_v1.Kind("Service")),
+									Port:  ref.To(gatewayapi_v1.PortNumber(8080)),
 								},
 							},
 						}},
@@ -7825,7 +7825,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7843,28 +7843,28 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []any{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
-									Group: ref.To(gatewayapi_v1beta1.Group("")),
-									Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
-									Name:  gatewayapi_v1beta1.ObjectName("kuard2"),
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1.BackendObjectReference{
+									Group: ref.To(gatewayapi_v1.Group("")),
+									Kind:  ref.To(gatewayapi_v1.Kind("Service")),
+									Name:  gatewayapi_v1.ObjectName("kuard2"),
 								},
 							},
 						}},
@@ -7874,7 +7874,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7892,21 +7892,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []any{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/"),
 							},
@@ -7914,21 +7914,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("invalid-one", 8080),
 							},
 						}},
 					}, {
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard2", 8080, 1),
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{{
-							Path: &gatewayapi_v1beta1.HTTPPathMatch{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{{
+							Path: &gatewayapi_v1.HTTPPathMatch{
 								Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 								Value: ref.To("/blog"),
 							},
 						}},
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 								BackendRef: gatewayapi.ServiceBackendObjectRef("invalid-two", 8080),
 							},
 						}},
@@ -7938,7 +7938,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -7958,30 +7958,30 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		objs: []any{
 			kuardService,
 			kuardService2,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
-									Group:     ref.To(gatewayapi_v1beta1.Group("")),
-									Kind:      ref.To(gatewayapi_v1beta1.Kind("Service")),
-									Namespace: ref.To(gatewayapi_v1beta1.Namespace("some-other-namespace")),
-									Name:      gatewayapi_v1beta1.ObjectName("kuard2"),
-									Port:      ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1.BackendObjectReference{
+									Group:     ref.To(gatewayapi_v1.Group("")),
+									Kind:      ref.To(gatewayapi_v1.Kind("Service")),
+									Namespace: ref.To(gatewayapi_v1.Namespace("some-other-namespace")),
+									Name:      gatewayapi_v1.ObjectName("kuard2"),
+									Port:      ref.To(gatewayapi_v1.PortNumber(8080)),
 								},
 							},
 						}},
@@ -7991,7 +7991,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8010,23 +8010,23 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTPRouteFilterRequestMirror not yet supported for httproute backendref", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
 								Filters: []gatewayapi_v1.HTTPRouteFilter{{
@@ -8040,7 +8040,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8057,25 +8057,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTPRouteFilterURLRewrite with custom HTTPPathModifierType is not supported", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterURLRewrite,
-							URLRewrite: &gatewayapi_v1beta1.HTTPURLRewriteFilter{
-								Path: &gatewayapi_v1beta1.HTTPPathModifier{
+							URLRewrite: &gatewayapi_v1.HTTPURLRewriteFilter{
+								Path: &gatewayapi_v1.HTTPPathModifier{
 									Type: "custom",
 								},
 							},
@@ -8086,7 +8086,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8103,25 +8103,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid RequestHeaderModifier due to duplicated headers", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom", Value: "duplicated"},
 									{Name: "Custom", Value: "duplicated"},
 								},
@@ -8133,7 +8133,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8150,29 +8150,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid RequestHeaderModifier after forward due to invalid headers", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
 								Filters: []gatewayapi_v1.HTTPRouteFilter{{
 									Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-									RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: "!invalid-header", Value: "foo"},
 										},
 									},
@@ -8185,7 +8185,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8204,25 +8204,25 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid ResponseHeaderModifier due to duplicated headers", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
 							Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom", Value: "duplicated"},
 									{Name: "Custom", Value: "duplicated"},
 								},
@@ -8234,7 +8234,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8251,29 +8251,29 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "Invalid ResponseHeaderModifier on backend due to invalid headers", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
 								Filters: []gatewayapi_v1.HTTPRouteFilter{{
 									Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: "!invalid-header", Value: "foo"},
 										},
 									},
@@ -8286,7 +8286,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8305,19 +8305,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "custom filter type is not supported", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1.HTTPRouteFilter{{
@@ -8329,7 +8329,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -8345,21 +8345,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "gateway.spec.addresses results in invalid gateway", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Addresses: []gatewayapi_v1beta1.GatewayAddress{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Addresses: []gatewayapi_v1.GatewayAddress{{
 					Value: "1.2.3.4",
 				}},
-				Listeners: []gatewayapi_v1beta1.Listener{{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8377,16 +8377,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "None of the addresses in Spec.Addresses have been assigned to the Gateway",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name: "http",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -8398,24 +8398,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "invalid allowedroutes API group results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Kinds: []gatewayapi_v1.RouteGroupKind{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group("invalid-group")),
+								Group: ref.To(gatewayapi_v1.Group("invalid-group")),
 								Kind:  "HTTPRoute",
 							},
 						},
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8433,7 +8433,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name:           "http",
 					SupportedKinds: nil,
@@ -8459,21 +8459,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "invalid allowedroutes API kind results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Kinds: []gatewayapi_v1.RouteGroupKind{
 							{Kind: "FooRoute"},
 						},
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8491,7 +8491,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name:           "http",
 					SupportedKinds: nil,
@@ -8517,21 +8517,21 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "allowedroute of TLSRoute on a non-TLS listener results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Kinds: []gatewayapi_v1.RouteGroupKind{
 							{Kind: "TLSRoute"},
 						},
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8549,7 +8549,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name:           "http",
 					SupportedKinds: nil,
@@ -8575,26 +8575,26 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "TLS certificate ref to a non-secret on an HTTPS listener results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							{
-								Group: ref.To(gatewayapi_v1beta1.Group("invalid-group")),
-								Kind:  ref.To(gatewayapi_v1beta1.Kind("NotASecret")),
+								Group: ref.To(gatewayapi_v1.Group("invalid-group")),
+								Kind:  ref.To(gatewayapi_v1.Kind("NotASecret")),
 								Name:  "foo",
 							},
 						},
@@ -8613,16 +8613,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -8648,23 +8648,23 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "nonexistent TLS certificate ref on an HTTPS listener results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("nonexistent-secret", "projectcontour"),
 						},
 					},
@@ -8682,16 +8682,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -8717,18 +8717,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "invalid listener protocol results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: "invalid",
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8746,7 +8746,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name:           "http",
 					SupportedKinds: nil,
@@ -8772,18 +8772,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "HTTPS listener without TLS defined results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8801,16 +8801,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -8831,18 +8831,18 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "TLS listener without TLS defined results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "tls",
 					Port:     443,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -8860,16 +8860,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"tls": {
 					Name: "tls",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TLSRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TCPRoute",
 						},
 					},
@@ -8890,24 +8890,24 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "TLS Passthrough listener with a TLS certificate ref defined results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "tls",
 					Port:     443,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("tlscert", "projectcontour"),
 						},
 					},
@@ -8925,16 +8925,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"tls": {
 					Name: "tls",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TLSRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TCPRoute",
 						},
 					},
@@ -8955,22 +8955,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "TLS listener with TLS.Mode=Terminate without a certificate ref results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "tls",
 					Port:     443,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
 					},
 				}},
@@ -8987,16 +8987,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"tls": {
 					Name: "tls",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TLSRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TCPRoute",
 						},
 					},
@@ -9017,22 +9017,22 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "HTTPS listener with TLS.Mode=Passthrough results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 					},
 				}},
@@ -9049,16 +9049,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"https": {
 					Name: "https",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -9079,19 +9079,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "Listener with FromNamespaces=Selector, no selector specified", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "http",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From:     ref.To(gatewayapi_v1.NamespacesFromSelector),
 								Selector: nil,
 							},
@@ -9111,16 +9111,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name: "http",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -9141,19 +9141,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "Listener with FromNamespaces=Selector, invalid selector (can't specify values with Exists operator)", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "http",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From: ref.To(gatewayapi_v1.NamespacesFromSelector),
 								Selector: &meta_v1.LabelSelector{
 									MatchExpressions: []meta_v1.LabelSelectorRequirement{{
@@ -9179,16 +9179,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name: "http",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -9209,19 +9209,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 	run(t, "Listener with FromNamespaces=Selector, invalid selector (must specify MatchLabels and/or MatchExpressions)", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "http",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Namespaces: &gatewayapi_v1.RouteNamespaces{
 								From:     ref.To(gatewayapi_v1.NamespacesFromSelector),
 								Selector: &meta_v1.LabelSelector{},
 							},
@@ -9241,16 +9241,16 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name: "http",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "HTTPRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "GRPCRoute",
 						},
 					},
@@ -9272,19 +9272,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "service with supported app protocol: h2c", testcase{
 		objs: []any{
 			kuardService4,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard4", 8080, 1),
@@ -9295,7 +9295,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9311,19 +9311,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "service with unsupported app protocol: wss", testcase{
 		objs: []any{
 			kuardService5,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard5", 8444, 1),
@@ -9334,7 +9334,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9350,54 +9350,54 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "HTTP listener with invalid AllowedRoute kind referenced by route parent ref", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80)},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80)},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{"foo.projectcontour.io"},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Hostnames: []gatewayapi_v1.Hostname{"foo.projectcontour.io"},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
 			},
 		},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{
 					{
 						Name:     "listener-1",
 						Port:     80,
 						Protocol: gatewayapi_v1.HTTPProtocolType,
-						AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-							Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+						AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+							Kinds: []gatewayapi_v1.RouteGroupKind{
 								{Kind: "FooRoute"},
 							},
 						},
-						Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+						Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 					},
 				},
 			},
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "listener-1", 80),
 					Conditions: []meta_v1.Condition{
 						{
 							Type:    string(gatewayapi_v1.RouteConditionAccepted),
 							Status:  contour_v1.ConditionFalse,
-							Reason:  string(gatewayapi_v1beta1.RouteReasonNotAllowedByListeners),
+							Reason:  string(gatewayapi_v1.RouteReasonNotAllowedByListeners),
 							Message: "No listeners included by this parent ref allowed this attachment.",
 						},
 						routeResolvedRefsCondition(),
@@ -9417,9 +9417,9 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Message: "Listeners are not valid",
 					},
 				},
-				ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+				ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 					"listener-1": {
-						Name:           gatewayapi_v1beta1.SectionName("listener-1"),
+						Name:           gatewayapi_v1.SectionName("listener-1"),
 						AttachedRoutes: int32(0),
 						Conditions: []meta_v1.Condition{
 							{
@@ -9445,19 +9445,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "route rule with timeouts.request and timeouts.backendRequest specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -9473,7 +9473,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9490,19 +9490,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "route rule with only timeouts.backendRequest specified", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
@@ -9516,7 +9516,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9532,19 +9532,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 	run(t, "timeouts with invalid request for httproute", testcase{
 		objs: []any{
 			kuardService,
-			&gatewayapi_v1beta1.HTTPRoute{
+			&gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "basic",
 					Namespace: "default",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 						Timeouts: &gatewayapi_v1.HTTPRouteTimeouts{
 							Request: ref.To(gatewayapi_v1.Duration("invalid")),
@@ -9555,7 +9555,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9572,7 +9572,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 	type testcase struct {
 		objs                    []any
-		gateway                 *gatewayapi_v1beta1.Gateway
+		gateway                 *gatewayapi_v1.Gateway
 		wantRouteConditions     []*status.RouteStatusUpdate
 		wantGatewayStatusUpdate []*status.GatewayStatusUpdate
 	}
@@ -9586,15 +9586,15 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
 					gateway:        tc.gateway,
-					gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+					gatewayclass: &gatewayapi_v1.GatewayClass{
 						TypeMeta: meta_v1.TypeMeta{},
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name: "test-gc",
 						},
-						Spec: gatewayapi_v1beta1.GatewayClassSpec{
+						Spec: gatewayapi_v1.GatewayClassSpec{
 							ControllerName: "projectcontour.io/contour",
 						},
-						Status: gatewayapi_v1beta1.GatewayClassStatus{
+						Status: gatewayapi_v1.GatewayClassStatus{
 							Conditions: []meta_v1.Condition{
 								{
 									Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -9661,21 +9661,21 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		})
 	}
 
-	gw := &gatewayapi_v1beta1.Gateway{
+	gw := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "tls-passthrough",
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -9713,8 +9713,8 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 						BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 							{
 								BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-									Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
-									Port: ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+									Kind: ref.To(gatewayapi_v1.Kind("Service")),
+									Port: ref.To(gatewayapi_v1.PortNumber(8080)),
 								},
 							},
 						},
@@ -9724,7 +9724,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9766,7 +9766,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9806,7 +9806,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 						BackendRefs: []gatewayapi_v1alpha2.BackendRef{
 							{
 								BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-									Kind: ref.To(gatewayapi_v1beta1.Kind("Service")),
+									Kind: ref.To(gatewayapi_v1.Kind("Service")),
 									Name: "kuard",
 								},
 							},
@@ -9817,7 +9817,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9859,7 +9859,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9901,7 +9901,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9945,7 +9945,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -9989,7 +9989,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10031,7 +10031,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10080,7 +10080,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef(gw.Namespace, gw.Name, "tls-passthrough", 444),
 					Conditions: []meta_v1.Condition{
@@ -10104,21 +10104,21 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 	})
 
 	run(t, "TLS Listener with invalid TLS mode", testcase{
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "tls",
 					Port:     443,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeType("invalid-mode")),
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -10147,7 +10147,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef(gw.Namespace, gw.Name, "tls", 443),
 					Conditions: []meta_v1.Condition{
@@ -10173,16 +10173,16 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"tls": {
 					Name: "tls",
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TLSRoute",
 						},
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 							Kind:  "TCPRoute",
 						},
 					},
@@ -10206,7 +10206,7 @@ func TestGatewayAPITLSRouteDAGStatus(t *testing.T) {
 func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 	type testcase struct {
 		objs                    []any
-		gateway                 *gatewayapi_v1beta1.Gateway
+		gateway                 *gatewayapi_v1.Gateway
 		wantRouteConditions     []*status.RouteStatusUpdate
 		wantGatewayStatusUpdate []*status.GatewayStatusUpdate
 	}
@@ -10219,15 +10219,15 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
-					gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+					gatewayclass: &gatewayapi_v1.GatewayClass{
 						TypeMeta: meta_v1.TypeMeta{},
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name: "test-gc",
 						},
-						Spec: gatewayapi_v1beta1.GatewayClassSpec{
+						Spec: gatewayapi_v1.GatewayClassSpec{
 							ControllerName: "projectcontour.io/contour",
 						},
-						Status: gatewayapi_v1beta1.GatewayClassStatus{
+						Status: gatewayapi_v1.GatewayClassStatus{
 							Conditions: []meta_v1.Condition{
 								{
 									Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -10252,18 +10252,18 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 
 			// Set a default gateway if not defined by a test
 			if tc.gateway == nil {
-				builder.Source.gateway = &gatewayapi_v1beta1.Gateway{
+				builder.Source.gateway = &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
 							Name:     "http",
 							Port:     80,
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -10356,10 +10356,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10373,7 +10373,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10395,10 +10395,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10413,7 +10413,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10440,10 +10440,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10457,7 +10457,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10484,10 +10484,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10501,7 +10501,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10528,10 +10528,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10543,7 +10543,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 							},
 							Headers: []gatewayapi_v1alpha2.GRPCHeaderMatch{
 								{
-									Type:  ref.To(gatewayapi_v1beta1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
+									Type:  ref.To(gatewayapi_v1.HeaderMatchType("UNKNOWN")), // <---- unknown type to break the test
 									Name:  gatewayapi_v1alpha2.GRPCHeaderName("foo"),
 									Value: "bar",
 								},
@@ -10556,7 +10556,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10583,10 +10583,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10611,7 +10611,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10638,10 +10638,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10651,8 +10651,8 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{{
 							Type: gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier,
-							RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Set: []gatewayapi_v1beta1.HTTPHeader{
+							RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Set: []gatewayapi_v1.HTTPHeader{
 									{Name: "custom", Value: "duplicated"},
 									{Name: "Custom", Value: "duplicated"},
 								},
@@ -10664,7 +10664,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10687,10 +10687,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10700,8 +10700,8 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{{
 							Type: gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier,
-							ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-								Add: []gatewayapi_v1beta1.HTTPHeader{
+							ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+								Add: []gatewayapi_v1.HTTPHeader{
 									{Name: "!invalid-header", Value: "foo"},
 								},
 							},
@@ -10712,7 +10712,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10739,10 +10739,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10753,12 +10753,12 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{
 							{
 								Type: gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard2", 8080),
 								},
 							}, {
 								Type: gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror,
-								RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
+								RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
 									BackendRef: gatewayapi.ServiceBackendObjectRef("kuard3", 8080),
 								},
 							},
@@ -10769,7 +10769,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10792,10 +10792,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10805,11 +10805,11 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						BackendRefs: gatewayapi.GRPCRouteBackendRef("kuard", 8080, 1),
 						Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{{
 							Type: gatewayapi_v1alpha2.GRPCRouteFilterRequestMirror,
-							RequestMirror: &gatewayapi_v1beta1.HTTPRequestMirrorFilter{
-								BackendRef: gatewayapi_v1beta1.BackendObjectReference{
-									Group: ref.To(gatewayapi_v1beta1.Group("")),
-									Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
-									Port:  ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+							RequestMirror: &gatewayapi_v1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayapi_v1.BackendObjectReference{
+									Group: ref.To(gatewayapi_v1.Group("")),
+									Kind:  ref.To(gatewayapi_v1.Kind("Service")),
+									Port:  ref.To(gatewayapi_v1.PortNumber(8080)),
 								},
 							},
 						}},
@@ -10819,7 +10819,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10842,10 +10842,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10862,7 +10862,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10890,10 +10890,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{
@@ -10909,7 +10909,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -10931,13 +10931,13 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
 						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 							// Wrong port.
 							gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http", 900),
 						},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -10951,7 +10951,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http", 900),
 					Conditions: []meta_v1.Condition{
@@ -10983,10 +10983,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{
@@ -10996,13 +10996,13 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 							}},
 							BackendRefs: []gatewayapi_v1alpha2.GRPCBackendRef{
 								{
-									BackendRef: gatewayapi_v1beta1.BackendRef{
+									BackendRef: gatewayapi_v1.BackendRef{
 										BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 									},
 									Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{{
 										Type: gatewayapi_v1alpha2.GRPCRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Set: []gatewayapi_v1beta1.HTTPHeader{
+										RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+											Set: []gatewayapi_v1.HTTPHeader{
 												{Name: "custom", Value: "duplicated"},
 												{Name: "Custom", Value: "duplicated"},
 											},
@@ -11017,7 +11017,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -11040,10 +11040,10 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
-					Hostnames: []gatewayapi_v1beta1.Hostname{
+					Hostnames: []gatewayapi_v1.Hostname{
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1alpha2.GRPCRouteRule{{
@@ -11052,13 +11052,13 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 						}},
 						BackendRefs: []gatewayapi_v1alpha2.GRPCBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("kuard", 8080),
 								},
 								Filters: []gatewayapi_v1alpha2.GRPCRouteFilter{{
 									Type: gatewayapi_v1alpha2.GRPCRouteFilterResponseHeaderModifier,
-									ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-										Set: []gatewayapi_v1beta1.HTTPHeader{
+									ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+										Set: []gatewayapi_v1.HTTPHeader{
 											{Name: "!invalid-header", Value: "foo"},
 										},
 									},
@@ -11071,7 +11071,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -11091,7 +11091,7 @@ func TestGatewayAPIGRPCRouteDAGStatus(t *testing.T) {
 func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 	type testcase struct {
 		objs                    []any
-		gateway                 *gatewayapi_v1beta1.Gateway
+		gateway                 *gatewayapi_v1.Gateway
 		wantRouteConditions     []*status.RouteStatusUpdate
 		wantGatewayStatusUpdate []*status.GatewayStatusUpdate
 	}
@@ -11104,15 +11104,15 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
-					gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+					gatewayclass: &gatewayapi_v1.GatewayClass{
 						TypeMeta: meta_v1.TypeMeta{},
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name: "test-gc",
 						},
-						Spec: gatewayapi_v1beta1.GatewayClassSpec{
+						Spec: gatewayapi_v1.GatewayClassSpec{
 							ControllerName: "projectcontour.io/contour",
 						},
-						Status: gatewayapi_v1beta1.GatewayClassStatus{
+						Status: gatewayapi_v1.GatewayClassStatus{
 							Conditions: []meta_v1.Condition{
 								{
 									Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -11137,18 +11137,18 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 
 			// Set a default gateway if not defined by a test
 			if tc.gateway == nil {
-				builder.Source.gateway = &gatewayapi_v1beta1.Gateway{
+				builder.Source.gateway = &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
 							Name:     "tcp",
 							Port:     10000,
 							Protocol: gatewayapi_v1.TCPProtocolType,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},
@@ -11224,21 +11224,21 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 
 	run(t, "allowedroute of TCPRoute on a non-TCP listener results in a listener condition", testcase{
 		objs: []any{},
-		gateway: &gatewayapi_v1beta1.Gateway{
+		gateway: &gatewayapi_v1.Gateway{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:      "contour",
 				Namespace: "projectcontour",
 			},
-			Spec: gatewayapi_v1beta1.GatewaySpec{
-				Listeners: []gatewayapi_v1beta1.Listener{{
+			Spec: gatewayapi_v1.GatewaySpec{
+				Listeners: []gatewayapi_v1.Listener{{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Kinds: []gatewayapi_v1.RouteGroupKind{
 							{Kind: "TCPRoute"},
 						},
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -11256,7 +11256,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 					Message: "Listeners are not valid",
 				},
 			},
-			ListenerStatus: map[string]*gatewayapi_v1beta1.ListenerStatus{
+			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				"http": {
 					Name:           "http",
 					SupportedKinds: nil,
@@ -11290,8 +11290,8 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
 					Rules: []gatewayapi_v1alpha2.TCPRouteRule{
 						{
@@ -11306,7 +11306,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -11332,8 +11332,8 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
 					Rules: []gatewayapi_v1alpha2.TCPRouteRule{
 						{},
@@ -11343,7 +11343,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -11364,8 +11364,8 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
 					},
 					Rules: []gatewayapi_v1alpha2.TCPRouteRule{
 						{
@@ -11377,7 +11377,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 		},
 		wantRouteConditions: []*status.RouteStatusUpdate{{
 			FullName: types.NamespacedName{Namespace: "default", Name: "basic"},
-			RouteParentStatuses: []*gatewayapi_v1beta1.RouteParentStatus{
+			RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
 				{
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
@@ -11394,7 +11394,7 @@ func TestGatewayAPITCPRouteDAGStatus(t *testing.T) {
 func TestGatewayAPIBackendTLSPolicyDAGStatus(t *testing.T) {
 	type testcase struct {
 		objs                           []any
-		gateway                        *gatewayapi_v1beta1.Gateway
+		gateway                        *gatewayapi_v1.Gateway
 		wantBackendTLSPolicyConditions []*status.BackendTLSPolicyStatusUpdate
 	}
 
@@ -11406,15 +11406,15 @@ func TestGatewayAPIBackendTLSPolicyDAGStatus(t *testing.T) {
 				Source: KubernetesCache{
 					RootNamespaces: []string{"roots", "marketing"},
 					FieldLogger:    fixture.NewTestLogger(t),
-					gatewayclass: &gatewayapi_v1beta1.GatewayClass{
+					gatewayclass: &gatewayapi_v1.GatewayClass{
 						TypeMeta: meta_v1.TypeMeta{},
 						ObjectMeta: meta_v1.ObjectMeta{
 							Name: "test-gc",
 						},
-						Spec: gatewayapi_v1beta1.GatewayClassSpec{
+						Spec: gatewayapi_v1.GatewayClassSpec{
 							ControllerName: "projectcontour.io/contour",
 						},
-						Status: gatewayapi_v1beta1.GatewayClassStatus{
+						Status: gatewayapi_v1.GatewayClassStatus{
 							Conditions: []meta_v1.Condition{
 								{
 									Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -11439,18 +11439,18 @@ func TestGatewayAPIBackendTLSPolicyDAGStatus(t *testing.T) {
 
 			// Set a default gateway if not defined by a test
 			if tc.gateway == nil {
-				builder.Source.gateway = &gatewayapi_v1beta1.Gateway{
+				builder.Source.gateway = &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Name:      "contour",
 						Namespace: "projectcontour",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
-						Listeners: []gatewayapi_v1beta1.Listener{{
+					Spec: gatewayapi_v1.GatewaySpec{
+						Listeners: []gatewayapi_v1.Listener{{
 							Name:     "http",
 							Port:     80,
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
 								},
 							},

--- a/internal/featuretests/v3/cluster_test.go
+++ b/internal/featuretests/v3/cluster_test.go
@@ -26,7 +26,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -691,14 +690,14 @@ func TestClusterCircuitbreakerAnnotationsGateway(t *testing.T) {
 		Annotate("projectcontour.io/max-retries", "7").
 		WithPorts(core_v1.ServicePort{Port: 80, TargetPort: intstr.FromString("8080")})
 
-	gc := &gatewayapi_v1beta1.GatewayClass{
+	gc := &gatewayapi_v1.GatewayClass{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "contour",
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -708,20 +707,20 @@ func TestClusterCircuitbreakerAnnotationsGateway(t *testing.T) {
 		},
 	}
 
-	gt := &gatewayapi_v1beta1.Gateway{
+	gt := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(gc.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(gc.Name),
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -732,21 +731,21 @@ func TestClusterCircuitbreakerAnnotationsGateway(t *testing.T) {
 	rh.OnAdd(gc)
 	rh.OnAdd(gt)
 
-	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
+	rh.OnAdd(&gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+			Rules: []gatewayapi_v1.HTTPRouteRule{
 				{
 					Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 					BackendRefs: gatewayapi.HTTPBackendRef("kuard", 80, 1),

--- a/internal/featuretests/v3/httproute_test.go
+++ b/internal/featuretests/v3/httproute_test.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
@@ -33,14 +32,14 @@ import (
 )
 
 var (
-	gc = &gatewayapi_v1beta1.GatewayClass{
+	gc = &gatewayapi_v1.GatewayClass{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "contour",
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -50,20 +49,20 @@ var (
 		},
 	}
 
-	gateway = &gatewayapi_v1beta1.Gateway{
+	gateway = &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(gc.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(gc.Name),
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -72,14 +71,14 @@ var (
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("tlscert", ""),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -109,21 +108,21 @@ func TestGateway_TLS(t *testing.T) {
 
 	rh.OnAdd(gateway)
 
-	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
+	rh.OnAdd(&gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc2", 80, 1),
 			}, {

--- a/internal/featuretests/v3/listeners_test.go
+++ b/internal/featuretests/v3/listeners_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -1285,20 +1284,20 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 
 	rh.OnAdd(gc)
 
-	rh.OnAdd(&gatewayapi_v1beta1.Gateway{
+	rh.OnAdd(&gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(gc.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(gc.Name),
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "http",
 					Port:     80,
 					Protocol: gatewayapi_v1.HTTPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -1307,14 +1306,14 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 					Name:     "https",
 					Port:     443,
 					Protocol: gatewayapi_v1.HTTPSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("tlscert", ""),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -1323,11 +1322,11 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 					Name:     "tls",
 					Port:     8443,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -1336,8 +1335,8 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 					Name:     "tcp",
 					Port:     27017,
 					Protocol: gatewayapi_v1.TCPProtocolType,
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -1346,22 +1345,22 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 		},
 	})
 
-	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
+	rh.OnAdd(&gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "basic",
 			Namespace: "default",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http", 0),
 					gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "https", 0),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc1", 80, 10),
 			}},
@@ -1386,8 +1385,8 @@ func TestGatewayListenersSetAddress(t *testing.T) {
 	rh.OnAdd(&gatewayapi_v1alpha2.TCPRoute{
 		ObjectMeta: fixture.ObjectMeta("tcproute-1"),
 		Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "tcp", 0),
 				},
 			},

--- a/internal/featuretests/v3/routesourcemetadata_test.go
+++ b/internal/featuretests/v3/routesourcemetadata_test.go
@@ -25,7 +25,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/dag"
@@ -153,21 +152,21 @@ func TestRouteSourceMetadataIsSet(t *testing.T) {
 	// Test a Gateway API HTTPRoute route gets it source metadata set correctly.
 	rh.OnAdd(gc)
 	rh.OnAdd(gateway)
-	httpRoute := &gatewayapi_v1beta1.HTTPRoute{
+	httpRoute := &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "httproute-kuard",
 			Namespace: "default",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayListenerParentRef("projectcontour", "contour", "http", 80),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"gatewayapi.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("kuard", 80, 1),
 			}},

--- a/internal/featuretests/v3/routeweight_test.go
+++ b/internal/featuretests/v3/routeweight_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
@@ -342,13 +341,13 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 	rh.OnAdd(fixture.NewService("svc2").
 		WithPorts(core_v1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)}))
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -358,17 +357,17 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 		},
 	})
 
-	rh.OnAdd(&gatewayapi_v1beta1.Gateway{
+	rh.OnAdd(&gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -377,21 +376,21 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 	})
 
 	// HTTPRoute with a single weight.
-	route1 := &gatewayapi_v1beta1.HTTPRoute{
+	route1 := &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
 			"app":  "contour",
 			"type": "controller",
 		}),
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRef("svc1", 80, 1),
 			}},
@@ -410,21 +409,21 @@ func TestHTTPRoute_RouteWithAServiceWeight(t *testing.T) {
 	})
 
 	// HTTPRoute with multiple weights.
-	route2 := &gatewayapi_v1beta1.HTTPRoute{
+	route2 := &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: fixture.ObjectMetaWithAnnotations("basic", map[string]string{
 			"app":  "contour",
 			"type": "controller",
 		}),
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/blog"),
 				BackendRefs: gatewayapi.HTTPBackendRefs(
 					gatewayapi.HTTPBackendRef("svc1", 80, 60),
@@ -459,13 +458,13 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 	rh.OnAdd(fixture.NewService("svc2").
 		WithPorts(core_v1.ServicePort{Port: 443, TargetPort: intstr.FromInt(8443)}))
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -475,20 +474,20 @@ func TestTLSRoute_RouteWithAServiceWeight(t *testing.T) {
 		},
 	})
 
-	rh.OnAdd(&gatewayapi_v1beta1.Gateway{
+	rh.OnAdd(&gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},

--- a/internal/featuretests/v3/tcproute_test.go
+++ b/internal/featuretests/v3/tcproute_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
@@ -46,13 +45,13 @@ func TestTCPRoute(t *testing.T) {
 	rh.OnAdd(svc1)
 	rh.OnAdd(svc2)
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -62,15 +61,15 @@ func TestTCPRoute(t *testing.T) {
 		},
 	})
 
-	gateway := &gatewayapi_v1beta1.Gateway{
+	gateway := &gatewayapi_v1.Gateway{
 		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "tcp-1",
 				Port:     10000,
 				Protocol: gatewayapi_v1.TCPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -82,12 +81,12 @@ func TestTCPRoute(t *testing.T) {
 	route1 := &gatewayapi_v1alpha2.TCPRoute{
 		ObjectMeta: fixture.ObjectMeta("tcproute-1"),
 		Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					{
-						Namespace:   ref.To(gatewayapi_v1beta1.Namespace("projectcontour")),
-						Name:        gatewayapi_v1beta1.ObjectName("contour"),
-						SectionName: ref.To(gatewayapi_v1beta1.SectionName("tcp-1")),
+						Namespace:   ref.To(gatewayapi_v1.Namespace("projectcontour")),
+						Name:        gatewayapi_v1.ObjectName("contour"),
+						SectionName: ref.To(gatewayapi_v1.SectionName("tcp-1")),
 					},
 				},
 			},
@@ -118,12 +117,12 @@ func TestTCPRoute(t *testing.T) {
 	// check that there is no route config
 	require.Empty(t, c.Request(routeType).Resources)
 
-	gateway.Spec.Listeners = append(gateway.Spec.Listeners, gatewayapi_v1beta1.Listener{
+	gateway.Spec.Listeners = append(gateway.Spec.Listeners, gatewayapi_v1.Listener{
 		Name:     "tcp-2",
 		Port:     10001,
 		Protocol: gatewayapi_v1.TCPProtocolType,
-		AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-			Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+		AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+			Namespaces: &gatewayapi_v1.RouteNamespaces{
 				From: ref.To(gatewayapi_v1.NamespacesFromAll),
 			},
 		},
@@ -136,9 +135,9 @@ func TestTCPRoute(t *testing.T) {
 			CommonRouteSpec: gatewayapi_v1alpha2.CommonRouteSpec{
 				ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 					{
-						Namespace:   ref.To(gatewayapi_v1beta1.Namespace("projectcontour")),
-						Name:        gatewayapi_v1beta1.ObjectName("contour"),
-						SectionName: ref.To(gatewayapi_v1beta1.SectionName("tcp-2")),
+						Namespace:   ref.To(gatewayapi_v1.Namespace("projectcontour")),
+						Name:        gatewayapi_v1.ObjectName("contour"),
+						SectionName: ref.To(gatewayapi_v1.SectionName("tcp-2")),
 					},
 				},
 			},
@@ -192,13 +191,13 @@ func TestTCPRoute_TLSTermination(t *testing.T) {
 	sec1 := featuretests.TLSSecret(t, "projectcontour/tlscert", &featuretests.ServerCertificate)
 	rh.OnAdd(sec1)
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -208,22 +207,22 @@ func TestTCPRoute_TLSTermination(t *testing.T) {
 		},
 	})
 
-	gateway := &gatewayapi_v1beta1.Gateway{
+	gateway := &gatewayapi_v1.Gateway{
 		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "tls",
 					Port:     5000,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("tlscert", ""),
 						},
 					},
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -236,12 +235,12 @@ func TestTCPRoute_TLSTermination(t *testing.T) {
 	route1 := &gatewayapi_v1alpha2.TCPRoute{
 		ObjectMeta: fixture.ObjectMeta("tcproute-1"),
 		Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					{
-						Namespace:   ref.To(gatewayapi_v1beta1.Namespace("projectcontour")),
-						Name:        gatewayapi_v1beta1.ObjectName("contour"),
-						SectionName: ref.To(gatewayapi_v1beta1.SectionName("tls")),
+						Namespace:   ref.To(gatewayapi_v1.Namespace("projectcontour")),
+						Name:        gatewayapi_v1.ObjectName("contour"),
+						SectionName: ref.To(gatewayapi_v1.SectionName("tls")),
 					},
 				},
 			},

--- a/internal/featuretests/v3/tlsroute_test.go
+++ b/internal/featuretests/v3/tlsroute_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	envoy_v3 "github.com/projectcontour/contour/internal/envoy/v3"
 	"github.com/projectcontour/contour/internal/featuretests"
@@ -46,13 +45,13 @@ func TestTLSRoute_TLSPassthrough(t *testing.T) {
 	rh.OnAdd(svc)
 	rh.OnAdd(svcAnother)
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -62,17 +61,17 @@ func TestTLSRoute_TLSPassthrough(t *testing.T) {
 		},
 	})
 
-	gatewayPassthrough := &gatewayapi_v1beta1.Gateway{
+	gatewayPassthrough := &gatewayapi_v1.Gateway{
 		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Port:     443,
 				Protocol: gatewayapi_v1.TLSProtocolType,
-				TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+				TLS: &gatewayapi_v1.GatewayTLSConfig{
 					Mode: ref.To(gatewayapi_v1.TLSModePassthrough),
 				},
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -258,27 +257,27 @@ func TestTLSRoute_TLSTermination(t *testing.T) {
 
 	rh.OnAdd(gc)
 
-	gateway := &gatewayapi_v1beta1.Gateway{
+	gateway := &gatewayapi_v1.Gateway{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "contour",
 			Namespace: "projectcontour",
 		},
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			GatewayClassName: gatewayapi_v1beta1.ObjectName(gc.Name),
-			Listeners: []gatewayapi_v1beta1.Listener{
+		Spec: gatewayapi_v1.GatewaySpec{
+			GatewayClassName: gatewayapi_v1.ObjectName(gc.Name),
+			Listeners: []gatewayapi_v1.Listener{
 				{
 					Name:     "tls",
 					Port:     5000,
 					Protocol: gatewayapi_v1.TLSProtocolType,
-					TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+					TLS: &gatewayapi_v1.GatewayTLSConfig{
 						Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-						CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+						CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 							gatewayapi.CertificateRef("tlscert", ""),
 						},
 					},
-					Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
-					AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-						Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+					Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
+					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+						Namespaces: &gatewayapi_v1.RouteNamespaces{
 							From: ref.To(gatewayapi_v1.NamespacesFromAll),
 						},
 					},
@@ -295,12 +294,12 @@ func TestTLSRoute_TLSTermination(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test1.projectcontour.io",
 			},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{
@@ -332,12 +331,12 @@ func TestTLSRoute_TLSTermination(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: gatewayapi_v1alpha2.TLSRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test2.projectcontour.io",
 			},
 			Rules: []gatewayapi_v1alpha2.TLSRouteRule{{

--- a/internal/featuretests/v3/upstreamtls_test.go
+++ b/internal/featuretests/v3/upstreamtls_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -245,13 +244,13 @@ func TestUpstreamTLSWithHTTPRoute(t *testing.T) {
 	rh.OnAdd(sec1)
 	rh.OnAdd(sec2)
 
-	rh.OnAdd(&gatewayapi_v1beta1.GatewayClass{
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
 		TypeMeta:   meta_v1.TypeMeta{},
 		ObjectMeta: fixture.ObjectMeta("test-gc"),
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
+		Spec: gatewayapi_v1.GatewayClassSpec{
 			ControllerName: "projectcontour.io/contour",
 		},
-		Status: gatewayapi_v1beta1.GatewayClassStatus{
+		Status: gatewayapi_v1.GatewayClassStatus{
 			Conditions: []meta_v1.Condition{
 				{
 					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
@@ -261,15 +260,15 @@ func TestUpstreamTLSWithHTTPRoute(t *testing.T) {
 		},
 	})
 
-	gateway := &gatewayapi_v1beta1.Gateway{
+	gateway := &gatewayapi_v1.Gateway{
 		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
-		Spec: gatewayapi_v1beta1.GatewaySpec{
-			Listeners: []gatewayapi_v1beta1.Listener{{
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
 				Name:     "http",
 				Port:     80,
 				Protocol: gatewayapi_v1.HTTPProtocolType,
-				AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-					Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
 						From: ref.To(gatewayapi_v1.NamespacesFromAll),
 					},
 				},
@@ -282,21 +281,21 @@ func TestUpstreamTLSWithHTTPRoute(t *testing.T) {
 		WithPorts(core_v1.ServicePort{Name: "http", Port: 443})
 	rh.OnAdd(svc)
 
-	rh.OnAdd(&gatewayapi_v1beta1.HTTPRoute{
+	rh.OnAdd(&gatewayapi_v1.HTTPRoute{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "authenticated",
 			Namespace: "default",
 		},
-		Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-			CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-				ParentRefs: []gatewayapi_v1beta1.ParentReference{
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
 					gatewayapi.GatewayParentRef("projectcontour", "contour"),
 				},
 			},
-			Hostnames: []gatewayapi_v1beta1.Hostname{
+			Hostnames: []gatewayapi_v1.Hostname{
 				"test.projectcontour.io",
 			},
-			Rules: []gatewayapi_v1beta1.HTTPRouteRule{{
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
 				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 				BackendRefs: gatewayapi.HTTPBackendRef("backend", 443, 1),
 			}},

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -17,66 +17,65 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/ref"
 )
 
-func CertificateRef(name, namespace string) gatewayapi_v1beta1.SecretObjectReference {
-	secretRef := gatewayapi_v1beta1.SecretObjectReference{
-		Group: ref.To(gatewayapi_v1beta1.Group("")),
-		Kind:  ref.To(gatewayapi_v1beta1.Kind("Secret")),
-		Name:  gatewayapi_v1beta1.ObjectName(name),
+func CertificateRef(name, namespace string) gatewayapi_v1.SecretObjectReference {
+	secretRef := gatewayapi_v1.SecretObjectReference{
+		Group: ref.To(gatewayapi_v1.Group("")),
+		Kind:  ref.To(gatewayapi_v1.Kind("Secret")),
+		Name:  gatewayapi_v1.ObjectName(name),
 	}
 
 	if namespace != "" {
-		secretRef.Namespace = ref.To(gatewayapi_v1beta1.Namespace(namespace))
+		secretRef.Namespace = ref.To(gatewayapi_v1.Namespace(namespace))
 	}
 
 	return secretRef
 }
 
-func GatewayParentRef(namespace, name string) gatewayapi_v1beta1.ParentReference {
-	parentRef := gatewayapi_v1beta1.ParentReference{
-		Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-		Kind:  ref.To(gatewayapi_v1beta1.Kind("Gateway")),
-		Name:  gatewayapi_v1beta1.ObjectName(name),
+func GatewayParentRef(namespace, name string) gatewayapi_v1.ParentReference {
+	parentRef := gatewayapi_v1.ParentReference{
+		Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+		Kind:  ref.To(gatewayapi_v1.Kind("Gateway")),
+		Name:  gatewayapi_v1.ObjectName(name),
 	}
 
 	if namespace != "" {
-		parentRef.Namespace = ref.To(gatewayapi_v1beta1.Namespace(namespace))
+		parentRef.Namespace = ref.To(gatewayapi_v1.Namespace(namespace))
 	}
 
 	return parentRef
 }
 
-func GatewayListenerParentRef(namespace, name, listener string, port int) gatewayapi_v1beta1.ParentReference {
+func GatewayListenerParentRef(namespace, name, listener string, port int) gatewayapi_v1.ParentReference {
 	parentRef := GatewayParentRef(namespace, name)
 
 	if listener != "" {
-		parentRef.SectionName = ref.To(gatewayapi_v1beta1.SectionName(listener))
+		parentRef.SectionName = ref.To(gatewayapi_v1.SectionName(listener))
 	}
 
 	if port != 0 {
-		parentRef.Port = ref.To(gatewayapi_v1beta1.PortNumber(port))
+		parentRef.Port = ref.To(gatewayapi_v1.PortNumber(port))
 	}
 
 	return parentRef
 }
 
-func ServiceBackendObjectRef(name string, port int) gatewayapi_v1beta1.BackendObjectReference {
-	return gatewayapi_v1beta1.BackendObjectReference{
-		Group: ref.To(gatewayapi_v1beta1.Group("")),
-		Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
-		Name:  gatewayapi_v1beta1.ObjectName(name),
-		Port:  ref.To(gatewayapi_v1beta1.PortNumber(port)),
+func ServiceBackendObjectRef(name string, port int) gatewayapi_v1.BackendObjectReference {
+	return gatewayapi_v1.BackendObjectReference{
+		Group: ref.To(gatewayapi_v1.Group("")),
+		Kind:  ref.To(gatewayapi_v1.Kind("Service")),
+		Name:  gatewayapi_v1.ObjectName(name),
+		Port:  ref.To(gatewayapi_v1.PortNumber(port)),
 	}
 }
 
-func HTTPRouteMatch(pathType gatewayapi_v1beta1.PathMatchType, value string) []gatewayapi_v1beta1.HTTPRouteMatch {
-	return []gatewayapi_v1beta1.HTTPRouteMatch{
+func HTTPRouteMatch(pathType gatewayapi_v1.PathMatchType, value string) []gatewayapi_v1.HTTPRouteMatch {
+	return []gatewayapi_v1.HTTPRouteMatch{
 		{
-			Path: &gatewayapi_v1beta1.HTTPPathMatch{
+			Path: &gatewayapi_v1.HTTPPathMatch{
 				Type:  ref.To(pathType),
 				Value: ref.To(value),
 			},
@@ -84,8 +83,8 @@ func HTTPRouteMatch(pathType gatewayapi_v1beta1.PathMatchType, value string) []g
 	}
 }
 
-func HTTPHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value string) []gatewayapi_v1beta1.HTTPHeaderMatch {
-	return []gatewayapi_v1beta1.HTTPHeaderMatch{
+func HTTPHeaderMatch(matchType gatewayapi_v1.HeaderMatchType, name, value string) []gatewayapi_v1.HTTPHeaderMatch {
+	return []gatewayapi_v1.HTTPHeaderMatch{
 		{
 			Type:  ref.To(matchType),
 			Name:  gatewayapi_v1.HTTPHeaderName(name),
@@ -94,11 +93,11 @@ func HTTPHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value s
 	}
 }
 
-func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1beta1.HTTPQueryParamMatch {
-	var matches []gatewayapi_v1beta1.HTTPQueryParamMatch
+func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1.HTTPQueryParamMatch {
+	var matches []gatewayapi_v1.HTTPQueryParamMatch
 
 	for name, val := range namesAndValues {
-		matches = append(matches, gatewayapi_v1beta1.HTTPQueryParamMatch{
+		matches = append(matches, gatewayapi_v1.HTTPQueryParamMatch{
 			Type:  ref.To(gatewayapi_v1.QueryParamMatchExact),
 			Name:  gatewayapi_v1.HTTPHeaderName(name),
 			Value: val,
@@ -108,8 +107,8 @@ func HTTPQueryParamMatches(namesAndValues map[string]string) []gatewayapi_v1beta
 	return matches
 }
 
-func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1beta1.HTTPBackendRef) []gatewayapi_v1beta1.HTTPBackendRef {
-	var res []gatewayapi_v1beta1.HTTPBackendRef
+func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1.HTTPBackendRef) []gatewayapi_v1.HTTPBackendRef {
+	var res []gatewayapi_v1.HTTPBackendRef
 
 	for _, ref := range backendRefs {
 		res = append(res, ref...)
@@ -117,10 +116,10 @@ func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1beta1.HTTPBackendRef) []gatew
 	return res
 }
 
-func HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1beta1.HTTPBackendRef {
-	return []gatewayapi_v1beta1.HTTPBackendRef{
+func HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1.HTTPBackendRef {
+	return []gatewayapi_v1.HTTPBackendRef{
 		{
-			BackendRef: gatewayapi_v1beta1.BackendRef{
+			BackendRef: gatewayapi_v1.BackendRef{
 				BackendObjectReference: ServiceBackendObjectRef(serviceName, port),
 				Weight:                 &weight,
 			},
@@ -141,10 +140,10 @@ func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayap
 	return []gatewayapi_v1alpha2.BackendRef{
 		{
 			BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-				Group: ref.To(gatewayapi_v1beta1.Group("")),
-				Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
+				Group: ref.To(gatewayapi_v1.Group("")),
+				Kind:  ref.To(gatewayapi_v1.Kind("Service")),
 				Name:  gatewayapi_v1alpha2.ObjectName(serviceName),
-				Port:  ref.To(gatewayapi_v1beta1.PortNumber(port)),
+				Port:  ref.To(gatewayapi_v1.PortNumber(port)),
 			},
 			Weight: weight,
 		},
@@ -156,10 +155,10 @@ func GRPCRouteBackendRef(serviceName string, port int, weight int32) []gatewayap
 		{
 			BackendRef: gatewayapi_v1alpha2.BackendRef{
 				BackendObjectReference: gatewayapi_v1alpha2.BackendObjectReference{
-					Group: ref.To(gatewayapi_v1beta1.Group("")),
-					Kind:  ref.To(gatewayapi_v1beta1.Kind("Service")),
+					Group: ref.To(gatewayapi_v1.Group("")),
+					Kind:  ref.To(gatewayapi_v1.Kind("Service")),
 					Name:  gatewayapi_v1alpha2.ObjectName(serviceName),
-					Port:  ref.To(gatewayapi_v1beta1.PortNumber(port)),
+					Port:  ref.To(gatewayapi_v1.PortNumber(port)),
 				},
 				Weight: &weight,
 			},
@@ -176,7 +175,7 @@ func GRPCMethodMatch(matchType gatewayapi_v1alpha2.GRPCMethodMatchType, service,
 	}
 }
 
-func GRPCHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
+func GRPCHeaderMatch(matchType gatewayapi_v1.HeaderMatchType, name, value string) []gatewayapi_v1alpha2.GRPCHeaderMatch {
 	return []gatewayapi_v1alpha2.GRPCHeaderMatch{
 		{
 			Type:  ref.To(matchType),
@@ -190,8 +189,8 @@ func GRPCHeaderMatch(matchType gatewayapi_v1beta1.HeaderMatchType, name, value s
 // to a Gateway with the given namespace/name, irrespective of whether a
 // section/listener name has been specified (i.e. a parent ref to a listener
 // on the specified gateway will return "true").
-func IsRefToGateway(parentRef gatewayapi_v1beta1.ParentReference, gateway types.NamespacedName) bool {
-	if parentRef.Group != nil && string(*parentRef.Group) != gatewayapi_v1beta1.GroupName {
+func IsRefToGateway(parentRef gatewayapi_v1.ParentReference, gateway types.NamespacedName) bool {
+	if parentRef.Group != nil && string(*parentRef.Group) != gatewayapi_v1.GroupName {
 		return false
 	}
 

--- a/internal/gatewayapi/listeners.go
+++ b/internal/gatewayapi/listeners.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/ref"
 )
@@ -45,7 +44,7 @@ type ValidateListenersResult struct {
 
 	// InvalidListenerConditions is a map from Gateway Listener name
 	// to a condition to set, if the Listener is invalid.
-	InvalidListenerConditions map[gatewayapi_v1beta1.SectionName]meta_v1.Condition
+	InvalidListenerConditions map[gatewayapi_v1.SectionName]meta_v1.Condition
 }
 
 type ListenerPort struct {
@@ -74,7 +73,7 @@ func conflictedCondition(reason gatewayapi_v1.ListenerConditionReason, msg strin
 // It returns a Listener name map, the ports to use, and conditions for all invalid listeners.
 // If a listener is not in the "InvalidListenerConditions" map, it is assumed to be valid according
 // to the above rules.
-func ValidateListeners(listeners []gatewayapi_v1beta1.Listener) ValidateListenersResult {
+func ValidateListeners(listeners []gatewayapi_v1.Listener) ValidateListenersResult {
 	// TLS-based protocols that can all exist on the same port.
 	compatibleTLSProtocols := sets.New(
 		gatewayapi_v1.HTTPSProtocolType,
@@ -84,7 +83,7 @@ func ValidateListeners(listeners []gatewayapi_v1beta1.Listener) ValidateListener
 
 	result := ValidateListenersResult{
 		ListenerNames:             map[string]string{},
-		InvalidListenerConditions: map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{},
+		InvalidListenerConditions: map[gatewayapi_v1.SectionName]meta_v1.Condition{},
 	}
 
 	for i, listener := range listeners {
@@ -209,7 +208,7 @@ func ValidateListeners(listeners []gatewayapi_v1beta1.Listener) ValidateListener
 	return result
 }
 
-func toContainerPort(listenerPort gatewayapi_v1beta1.PortNumber) int32 {
+func toContainerPort(listenerPort gatewayapi_v1.PortNumber) int32 {
 	// Add 8000 to the Listener port, wrapping around if needed,
 	// and skipping over privileged ports 1-1023.
 

--- a/internal/gatewayapi/listeners_test.go
+++ b/internal/gatewayapi/listeners_test.go
@@ -19,14 +19,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/ref"
 )
 
 func TestValidateListeners(t *testing.T) {
 	t.Run("All HTTP listeners are valid on a single port, some non-HTTP listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -36,25 +35,25 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "non-http-listener-1",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -67,7 +66,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("HTTP listeners on multiple ports, some non-HTTP listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -77,25 +76,25 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     8080,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "non-http-listener-1",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -109,7 +108,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Two HTTP listeners with the same hostname, some HTTP listeners on another port, some non-HTTP listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -119,31 +118,31 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")), // duplicate hostname
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")), // duplicate hostname
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "listener-5",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     8080,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "non-http-listener-1",
 				Protocol: gatewayapi_v1.TLSProtocolType, // non-HTTP
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -153,7 +152,7 @@ func TestValidateListeners(t *testing.T) {
 			{Name: "http-8080", Port: 8080, ContainerPort: 16080, Protocol: "http"},
 			{Name: "https-443", Port: 443, ContainerPort: 8443, Protocol: "https"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"listener-3": {
 				Type:    string(gatewayapi_v1.ListenerConditionConflicted),
 				Status:  meta_v1.ConditionTrue,
@@ -164,7 +163,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("All HTTPS/TLS listeners are valid, some non-HTTPS/TLS listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
@@ -174,25 +173,25 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "non-http-listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -205,7 +204,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("HTTPS listeners on two different ports, some non-HTTPS listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
@@ -215,25 +214,25 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("*.projectcontour.io")),
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     8443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "http-listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -247,7 +246,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Two HTTPS/TLS listeners on same port with the same hostname, some HTTPS/TLS listeners on another port, some HTTP listeners as well", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
@@ -257,31 +256,31 @@ func TestValidateListeners(t *testing.T) {
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.TLSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")), // duplicate hostname
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")), // duplicate hostname
 			},
 			{
 				Name:     "listener-4",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "listener-5",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     8443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.envoyproxy.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.envoyproxy.io")),
 			},
 			{
 				Name:     "http-listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("local.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("local.projectcontour.io")),
 			},
 		}
 
@@ -291,7 +290,7 @@ func TestValidateListeners(t *testing.T) {
 			{Name: "https-443", Port: 443, ContainerPort: 8443, Protocol: "https"},
 			{Name: "https-8443", Port: 8443, ContainerPort: 16443, Protocol: "https"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"listener-3": {
 				Type:    string(gatewayapi_v1.ListenerConditionConflicted),
 				Status:  meta_v1.ConditionTrue,
@@ -302,30 +301,30 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Two HTTP and one HTTPS listeners, each with an invalid hostname", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "listener-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("192.168.1.1")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("192.168.1.1")),
 			},
 			{
 				Name:     "listener-2",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
 				Port:     80,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("*.*.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("*.*.projectcontour.io")),
 			},
 			{
 				Name:     "listener-3",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
 				Port:     443,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname(".invalid.$.")),
+				Hostname: ref.To(gatewayapi_v1.Hostname(".invalid.$.")),
 			},
 		}
 
 		res := ValidateListeners(listeners)
 		assert.Empty(t, res.Ports)
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"listener-1": {
 				Type:    string(gatewayapi_v1.ListenerConditionProgrammed),
 				Status:  meta_v1.ConditionFalse,
@@ -348,23 +347,23 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Three HTTPS listeners on the same port, each with a different hostname", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "https-1",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-1.gateway.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("https-1.gateway.projectcontour.io")),
 				Port:     443,
 			},
 			{
 				Name:     "https-2",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-2.gateway.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("https-2.gateway.projectcontour.io")),
 				Port:     443,
 			},
 			{
 				Name:     "https-3",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
-				Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-3.gateway.projectcontour.io")),
+				Hostname: ref.To(gatewayapi_v1.Hostname("https-3.gateway.projectcontour.io")),
 				Port:     443,
 			},
 		}
@@ -376,7 +375,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Conflicting protocols on a port", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "http",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -417,7 +416,7 @@ func TestValidateListeners(t *testing.T) {
 			{Name: "http-9999", Port: 9999, ContainerPort: 17999, Protocol: "http"},
 			{Name: "tcp-11111", Port: 11111, ContainerPort: 19111, Protocol: "tcp"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"https": {
 				Type:    string(gatewayapi_v1.ListenerConditionConflicted),
 				Status:  meta_v1.ConditionTrue,
@@ -440,7 +439,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Conflicting protocols on a port (reverse order)", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "https",
 				Protocol: gatewayapi_v1.HTTPSProtocolType,
@@ -481,7 +480,7 @@ func TestValidateListeners(t *testing.T) {
 			{Name: "https-9999", Port: 9999, ContainerPort: 17999, Protocol: "https"},
 			{Name: "https-11111", Port: 11111, ContainerPort: 19111, Protocol: "https"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"http": {
 				Type:    string(gatewayapi_v1.ListenerConditionConflicted),
 				Status:  meta_v1.ConditionTrue,
@@ -504,7 +503,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Three TCP listeners on different ports", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "tcp-1",
 				Protocol: gatewayapi_v1.TCPProtocolType,
@@ -528,7 +527,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Listeners with various edge-case port numbers", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "http-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -556,7 +555,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Listeners with ports that map to the same container ports", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "http-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -573,7 +572,7 @@ func TestValidateListeners(t *testing.T) {
 		assert.ElementsMatch(t, res.Ports, []ListenerPort{
 			{Name: "http-58000", Port: 58000, ContainerPort: 1488, Protocol: "http"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"http-2": {
 				Type:    string(gatewayapi_v1.ListenerConditionAccepted),
 				Status:  meta_v1.ConditionFalse,
@@ -584,7 +583,7 @@ func TestValidateListeners(t *testing.T) {
 	})
 
 	t.Run("Listeners with ports that map to the same container ports, reverse order", func(t *testing.T) {
-		listeners := []gatewayapi_v1beta1.Listener{
+		listeners := []gatewayapi_v1.Listener{
 			{
 				Name:     "http-1",
 				Protocol: gatewayapi_v1.HTTPProtocolType,
@@ -601,7 +600,7 @@ func TestValidateListeners(t *testing.T) {
 		assert.ElementsMatch(t, res.Ports, []ListenerPort{
 			{Name: "http-59000", Port: 59000, ContainerPort: 1465, Protocol: "http"},
 		})
-		assert.Equal(t, map[gatewayapi_v1beta1.SectionName]meta_v1.Condition{
+		assert.Equal(t, map[gatewayapi_v1.SectionName]meta_v1.Condition{
 			"http-2": {
 				Type:    string(gatewayapi_v1.ListenerConditionAccepted),
 				Status:  meta_v1.ConditionFalse,

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -24,6 +24,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -59,22 +60,22 @@ func isStatusEqual(objA, objB any) bool {
 				return true
 			}
 		}
-	case *gatewayapi_v1beta1.GatewayClass:
-		if b, ok := objB.(*gatewayapi_v1beta1.GatewayClass); ok {
+	case *gatewayapi_v1.GatewayClass:
+		if b, ok := objB.(*gatewayapi_v1.GatewayClass); ok {
 			if cmp.Equal(a.Status, b.Status,
 				cmpopts.IgnoreFields(meta_v1.Condition{}, "LastTransitionTime")) {
 				return true
 			}
 		}
-	case *gatewayapi_v1beta1.Gateway:
-		if b, ok := objB.(*gatewayapi_v1beta1.Gateway); ok {
+	case *gatewayapi_v1.Gateway:
+		if b, ok := objB.(*gatewayapi_v1.Gateway); ok {
 			if cmp.Equal(a.Status, b.Status,
 				cmpopts.IgnoreFields(meta_v1.Condition{}, "LastTransitionTime")) {
 				return true
 			}
 		}
-	case *gatewayapi_v1beta1.HTTPRoute:
-		if b, ok := objB.(*gatewayapi_v1beta1.HTTPRoute); ok {
+	case *gatewayapi_v1.HTTPRoute:
+		if b, ok := objB.(*gatewayapi_v1.HTTPRoute); ok {
 			if cmp.Equal(a.Status, b.Status,
 				cmpopts.IgnoreFields(meta_v1.Condition{}, "LastTransitionTime")) {
 				return true
@@ -111,10 +112,10 @@ func IsObjectEqual(oldObj, newObj client.Object) (bool, error) {
 		*contour_v1.TLSCertificateDelegation:
 		return isGenerationEqual(oldObj, newObj), nil
 
-	case *gatewayapi_v1beta1.GatewayClass,
-		*gatewayapi_v1beta1.Gateway,
+	case *gatewayapi_v1.GatewayClass,
+		*gatewayapi_v1.Gateway,
 		*gatewayapi_v1beta1.ReferenceGrant,
-		*gatewayapi_v1beta1.HTTPRoute,
+		*gatewayapi_v1.HTTPRoute,
 		*gatewayapi_v1alpha2.TLSRoute,
 		*gatewayapi_v1alpha2.GRPCRoute,
 		*gatewayapi_v1alpha2.TCPRoute,

--- a/internal/k8s/helpers_test.go
+++ b/internal/k8s/helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -202,9 +203,9 @@ func TestIsEqualForGeneration(t *testing.T) {
 	run(t, &contour_v1.HTTPProxy{})
 	run(t, &contour_v1alpha1.ExtensionService{})
 	run(t, &contour_v1.TLSCertificateDelegation{})
-	run(t, &gatewayapi_v1beta1.GatewayClass{})
-	run(t, &gatewayapi_v1beta1.Gateway{})
-	run(t, &gatewayapi_v1beta1.HTTPRoute{})
+	run(t, &gatewayapi_v1.GatewayClass{})
+	run(t, &gatewayapi_v1.Gateway{})
+	run(t, &gatewayapi_v1.HTTPRoute{})
 	run(t, &gatewayapi_v1alpha2.TLSRoute{})
 	run(t, &gatewayapi_v1beta1.ReferenceGrant{})
 	run(t, &gatewayapi_v1alpha2.GRPCRoute{})

--- a/internal/k8s/kind.go
+++ b/internal/k8s/kind.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -49,7 +50,7 @@ func KindOf(obj any) string {
 			return "Ingress"
 		case *contour_v1.HTTPProxy:
 			return "HTTPProxy"
-		case *gatewayapi_v1beta1.HTTPRoute:
+		case *gatewayapi_v1.HTTPRoute:
 			return "HTTPRoute"
 		case *gatewayapi_v1alpha2.GRPCRoute:
 			return "GRPCRoute"
@@ -57,12 +58,14 @@ func KindOf(obj any) string {
 			return "TLSRoute"
 		case *gatewayapi_v1alpha2.TCPRoute:
 			return "TCPRoute"
-		case *gatewayapi_v1beta1.Gateway:
+		case *gatewayapi_v1.Gateway:
 			return "Gateway"
-		case *gatewayapi_v1beta1.GatewayClass:
+		case *gatewayapi_v1.GatewayClass:
 			return "GatewayClass"
 		case *gatewayapi_v1beta1.ReferenceGrant:
 			return "ReferenceGrant"
+		case *gatewayapi_v1alpha2.BackendTLSPolicy:
+			return "BackendTLSPolicy"
 		case *contour_v1.TLSCertificateDelegation:
 			return "TLSCertificateDelegation"
 		case *contour_v1alpha1.ExtensionService:

--- a/internal/k8s/kind_test.go
+++ b/internal/k8s/kind_test.go
@@ -20,6 +20,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -44,12 +45,13 @@ func TestKindOf(t *testing.T) {
 		{"ContourConfiguration", &contour_v1alpha1.ContourConfiguration{}},
 		{"ContourDeployment", &contour_v1alpha1.ContourDeployment{}},
 		{"GRPCRoute", &gatewayapi_v1alpha2.GRPCRoute{}},
-		{"HTTPRoute", &gatewayapi_v1beta1.HTTPRoute{}},
+		{"HTTPRoute", &gatewayapi_v1.HTTPRoute{}},
 		{"TLSRoute", &gatewayapi_v1alpha2.TLSRoute{}},
 		{"TCPRoute", &gatewayapi_v1alpha2.TCPRoute{}},
-		{"Gateway", &gatewayapi_v1beta1.Gateway{}},
-		{"GatewayClass", &gatewayapi_v1beta1.GatewayClass{}},
+		{"Gateway", &gatewayapi_v1.Gateway{}},
+		{"GatewayClass", &gatewayapi_v1.GatewayClass{}},
 		{"ReferenceGrant", &gatewayapi_v1beta1.ReferenceGrant{}},
+		{"BackendTLSPolicy", &gatewayapi_v1alpha2.BackendTLSPolicy{}},
 		{
 			"Foo", &unstructured.Unstructured{
 				Object: map[string]any{

--- a/internal/k8s/scheme.go
+++ b/internal/k8s/scheme.go
@@ -16,6 +16,7 @@ package k8s
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -34,6 +35,7 @@ func NewContourScheme() (*runtime.Scheme, error) {
 		scheme.AddToScheme,
 		gatewayapi_v1alpha2.AddToScheme,
 		gatewayapi_v1beta1.AddToScheme,
+		gatewayapi_v1.AddToScheme,
 	}
 
 	if err := b.AddToScheme(s); err != nil {

--- a/internal/k8s/statusaddress.go
+++ b/internal/k8s/statusaddress.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/annotation"
@@ -133,7 +132,7 @@ func (s *StatusAddressUpdater) OnAdd(obj any, _ bool) {
 			}),
 		))
 
-	case *gatewayapi_v1beta1.Gateway:
+	case *gatewayapi_v1.Gateway:
 		switch {
 		// Specific Gateway configured: check if the added Gateway
 		// matches.
@@ -148,7 +147,7 @@ func (s *StatusAddressUpdater) OnAdd(obj any, _ bool) {
 		// Otherwise, check if the added Gateway's class is controlled
 		// by us.
 		default:
-			gc := &gatewayapi_v1beta1.GatewayClass{}
+			gc := &gatewayapi_v1.GatewayClass{}
 			if err := s.Cache.Get(context.Background(), client.ObjectKey{Name: string(o.Spec.GatewayClassName)}, gc); err != nil {
 				s.Logger.
 					WithField("name", o.Name).
@@ -172,9 +171,9 @@ func (s *StatusAddressUpdater) OnAdd(obj any, _ bool) {
 		s.StatusUpdater.Send(NewStatusUpdate(
 			o.Name,
 			o.Namespace,
-			&gatewayapi_v1beta1.Gateway{},
+			&gatewayapi_v1.Gateway{},
 			StatusMutatorFunc(func(obj client.Object) client.Object {
-				gateway, ok := obj.(*gatewayapi_v1beta1.Gateway)
+				gateway, ok := obj.(*gatewayapi_v1.Gateway)
 				if !ok {
 					panic(fmt.Sprintf("Unsupported object %s/%s in status Address mutator",
 						obj.GetName(), obj.GetNamespace(),
@@ -292,13 +291,13 @@ func lbStatusToGatewayAddresses(lbs core_v1.LoadBalancerStatus) []gatewayapi_v1.
 	for _, lbi := range lbs.Ingress {
 		if len(lbi.IP) > 0 {
 			addrs = append(addrs, gatewayapi_v1.GatewayStatusAddress{
-				Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+				Type:  ref.To(gatewayapi_v1.IPAddressType),
 				Value: lbi.IP,
 			})
 		}
 		if len(lbi.Hostname) > 0 {
 			addrs = append(addrs, gatewayapi_v1.GatewayStatusAddress{
-				Type:  ref.To(gatewayapi_v1beta1.HostnameAddressType),
+				Type:  ref.To(gatewayapi_v1.HostnameAddressType),
 				Value: lbi.Hostname,
 			})
 		}

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/fixture"
@@ -378,21 +377,21 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 		status                     core_v1.LoadBalancerStatus
 		gatewayClassControllerName string
 		gatewayRef                 *types.NamespacedName
-		preop                      *gatewayapi_v1beta1.Gateway
-		postop                     *gatewayapi_v1beta1.Gateway
+		preop                      *gatewayapi_v1.Gateway
+		postop                     *gatewayapi_v1.Gateway
 	}{
 		"happy path (IP)": {
 			status:                     ipLBStatus,
 			gatewayClassControllerName: "projectcontour.io/contour",
-			preop: &gatewayapi_v1beta1.Gateway{
+			preop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -401,15 +400,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 				},
 			},
-			postop: &gatewayapi_v1beta1.Gateway{
+			postop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -418,11 +417,11 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 					Addresses: []gatewayapi_v1.GatewayStatusAddress{
 						{
-							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Type:  ref.To(gatewayapi_v1.IPAddressType),
 							Value: ipLBStatus.Ingress[0].IP,
 						},
 						{
-							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Type:  ref.To(gatewayapi_v1.IPAddressType),
 							Value: ipLBStatus.Ingress[1].IP,
 						},
 					},
@@ -432,15 +431,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 		"happy path (hostname)": {
 			status:                     hostnameLBStatus,
 			gatewayClassControllerName: "projectcontour.io/contour",
-			preop: &gatewayapi_v1beta1.Gateway{
+			preop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -449,15 +448,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 				},
 			},
-			postop: &gatewayapi_v1beta1.Gateway{
+			postop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -466,7 +465,7 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 					Addresses: []gatewayapi_v1.GatewayStatusAddress{
 						{
-							Type:  ref.To(gatewayapi_v1beta1.HostnameAddressType),
+							Type:  ref.To(gatewayapi_v1.HostnameAddressType),
 							Value: hostnameLBStatus.Ingress[0].Hostname,
 						},
 					},
@@ -476,15 +475,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 		"Gateway not controlled by this Contour": {
 			status:                     ipLBStatus,
 			gatewayClassControllerName: "projectcontour.io/some-other-controller",
-			preop: &gatewayapi_v1beta1.Gateway{
+			preop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -493,15 +492,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 				},
 			},
-			postop: &gatewayapi_v1beta1.Gateway{
+			postop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -514,15 +513,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 		"Specific gateway configured, gateway does not match": {
 			status:     ipLBStatus,
 			gatewayRef: &types.NamespacedName{Namespace: "projectcontour", Name: "contour-gateway"},
-			preop: &gatewayapi_v1beta1.Gateway{
+			preop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "some-other-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -531,15 +530,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 				},
 			},
-			postop: &gatewayapi_v1beta1.Gateway{
+			postop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "some-other-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -552,15 +551,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 		"Specific gateway configured, gateway matches": {
 			status:     ipLBStatus,
 			gatewayRef: &types.NamespacedName{Namespace: "projectcontour", Name: "contour-gateway"},
-			preop: &gatewayapi_v1beta1.Gateway{
+			preop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -569,15 +568,15 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 				},
 			},
-			postop: &gatewayapi_v1beta1.Gateway{
+			postop: &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: "projectcontour",
 					Name:      "contour-gateway",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-gatewayclass"),
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-gatewayclass"),
 				},
-				Status: gatewayapi_v1beta1.GatewayStatus{
+				Status: gatewayapi_v1.GatewayStatus{
 					Conditions: []meta_v1.Condition{
 						{
 							Type:   string(gatewayapi_v1.GatewayConditionProgrammed),
@@ -586,11 +585,11 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					},
 					Addresses: []gatewayapi_v1.GatewayStatusAddress{
 						{
-							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Type:  ref.To(gatewayapi_v1.IPAddressType),
 							Value: ipLBStatus.Ingress[0].IP,
 						},
 						{
-							Type:  ref.To(gatewayapi_v1beta1.IPAddressType),
+							Type:  ref.To(gatewayapi_v1.IPAddressType),
 							Value: ipLBStatus.Ingress[1].IP,
 						},
 					},
@@ -612,7 +611,7 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					// with the data from the API server; this simulates that behavior by
 					// updating the struct pointed to by the third argument with the fields
 					// we care about. See Run's godoc for more info.
-					args[2].(*gatewayapi_v1beta1.GatewayClass).Spec.ControllerName = gatewayapi_v1beta1.GatewayController(tc.gatewayClassControllerName)
+					args[2].(*gatewayapi_v1.GatewayClass).Spec.ControllerName = gatewayapi_v1.GatewayController(tc.gatewayClassControllerName)
 				}).
 				Return(nil)
 
@@ -643,7 +642,7 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 					// with the data from the API server; this simulates that behavior by
 					// updating the struct pointed to by the third argument with the fields
 					// we care about. See Run's godoc for more info.
-					args[2].(*gatewayapi_v1beta1.GatewayClass).Spec.ControllerName = gatewayapi_v1beta1.GatewayController(tc.gatewayClassControllerName)
+					args[2].(*gatewayapi_v1.GatewayClass).Spec.ControllerName = gatewayapi_v1.GatewayController(tc.gatewayClassControllerName)
 				}).
 				Return(nil)
 

--- a/internal/provisioner/controller/gatewayclass.go
+++ b/internal/provisioner/controller/gatewayclass.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 )
@@ -45,14 +44,14 @@ const (
 
 // gatewayClassReconciler reconciles GatewayClass objects.
 type gatewayClassReconciler struct {
-	gatewayController gatewayapi_v1beta1.GatewayController
+	gatewayController gatewayapi_v1.GatewayController
 	client            client.Client
 	log               logr.Logger
 }
 
 func NewGatewayClassController(mgr manager.Manager, gatewayController string) (controller.Controller, error) {
 	r := &gatewayClassReconciler{
-		gatewayController: gatewayapi_v1beta1.GatewayController(gatewayController),
+		gatewayController: gatewayapi_v1.GatewayController(gatewayController),
 		client:            mgr.GetClient(),
 		log:               ctrl.Log.WithName("gatewayclass-controller"),
 	}
@@ -63,7 +62,7 @@ func NewGatewayClassController(mgr manager.Manager, gatewayController string) (c
 	}
 
 	if err := c.Watch(
-		source.Kind(mgr.GetCache(), &gatewayapi_v1beta1.GatewayClass{}),
+		source.Kind(mgr.GetCache(), &gatewayapi_v1.GatewayClass{}),
 		&handler.EnqueueRequestForObject{},
 		predicate.NewPredicateFuncs(r.hasMatchingController),
 	); err != nil {
@@ -83,7 +82,7 @@ func NewGatewayClassController(mgr manager.Manager, gatewayController string) (c
 }
 
 func (r *gatewayClassReconciler) hasMatchingController(obj client.Object) bool {
-	gatewayClass, ok := obj.(*gatewayapi_v1beta1.GatewayClass)
+	gatewayClass, ok := obj.(*gatewayapi_v1.GatewayClass)
 	if !ok {
 		return false
 	}
@@ -95,7 +94,7 @@ func (r *gatewayClassReconciler) hasMatchingController(obj client.Object) bool {
 // for all provisioner-controlled GatewayClasses that have a ParametersRef to
 // the specified ContourDeployment object.
 func (r *gatewayClassReconciler) mapContourDeploymentToGatewayClasses(ctx context.Context, contourDeployment client.Object) []reconcile.Request {
-	var gatewayClasses gatewayapi_v1beta1.GatewayClassList
+	var gatewayClasses gatewayapi_v1.GatewayClassList
 	if err := r.client.List(ctx, &gatewayClasses); err != nil {
 		r.log.Error(err, "error listing gateway classes")
 		return nil
@@ -129,7 +128,7 @@ func (r *gatewayClassReconciler) mapContourDeploymentToGatewayClasses(ctx contex
 }
 
 func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	gatewayClass := &gatewayapi_v1beta1.GatewayClass{}
+	gatewayClass := &gatewayapi_v1.GatewayClass{}
 	if err := r.client.Get(ctx, req.NamespacedName, gatewayClass); err != nil {
 		// GatewayClass no longer exists, nothing to do.
 		if errors.IsNotFound(err) {
@@ -266,7 +265,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-func (r *gatewayClassReconciler) setConditions(ctx context.Context, gatewayClass *gatewayapi_v1beta1.GatewayClass, newConds map[string]meta_v1.Condition) error {
+func (r *gatewayClassReconciler) setConditions(ctx context.Context, gatewayClass *gatewayapi_v1.GatewayClass, newConds map[string]meta_v1.Condition) error {
 	var unchangedConds, updatedConds []meta_v1.Condition
 	for _, existing := range gatewayClass.Status.Conditions {
 		if cond, ok := newConds[existing.Type]; ok {
@@ -338,7 +337,7 @@ func (r *gatewayClassReconciler) getSupportedVersionCondition(ctx context.Contex
 
 // isValidParametersRef returns true if the provided ParametersReference is
 // to a ContourDeployment resource that exists.
-func (r *gatewayClassReconciler) isValidParametersRef(ctx context.Context, ref *gatewayapi_v1beta1.ParametersReference) (bool, *contour_v1alpha1.ContourDeployment, error) {
+func (r *gatewayClassReconciler) isValidParametersRef(ctx context.Context, ref *gatewayapi_v1.ParametersReference) (bool, *contour_v1alpha1.ContourDeployment, error) {
 	if ref == nil {
 		return true, nil, nil
 	}
@@ -363,7 +362,7 @@ func (r *gatewayClassReconciler) isValidParametersRef(ctx context.Context, ref *
 	return true, params, nil
 }
 
-func isContourDeploymentRef(ref *gatewayapi_v1beta1.ParametersReference) bool {
+func isContourDeploymentRef(ref *gatewayapi_v1.ParametersReference) bool {
 	if ref == nil {
 		return false
 	}

--- a/internal/provisioner/scheme.go
+++ b/internal/provisioner/scheme.go
@@ -17,6 +17,7 @@ import (
 	apiextensions_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -33,6 +34,7 @@ func CreateScheme() (*runtime.Scheme, error) {
 		apiextensions_v1.AddToScheme,
 		gatewayapi_v1alpha2.AddToScheme,
 		gatewayapi_v1beta1.AddToScheme,
+		gatewayapi_v1.AddToScheme,
 		contour_v1alpha1.AddToScheme,
 	}
 

--- a/internal/status/backendtlspolicyconditions.go
+++ b/internal/status/backendtlspolicyconditions.go
@@ -20,8 +20,8 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 )
@@ -32,7 +32,7 @@ type BackendTLSPolicyStatusUpdate struct {
 	FullName               types.NamespacedName
 	PolicyAncestorStatuses []*gatewayapi_v1alpha2.PolicyAncestorStatus
 	GatewayRef             types.NamespacedName
-	GatewayController      gatewayapi_v1beta1.GatewayController
+	GatewayController      gatewayapi_v1.GatewayController
 	Generation             int64
 	TransitionTime         meta_v1.Time
 }
@@ -41,12 +41,12 @@ type BackendTLSPolicyStatusUpdate struct {
 // PolicyAncestorStatus.
 type BackendTLSPolicyAncestorStatusUpdate struct {
 	*BackendTLSPolicyStatusUpdate
-	ancestorRef gatewayapi_v1beta1.ParentReference
+	ancestorRef gatewayapi_v1.ParentReference
 }
 
 // StatusUpdateFor returns a BackendTLSPolicyAncestorStatusUpdate for the given
 // ancestor ref.
-func (b *BackendTLSPolicyStatusUpdate) StatusUpdateFor(ancestorRef gatewayapi_v1beta1.ParentReference) *BackendTLSPolicyAncestorStatusUpdate {
+func (b *BackendTLSPolicyStatusUpdate) StatusUpdateFor(ancestorRef gatewayapi_v1.ParentReference) *BackendTLSPolicyAncestorStatusUpdate {
 	return &BackendTLSPolicyAncestorStatusUpdate{
 		BackendTLSPolicyStatusUpdate: b,
 		ancestorRef:                  ancestorRef,
@@ -106,7 +106,7 @@ func (b *BackendTLSPolicyAncestorStatusUpdate) AddCondition(conditionType gatewa
 
 // ConditionsForAncestorRef returns the list of conditions for a given ancestor
 // if it exists.
-func (b *BackendTLSPolicyStatusUpdate) ConditionsForAncestorRef(ancestorRef gatewayapi_v1beta1.ParentReference) []meta_v1.Condition {
+func (b *BackendTLSPolicyStatusUpdate) ConditionsForAncestorRef(ancestorRef gatewayapi_v1.ParentReference) []meta_v1.Condition {
 	for _, pas := range b.PolicyAncestorStatuses {
 		if pas.AncestorRef == ancestorRef {
 			return pas.Conditions

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -21,8 +21,8 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -37,7 +37,7 @@ type ConditionType string
 const ValidCondition ConditionType = "Valid"
 
 // NewCache creates a new Cache for holding status updates.
-func NewCache(gateway types.NamespacedName, gatewayController gatewayapi_v1beta1.GatewayController) Cache {
+func NewCache(gateway types.NamespacedName, gatewayController gatewayapi_v1.GatewayController) Cache {
 	return Cache{
 		gatewayRef:              gateway,
 		gatewayController:       gatewayController,
@@ -59,7 +59,7 @@ type CacheEntry interface {
 // KindAccessor.
 type Cache struct {
 	gatewayRef        types.NamespacedName
-	gatewayController gatewayapi_v1beta1.GatewayController
+	gatewayController gatewayapi_v1.GatewayController
 
 	proxyUpdates            map[types.NamespacedName]*ProxyUpdate
 	gatewayUpdates          map[types.NamespacedName]*GatewayStatusUpdate
@@ -133,7 +133,7 @@ func (c *Cache) GetStatusUpdates() []k8s.StatusUpdate {
 	for fullname, gwUpdate := range c.gatewayUpdates {
 		update := k8s.StatusUpdate{
 			NamespacedName: fullname,
-			Resource:       &gatewayapi_v1beta1.Gateway{},
+			Resource:       &gatewayapi_v1.Gateway{},
 			Mutator:        gwUpdate,
 		}
 
@@ -192,10 +192,10 @@ func (c *Cache) GetBackendTLSPolicyUpdates() []*BackendTLSPolicyStatusUpdate {
 // status changes as well as a function to commit the change back to the cache when everything
 // is done. The commit function pattern is used so that the GatewayStatusUpdate does not need
 // to know anything the cache internals.
-func (c *Cache) GatewayStatusAccessor(nsName types.NamespacedName, generation int64, gs *gatewayapi_v1beta1.GatewayStatus) (*GatewayStatusUpdate, func()) {
+func (c *Cache) GatewayStatusAccessor(nsName types.NamespacedName, generation int64, gs *gatewayapi_v1.GatewayStatus) (*GatewayStatusUpdate, func()) {
 	gu := &GatewayStatusUpdate{
 		FullName:           nsName,
-		Conditions:         make(map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition),
+		Conditions:         make(map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition),
 		ExistingConditions: getGatewayConditions(gs),
 		Generation:         generation,
 		TransitionTime:     meta_v1.NewTime(time.Now()),

--- a/internal/status/cache_test.go
+++ b/internal/status/cache_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -51,7 +51,7 @@ func TestCacheAcquisition(t *testing.T) {
 	proxy := &contour_v1.HTTPProxy{
 		ObjectMeta: fixture.ObjectMeta("test/proxy"),
 	}
-	httpRoute := &gatewayapi_v1beta1.HTTPRoute{
+	httpRoute := &gatewayapi_v1.HTTPRoute{
 		ObjectMeta: fixture.ObjectMeta("test/httproute"),
 	}
 	cache := NewCache(types.NamespacedName{Name: "contour", Namespace: "projectcontour"}, "")

--- a/internal/status/gatewayclass.go
+++ b/internal/status/gatewayclass.go
@@ -14,12 +14,12 @@
 package status
 
 import (
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // SetGatewayClassAccepted inserts or updates the Accepted condition
 // for the provided GatewayClass.
-func SetGatewayClassAccepted(gc *gatewayapi_v1beta1.GatewayClass, accepted bool) *gatewayapi_v1beta1.GatewayClass {
+func SetGatewayClassAccepted(gc *gatewayapi_v1.GatewayClass, accepted bool) *gatewayapi_v1.GatewayClass {
 	gc.Status.Conditions = mergeConditions(gc.Status.Conditions, computeGatewayClassAcceptedCondition(gc, accepted))
 	return gc
 }

--- a/internal/status/gatewayclassconditions.go
+++ b/internal/status/gatewayclassconditions.go
@@ -19,13 +19,12 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-const ReasonOlderGatewayClassExists gatewayapi_v1beta1.GatewayClassConditionReason = "OlderGatewayClassExists"
+const ReasonOlderGatewayClassExists gatewayapi_v1.GatewayClassConditionReason = "OlderGatewayClassExists"
 
 // computeGatewayClassAcceptedCondition computes the GatewayClass Accepted status condition.
-func computeGatewayClassAcceptedCondition(gatewayClass *gatewayapi_v1beta1.GatewayClass, accepted bool) meta_v1.Condition {
+func computeGatewayClassAcceptedCondition(gatewayClass *gatewayapi_v1.GatewayClass, accepted bool) meta_v1.Condition {
 	switch accepted {
 	case true:
 		return meta_v1.Condition{

--- a/internal/status/gatewayclassconditions_test.go
+++ b/internal/status/gatewayclassconditions_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
@@ -50,7 +49,7 @@ func TestComputeGatewayClassAcceptedCondition(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		gc := &gatewayapi_v1beta1.GatewayClass{
+		gc := &gatewayapi_v1.GatewayClass{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Generation: 7,
 			},

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -20,7 +20,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/projectcontour/contour/internal/ref"
 )
@@ -31,18 +31,18 @@ const MessageValidGateway = "Valid Gateway"
 // Gateway's status.
 type GatewayStatusUpdate struct {
 	FullName           types.NamespacedName
-	Conditions         map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition
-	ExistingConditions map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition
-	ListenerStatus     map[string]*gatewayapi_v1beta1.ListenerStatus
+	Conditions         map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition
+	ExistingConditions map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition
+	ListenerStatus     map[string]*gatewayapi_v1.ListenerStatus
 	Generation         int64
 	TransitionTime     meta_v1.Time
 }
 
 // AddCondition returns a meta_v1.Condition for a given GatewayConditionType.
 func (gatewayUpdate *GatewayStatusUpdate) AddCondition(
-	cond gatewayapi_v1beta1.GatewayConditionType,
+	cond gatewayapi_v1.GatewayConditionType,
 	status meta_v1.ConditionStatus,
-	reason gatewayapi_v1beta1.GatewayConditionReason,
+	reason gatewayapi_v1.GatewayConditionReason,
 	message string,
 ) meta_v1.Condition {
 	if c, ok := gatewayUpdate.Conditions[cond]; ok {
@@ -61,19 +61,19 @@ func (gatewayUpdate *GatewayStatusUpdate) AddCondition(
 	return newCond
 }
 
-func (gatewayUpdate *GatewayStatusUpdate) SetListenerSupportedKinds(listenerName string, kinds []gatewayapi_v1beta1.Kind) {
+func (gatewayUpdate *GatewayStatusUpdate) SetListenerSupportedKinds(listenerName string, kinds []gatewayapi_v1.Kind) {
 	if gatewayUpdate.ListenerStatus == nil {
-		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1beta1.ListenerStatus{}
+		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1.ListenerStatus{}
 	}
 	if gatewayUpdate.ListenerStatus[listenerName] == nil {
-		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1beta1.ListenerStatus{
-			Name: gatewayapi_v1beta1.SectionName(listenerName),
+		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1.ListenerStatus{
+			Name: gatewayapi_v1.SectionName(listenerName),
 		}
 	}
 
 	for _, kind := range kinds {
-		groupKind := gatewayapi_v1beta1.RouteGroupKind{
-			Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
+		groupKind := gatewayapi_v1.RouteGroupKind{
+			Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
 			Kind:  kind,
 		}
 
@@ -83,11 +83,11 @@ func (gatewayUpdate *GatewayStatusUpdate) SetListenerSupportedKinds(listenerName
 
 func (gatewayUpdate *GatewayStatusUpdate) SetListenerAttachedRoutes(listenerName string, numRoutes int) {
 	if gatewayUpdate.ListenerStatus == nil {
-		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1beta1.ListenerStatus{}
+		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1.ListenerStatus{}
 	}
 	if gatewayUpdate.ListenerStatus[listenerName] == nil {
-		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1beta1.ListenerStatus{
-			Name: gatewayapi_v1beta1.SectionName(listenerName),
+		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1.ListenerStatus{
+			Name: gatewayapi_v1.SectionName(listenerName),
 		}
 	}
 
@@ -97,17 +97,17 @@ func (gatewayUpdate *GatewayStatusUpdate) SetListenerAttachedRoutes(listenerName
 // AddListenerCondition adds a Condition for the specified listener.
 func (gatewayUpdate *GatewayStatusUpdate) AddListenerCondition(
 	listenerName string,
-	cond gatewayapi_v1beta1.ListenerConditionType,
+	cond gatewayapi_v1.ListenerConditionType,
 	status meta_v1.ConditionStatus,
-	reason gatewayapi_v1beta1.ListenerConditionReason,
+	reason gatewayapi_v1.ListenerConditionReason,
 	message string,
 ) meta_v1.Condition {
 	if gatewayUpdate.ListenerStatus == nil {
-		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1beta1.ListenerStatus{}
+		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1.ListenerStatus{}
 	}
 	if gatewayUpdate.ListenerStatus[listenerName] == nil {
-		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1beta1.ListenerStatus{
-			Name: gatewayapi_v1beta1.SectionName(listenerName),
+		gatewayUpdate.ListenerStatus[listenerName] = &gatewayapi_v1.ListenerStatus{
+			Name: gatewayapi_v1.SectionName(listenerName),
 		}
 	}
 
@@ -140,18 +140,18 @@ func (gatewayUpdate *GatewayStatusUpdate) AddListenerCondition(
 	return newCond
 }
 
-func getGatewayConditions(gs *gatewayapi_v1beta1.GatewayStatus) map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition {
-	conditions := make(map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition)
+func getGatewayConditions(gs *gatewayapi_v1.GatewayStatus) map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition {
+	conditions := make(map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition)
 	for _, cond := range gs.Conditions {
-		if _, ok := conditions[gatewayapi_v1beta1.GatewayConditionType(cond.Type)]; !ok {
-			conditions[gatewayapi_v1beta1.GatewayConditionType(cond.Type)] = cond
+		if _, ok := conditions[gatewayapi_v1.GatewayConditionType(cond.Type)]; !ok {
+			conditions[gatewayapi_v1.GatewayConditionType(cond.Type)] = cond
 		}
 	}
 	return conditions
 }
 
 func (gatewayUpdate *GatewayStatusUpdate) Mutate(obj client.Object) client.Object {
-	o, ok := obj.(*gatewayapi_v1beta1.Gateway)
+	o, ok := obj.(*gatewayapi_v1.Gateway)
 	if !ok {
 		panic(fmt.Sprintf("Unsupported %T object %s/%s in GatewayStatusUpdate status mutator",
 			obj, gatewayUpdate.FullName.Namespace, gatewayUpdate.FullName.Name,
@@ -196,7 +196,7 @@ func (gatewayUpdate *GatewayStatusUpdate) Mutate(obj client.Object) client.Objec
 
 	// Overwrite all listener statuses since we re-compute all of them
 	// for each Gateway status update.
-	var listenerStatusToWrite []gatewayapi_v1beta1.ListenerStatus
+	var listenerStatusToWrite []gatewayapi_v1.ListenerStatus
 	for _, status := range gatewayUpdate.ListenerStatus {
 		if status.Conditions == nil {
 			// Conditions is a required field so we have to specify an empty slice here
@@ -204,7 +204,7 @@ func (gatewayUpdate *GatewayStatusUpdate) Mutate(obj client.Object) client.Objec
 		}
 		if status.SupportedKinds == nil {
 			// SupportedKinds is a required field so we have to specify an empty slice here
-			status.SupportedKinds = []gatewayapi_v1beta1.RouteGroupKind{}
+			status.SupportedKinds = []gatewayapi_v1.RouteGroupKind{}
 		}
 		listenerStatusToWrite = append(listenerStatusToWrite, *status)
 	}

--- a/internal/status/gatewaystatus_test.go
+++ b/internal/status/gatewaystatus_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/k8s"
 	"github.com/projectcontour/contour/internal/ref"
@@ -39,7 +38,7 @@ func TestGatewayAddCondition(t *testing.T) {
 
 	gatewayUpdate := GatewayStatusUpdate{
 		FullName:           k8s.NamespacedNameFrom("test/test"),
-		Conditions:         make(map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition),
+		Conditions:         make(map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition),
 		ExistingConditions: nil,
 		Generation:         testGeneration,
 		TransitionTime:     meta_v1.Time{},
@@ -62,8 +61,8 @@ func TestGatewayAddCondition(t *testing.T) {
 func TestGatewaySetListenerSupportedKinds(t *testing.T) {
 	var gsu GatewayStatusUpdate
 
-	gsu.SetListenerSupportedKinds("http", []gatewayapi_v1beta1.Kind{"HTTPRoute"})
-	gsu.SetListenerSupportedKinds("https", []gatewayapi_v1beta1.Kind{"HTTPRoute", "TLSRoute"})
+	gsu.SetListenerSupportedKinds("http", []gatewayapi_v1.Kind{"HTTPRoute"})
+	gsu.SetListenerSupportedKinds("https", []gatewayapi_v1.Kind{"HTTPRoute", "TLSRoute"})
 
 	assert.Len(t, gsu.ListenerStatus, 2)
 
@@ -71,16 +70,16 @@ func TestGatewaySetListenerSupportedKinds(t *testing.T) {
 	require.NotNil(t, gsu.ListenerStatus["https"])
 
 	assert.ElementsMatch(t,
-		[]gatewayapi_v1beta1.RouteGroupKind{
-			{Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)), Kind: "HTTPRoute"},
+		[]gatewayapi_v1.RouteGroupKind{
+			{Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)), Kind: "HTTPRoute"},
 		},
 		gsu.ListenerStatus["http"].SupportedKinds,
 	)
 
 	assert.ElementsMatch(t,
-		[]gatewayapi_v1beta1.RouteGroupKind{
-			{Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)), Kind: "HTTPRoute"},
-			{Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)), Kind: "TLSRoute"},
+		[]gatewayapi_v1.RouteGroupKind{
+			{Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)), Kind: "HTTPRoute"},
+			{Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)), Kind: "TLSRoute"},
 		},
 		gsu.ListenerStatus["https"].SupportedKinds,
 	)
@@ -104,18 +103,18 @@ func TestGatewaySetListenerAttachedRoutes(t *testing.T) {
 func TestGatewayMutate(t *testing.T) {
 	var gsu GatewayStatusUpdate
 
-	gsu.ListenerStatus = map[string]*gatewayapi_v1beta1.ListenerStatus{
+	gsu.ListenerStatus = map[string]*gatewayapi_v1.ListenerStatus{
 		"http": {
 			Name:           "http",
 			AttachedRoutes: 7,
-			SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+			SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 				{
-					Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-					Kind:  gatewayapi_v1beta1.Kind("FooRoute"),
+					Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+					Kind:  gatewayapi_v1.Kind("FooRoute"),
 				},
 				{
-					Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-					Kind:  gatewayapi_v1beta1.Kind("BarRoute"),
+					Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+					Kind:  gatewayapi_v1.Kind("BarRoute"),
 				},
 			},
 			Conditions: []meta_v1.Condition{},
@@ -123,26 +122,26 @@ func TestGatewayMutate(t *testing.T) {
 		"https": {
 			Name:           "https",
 			AttachedRoutes: 77,
-			SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+			SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 				{
-					Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-					Kind:  gatewayapi_v1beta1.Kind("TLSRoute"),
+					Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+					Kind:  gatewayapi_v1.Kind("TLSRoute"),
 				},
 			},
 			Conditions: []meta_v1.Condition{},
 		},
 	}
 
-	gw := &gatewayapi_v1beta1.Gateway{
-		Status: gatewayapi_v1beta1.GatewayStatus{
-			Listeners: []gatewayapi_v1beta1.ListenerStatus{
+	gw := &gatewayapi_v1.Gateway{
+		Status: gatewayapi_v1.GatewayStatus{
+			Listeners: []gatewayapi_v1.ListenerStatus{
 				{
 					Name:           "http",
 					AttachedRoutes: 3,
-					SupportedKinds: []gatewayapi_v1beta1.RouteGroupKind{
+					SupportedKinds: []gatewayapi_v1.RouteGroupKind{
 						{
-							Group: ref.To(gatewayapi_v1beta1.Group(gatewayapi_v1beta1.GroupName)),
-							Kind:  gatewayapi_v1beta1.Kind("HTTPRoute"),
+							Group: ref.To(gatewayapi_v1.Group(gatewayapi_v1.GroupName)),
+							Kind:  gatewayapi_v1.Kind("HTTPRoute"),
 						},
 					},
 					Conditions: []meta_v1.Condition{},
@@ -151,12 +150,12 @@ func TestGatewayMutate(t *testing.T) {
 		},
 	}
 
-	got, ok := gsu.Mutate(gw).(*gatewayapi_v1beta1.Gateway)
+	got, ok := gsu.Mutate(gw).(*gatewayapi_v1.Gateway)
 	require.True(t, ok)
 
 	assert.Len(t, got.Status.Listeners, 2)
 
-	var want []gatewayapi_v1beta1.ListenerStatus
+	var want []gatewayapi_v1.ListenerStatus
 	for _, v := range gsu.ListenerStatus {
 		want = append(want, *v)
 	}
@@ -203,17 +202,17 @@ func TestGatewayAddListenerCondition(t *testing.T) {
 func TestGetGatewayConditions(t *testing.T) {
 	tests := map[string]struct {
 		conditions []meta_v1.Condition
-		want       map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition
+		want       map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition
 	}{
 		"no gateway conditions": {
 			conditions: nil,
-			want:       map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition{},
+			want:       map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition{},
 		},
 		"one gateway condition": {
 			conditions: []meta_v1.Condition{
 				{Type: string(gatewayapi_v1.GatewayConditionProgrammed)},
 			},
-			want: map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition{
+			want: map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition{
 				gatewayapi_v1.GatewayConditionProgrammed: {Type: string(gatewayapi_v1.GatewayConditionProgrammed)},
 			},
 		},
@@ -222,7 +221,7 @@ func TestGetGatewayConditions(t *testing.T) {
 				{Type: string(gatewayapi_v1.GatewayConditionProgrammed)},
 				{Type: string(gatewayapi_v1.GatewayConditionAccepted)},
 			},
-			want: map[gatewayapi_v1beta1.GatewayConditionType]meta_v1.Condition{
+			want: map[gatewayapi_v1.GatewayConditionType]meta_v1.Condition{
 				gatewayapi_v1.GatewayConditionProgrammed: {Type: string(gatewayapi_v1.GatewayConditionProgrammed)},
 				gatewayapi_v1.GatewayConditionAccepted:   {Type: string(gatewayapi_v1.GatewayConditionAccepted)},
 			},
@@ -231,7 +230,7 @@ func TestGetGatewayConditions(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := getGatewayConditions(&gatewayapi_v1beta1.GatewayStatus{Conditions: tc.conditions})
+			got := getGatewayConditions(&gatewayapi_v1.GatewayStatus{Conditions: tc.conditions})
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -20,32 +20,32 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 )
 
 const (
-	ConditionValidBackendRefs gatewayapi_v1beta1.RouteConditionType = "ValidBackendRefs"
-	ConditionValidMatches     gatewayapi_v1beta1.RouteConditionType = "ValidMatches"
+	ConditionValidBackendRefs gatewayapi_v1.RouteConditionType = "ValidBackendRefs"
+	ConditionValidMatches     gatewayapi_v1.RouteConditionType = "ValidMatches"
 )
 
 const (
-	ReasonDegraded                      gatewayapi_v1beta1.RouteConditionReason = "Degraded"
-	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1beta1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
-	ReasonInvalidPathMatch              gatewayapi_v1beta1.RouteConditionReason = "InvalidPathMatch"
-	ReasonInvalidMethodMatch            gatewayapi_v1beta1.RouteConditionReason = "InvalidMethodMatch"
-	ReasonInvalidGateway                gatewayapi_v1beta1.RouteConditionReason = "InvalidGateway"
+	ReasonDegraded                      gatewayapi_v1.RouteConditionReason = "Degraded"
+	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
+	ReasonInvalidPathMatch              gatewayapi_v1.RouteConditionReason = "InvalidPathMatch"
+	ReasonInvalidMethodMatch            gatewayapi_v1.RouteConditionReason = "InvalidMethodMatch"
+	ReasonInvalidGateway                gatewayapi_v1.RouteConditionReason = "InvalidGateway"
 )
 
 // RouteStatusUpdate represents an atomic update to a
 // Route's status.
 type RouteStatusUpdate struct {
 	FullName            types.NamespacedName
-	RouteParentStatuses []*gatewayapi_v1beta1.RouteParentStatus
+	RouteParentStatuses []*gatewayapi_v1.RouteParentStatus
 	GatewayRef          types.NamespacedName
-	GatewayController   gatewayapi_v1beta1.GatewayController
+	GatewayController   gatewayapi_v1.GatewayController
 	Resource            client.Object
 	Generation          int64
 	TransitionTime      meta_v1.Time
@@ -55,11 +55,11 @@ type RouteStatusUpdate struct {
 // parent ref's RouteParentStatus.
 type RouteParentStatusUpdate struct {
 	*RouteStatusUpdate
-	parentRef gatewayapi_v1beta1.ParentReference
+	parentRef gatewayapi_v1.ParentReference
 }
 
 // StatusUpdateFor returns a RouteParentStatusUpdate for the given parent ref.
-func (r *RouteStatusUpdate) StatusUpdateFor(parentRef gatewayapi_v1beta1.ParentReference) *RouteParentStatusUpdate {
+func (r *RouteStatusUpdate) StatusUpdateFor(parentRef gatewayapi_v1.ParentReference) *RouteParentStatusUpdate {
 	return &RouteParentStatusUpdate{
 		RouteStatusUpdate: r,
 		parentRef:         parentRef,
@@ -68,8 +68,8 @@ func (r *RouteStatusUpdate) StatusUpdateFor(parentRef gatewayapi_v1beta1.ParentR
 
 // AddCondition adds a condition with the given properties
 // to the RouteParentStatus.
-func (r *RouteParentStatusUpdate) AddCondition(conditionType gatewayapi_v1beta1.RouteConditionType, status meta_v1.ConditionStatus, reason gatewayapi_v1beta1.RouteConditionReason, message string) meta_v1.Condition {
-	var rps *gatewayapi_v1beta1.RouteParentStatus
+func (r *RouteParentStatusUpdate) AddCondition(conditionType gatewayapi_v1.RouteConditionType, status meta_v1.ConditionStatus, reason gatewayapi_v1.RouteConditionReason, message string) meta_v1.Condition {
+	var rps *gatewayapi_v1.RouteParentStatus
 
 	for _, v := range r.RouteParentStatuses {
 		if v.ParentRef == r.parentRef {
@@ -79,7 +79,7 @@ func (r *RouteParentStatusUpdate) AddCondition(conditionType gatewayapi_v1beta1.
 	}
 
 	if rps == nil {
-		rps = &gatewayapi_v1beta1.RouteParentStatus{
+		rps = &gatewayapi_v1.RouteParentStatus{
 			ParentRef:      r.parentRef,
 			ControllerName: r.GatewayController,
 		}
@@ -118,7 +118,7 @@ func (r *RouteParentStatusUpdate) AddCondition(conditionType gatewayapi_v1beta1.
 }
 
 // ConditionExists returns whether or not a condition with the given type exists.
-func (r *RouteParentStatusUpdate) ConditionExists(conditionType gatewayapi_v1beta1.RouteConditionType) bool {
+func (r *RouteParentStatusUpdate) ConditionExists(conditionType gatewayapi_v1.RouteConditionType) bool {
 	for _, c := range r.ConditionsForParentRef(r.parentRef) {
 		if c.Type == string(conditionType) {
 			return true
@@ -127,7 +127,7 @@ func (r *RouteParentStatusUpdate) ConditionExists(conditionType gatewayapi_v1bet
 	return false
 }
 
-func (r *RouteStatusUpdate) ConditionsForParentRef(parentRef gatewayapi_v1beta1.ParentReference) []meta_v1.Condition {
+func (r *RouteStatusUpdate) ConditionsForParentRef(parentRef gatewayapi_v1.ParentReference) []meta_v1.Condition {
 	for _, rps := range r.RouteParentStatuses {
 		if rps.ParentRef == parentRef {
 			return rps.Conditions
@@ -138,7 +138,7 @@ func (r *RouteStatusUpdate) ConditionsForParentRef(parentRef gatewayapi_v1beta1.
 }
 
 func (r *RouteStatusUpdate) Mutate(obj client.Object) client.Object {
-	var newRouteParentStatuses []gatewayapi_v1beta1.RouteParentStatus
+	var newRouteParentStatuses []gatewayapi_v1.RouteParentStatus
 
 	for _, rps := range r.RouteParentStatuses {
 		for i := range rps.Conditions {
@@ -152,7 +152,7 @@ func (r *RouteStatusUpdate) Mutate(obj client.Object) client.Object {
 	}
 
 	switch o := obj.(type) {
-	case *gatewayapi_v1beta1.HTTPRoute:
+	case *gatewayapi_v1.HTTPRoute:
 		route := o.DeepCopy()
 
 		// Get all the RouteParentStatuses that are for other Gateways.

--- a/internal/status/routeconditions_test.go
+++ b/internal/status/routeconditions_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -36,12 +36,12 @@ func TestHTTPRouteAddCondition(t *testing.T) {
 
 	rpsUpdate := httpRouteUpdate.StatusUpdateFor(parentRef)
 
-	rpsUpdate.AddCondition(gatewayapi_v1beta1.RouteConditionAccepted, meta_v1.ConditionTrue, "Valid", "Valid HTTPRoute")
+	rpsUpdate.AddCondition(gatewayapi_v1.RouteConditionAccepted, meta_v1.ConditionTrue, "Valid", "Valid HTTPRoute")
 
 	require.Len(t, httpRouteUpdate.ConditionsForParentRef(parentRef), 1)
 	got := httpRouteUpdate.ConditionsForParentRef(parentRef)[0]
 
-	assert.EqualValues(t, gatewayapi_v1beta1.RouteConditionAccepted, got.Type)
+	assert.EqualValues(t, gatewayapi_v1.RouteConditionAccepted, got.Type)
 	assert.EqualValues(t, meta_v1.ConditionTrue, got.Status)
 	assert.EqualValues(t, "Valid", got.Reason)
 	assert.EqualValues(t, "Valid HTTPRoute", got.Message)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -46,8 +46,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -105,7 +105,7 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 	require.NoError(t, contour_v1.AddToScheme(scheme))
 	require.NoError(t, contour_v1alpha1.AddToScheme(scheme))
 	require.NoError(t, gatewayapi_v1alpha2.AddToScheme(scheme))
-	require.NoError(t, gatewayapi_v1beta1.AddToScheme(scheme))
+	require.NoError(t, gatewayapi_v1.AddToScheme(scheme))
 	require.NoError(t, certmanagerv1.AddToScheme(scheme))
 	require.NoError(t, apiextensions_v1.AddToScheme(scheme))
 
@@ -372,7 +372,7 @@ func (f *Framework) CreateHTTPProxyAndWaitFor(proxy *contour_v1.HTTPProxy, condi
 
 // CreateHTTPRouteAndWaitFor creates the provided HTTPRoute in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1beta1.HTTPRoute, condition func(*gatewayapi_v1beta1.HTTPRoute) bool) (*gatewayapi_v1beta1.HTTPRoute, bool) {
+func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1.HTTPRoute, condition func(*gatewayapi_v1.HTTPRoute) bool) (*gatewayapi_v1.HTTPRoute, bool) {
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
@@ -438,19 +438,19 @@ func (f *Framework) DeleteNamespace(name string, waitForDeletion bool) {
 
 // CreateGatewayAndWaitFor creates a gateway in the
 // Kubernetes API or fails the test if it encounters an error.
-func (f *Framework) CreateGatewayAndWaitFor(gateway *gatewayapi_v1beta1.Gateway, condition func(*gatewayapi_v1beta1.Gateway) bool) (*gatewayapi_v1beta1.Gateway, bool) {
+func (f *Framework) CreateGatewayAndWaitFor(gateway *gatewayapi_v1.Gateway, condition func(*gatewayapi_v1.Gateway) bool) (*gatewayapi_v1.Gateway, bool) {
 	return createAndWaitFor(f.t, f.Client, gateway, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateGatewayClassAndWaitFor creates a GatewayClass in the
 // Kubernetes API or fails the test if it encounters an error.
-func (f *Framework) CreateGatewayClassAndWaitFor(gatewayClass *gatewayapi_v1beta1.GatewayClass, condition func(*gatewayapi_v1beta1.GatewayClass) bool) (*gatewayapi_v1beta1.GatewayClass, bool) {
+func (f *Framework) CreateGatewayClassAndWaitFor(gatewayClass *gatewayapi_v1.GatewayClass, condition func(*gatewayapi_v1.GatewayClass) bool) (*gatewayapi_v1.GatewayClass, bool) {
 	return createAndWaitFor(f.t, f.Client, gatewayClass, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // DeleteGateway deletes the provided gateway in the Kubernetes API
 // or fails the test if it encounters an error.
-func (f *Framework) DeleteGateway(gw *gatewayapi_v1beta1.Gateway, waitForDeletion bool) error {
+func (f *Framework) DeleteGateway(gw *gatewayapi_v1.Gateway, waitForDeletion bool) error {
 	require.NoError(f.t, f.Client.Delete(context.TODO(), gw))
 
 	if waitForDeletion {
@@ -464,7 +464,7 @@ func (f *Framework) DeleteGateway(gw *gatewayapi_v1beta1.Gateway, waitForDeletio
 
 // DeleteGatewayClass deletes the provided gatewayclass in the
 // Kubernetes API or fails the test if it encounters an error.
-func (f *Framework) DeleteGatewayClass(gwc *gatewayapi_v1beta1.GatewayClass, waitForDeletion bool) error {
+func (f *Framework) DeleteGatewayClass(gwc *gatewayapi_v1.GatewayClass, waitForDeletion bool) error {
 	require.NoError(f.t, f.Client.Delete(context.TODO(), gwc))
 
 	if waitForDeletion {

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
@@ -116,19 +115,19 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 			delete(service.Annotations, "projectcontour.io/upstream-protocol.tls")
 		})
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"backend-tls-policy.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"backend-tls-policy.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-secure", 443, 1),

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -29,7 +29,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/gatewayapi"
@@ -82,13 +81,13 @@ var _ = Describe("Gateway API", func() {
 		contourConfigFile     string
 		additionalContourArgs []string
 
-		contourGatewayClass *gatewayapi_v1beta1.GatewayClass
-		contourGateway      *gatewayapi_v1beta1.Gateway
+		contourGatewayClass *gatewayapi_v1.GatewayClass
+		contourGateway      *gatewayapi_v1.Gateway
 	)
 
 	// Creates specified gateway in namespace and runs namespaced test
 	// body. Modifies contour config to point to gateway.
-	testWithGateway := func(gateway *gatewayapi_v1beta1.Gateway, gatewayClass *gatewayapi_v1beta1.GatewayClass, body e2e.NamespacedGatewayTestBody) e2e.NamespacedTestBody {
+	testWithGateway := func(gateway *gatewayapi_v1.Gateway, gatewayClass *gatewayapi_v1.GatewayClass, body e2e.NamespacedGatewayTestBody) e2e.NamespacedTestBody {
 		return func(namespace string) {
 			Context(fmt.Sprintf("with gateway %s/%s, controllerName: %s", namespace, gateway.Name, gatewayClass.Spec.ControllerName), func() {
 				BeforeEach(func() {
@@ -161,7 +160,7 @@ var _ = Describe("Gateway API", func() {
 		// we don't expect GatewayClasses to be reconciled
 		// or become valid.
 		if reconcileMode == ReconcileModeGateway {
-			gatewayClassCond = func(*gatewayapi_v1beta1.GatewayClass) bool { return true }
+			gatewayClassCond = func(*gatewayapi_v1.GatewayClass) bool { return true }
 		}
 
 		f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassCond)
@@ -176,19 +175,19 @@ var _ = Describe("Gateway API", func() {
 	Describe("Gateway with one HTTP listener", func() {
 		testWithHTTPGateway := func(body e2e.NamespacedGatewayTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
-			gw := &gatewayapi_v1beta1.Gateway{
+			gw := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "http",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(gatewayClass.Name),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(gatewayClass.Name),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -217,22 +216,22 @@ var _ = Describe("Gateway API", func() {
 		testWithHTTPSGateway := func(hostname string, body e2e.NamespacedGatewayTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
 
-			gw := &gatewayapi_v1beta1.Gateway{
+			gw := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "https",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(gatewayClass.Name),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(gatewayClass.Name),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "insecure",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Kinds: []gatewayapi_v1.RouteGroupKind{
 									{Kind: "HTTPRoute"},
 								},
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -240,17 +239,17 @@ var _ = Describe("Gateway API", func() {
 						{
 							Name:     "secure",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(443),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+							Port:     gatewayapi_v1.PortNumber(443),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert", ""),
 								},
 							},
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Kinds: []gatewayapi_v1.RouteGroupKind{
 									{Kind: "HTTPRoute"},
 								},
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -277,28 +276,28 @@ var _ = Describe("Gateway API", func() {
 	Describe("Gateway with multiple HTTPS listeners, each with a different hostname and TLS cert", func() {
 		testWithMultipleHTTPSListenersGateway := func(body e2e.NamespacedTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "multiple-https-listeners",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(gatewayClass.Name),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(gatewayClass.Name),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(443),
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-1.gateway.projectcontour.io")),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+							Port:     gatewayapi_v1.PortNumber(443),
+							Hostname: ref.To(gatewayapi_v1.Hostname("https-1.gateway.projectcontour.io")),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert-1", ""),
 								},
 							},
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Kinds: []gatewayapi_v1.RouteGroupKind{
 									{Kind: "HTTPRoute"},
 								},
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -306,18 +305,18 @@ var _ = Describe("Gateway API", func() {
 						{
 							Name:     "https-2",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(443),
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-2.gateway.projectcontour.io")),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+							Port:     gatewayapi_v1.PortNumber(443),
+							Hostname: ref.To(gatewayapi_v1.Hostname("https-2.gateway.projectcontour.io")),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert-2", ""),
 								},
 							},
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Kinds: []gatewayapi_v1.RouteGroupKind{
 									{Kind: "HTTPRoute"},
 								},
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -325,18 +324,18 @@ var _ = Describe("Gateway API", func() {
 						{
 							Name:     "https-3",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(443),
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-3.gateway.projectcontour.io")),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+							Port:     gatewayapi_v1.PortNumber(443),
+							Hostname: ref.To(gatewayapi_v1.Hostname("https-3.gateway.projectcontour.io")),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									gatewayapi.CertificateRef("tlscert-3", ""),
 								},
 							},
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Kinds: []gatewayapi_v1beta1.RouteGroupKind{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Kinds: []gatewayapi_v1.RouteGroupKind{
 									{Kind: "HTTPRoute"},
 								},
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -362,19 +361,19 @@ var _ = Describe("Gateway API", func() {
 	Describe("Gateway with TCP listener", func() {
 		testWithTCPGateway := func(body e2e.NamespacedGatewayTestBody) e2e.NamespacedTestBody {
 			gatewayClass := getGatewayClass()
-			gw := &gatewayapi_v1beta1.Gateway{
+			gw := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "tcp",
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(gatewayClass.Name),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(gatewayClass.Name),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "tcp",
 							Protocol: gatewayapi_v1.TCPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -398,15 +397,15 @@ func getRandomNumber() int64 {
 	return nBig.Int64()
 }
 
-func getGatewayClass() *gatewayapi_v1beta1.GatewayClass {
+func getGatewayClass() *gatewayapi_v1.GatewayClass {
 	randNumber := getRandomNumber()
 
-	return &gatewayapi_v1beta1.GatewayClass{
+	return &gatewayapi_v1.GatewayClass{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: fmt.Sprintf("contour-class-%d", randNumber),
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
-			ControllerName: gatewayapi_v1beta1.GatewayController(fmt.Sprintf("projectcontour.io/ingress-controller-%d", randNumber)),
+		Spec: gatewayapi_v1.GatewayClassSpec{
+			ControllerName: gatewayapi_v1.GatewayController(fmt.Sprintf("projectcontour.io/ingress-controller-%d", randNumber)),
 		},
 	}
 }

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -22,7 +22,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
@@ -35,33 +34,33 @@ func testHostRewrite(namespace string, gateway types.NamespacedName) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "host-rewrite",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"hostrewrite.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"hostrewrite.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{
-								Path: &gatewayapi_v1beta1.HTTPPathMatch{
+								Path: &gatewayapi_v1.HTTPPathMatch{
 									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
 									Value: ref.To("/"),
 								},
 							},
 						},
-						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+						Filters: []gatewayapi_v1.HTTPRouteFilter{
 							{
 								Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-								RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-									Add: []gatewayapi_v1beta1.HTTPHeader{
+								RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+									Add: []gatewayapi_v1.HTTPHeader{
 										{Name: gatewayapi_v1.HTTPHeaderName("Host"), Value: "rewritten.com"},
 									},
 								},

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -26,7 +26,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
@@ -40,18 +39,18 @@ func testMultipleHTTPSListeners(namespace string) {
 		for _, tc := range []string{"1", "2", "3"} {
 			f.Fixtures.Echo.Deploy(namespace, "echo-"+tc)
 
-			route := &gatewayapi_v1beta1.HTTPRoute{
+			route := &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-" + tc,
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{
 							gatewayapi.GatewayListenerParentRef("", "multiple-https-listeners", "https-"+tc, 0),
 						},
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo-"+tc, 80, 1),

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
@@ -36,27 +36,27 @@ func testGatewayMultipleQueryParamMatch(namespace string, gateway types.Namespac
 		f.Fixtures.Echo.Deploy(namespace, "echo-3")
 		f.Fixtures.Echo.Deploy(namespace, "echo-4")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "httproute-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"queryparams.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
 					},
 					{
-						Matches: []gatewayapi_v1beta1.HTTPRouteMatch{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "dolphin"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -24,7 +24,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
@@ -37,34 +36,34 @@ func testRequestHeaderModifierBackendRef(namespace string, gateway types.Namespa
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"requestheadermodifierbackendref.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"requestheadermodifierbackendref.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/filter"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("echo-header-filter", 80),
 								},
-								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								Filters: []gatewayapi_v1.HTTPRouteFilter{
 									{
 										Type: gatewayapi_v1.HTTPRouteFilterRequestHeaderModifier,
-										RequestHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Add: []gatewayapi_v1beta1.HTTPHeader{
+										RequestHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+											Add: []gatewayapi_v1.HTTPHeader{
 												{Name: gatewayapi_v1.HTTPHeaderName("My-Header"), Value: "Foo"},
 											},
-											Set: []gatewayapi_v1beta1.HTTPHeader{
+											Set: []gatewayapi_v1.HTTPHeader{
 												{Name: gatewayapi_v1.HTTPHeaderName("Replace-Header"), Value: "Bar"},
 											},
 											Remove: []string{"Other-Header"},

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -24,7 +24,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
@@ -37,29 +36,29 @@ func testRequestRedirectRule(namespace string, gateway types.NamespacedName) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "httproute-redirect",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"requestredirectrule.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"requestredirectrule.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/complex-redirect"),
-						Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+						Filters: []gatewayapi_v1.HTTPRouteFilter{
 							{
 								Type: gatewayapi_v1.HTTPRouteFilterRequestRedirect,
-								RequestRedirect: &gatewayapi_v1beta1.HTTPRequestRedirectFilter{
-									Hostname:   ref.To(gatewayapi_v1beta1.PreciseHostname("envoyproxy.io")),
+								RequestRedirect: &gatewayapi_v1.HTTPRequestRedirectFilter{
+									Hostname:   ref.To(gatewayapi_v1.PreciseHostname("envoyproxy.io")),
 									StatusCode: ref.To(301),
 									Scheme:     ref.To("https"),
-									Port:       ref.To(gatewayapi_v1beta1.PortNumber(8080)),
+									Port:       ref.To(gatewayapi_v1.PortNumber(8080)),
 								},
 							},
 						},

--- a/test/e2e/gateway/response_header_modifier_test.go
+++ b/test/e2e/gateway/response_header_modifier_test.go
@@ -24,7 +24,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/test/e2e"
@@ -37,34 +36,34 @@ func testResponseHeaderModifierBackendRef(namespace string, gateway types.Namesp
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-filter")
 		f.Fixtures.Echo.Deploy(namespace, "echo-header-nofilter")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-filter-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"responseheadermodifierbackendref.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"responseheadermodifierbackendref.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches: gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/filter"),
-						BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("echo-header-filter", 80),
 								},
-								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								Filters: []gatewayapi_v1.HTTPRouteFilter{
 									{
 										Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-										ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Add: []gatewayapi_v1beta1.HTTPHeader{
+										ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+											Add: []gatewayapi_v1.HTTPHeader{
 												{Name: gatewayapi_v1.HTTPHeaderName("My-Header"), Value: "Foo"},
 											},
-											Set: []gatewayapi_v1beta1.HTTPHeader{
+											Set: []gatewayapi_v1.HTTPHeader{
 												{Name: gatewayapi_v1.HTTPHeaderName("Replace-Header"), Value: "Bar"},
 											},
 											Remove: []string{"Other-Header"},
@@ -73,7 +72,7 @@ func testResponseHeaderModifierBackendRef(namespace string, gateway types.Namesp
 								},
 							},
 							{
-								BackendRef: gatewayapi_v1beta1.BackendRef{
+								BackendRef: gatewayapi_v1.BackendRef{
 									BackendObjectReference: gatewayapi.ServiceBackendObjectRef("echo-header-nofilter", 80),
 								},
 							},

--- a/test/e2e/gateway/tcproute_test.go
+++ b/test/e2e/gateway/tcproute_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
@@ -41,11 +41,11 @@ func testTCPRoute(namespace string, gateway types.NamespacedName) {
 				Name:      "tcproute-1",
 			},
 			Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
 					ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 						{
-							Namespace: ref.To(gatewayapi_v1beta1.Namespace(gateway.Namespace)),
-							Name:      gatewayapi_v1beta1.ObjectName(gateway.Name),
+							Namespace: ref.To(gatewayapi_v1.Namespace(gateway.Namespace)),
+							Name:      gatewayapi_v1.ObjectName(gateway.Name),
 						},
 					},
 				},

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -22,7 +22,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
@@ -36,23 +35,23 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 		f.Fixtures.Echo.Deploy(namespace, "echo-insecure")
 		f.Fixtures.Echo.Deploy(namespace, "echo-secure")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"tls-gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"tls-gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						{
-							Namespace:   ref.To(gatewayapi_v1beta1.Namespace(gateway.Namespace)),
-							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
-							SectionName: ref.To(gatewayapi_v1beta1.SectionName("insecure")),
+							Namespace:   ref.To(gatewayapi_v1.Namespace(gateway.Namespace)),
+							Name:        gatewayapi_v1.ObjectName(gateway.Name),
+							SectionName: ref.To(gatewayapi_v1.SectionName("insecure")),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-insecure", 80, 1),
@@ -62,23 +61,23 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 		}
 		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
 
-		route = &gatewayapi_v1beta1.HTTPRoute{
+		route = &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-2",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"tls-gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"tls-gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						{
-							Namespace:   ref.To(gatewayapi_v1beta1.Namespace(gateway.Namespace)),
-							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
-							SectionName: ref.To(gatewayapi_v1beta1.SectionName("secure")),
+							Namespace:   ref.To(gatewayapi_v1.Namespace(gateway.Namespace)),
+							Name:        gatewayapi_v1.ObjectName(gateway.Name),
+							SectionName: ref.To(gatewayapi_v1.SectionName("secure")),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-secure", 80, 1),

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/projectcontour/contour/internal/gatewayapi"
 	"github.com/projectcontour/contour/internal/ref"
@@ -37,23 +36,23 @@ func testTLSWildcardHost(namespace string, gateway types.NamespacedName) {
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 
-		route := &gatewayapi_v1beta1.HTTPRoute{
+		route := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,
 				Name:      "http-route-1",
 			},
-			Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-				Hostnames: []gatewayapi_v1beta1.Hostname{"*.wildcardhost.gateway.projectcontour.io"},
-				CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayapi_v1beta1.ParentReference{
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"*.wildcardhost.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
 						{
-							Namespace:   ref.To(gatewayapi_v1beta1.Namespace(gateway.Namespace)),
-							Name:        gatewayapi_v1beta1.ObjectName(gateway.Name),
-							SectionName: ref.To(gatewayapi_v1beta1.SectionName("secure")),
+							Namespace:   ref.To(gatewayapi_v1.Namespace(gateway.Namespace)),
+							Name:        gatewayapi_v1.ObjectName(gateway.Name),
+							SectionName: ref.To(gatewayapi_v1.SectionName("secure")),
 						},
 					},
 				},
-				Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+				Rules: []gatewayapi_v1.HTTPRouteRule{
 					{
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -19,12 +19,11 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // GatewayClassAccepted returns true if the gateway has a .status.conditions
 // entry of Accepted: true".
-func GatewayClassAccepted(gatewayClass *gatewayapi_v1beta1.GatewayClass) bool {
+func GatewayClassAccepted(gatewayClass *gatewayapi_v1.GatewayClass) bool {
 	if gatewayClass == nil {
 		return false
 	}
@@ -38,7 +37,7 @@ func GatewayClassAccepted(gatewayClass *gatewayapi_v1beta1.GatewayClass) bool {
 
 // GatewayClassNotAccepted returns true if the gateway has a .status.conditions
 // entry of Accepted: false".
-func GatewayClassNotAccepted(gatewayClass *gatewayapi_v1beta1.GatewayClass) bool {
+func GatewayClassNotAccepted(gatewayClass *gatewayapi_v1.GatewayClass) bool {
 	if gatewayClass == nil {
 		return false
 	}
@@ -52,7 +51,7 @@ func GatewayClassNotAccepted(gatewayClass *gatewayapi_v1beta1.GatewayClass) bool
 
 // GatewayAccepted returns true if the gateway has a .status.conditions
 // entry of "Accepted: true".
-func GatewayAccepted(gateway *gatewayapi_v1beta1.Gateway) bool {
+func GatewayAccepted(gateway *gatewayapi_v1.Gateway) bool {
 	if gateway == nil {
 		return false
 	}
@@ -66,7 +65,7 @@ func GatewayAccepted(gateway *gatewayapi_v1beta1.Gateway) bool {
 
 // GatewayProgrammed returns true if the gateway has a .status.conditions
 // entry of "Programmed: true".
-func GatewayProgrammed(gateway *gatewayapi_v1beta1.Gateway) bool {
+func GatewayProgrammed(gateway *gatewayapi_v1.Gateway) bool {
 	if gateway == nil {
 		return false
 	}
@@ -80,7 +79,7 @@ func GatewayProgrammed(gateway *gatewayapi_v1beta1.Gateway) bool {
 
 // ListenerAccepted returns true if the gateway has status for the named
 // listener with a condition of "Accepted: true".
-func ListenerAccepted(gateway *gatewayapi_v1beta1.Gateway, listener gatewayapi_v1beta1.SectionName) bool {
+func ListenerAccepted(gateway *gatewayapi_v1.Gateway, listener gatewayapi_v1.SectionName) bool {
 	for _, listenerStatus := range gateway.Status.Listeners {
 		if listenerStatus.Name == listener {
 			return conditionExists(
@@ -96,7 +95,7 @@ func ListenerAccepted(gateway *gatewayapi_v1beta1.Gateway, listener gatewayapi_v
 
 // GatewayHasAddress returns true if the gateway has a non-empty
 // .status.addresses entry.
-func GatewayHasAddress(gateway *gatewayapi_v1beta1.Gateway) bool {
+func GatewayHasAddress(gateway *gatewayapi_v1.Gateway) bool {
 	if gateway == nil {
 		return false
 	}
@@ -106,13 +105,13 @@ func GatewayHasAddress(gateway *gatewayapi_v1beta1.Gateway) bool {
 
 // HTTPRouteAccepted returns true if the route has a .status.conditions
 // entry of "Accepted: true".
-func HTTPRouteAccepted(route *gatewayapi_v1beta1.HTTPRoute) bool {
+func HTTPRouteAccepted(route *gatewayapi_v1.HTTPRoute) bool {
 	if route == nil {
 		return false
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExists(gw.Conditions, string(gatewayapi_v1beta1.RouteConditionAccepted), meta_v1.ConditionTrue) {
+		if conditionExists(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionTrue) {
 			return true
 		}
 	}
@@ -121,7 +120,7 @@ func HTTPRouteAccepted(route *gatewayapi_v1beta1.HTTPRoute) bool {
 }
 
 // HTTPRouteIgnoredByContour returns true if the route has an empty .status.parents.conditions list
-func HTTPRouteIgnoredByContour(route *gatewayapi_v1beta1.HTTPRoute) bool {
+func HTTPRouteIgnoredByContour(route *gatewayapi_v1.HTTPRoute) bool {
 	if route == nil {
 		return false
 	}
@@ -137,7 +136,7 @@ func TCPRouteAccepted(route *gatewayapi_v1alpha2.TCPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExists(gw.Conditions, string(gatewayapi_v1beta1.RouteConditionAccepted), meta_v1.ConditionTrue) {
+		if conditionExists(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionTrue) {
 			return true
 		}
 	}

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -52,12 +51,12 @@ func TestProvisioner(t *testing.T) {
 var _ = BeforeSuite(func() {
 	require.NoError(f.T(), f.Provisioner.EnsureResourcesForInclusterProvisioner())
 
-	gc := &gatewayapi_v1beta1.GatewayClass{
+	gc := &gatewayapi_v1.GatewayClass{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "contour",
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
-			ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
+		Spec: gatewayapi_v1.GatewayClassSpec{
+			ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
 		},
 	}
 
@@ -79,10 +78,10 @@ var _ = BeforeSuite(func() {
 		}
 		require.NoError(f.T(), f.Client.Create(context.Background(), params))
 
-		gc.Spec.ParametersRef = &gatewayapi_v1beta1.ParametersReference{
+		gc.Spec.ParametersRef = &gatewayapi_v1.ParametersReference{
 			Group:     "projectcontour.io",
 			Kind:      "ContourDeployment",
-			Namespace: ref.To(gatewayapi_v1beta1.Namespace(params.Namespace)),
+			Namespace: ref.To(gatewayapi_v1.Namespace(params.Namespace)),
 			Name:      params.Name,
 		}
 	}
@@ -104,16 +103,16 @@ var _ = BeforeSuite(func() {
 	}
 	require.NoError(f.T(), f.Client.Create(context.Background(), paramsEnvoyDeployment))
 
-	gcWithEnvoyDeployment := &gatewayapi_v1beta1.GatewayClass{
+	gcWithEnvoyDeployment := &gatewayapi_v1.GatewayClass{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "contour-with-envoy-deployment",
 		},
-		Spec: gatewayapi_v1beta1.GatewayClassSpec{
-			ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
-			ParametersRef: &gatewayapi_v1beta1.ParametersReference{
+		Spec: gatewayapi_v1.GatewayClassSpec{
+			ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
+			ParametersRef: &gatewayapi_v1.ParametersReference{
 				Group:     "projectcontour.io",
 				Kind:      "ContourDeployment",
-				Namespace: ref.To(gatewayapi_v1beta1.Namespace(paramsEnvoyDeployment.Namespace)),
+				Namespace: ref.To(gatewayapi_v1.Namespace(paramsEnvoyDeployment.Namespace)),
 				Name:      paramsEnvoyDeployment.Name,
 			},
 		},
@@ -129,7 +128,7 @@ var _ = AfterSuite(func() {
 	require.NoError(f.T(), f.Provisioner.DeleteResourcesForInclusterProvisioner())
 
 	for _, name := range []string{"contour", "contour-with-envoy-deployment"} {
-		gc := &gatewayapi_v1beta1.GatewayClass{
+		gc := &gatewayapi_v1.GatewayClass{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: name,
 			},
@@ -146,7 +145,7 @@ var _ = Describe("Gateway provisioner", func() {
 		// This test will fail if we bump the Gateway API module and CRDs but
 		// forget to update the supported version we check for.
 		require.Eventually(f.T(), func() bool {
-			gc := &gatewayapi_v1beta1.GatewayClass{
+			gc := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour",
 				},
@@ -168,16 +167,16 @@ var _ = Describe("Gateway provisioner", func() {
 		Specify("GatewayClass parameters are handled correctly", func() {
 			// Create GatewayClass with a reference to a nonexistent ContourDeployment,
 			// it should be set to "Accepted: false" since the ref is invalid.
-			gatewayClass := &gatewayapi_v1beta1.GatewayClass{
+			gatewayClass := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: "contour-with-params",
 				},
-				Spec: gatewayapi_v1beta1.GatewayClassSpec{
-					ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
-					ParametersRef: &gatewayapi_v1beta1.ParametersReference{
+				Spec: gatewayapi_v1.GatewayClassSpec{
+					ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
+					ParametersRef: &gatewayapi_v1.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
-						Namespace: ref.To(gatewayapi_v1beta1.Namespace(namespace)),
+						Namespace: ref.To(gatewayapi_v1.Namespace(namespace)),
 						Name:      "contour-params",
 					},
 				},
@@ -187,20 +186,20 @@ var _ = Describe("Gateway provisioner", func() {
 
 			// Create a Gateway using that GatewayClass, it should not be accepted
 			// since the GatewayClass is not accepted.
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "http",
 					Namespace: namespace,
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-with-params"),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-with-params"),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -211,7 +210,7 @@ var _ = Describe("Gateway provisioner", func() {
 			require.NoError(f.T(), f.Client.Create(context.Background(), gateway))
 
 			require.Never(f.T(), func() bool {
-				gw := &gatewayapi_v1beta1.Gateway{}
+				gw := &gatewayapi_v1.Gateway{}
 				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(gateway), gw); err != nil {
 					return false
 				}
@@ -233,7 +232,7 @@ var _ = Describe("Gateway provisioner", func() {
 
 			// Now the GatewayClass should be accepted.
 			require.Eventually(f.T(), func() bool {
-				gc := &gatewayapi_v1beta1.GatewayClass{}
+				gc := &gatewayapi_v1.GatewayClass{}
 				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(gatewayClass), gc); err != nil {
 					return false
 				}
@@ -243,7 +242,7 @@ var _ = Describe("Gateway provisioner", func() {
 
 			// And now the Gateway should be accepted.
 			require.Eventually(f.T(), func() bool {
-				gw := &gatewayapi_v1beta1.Gateway{}
+				gw := &gatewayapi_v1.Gateway{}
 				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(gateway), gw); err != nil {
 					return false
 				}
@@ -257,20 +256,20 @@ var _ = Describe("Gateway provisioner", func() {
 
 	f.NamespacedTest("gateway-with-envoy-deployment", func(namespace string) {
 		Specify("A gateway with Envoy as a deployment can be provisioned and routes traffic correctly", func() {
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "http",
 					Namespace: namespace,
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName("contour-with-envoy-deployment"),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName("contour-with-envoy-deployment"),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -279,26 +278,26 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1beta1.Gateway) bool {
+			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
 			})
 			require.True(f.T(), ok)
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
-			route := &gatewayapi_v1beta1.HTTPRoute{
+			route := &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-1",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					Hostnames: []gatewayapi_v1beta1.Hostname{"provisioner.projectcontour.io"},
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					Hostnames: []gatewayapi_v1.Hostname{"provisioner.projectcontour.io"},
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{
 							gatewayapi.GatewayParentRef("", gateway.Name),
 						},
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
@@ -329,34 +328,34 @@ var _ = Describe("Gateway provisioner", func() {
 			f.Certs.CreateSelfSignedCert(namespace, "https-1-cert", "https-1-cert", "https-1.provisioner.projectcontour.io")
 			f.Certs.CreateSelfSignedCert(namespace, "https-2-cert", "https-2-cert", "https-2.provisioner.projectcontour.io")
 
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "many-listeners",
 					Namespace: namespace,
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
+				Spec: gatewayapi_v1.GatewaySpec{
 					GatewayClassName: "contour",
-					Listeners: []gatewayapi_v1beta1.Listener{
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http-1",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     80,
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("http-1.provisioner.projectcontour.io")),
+							Hostname: ref.To(gatewayapi_v1.Hostname("http-1.provisioner.projectcontour.io")),
 						},
 						{
 							Name:     "http-2",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
 							Port:     81,
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("http-2.provisioner.projectcontour.io")),
+							Hostname: ref.To(gatewayapi_v1.Hostname("http-2.provisioner.projectcontour.io")),
 						},
 						{
 							Name:     "https-1",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     443,
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-1.provisioner.projectcontour.io")),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							Hostname: ref.To(gatewayapi_v1.Hostname("https-1.provisioner.projectcontour.io")),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									{Name: "https-1-cert"},
 								},
 							},
@@ -365,10 +364,10 @@ var _ = Describe("Gateway provisioner", func() {
 							Name:     "https-2",
 							Protocol: gatewayapi_v1.HTTPSProtocolType,
 							Port:     444,
-							Hostname: ref.To(gatewayapi_v1beta1.Hostname("https-2.provisioner.projectcontour.io")),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							Hostname: ref.To(gatewayapi_v1.Hostname("https-2.provisioner.projectcontour.io")),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ref.To(gatewayapi_v1.TLSModeTerminate),
-								CertificateRefs: []gatewayapi_v1beta1.SecretObjectReference{
+								CertificateRefs: []gatewayapi_v1.SecretObjectReference{
 									{Name: "https-2-cert"},
 								},
 							},
@@ -387,7 +386,7 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1beta1.Gateway) bool {
+			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				if !(e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)) {
 					return false
 				}
@@ -405,18 +404,18 @@ var _ = Describe("Gateway provisioner", func() {
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
 			// This HTTPRoute will attach to all of the HTTP and HTTPS Listeners.
-			httpRoute := &gatewayapi_v1beta1.HTTPRoute{
+			httpRoute := &gatewayapi_v1.HTTPRoute{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Namespace: namespace,
 					Name:      "httproute-1",
 				},
-				Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayapi_v1beta1.ParentReference{
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{
 							gatewayapi.GatewayParentRef("", gateway.Name),
 						},
 					},
-					Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+					Rules: []gatewayapi_v1.HTTPRouteRule{
 						{
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
@@ -472,11 +471,11 @@ var _ = Describe("Gateway provisioner", func() {
 					Name:      "tcproute-1",
 				},
 				Spec: gatewayapi_v1alpha2.TCPRouteSpec{
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
 						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 							{
-								Namespace: ref.To(gatewayapi_v1beta1.Namespace(gateway.Namespace)),
-								Name:      gatewayapi_v1beta1.ObjectName(gateway.Name),
+								Namespace: ref.To(gatewayapi_v1.Namespace(gateway.Namespace)),
+								Name:      gatewayapi_v1.ObjectName(gateway.Name),
 							},
 						},
 					},
@@ -521,16 +520,16 @@ var _ = Describe("Gateway provisioner", func() {
 		objectTestName := "contour-params-with-watch-namespaces"
 		BeforeEach(func() {
 			By("create gatewayclass that reference contourDeployment with watchNamespace value")
-			gatewayClass := &gatewayapi_v1beta1.GatewayClass{
+			gatewayClass := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: objectTestName,
 				},
-				Spec: gatewayapi_v1beta1.GatewayClassSpec{
-					ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
-					ParametersRef: &gatewayapi_v1beta1.ParametersReference{
+				Spec: gatewayapi_v1.GatewayClassSpec{
+					ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
+					ParametersRef: &gatewayapi_v1.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
-						Namespace: ref.To(gatewayapi_v1beta1.Namespace(namespace)),
+						Namespace: ref.To(gatewayapi_v1.Namespace(namespace)),
 						Name:      objectTestName,
 					},
 				},
@@ -555,7 +554,7 @@ var _ = Describe("Gateway provisioner", func() {
 
 			// Now the GatewayClass should be accepted.
 			require.Eventually(f.T(), func() bool {
-				gc := &gatewayapi_v1beta1.GatewayClass{}
+				gc := &gatewayapi_v1.GatewayClass{}
 				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(gatewayClass), gc); err != nil {
 					return false
 				}
@@ -564,7 +563,7 @@ var _ = Describe("Gateway provisioner", func() {
 			}, time.Minute, time.Second)
 		})
 		AfterEach(func() {
-			require.NoError(f.T(), f.DeleteGatewayClass(&gatewayapi_v1beta1.GatewayClass{
+			require.NoError(f.T(), f.DeleteGatewayClass(&gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: objectTestName,
 				},
@@ -573,20 +572,20 @@ var _ = Describe("Gateway provisioner", func() {
 		Specify("A gateway can be provisioned that only reconciles routes in a subset of namespaces", func() {
 			By("This tests deploy 3 dev namespaces testns-1, testns-2, testns-3")
 			By("Deploy gateway that referencing above gatewayclass")
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "http-for-watchnamespaces",
 					Namespace: namespace,
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(objectTestName),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(objectTestName),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "http",
 							Protocol: gatewayapi_v1.HTTPProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(80),
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							Port:     gatewayapi_v1.PortNumber(80),
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									// TODO: set to from all for now
 									// The correct way would be label the testns-1, testns-2, testns-3, then select by label
 									From: ref.To(gatewayapi_v1.NamespacesFromAll),
@@ -597,7 +596,7 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1beta1.Gateway) bool {
+			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
 			})
 			require.True(f.T(), ok, fmt.Sprintf("gateway is %v", gateway))
@@ -624,19 +623,19 @@ var _ = Describe("Gateway provisioner", func() {
 			for _, t := range testcases {
 				f.Fixtures.Echo.Deploy(t.namespace, "echo")
 
-				route := &gatewayapi_v1beta1.HTTPRoute{
+				route := &gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: t.namespace,
 						Name:      "httproute-1",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						Hostnames: []gatewayapi_v1beta1.Hostname{"provisioner.projectcontour.io"},
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						Hostnames: []gatewayapi_v1.Hostname{"provisioner.projectcontour.io"},
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
 								gatewayapi.GatewayParentRef("", gateway.Name),
 							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+						Rules: []gatewayapi_v1.HTTPRouteRule{
 							{
 								Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/prefix"),
 								BackendRefs: gatewayapi.HTTPBackendRef("echo", 80, 1),
@@ -649,7 +648,7 @@ var _ = Describe("Gateway provisioner", func() {
 					// set route's parentRef's namespace to the gateway's namespace
 					route.Spec.CommonRouteSpec.ParentRefs[0].Namespace = (*gatewayapi_v1.Namespace)(&namespace)
 					// set the route's hostnames to custom name with namespace inside
-					route.Spec.Hostnames = []gatewayapi_v1beta1.Hostname{gatewayapi_v1beta1.Hostname("provisioner.projectcontour.io." + t.namespace)}
+					route.Spec.Hostnames = []gatewayapi_v1.Hostname{gatewayapi_v1.Hostname("provisioner.projectcontour.io." + t.namespace)}
 
 					By(fmt.Sprintf("Expect namespace %s to be watched by contour", t.namespace))
 					hr, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
@@ -675,7 +674,7 @@ var _ = Describe("Gateway provisioner", func() {
 
 					By(fmt.Sprintf("Expect httproute under namespace %s is not accepted for a period of time", t.namespace))
 					require.Never(f.T(), func() bool {
-						hr = &gatewayapi_v1beta1.HTTPRoute{}
+						hr = &gatewayapi_v1.HTTPRoute{}
 						if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(hr), hr); err != nil {
 							return false
 						}
@@ -689,16 +688,16 @@ var _ = Describe("Gateway provisioner", func() {
 		objectTestName := "contour-params-with-disabled-features"
 		BeforeEach(func() {
 			By("create gatewayclass that reference contourDeployment with disabled-features value")
-			gatewayClass := &gatewayapi_v1beta1.GatewayClass{
+			gatewayClass := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: objectTestName,
 				},
-				Spec: gatewayapi_v1beta1.GatewayClassSpec{
-					ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
-					ParametersRef: &gatewayapi_v1beta1.ParametersReference{
+				Spec: gatewayapi_v1.GatewayClassSpec{
+					ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
+					ParametersRef: &gatewayapi_v1.ParametersReference{
 						Group:     "projectcontour.io",
 						Kind:      "ContourDeployment",
-						Namespace: ref.To(gatewayapi_v1beta1.Namespace(namespace)),
+						Namespace: ref.To(gatewayapi_v1.Namespace(namespace)),
 						Name:      objectTestName,
 					},
 				},
@@ -723,7 +722,7 @@ var _ = Describe("Gateway provisioner", func() {
 
 			// Now the GatewayClass should be accepted.
 			require.Eventually(f.T(), func() bool {
-				gc := &gatewayapi_v1beta1.GatewayClass{}
+				gc := &gatewayapi_v1.GatewayClass{}
 				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(gatewayClass), gc); err != nil {
 					return false
 				}
@@ -732,7 +731,7 @@ var _ = Describe("Gateway provisioner", func() {
 			}, time.Minute, time.Second)
 		})
 		AfterEach(func() {
-			require.NoError(f.T(), f.DeleteGatewayClass(&gatewayapi_v1beta1.GatewayClass{
+			require.NoError(f.T(), f.DeleteGatewayClass(&gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: objectTestName,
 				},
@@ -740,23 +739,23 @@ var _ = Describe("Gateway provisioner", func() {
 		})
 		Specify("A gateway can be provisioned that ignore CRDs in disabledFeatures", func() {
 			By("Deploy gateway that referencing above gatewayclass")
-			gateway := &gatewayapi_v1beta1.Gateway{
+			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:      "tlsroute",
 					Namespace: namespace,
 				},
-				Spec: gatewayapi_v1beta1.GatewaySpec{
-					GatewayClassName: gatewayapi_v1beta1.ObjectName(objectTestName),
-					Listeners: []gatewayapi_v1beta1.Listener{
+				Spec: gatewayapi_v1.GatewaySpec{
+					GatewayClassName: gatewayapi_v1.ObjectName(objectTestName),
+					Listeners: []gatewayapi_v1.Listener{
 						{
 							Name:     "https",
 							Protocol: gatewayapi_v1.TLSProtocolType,
-							Port:     gatewayapi_v1beta1.PortNumber(443),
-							TLS: &gatewayapi_v1beta1.GatewayTLSConfig{
+							Port:     gatewayapi_v1.PortNumber(443),
+							TLS: &gatewayapi_v1.GatewayTLSConfig{
 								Mode: ptr.To(gatewayapi_v1.TLSModePassthrough),
 							},
-							AllowedRoutes: &gatewayapi_v1beta1.AllowedRoutes{
-								Namespaces: &gatewayapi_v1beta1.RouteNamespaces{
+							AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+								Namespaces: &gatewayapi_v1.RouteNamespaces{
 									From: ref.To(gatewayapi_v1.NamespacesFromSame),
 								},
 							},
@@ -765,7 +764,7 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1beta1.Gateway) bool {
+			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
 			})
 			require.True(f.T(), ok, fmt.Sprintf("gateway is %v", gateway))
@@ -779,7 +778,7 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 				Spec: gatewayapi_v1alpha2.TLSRouteSpec{
 					Hostnames: []gatewayapi_v1alpha2.Hostname{"provisioner.projectcontour.io"},
-					CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
 						ParentRefs: []gatewayapi_v1alpha2.ParentReference{
 							{
 								Namespace: ref.To(gatewayapi_v1alpha2.Namespace(gateway.Namespace)),

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -31,7 +31,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/k8s"
@@ -148,12 +147,12 @@ var _ = Describe("When upgrading", func() {
 
 			Eventually(sess, f.RetryTimeout, f.RetryInterval).Should(gexec.Exit(0))
 
-			gc, ok := f.CreateGatewayClassAndWaitFor(&gatewayapi_v1beta1.GatewayClass{
+			gc, ok := f.CreateGatewayClassAndWaitFor(&gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: gatewayClassName,
 				},
-				Spec: gatewayapi_v1beta1.GatewayClassSpec{
-					ControllerName: gatewayapi_v1beta1.GatewayController("projectcontour.io/gateway-controller"),
+				Spec: gatewayapi_v1.GatewayClassSpec{
+					ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
 				},
 			}, e2e.GatewayClassAccepted)
 
@@ -164,7 +163,7 @@ var _ = Describe("When upgrading", func() {
 		AfterEach(func() {
 			require.NoError(f.T(), f.Provisioner.DeleteResourcesForInclusterProvisioner())
 
-			gc := &gatewayapi_v1beta1.GatewayClass{
+			gc := &gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: gatewayClassName,
 				},
@@ -179,23 +178,23 @@ var _ = Describe("When upgrading", func() {
 
 				appHost := "upgrade.provisioner.projectcontour.io"
 
-				gateway, ok := f.CreateGatewayAndWaitFor(&gatewayapi_v1beta1.Gateway{
+				gateway, ok := f.CreateGatewayAndWaitFor(&gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: namespace,
 						Name:      "upgrade-gateway",
 					},
-					Spec: gatewayapi_v1beta1.GatewaySpec{
+					Spec: gatewayapi_v1.GatewaySpec{
 						GatewayClassName: gatewayClassName,
-						Listeners: []gatewayapi_v1beta1.Listener{
+						Listeners: []gatewayapi_v1.Listener{
 							{
 								Name:     "http",
-								Port:     gatewayapi_v1beta1.PortNumber(80),
+								Port:     gatewayapi_v1.PortNumber(80),
 								Protocol: gatewayapi_v1.HTTPProtocolType,
-								Hostname: ref.To(gatewayapi_v1beta1.Hostname(appHost)),
+								Hostname: ref.To(gatewayapi_v1.Hostname(appHost)),
 							},
 						},
 					},
-				}, func(gw *gatewayapi_v1beta1.Gateway) bool {
+				}, func(gw *gatewayapi_v1.Gateway) bool {
 					return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
 				})
 				require.True(t, ok)
@@ -205,34 +204,34 @@ var _ = Describe("When upgrading", func() {
 
 				f.Fixtures.Echo.DeployN(namespace, "echo", 2)
 
-				f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1beta1.HTTPRoute{
+				f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: namespace,
 						Name:      "echo",
 					},
-					Spec: gatewayapi_v1beta1.HTTPRouteSpec{
-						CommonRouteSpec: gatewayapi_v1beta1.CommonRouteSpec{
-							ParentRefs: []gatewayapi_v1beta1.ParentReference{
-								{Name: gatewayapi_v1beta1.ObjectName(gateway.Name)},
+					Spec: gatewayapi_v1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+							ParentRefs: []gatewayapi_v1.ParentReference{
+								{Name: gatewayapi_v1.ObjectName(gateway.Name)},
 							},
 						},
-						Rules: []gatewayapi_v1beta1.HTTPRouteRule{
+						Rules: []gatewayapi_v1.HTTPRouteRule{
 							{
-								BackendRefs: []gatewayapi_v1beta1.HTTPBackendRef{
+								BackendRefs: []gatewayapi_v1.HTTPBackendRef{
 									{
-										BackendRef: gatewayapi_v1beta1.BackendRef{
-											BackendObjectReference: gatewayapi_v1beta1.BackendObjectReference{
-												Name: gatewayapi_v1beta1.ObjectName("echo"),
-												Port: ref.To(gatewayapi_v1beta1.PortNumber(80)),
+										BackendRef: gatewayapi_v1.BackendRef{
+											BackendObjectReference: gatewayapi_v1.BackendObjectReference{
+												Name: gatewayapi_v1.ObjectName("echo"),
+												Port: ref.To(gatewayapi_v1.PortNumber(80)),
 											},
 										},
 									},
 								},
-								Filters: []gatewayapi_v1beta1.HTTPRouteFilter{
+								Filters: []gatewayapi_v1.HTTPRouteFilter{
 									{
 										Type: gatewayapi_v1.HTTPRouteFilterResponseHeaderModifier,
-										ResponseHeaderModifier: &gatewayapi_v1beta1.HTTPHeaderFilter{
-											Set: []gatewayapi_v1beta1.HTTPHeader{
+										ResponseHeaderModifier: &gatewayapi_v1.HTTPHeaderFilter{
+											Set: []gatewayapi_v1.HTTPHeader{
 												{
 													Name:  gatewayapi_v1.HTTPHeaderName("X-Envoy-Response-Flags"),
 													Value: "%RESPONSE_FLAGS%",


### PR DESCRIPTION
Only files that set up an API client scheme or use ReferenceGrant should have the v1beta1 import

Fixes: #6150