### PR TITLE
handle Route conflicts with HTTPRoute.Matches

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1517,7 +1517,3 @@ type SlowStartPolicy struct {
 
 // +kubebuilder:validation:Enum=grpcroutes;tlsroutes;extensionservices;backendtlspolicies
 type Feature string
-
-const (
-	KindHTTPProxy = "HTTPProxy"
-)

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1517,3 +1517,7 @@ type SlowStartPolicy struct {
 
 // +kubebuilder:validation:Enum=grpcroutes;tlsroutes;extensionservices;backendtlspolicies
 type Feature string
+
+const (
+	KindHTTPProxy = "HTTPProxy"
+)

--- a/changelogs/unreleased/6188-lubronzhan-minor.md
+++ b/changelogs/unreleased/6188-lubronzhan-minor.md
@@ -5,4 +5,4 @@ It's possible that multiple HTTPRoutes will define the same Match conditions. In
 - The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
 - The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
 
-With above ordering, any HTTPRoute that ranks lower is marked with Conflict condition.
+With above ordering, any HTTPRoute that ranks lower is marked with the `Accepted: False` Condition and Reason `RuleMatchConflict `.

--- a/changelogs/unreleased/6188-lubronzhan-minor.md
+++ b/changelogs/unreleased/6188-lubronzhan-minor.md
@@ -1,0 +1,8 @@
+## Gateway API: handle Route conflicts with HTTPRoute.Matches
+
+It's possible that multiple HTTPRoutes will define the same Match conditions. In this case the following logic is applied to resolve the conflict:
+
+- The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
+- The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
+
+With above ordering, any HTTPRoute that ranks lower is marked with Conflict condition.

--- a/changelogs/unreleased/6188-lubronzhan-minor.md
+++ b/changelogs/unreleased/6188-lubronzhan-minor.md
@@ -5,4 +5,6 @@ It's possible that multiple HTTPRoutes will define the same Match conditions. In
 - The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
 - The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
 
-With above ordering, any HTTPRoute that ranks lower is marked with the `Accepted: False` Condition and Reason `RuleMatchConflict `.
+With above ordering, any HTTPRoute that ranks lower, will be marked with below conditions accordionly
+1. If only partial rules under this HTTPRoute are conflicted, it's marked with `Accepted: True` and `PartiallyInvalid: true` Conditions and Reason: `RuleMatchPartiallyConflict`.
+2. If all the rules under this HTTPRoute are conflicted, it's marked with `Accepted: False` Condition and Reason `RuleMatchConflict`.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -761,9 +761,10 @@ func (v *VirtualHost) AddRoute(route *Route) {
 }
 
 // HasConflictRoute returns true if there is existing Path + Headers
-// + QueryParams combination match this route candidate.
+// + QueryParams combination match this route candidate and also they are same kind of Route.
 func (v *VirtualHost) HasConflictRoute(route *Route) bool {
-	if _, ok := v.Routes[conditionsToString(route)]; ok {
+	// If match exist and kind is the same kind, return true.
+	if r, ok := v.Routes[conditionsToString(route)]; ok && r.Kind == route.Kind {
 		return true
 	}
 	return false

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -749,9 +749,6 @@ type VirtualHost struct {
 	IPFilterRules []IPFilterRule
 
 	Routes map[string]*Route
-
-	// key is path + headerKey + queryParam
-	RouteHeaderAndQueryParamMatchMap map[string]*Route
 }
 
 // Add route to VirtualHosts.Routes map.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -394,23 +394,6 @@ func (r *Route) HasPathRegex() bool {
 	return ok
 }
 
-const KindHTTPProxy = "HTTPProxy"
-
-// SameRoute returns whether the route is the same as passed in route
-func (r *Route) SameRoute(route *Route) bool {
-	if r == nil && route == nil {
-		return true
-	}
-	if r == nil || route == nil {
-		return false
-	}
-	return r.Name == route.Name && r.Namespace == route.Namespace
-}
-
-func (r *Route) IsHTTPRoute() bool {
-	return r.Kind == KindHTTPRoute
-}
-
 // RouteTimeoutPolicy defines the timeout policy for a route.
 type RouteTimeoutPolicy struct {
 	// ResponseTimeout is the timeout applied to the response
@@ -780,13 +763,10 @@ func (v *VirtualHost) AddRoute(route *Route) {
 	v.Routes[conditionsToString(route)] = route
 }
 
-// HasConflictRoute returns true HTTPRoute type and there is existing Path + Headers
+// HasConflictRoute returns true if there is existing Path + Headers
 // + QueryParams combination match this route candidate.
-func (v *VirtualHost) HasConflictHTTPRoute(route *Route) bool {
-	if !route.IsHTTPRoute() {
-		return false
-	}
-	if r, ok := v.Routes[conditionsToString(route)]; ok && !r.SameRoute(route) {
+func (v *VirtualHost) HasConflictRoute(route *Route) bool {
+	if _, ok := v.Routes[conditionsToString(route)]; ok {
 		return true
 	}
 	return false

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -272,12 +272,13 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 		rs             []Route
 		expectConflict bool
 	}{
-		"2 different routes with same path and header, expect conflict": {
+		"2 different routes with same path and header, with same kind, expect conflict": {
 			vHost: VirtualHost{
 				Routes: map[string]*Route{},
 			},
 			rs: []Route{
 				{
+					Kind:               KindHTTPRoute,
 					Name:               "a",
 					Namespace:          "b",
 					PathMatchCondition: prefixSegment("/path1"),
@@ -297,7 +298,7 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 			},
 			expectConflict: true,
 		},
-		"2 different routes with same path and header and query params, expect conflict": {
+		"2 different routes with same path and header and query params, with same kind, expect conflict": {
 			vHost: VirtualHost{
 				Routes: map[string]*Route{},
 			},
@@ -329,7 +330,65 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 			},
 			expectConflict: true,
 		},
-		"2 different routes with same path and header, but different query params, don't expect conflict": {
+		"2 different routes with same path and header, but different kind, expect no conflict": {
+			vHost: VirtualHost{
+				Routes: map[string]*Route{},
+			},
+			rs: []Route{
+				{
+					Kind:               KindTCPRoute,
+					Name:               "a",
+					Namespace:          "b",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+				},
+				{
+					Kind:               KindHTTPRoute,
+					Name:               "b",
+					Namespace:          "c",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+				},
+			},
+			expectConflict: false,
+		},
+		"2 different routes with same path and header and query params, but different kind, expect no conflict": {
+			vHost: VirtualHost{
+				Routes: map[string]*Route{},
+			},
+			rs: []Route{
+				{
+					Kind:               KindHTTPRoute,
+					Name:               "a",
+					Namespace:          "b",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+				{
+					Kind:               KindTCPRoute,
+					Name:               "c",
+					Namespace:          "d",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+			},
+			expectConflict: false,
+		},
+		"2 different routes with same path and header, but different query params, with same kind, don't expect conflict": {
 			vHost: VirtualHost{
 				Routes: map[string]*Route{},
 			},
@@ -361,7 +420,7 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 			},
 			expectConflict: false,
 		},
-		"2 different routes with different path, don't expect conflict": {
+		"2 different routes with different path, with same kind, don't expect conflict": {
 			vHost: VirtualHost{
 				Routes: map[string]*Route{},
 			},

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -336,7 +336,7 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 			},
 			rs: []Route{
 				{
-					Kind:               KindTCPRoute,
+					Kind:               KindGRPCRoute,
 					Name:               "a",
 					Namespace:          "b",
 					PathMatchCondition: prefixSegment("/path1"),
@@ -374,7 +374,7 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 					},
 				},
 				{
-					Kind:               KindTCPRoute,
+					Kind:               KindGRPCRoute,
 					Name:               "c",
 					Namespace:          "d",
 					PathMatchCondition: prefixSegment("/path1"),

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -278,7 +278,6 @@ func TestHasConflictHTTPRoute(t *testing.T) {
 			},
 			rs: []Route{
 				{
-					Kind:               KindHTTPRoute,
 					Name:               "a",
 					Namespace:          "b",
 					PathMatchCondition: prefixSegment("/path1"),
@@ -368,7 +367,7 @@ func TestHasConflictHTTPRoute(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			c.vHost.AddRoute(&c.rs[0])
 
-			assert.Equal(t, c.vHost.HasConflictHTTPRoute(&c.rs[1]), c.expectConflict)
+			assert.Equal(t, c.vHost.HasConflictRoute(&c.rs[1]), c.expectConflict)
 		})
 	}
 }

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -266,7 +266,7 @@ func TestServiceClusterRebalance(t *testing.T) {
 	}
 }
 
-func TestHasConflictHTTPRoute(t *testing.T) {
+func TestHasConflictRouteForVirtualHost(t *testing.T) {
 	cases := map[string]struct {
 		vHost          VirtualHost
 		rs             []Route
@@ -328,6 +328,38 @@ func TestHasConflictHTTPRoute(t *testing.T) {
 				},
 			},
 			expectConflict: true,
+		},
+		"2 different routes with same path and header, but different query params, don't expect conflict": {
+			vHost: VirtualHost{
+				Routes: map[string]*Route{},
+			},
+			rs: []Route{
+				{
+					Kind:               KindHTTPRoute,
+					Name:               "a",
+					Namespace:          "b",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+				{
+					Kind:               KindHTTPRoute,
+					Name:               "c",
+					Namespace:          "d",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-2different", Value: "value-2different", MatchType: QueryParamMatchTypePrefix},
+					},
+				},
+			},
+			expectConflict: false,
 		},
 		"2 different routes with different path, don't expect conflict": {
 			vHost: VirtualHost{

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -2462,7 +2462,7 @@ func handlePathRewritePrefixRemoval(p *PathRewritePolicy, mc *matchConditions) *
 }
 
 // sort routes based on creationTimestamp in ascending order
-// if creationTimestamps are the same, sort based on name, then namespace in alphetical ascending order
+// if creationTimestamps are the same, sort based on namespaced name ("<namespace>/<name>") in alphetical ascending order
 func sortRoutes(m map[types.NamespacedName]*gatewayapi_v1.HTTPRoute) []*gatewayapi_v1.HTTPRoute {
 	routes := []*gatewayapi_v1.HTTPRoute{}
 	for _, r := range m {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1452,7 +1452,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 		routeAccessor.AddCondition(
 			gatewayapi_v1.RouteConditionAccepted,
 			meta_v1.ConditionFalse,
-			status.ReasonRouteConflict,
+			status.ReasonRouteRuleMatchConflict,
 			"HTTPRoute's Match has conflict with other HTTPRoute's Match",
 		)
 	} else {
@@ -2460,8 +2460,8 @@ func sortRoutes(m map[types.NamespacedName]*gatewayapi_v1.HTTPRoute) []*gatewaya
 	sort.SliceStable(routes, func(i, j int) bool {
 		// if the creation time is the same, compare the route name
 		if routes[i].CreationTimestamp.Equal(&routes[j].CreationTimestamp) {
-			return fmt.Sprintf("%s/%s", routes[i].Namespace, routes[i].Name) <
-				fmt.Sprintf("%s/%s", routes[j].Namespace, routes[j].Name)
+			return k8s.NamespacedNameOf(routes[i]).String() <
+				k8s.NamespacedNameOf(routes[j]).String()
 		}
 		return routes[i].CreationTimestamp.Before(&routes[j].CreationTimestamp)
 	})

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -2414,8 +2414,8 @@ func handlePathRewritePrefixRemoval(p *PathRewritePolicy, mc *matchConditions) *
 	return p
 }
 
-// sort routes based on age in ascending order
-// if creation times are the same, sort based on name in ascending order
+// sort routes based on creationTimestamp in ascending order
+// if creationTimestamps are the same, sort based on name, then namespace in alphetical ascending order
 func sortRoutes(m map[types.NamespacedName]*gatewayapi_v1.HTTPRoute) []*gatewayapi_v1.HTTPRoute {
 	routes := []*gatewayapi_v1.HTTPRoute{}
 	for _, r := range m {

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1472,14 +1472,14 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 			gatewayapi_v1.RouteConditionAccepted,
 			meta_v1.ConditionFalse,
 			status.ReasonRouteRuleMatchConflict,
-			"HTTPRoute's Match has conflict with other HTTPRoute's Match",
+			status.MessageRouteRuleMatchConflict,
 		)
 	} else if invalidRuleCnt > 0 {
 		routeAccessor.AddCondition(
 			gatewayapi_v1.RouteConditionPartiallyInvalid,
 			meta_v1.ConditionTrue,
 			status.ReasonRouteRuleMatchPartiallyConflict,
-			"Dropped Rule: HTTPRoute's rule(s) has(ve) been droped because of conflict against other HTTPRoute's rule(s)",
+			status.MessageRouteRuleMatchPartiallyConflict,
 		)
 	}
 }

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1446,7 +1446,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 		routes = append(routes, routesPerRule...)
 	}
 
-	// check all the routes at once in case there is conclict
+	// check all the routes at once in case there is conflict
 	if p.hasConflictRoute(listener, hosts, routes) {
 		// skip adding the route to svhost or vhost since it's marked as conflict route
 		routeAccessor.AddCondition(
@@ -2460,10 +2460,8 @@ func sortRoutes(m map[types.NamespacedName]*gatewayapi_v1.HTTPRoute) []*gatewaya
 	sort.SliceStable(routes, func(i, j int) bool {
 		// if the creation time is the same, compare the route name
 		if routes[i].CreationTimestamp.Equal(&routes[j].CreationTimestamp) {
-			if routes[i].Name == routes[j].Name {
-				return routes[i].Namespace < routes[j].Namespace
-			}
-			return routes[i].Name < routes[j].Name
+			return fmt.Sprintf("%s/%s", routes[i].Namespace, routes[i].Name) <
+				fmt.Sprintf("%s/%s", routes[j].Namespace, routes[j].Name)
 		}
 		return routes[i].CreationTimestamp.Before(&routes[j].CreationTimestamp)
 	})

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -1087,7 +1087,7 @@ func TestHasConflictRoute(t *testing.T) {
 					Name: "http-1",
 					AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
 						Namespaces: &gatewayapi_v1.RouteNamespaces{
-							From: ref.To(gatewayapi_v1.NamespacesFromSame),
+							From: ptr.To(gatewayapi_v1.NamespacesFromSame),
 						},
 					},
 				},

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -836,7 +836,7 @@ func TestSortRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "3 httproutes with same creation timestamp, smaller name comes first ",
+			name: "3 httproutes with same creation timestamps, same namespaces, smaller name comes first",
 			m: map[types.NamespacedName]*gatewayapi_v1.HTTPRoute{
 				{
 					Namespace: "ns", Name: "name3",
@@ -884,6 +884,61 @@ func TestSortRoutes(t *testing.T) {
 				{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace:         "ns",
+						Name:              "name3",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+			},
+		},
+		{
+			name: "3 httproutes with same creation timestamp, smaller namespaces comes first",
+			m: map[types.NamespacedName]*gatewayapi_v1.HTTPRoute{
+				{
+					Namespace: "ns3", Name: "name1",
+				}: {
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns3",
+						Name:              "name3",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+				{
+					Namespace: "ns2", Name: "name2",
+				}: {
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns2",
+						Name:              "name2",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+				{
+					Namespace: "ns1", Name: "name3",
+				}: {
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns1",
+						Name:              "name3",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+			},
+			expected: []*gatewayapi_v1.HTTPRoute{
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns1",
+						Name:              "name3",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns2",
+						Name:              "name2",
+						CreationTimestamp: meta_v1.NewTime(time1),
+					},
+				},
+				{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace:         "ns3",
 						Name:              "name3",
 						CreationTimestamp: meta_v1.NewTime(time1),
 					},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -16,6 +16,7 @@ package dag
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -5510,7 +5511,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1.HTTPRouteRule{{
-						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchExact, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
 				},
@@ -5543,6 +5544,193 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 			},
 		},
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", gatewayapi_v1.HTTPProtocolType, 2),
+	})
+
+	run(t, "3 httproutes, but duplicate match condition between these 3. The 2 rank lower gets Conflict condition ", testcase{
+		objs: []any{
+			kuardService,
+			// first HTTPRoute with oldest creationTimestamp
+			&gatewayapi_v1.HTTPRoute{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind: KindHTTPRoute,
+				},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "basic-1",
+					Namespace:         "default",
+					CreationTimestamp: meta_v1.NewTime(time.Date(2020, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+				},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					},
+					Hostnames: []gatewayapi_v1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{
+								Path: &gatewayapi_v1.HTTPPathMatch{
+									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ref.To("/"),
+								},
+								Headers: []gatewayapi_v1.HTTPHeaderMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.HeaderMatchExact), // <---- unknown type to break the test
+										Name:  gatewayapi_v1.HTTPHeaderName("foo"),
+										Value: "bar",
+									},
+								},
+								QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+										Name:  "param-1",
+										Value: "valid-[a-z]?-[A-Za-z]+-[0=9]+-\\d+",
+									},
+								},
+							},
+							{
+								Path: &gatewayapi_v1.HTTPPathMatch{
+									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ref.To("/"),
+								},
+								Headers: []gatewayapi_v1.HTTPHeaderMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Name:  gatewayapi_v1.HTTPHeaderName("a"),
+										Value: "b",
+									},
+								},
+							},
+						},
+
+						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					}},
+				},
+			},
+			// second HTTPRoute with 2nd oldest creationTimestamp, conflict with 1st HTTPRoute
+			&gatewayapi_v1.HTTPRoute{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind: KindHTTPRoute,
+				},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "basic-2",
+					Namespace:         "default",
+					CreationTimestamp: meta_v1.NewTime(time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+				},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					},
+					Hostnames: []gatewayapi_v1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{
+								Path: &gatewayapi_v1.HTTPPathMatch{
+									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ref.To("/"),
+								},
+								Headers: []gatewayapi_v1.HTTPHeaderMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Name:  gatewayapi_v1.HTTPHeaderName("a"),
+										Value: "b",
+									},
+								},
+							},
+						},
+
+						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					}},
+				},
+			},
+			// 3rd HTTPRoute with newest creationTimestamp, conflict with 1st HTTPRoute
+			&gatewayapi_v1.HTTPRoute{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind: KindHTTPRoute,
+				},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "basic-3",
+					Namespace:         "default",
+					CreationTimestamp: meta_v1.NewTime(time.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+				},
+				Spec: gatewayapi_v1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+						ParentRefs: []gatewayapi_v1.ParentReference{gatewayapi.GatewayParentRef("projectcontour", "contour")},
+					},
+					Hostnames: []gatewayapi_v1.Hostname{
+						"test.projectcontour.io",
+					},
+					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{
+								Path: &gatewayapi_v1.HTTPPathMatch{
+									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ref.To("/"),
+								},
+								Headers: []gatewayapi_v1.HTTPHeaderMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Name:  gatewayapi_v1.HTTPHeaderName("foo"),
+										Value: "bar",
+									},
+								},
+								QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
+									{
+										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+										Name:  "param-1",
+										Value: "valid-[a-z]?-[A-Za-z]+-[0=9]+-\\d+",
+									},
+								},
+							},
+						},
+
+						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
+					}},
+				},
+			},
+		},
+		wantRouteConditions: []*status.RouteStatusUpdate{
+			{
+				FullName: types.NamespacedName{Namespace: "default", Name: "basic-1"},
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
+					{
+						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+						Conditions: []meta_v1.Condition{
+							routeResolvedRefsCondition(),
+							routeAcceptedHTTPRouteCondition(),
+						},
+					},
+				},
+			},
+			{
+				FullName: types.NamespacedName{Namespace: "default", Name: "basic-2"},
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
+					{
+						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+						Conditions: []meta_v1.Condition{
+							routeAcceptedFalse(status.ReasonRouteConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
+							routeResolvedRefsCondition(),
+						},
+					},
+				},
+			},
+			{
+				FullName: types.NamespacedName{Namespace: "default", Name: "basic-3"},
+				RouteParentStatuses: []*gatewayapi_v1.RouteParentStatus{
+					{
+						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
+						Conditions: []meta_v1.Condition{
+							routeAcceptedFalse(status.ReasonRouteConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
+							routeResolvedRefsCondition(),
+						},
+					},
+				},
+			},
+		},
+		// is it ok to show the listeners are attached, just it's not accepted because of the conflict
+		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", gatewayapi_v1.HTTPProtocolType, 3),
 	})
 
 	run(t, "prefix path match not starting with '/' for httproute", testcase{

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5511,6 +5511,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						"test.projectcontour.io",
 					},
 					Rules: []gatewayapi_v1.HTTPRouteRule{{
+						// changed to different matches in case there is conflict with above HTTPRoute
 						Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchExact, "/"),
 						BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 					}},
