### PR TITLE
Fixes BackendTLSPolicy Status Update data race

### DIFF
--- a/changelogs/unreleased/6185-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6185-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Fix data race in BackendTlSPolicy status update logic.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -2098,7 +2098,6 @@ func (p *GatewayAPIProcessor) computeBackendTLSPolicies(routeNamespace string, b
 		backendTLSPolicyAccessor, commit := p.dag.StatusCache.BackendTLSPolicyConditionsAccessor(
 			k8s.NamespacedNameOf(backendTLSPolicy),
 			backendTLSPolicy.GetGeneration(),
-			backendTLSPolicy,
 		)
 		defer commit()
 		backendTLSPolicyAncestorStatus := backendTLSPolicyAccessor.StatusUpdateFor(routeParentRef)

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -11471,7 +11471,6 @@ func TestGatewayAPIBackendTLSPolicyDAGStatus(t *testing.T) {
 				cmpopts.IgnoreFields(status.BackendTLSPolicyStatusUpdate{}, "GatewayRef"),
 				cmpopts.IgnoreFields(status.BackendTLSPolicyStatusUpdate{}, "Generation"),
 				cmpopts.IgnoreFields(status.BackendTLSPolicyStatusUpdate{}, "TransitionTime"),
-				cmpopts.IgnoreFields(status.BackendTLSPolicyStatusUpdate{}, "Resource"),
 				cmpopts.SortSlices(func(i, j meta_v1.Condition) bool {
 					return i.Message < j.Message
 				}),

--- a/internal/status/backendtlspolicyconditions.go
+++ b/internal/status/backendtlspolicyconditions.go
@@ -33,7 +33,6 @@ type BackendTLSPolicyStatusUpdate struct {
 	PolicyAncestorStatuses []*gatewayapi_v1alpha2.PolicyAncestorStatus
 	GatewayRef             types.NamespacedName
 	GatewayController      gatewayapi_v1beta1.GatewayController
-	Resource               client.Object
 	Generation             int64
 	TransitionTime         meta_v1.Time
 }

--- a/internal/status/cache.go
+++ b/internal/status/cache.go
@@ -21,6 +21,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -102,7 +103,7 @@ func (c *Cache) GetStatusUpdates() []k8s.StatusUpdate {
 	for fullname, backendTLSPolicyUpdate := range c.backendTLSPolicyUpdates {
 		update := k8s.StatusUpdate{
 			NamespacedName: fullname,
-			Resource:       backendTLSPolicyUpdate.Resource,
+			Resource:       &gatewayapi_v1alpha2.BackendTLSPolicy{},
 			Mutator:        backendTLSPolicyUpdate,
 		}
 
@@ -269,14 +270,13 @@ func (c *Cache) RouteConditionsAccessor(nsName types.NamespacedName, generation 
 // to build up a list of metav1.Conditions as well as a function to commit the change back to the
 // cache when everything is done. The commit function pattern is used so that the
 // BackendTLSPolicyStatusUpdate does not need to know anything the cache internals.
-func (c *Cache) BackendTLSPolicyConditionsAccessor(nsName types.NamespacedName, generation int64, resource client.Object) (*BackendTLSPolicyStatusUpdate, func()) {
+func (c *Cache) BackendTLSPolicyConditionsAccessor(nsName types.NamespacedName, generation int64) (*BackendTLSPolicyStatusUpdate, func()) {
 	pu := &BackendTLSPolicyStatusUpdate{
 		FullName:          nsName,
 		GatewayRef:        c.gatewayRef,
 		GatewayController: c.gatewayController,
 		Generation:        generation,
 		TransitionTime:    meta_v1.NewTime(time.Now()),
-		Resource:          resource,
 	}
 
 	return pu, func() {


### PR DESCRIPTION
DAG cache objects were being written to when StatusUpdater fetched resource to perform update on since status updates held a reference to them.