### PR TITLE
Gateway API: Fix for Listener/Route hostname isolation

### DIFF
--- a/changelogs/unreleased/6162-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/6162-sunjayBhatia-minor.md
@@ -1,0 +1,5 @@
+## Gateway API: Implement Listener/Route hostname isolation
+
+Gateway API spec update in this [GEP](https://github.com/kubernetes-sigs/gateway-api/pull/2465).
+Updates logic on finding intersecting route and Listener hostnames to factor in the other Listeners on a Gateway that the route in question may not actually be attached to.
+Requests should be "isolated" to the most specific Listener and it's attached routes.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -221,6 +221,8 @@ func (p *GatewayAPIProcessor) processRoute(
 			p.resolveRouteRefs(route, routeParentStatus)
 		}
 
+		// Collect other Listeners with configured hostnames so we can
+		// calculate Listener/Route hostname intersection properly.
 		otherListenerHostnames := []string{}
 		for _, listener := range listeners {
 			name := string(listener.listener.Name)

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -831,9 +831,13 @@ func TestGetListenersForRouteParentRef(t *testing.T) {
 				map[string]int{},
 				rpsu)
 
-			var want []*listenerInfo
-			for _, i := range tc.want {
-				want = append(want, tc.listeners[i])
+			var want map[string]*listenerInfo
+			if len(tc.want) > 0 {
+				want = map[string]*listenerInfo{}
+				for _, i := range tc.want {
+					listener := tc.listeners[i]
+					want[string(listener.listener.Name)] = listener
+				}
 			}
 
 			assert.Equal(t, want, got)

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -97,12 +97,6 @@ func TestGatewayConformance(t *testing.T) {
 			// sends a request for an unknown (to Contour/Envoy) host which fails
 			// instead of returning a 404.
 			tests.HTTPRouteHTTPSListener.ShortName,
-
-			// The cases in this test that fail involve Listener/HTTPRoute hostname
-			// intersection and ensuring requests are only routed to the most
-			// specific Listeners/Routes that match them.
-			// See: https://github.com/projectcontour/contour/pull/6162
-			tests.GatewayHTTPListenerIsolation.ShortName,
 		},
 		ExemptFeatures: sets.New(
 			features.SupportMesh,


### PR DESCRIPTION
Requests should be "isolated" to the most specific Listener and it's attached routes. This means our existing logic on finding intersecting route and Listener hostnames needs an update to factor in the other Listeners on a Gateway that the route in question may not actually be attached to.

Fix for conformance test: https://github.com/kubernetes-sigs/gateway-api/pull/2669

https://github.com/kubernetes-sigs/gateway-api/pull/2465 for spec