@@ -5575,7 +5576,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 								},
 								Headers: []gatewayapi_v1.HTTPHeaderMatch{
 									{
-										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact), // <---- unknown type to break the test
+										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact),
 										Name:  gatewayapi_v1.HTTPHeaderName("foo"),
 										Value: "bar",
 									},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5570,19 +5570,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{
 								Path: &gatewayapi_v1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
+									Type:  ptr.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ptr.To("/"),
 								},
 								Headers: []gatewayapi_v1.HTTPHeaderMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.HeaderMatchExact), // <---- unknown type to break the test
+										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact), // <---- unknown type to break the test
 										Name:  gatewayapi_v1.HTTPHeaderName("foo"),
 										Value: "bar",
 									},
 								},
 								QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+										Type:  ptr.To(gatewayapi_v1.QueryParamMatchRegularExpression),
 										Name:  "param-1",
 										Value: "valid-[a-z]?-[A-Za-z]+-[0=9]+-\\d+",
 									},
@@ -5590,12 +5590,12 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							},
 							{
 								Path: &gatewayapi_v1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
+									Type:  ptr.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ptr.To("/"),
 								},
 								Headers: []gatewayapi_v1.HTTPHeaderMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact),
 										Name:  gatewayapi_v1.HTTPHeaderName("a"),
 										Value: "b",
 									},
@@ -5628,12 +5628,12 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{
 								Path: &gatewayapi_v1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
+									Type:  ptr.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ptr.To("/"),
 								},
 								Headers: []gatewayapi_v1.HTTPHeaderMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact),
 										Name:  gatewayapi_v1.HTTPHeaderName("a"),
 										Value: "b",
 									},
@@ -5666,19 +5666,19 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 						Matches: []gatewayapi_v1.HTTPRouteMatch{
 							{
 								Path: &gatewayapi_v1.HTTPPathMatch{
-									Type:  ref.To(gatewayapi_v1.PathMatchPathPrefix),
-									Value: ref.To("/"),
+									Type:  ptr.To(gatewayapi_v1.PathMatchPathPrefix),
+									Value: ptr.To("/"),
 								},
 								Headers: []gatewayapi_v1.HTTPHeaderMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.HeaderMatchExact),
+										Type:  ptr.To(gatewayapi_v1.HeaderMatchExact),
 										Name:  gatewayapi_v1.HTTPHeaderName("foo"),
 										Value: "bar",
 									},
 								},
 								QueryParams: []gatewayapi_v1.HTTPQueryParamMatch{
 									{
-										Type:  ref.To(gatewayapi_v1.QueryParamMatchRegularExpression),
+										Type:  ptr.To(gatewayapi_v1.QueryParamMatchRegularExpression),
 										Name:  "param-1",
 										Value: "valid-[a-z]?-[A-Za-z]+-[0=9]+-\\d+",
 									},

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5558,7 +5558,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:              "basic-1",
 					Namespace:         "default",
-					CreationTimestamp: meta_v1.NewTime(time.Date(2020, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+					CreationTimestamp: meta_v1.Date(2020, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
 				},
 				Spec: gatewayapi_v1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
@@ -5616,7 +5616,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:              "basic-2",
 					Namespace:         "default",
-					CreationTimestamp: meta_v1.NewTime(time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+					CreationTimestamp: meta_v1.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
 				},
 				Spec: gatewayapi_v1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
@@ -5654,7 +5654,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name:              "basic-3",
 					Namespace:         "default",
-					CreationTimestamp: meta_v1.NewTime(time.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC)),
+					CreationTimestamp: meta_v1.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
 				},
 				Spec: gatewayapi_v1.HTTPRouteSpec{
 					CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
@@ -5711,7 +5711,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					{
 						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 						Conditions: []meta_v1.Condition{
-							routeAcceptedFalse(status.ReasonRouteConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
+							routeAcceptedFalse(status.ReasonRouteRuleMatchConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
 							routeResolvedRefsCondition(),
 						},
 					},
@@ -5723,7 +5723,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					{
 						ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 						Conditions: []meta_v1.Condition{
-							routeAcceptedFalse(status.ReasonRouteConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
+							routeAcceptedFalse(status.ReasonRouteRuleMatchConflict, "HTTPRoute's Match has conflict with other HTTPRoute's Match"),
 							routeResolvedRefsCondition(),
 						},
 					},

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -37,6 +37,7 @@ const (
 	ReasonInvalidPathMatch              gatewayapi_v1.RouteConditionReason = "InvalidPathMatch"
 	ReasonInvalidMethodMatch            gatewayapi_v1.RouteConditionReason = "InvalidMethodMatch"
 	ReasonInvalidGateway                gatewayapi_v1.RouteConditionReason = "InvalidGateway"
+	ReasonRouteConflict                 gatewayapi_v1.RouteConditionReason = "RouteConflict"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -37,7 +37,7 @@ const (
 	ReasonInvalidPathMatch              gatewayapi_v1.RouteConditionReason = "InvalidPathMatch"
 	ReasonInvalidMethodMatch            gatewayapi_v1.RouteConditionReason = "InvalidMethodMatch"
 	ReasonInvalidGateway                gatewayapi_v1.RouteConditionReason = "InvalidGateway"
-	ReasonRouteConflict                 gatewayapi_v1.RouteConditionReason = "RouteConflict"
+	ReasonRouteRuleMatchConflict        gatewayapi_v1.RouteConditionReason = "RuleMatchConflict"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -39,6 +39,9 @@ const (
 	ReasonInvalidGateway                  gatewayapi_v1.RouteConditionReason = "InvalidGateway"
 	ReasonRouteRuleMatchConflict          gatewayapi_v1.RouteConditionReason = "RuleMatchConflict"
 	ReasonRouteRuleMatchPartiallyConflict gatewayapi_v1.RouteConditionReason = "RuleMatchPartiallyConflict"
+
+	MessageRouteRuleMatchConflict          string = "HTTPRoute's Match has conflict with other HTTPRoute's Match"
+	MessageRouteRuleMatchPartiallyConflict string = "Dropped Rule: HTTPRoute's rule(s) has(ve) been dropped because of conflict against other HTTPRoute's rule(s)"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -32,12 +32,13 @@ const (
 )
 
 const (
-	ReasonDegraded                      gatewayapi_v1.RouteConditionReason = "Degraded"
-	ReasonAllBackendRefsHaveZeroWeights gatewayapi_v1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
-	ReasonInvalidPathMatch              gatewayapi_v1.RouteConditionReason = "InvalidPathMatch"
-	ReasonInvalidMethodMatch            gatewayapi_v1.RouteConditionReason = "InvalidMethodMatch"
-	ReasonInvalidGateway                gatewayapi_v1.RouteConditionReason = "InvalidGateway"
-	ReasonRouteRuleMatchConflict        gatewayapi_v1.RouteConditionReason = "RuleMatchConflict"
+	ReasonDegraded                        gatewayapi_v1.RouteConditionReason = "Degraded"
+	ReasonAllBackendRefsHaveZeroWeights   gatewayapi_v1.RouteConditionReason = "AllBackendRefsHaveZeroWeights"
+	ReasonInvalidPathMatch                gatewayapi_v1.RouteConditionReason = "InvalidPathMatch"
+	ReasonInvalidMethodMatch              gatewayapi_v1.RouteConditionReason = "InvalidMethodMatch"
+	ReasonInvalidGateway                  gatewayapi_v1.RouteConditionReason = "InvalidGateway"
+	ReasonRouteRuleMatchConflict          gatewayapi_v1.RouteConditionReason = "RuleMatchConflict"
+	ReasonRouteRuleMatchPartiallyConflict gatewayapi_v1.RouteConditionReason = "RuleMatchPartiallyConflict"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -181,6 +181,8 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-request-redirect-rule", testWithHTTPGateway(testRequestRedirectRule))
 
 		f.NamespacedTest("gateway-backend-tls-policy", testWithHTTPGateway(testBackendTLSPolicy))
+
+		f.NamespacedTest("gateway-httproute-conflict-match", testWithHTTPGateway(testHTTPRouteConflictMatch))
 	})
 
 	Describe("Gateway with one HTTP listener and one HTTPS listener", func() {

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -183,6 +183,8 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-backend-tls-policy", testWithHTTPGateway(testBackendTLSPolicy))
 
 		f.NamespacedTest("gateway-httproute-conflict-match", testWithHTTPGateway(testHTTPRouteConflictMatch))
+
+		f.NamespacedTest("gateway-httproute-partially-conflict-match", testWithHTTPGateway(testHTTPRoutePartiallyConflictMatch))
 	})
 
 	Describe("Gateway with one HTTP listener and one HTTPS listener", func() {

--- a/test/e2e/gateway/http_route_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_conflict_match_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) {
-	Specify("Creates two http routes, second one has conflict match condition as the first one", func() {
+	Specify("Creates two http routes, second one has conflict match against the first one, report Accepted: false", func() {
 		By("create httproute-1 first")
 		route1 := &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/gateway/http_route_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_conflict_match_test.go
@@ -1,0 +1,86 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) {
+	Specify("Creates two http routes, second one has conflict match condition as the first one", func() {
+		By("create httproute-1 first")
+		route1 := &gatewayapi_v1.HTTPRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "httproute-1",
+			},
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.HTTPRouteRule{
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
+					},
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "dolphin"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
+
+		By("create httproute-2 with conflicted matches")
+		route2 := &gatewayapi_v1.HTTPRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "httproute-2",
+			},
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.HTTPRouteRule{
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteNotAcceptedDueToConflict)
+	})
+}

--- a/test/e2e/gateway/http_route_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_conflict_match_test.go
@@ -17,6 +17,7 @@ package gateway
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -56,7 +57,8 @@ func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		By("create httproute-2 with conflicted matches")
 		route2 := &gatewayapi_v1.HTTPRoute{
@@ -81,6 +83,7 @@ func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteNotAcceptedDueToConflict)
+		_, ok = f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteNotAcceptedDueToConflict)
+		require.True(f.T(), ok)
 	})
 }

--- a/test/e2e/gateway/http_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_partially_conflict_match_test.go
@@ -80,7 +80,7 @@ func testHTTPRoutePartiallyConflictMatch(namespace string, gateway types.Namespa
 					},
 					{
 						Matches: []gatewayapi_v1.HTTPRouteMatch{
-							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"no conflict": "no joke", "no conflict again": "no joke"})},
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"no-conflict": "no-joke", "no-conflict-again": "no-joke"})},
 						},
 						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),
 					},

--- a/test/e2e/gateway/http_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_partially_conflict_match_test.go
@@ -1,0 +1,99 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+func testHTTPRoutePartiallyConflictMatch(namespace string, gateway types.NamespacedName) {
+	Specify("Creates two http routes, second one has conflict match condition as the first one", func() {
+		By("create httproute-1 first")
+		route1 := &gatewayapi_v1.HTTPRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "httproute-1",
+			},
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.HTTPRouteRule{
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
+					},
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "dolphin"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
+
+		By("create httproute-2 with only partially conflicted matches")
+		route2 := &gatewayapi_v1.HTTPRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "httproute-2",
+			},
+			Spec: gatewayapi_v1.HTTPRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.HTTPRouteRule{
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"animal": "whale"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-1", 80, 1),
+					},
+					{
+						Matches: []gatewayapi_v1.HTTPRouteMatch{
+							{QueryParams: gatewayapi.HTTPQueryParamMatches(map[string]string{"no conflict": "no joke", "no conflict again": "no joke"})},
+						},
+						BackendRefs: gatewayapi.HTTPBackendRef("echo-2", 80, 1),
+					},
+				},
+			},
+		}
+		f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRoutePartiallyAccepted)
+		// 1) Drop Rule(s): With this approach, implementations will drop the
+		//    invalid Route Rule(s) until they are fully valid again. The message
+		//    for this condition MUST start with the prefix "Dropped Rule" and
+		//    include information about which Rules have been dropped. In this
+		//    state, the "Accepted" condition MUST be set to "True" with the latest
+		//    generation of the resource.
+		f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteAccepted)
+	})
+}

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -130,7 +130,7 @@ func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), "HTTPRoute's Match has conflict with other HTTPRoute's Match") {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), status.MessageRouteRuleMatchConflict) {
 			return false
 		}
 	}
@@ -147,7 +147,7 @@ func HTTPRoutePartiallyAccepted(route *gatewayapi_v1.HTTPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), "Dropped Rule: HTTPRoute's rule(s) has(ve) been droped because of conflict against other HTTPRoute's rule(s)") {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), status.MessageRouteRuleMatchPartiallyConflict) {
 			return false
 		}
 	}

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -131,24 +131,24 @@ func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 
 	for _, gw := range route.Status.Parents {
 		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), status.MessageRouteRuleMatchConflict) {
-			return false
+			return true
 		}
 	}
 
 	return false
 }
 
-// HTTPRoutePartiallyAccepted returns true if the route has a .status.conditions
+// HTTPRoutePartiallyInvalid returns true if the route has a .status.conditions
 // entry of "PartiallyInvalid: true" && "Reason: RuleMatchPartiallyConflict" && "Message:
 // HTTPRoute's Match has partial conflict with other HTTPRoute's Match".
-func HTTPRoutePartiallyAccepted(route *gatewayapi_v1.HTTPRoute) bool {
+func HTTPRoutePartiallyInvalid(route *gatewayapi_v1.HTTPRoute) bool {
 	if route == nil {
 		return false
 	}
 
 	for _, gw := range route.Status.Parents {
 		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), status.MessageRouteRuleMatchPartiallyConflict) {
-			return false
+			return true
 		}
 	}
 

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -122,8 +122,8 @@ func HTTPRouteAccepted(route *gatewayapi_v1.HTTPRoute) bool {
 }
 
 // HTTPRouteNotAcceptedDueToConflict returns true if the route has a .status.conditions
-// entry of "Accepted: false" && "Reason: RouteConflict" && "Message: HTTPRoute's Match has
-// conflict with other HTTPRoute's Match"
+// entry of "Accepted: false" && "Reason: RouteMatchConflict" && "Message: HTTPRoute's Match has
+// conflict with other HTTPRoute's Match".
 func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 	if route == nil {
 		return false
@@ -131,6 +131,23 @@ func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 
 	for _, gw := range route.Status.Parents {
 		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), "HTTPRoute's Match has conflict with other HTTPRoute's Match") {
+			return false
+		}
+	}
+
+	return false
+}
+
+// HTTPRoutePartiallyAccepted returns true if the route has a .status.conditions
+// entry of "PartiallyInvalid: true" && "Reason: RuleMatchPartiallyConflict" && "Message:
+// HTTPRoute's Match has partial conflict with other HTTPRoute's Match".
+func HTTPRoutePartiallyAccepted(route *gatewayapi_v1.HTTPRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), "Dropped Rule: HTTPRoute's rule(s) has(ve) been droped because of conflict against other HTTPRoute's rule(s)") {
 			return false
 		}
 	}

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -130,7 +130,7 @@ func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteConflict), "HTTPRoute's Match has conflict with other HTTPRoute's Match") {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), "HTTPRoute's Match has conflict with other HTTPRoute's Match") {
 			return false
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/projectcontour/contour/issues/3608

Now if there is conflicts between HTTPRoute's match, then only the HTTPRoute with
- older creationTimestamp
- alphabetically smaller on `namespace/name`

, will be chosen as the valid HTTPRoute, other HTTPRoute will be marked as conflict condition

TODO:
- [x]  Mark HTTPRoute as conflict condition if needed
- [x]  E2E Test

Signed-off-by: lubronzhan <lubronzhan@gmail.com>