### PR TITLE
Add test demonstrating backendtlspolicy precedence

### DIFF
--- a/internal/featuretests/v3/upstreamtls_test.go
+++ b/internal/featuretests/v3/upstreamtls_test.go
@@ -340,3 +340,117 @@ func TestUpstreamTLSWithHTTPRoute(t *testing.T) {
 		TypeUrl: clusterType,
 	})
 }
+
+func TestBackendTLSPolicyPrecedenceOverUpstreamProtocolAnnotationWithHTTPRoute(t *testing.T) {
+	rh, c, done := setup(t, func(b *dag.Builder) {
+		for _, processor := range b.Processors {
+			if gatewayAPIProcessor, ok := processor.(*dag.GatewayAPIProcessor); ok {
+				gatewayAPIProcessor.UpstreamTLS = &dag.UpstreamTLS{
+					MinimumProtocolVersion: "1.2",
+					MaximumProtocolVersion: "1.2",
+				}
+			}
+		}
+	})
+	defer done()
+
+	sec1 := featuretests.CASecret(t, "sec1", &featuretests.CACertificate)
+	rh.OnAdd(sec1)
+
+	rh.OnAdd(&gatewayapi_v1.GatewayClass{
+		TypeMeta:   meta_v1.TypeMeta{},
+		ObjectMeta: fixture.ObjectMeta("test-gc"),
+		Spec: gatewayapi_v1.GatewayClassSpec{
+			ControllerName: "projectcontour.io/contour",
+		},
+		Status: gatewayapi_v1.GatewayClassStatus{
+			Conditions: []meta_v1.Condition{
+				{
+					Type:   string(gatewayapi_v1.GatewayClassConditionStatusAccepted),
+					Status: meta_v1.ConditionTrue,
+				},
+			},
+		},
+	})
+
+	gateway := &gatewayapi_v1.Gateway{
+		ObjectMeta: fixture.ObjectMeta("projectcontour/contour"),
+		Spec: gatewayapi_v1.GatewaySpec{
+			Listeners: []gatewayapi_v1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayapi_v1.HTTPProtocolType,
+				AllowedRoutes: &gatewayapi_v1.AllowedRoutes{
+					Namespaces: &gatewayapi_v1.RouteNamespaces{
+						From: ptr.To(gatewayapi_v1.NamespacesFromAll),
+					},
+				},
+			}},
+		},
+	}
+	rh.OnAdd(gateway)
+
+	svc := fixture.NewService("backend").
+		Annotate("projectcontour.io/upstream-protocol.h2", "443").
+		WithPorts(core_v1.ServicePort{Name: "http", Port: 443})
+	rh.OnAdd(svc)
+
+	rh.OnAdd(&gatewayapi_v1.HTTPRoute{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "authenticated",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+				ParentRefs: []gatewayapi_v1.ParentReference{
+					gatewayapi.GatewayParentRef("projectcontour", "contour"),
+				},
+			},
+			Hostnames: []gatewayapi_v1.Hostname{
+				"test.projectcontour.io",
+			},
+			Rules: []gatewayapi_v1.HTTPRouteRule{{
+				Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
+				BackendRefs: gatewayapi.HTTPBackendRef("backend", 443, 1),
+			}},
+		},
+	})
+
+	rh.OnAdd(&gatewayapi_v1alpha2.BackendTLSPolicy{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "authenticated",
+			Namespace: "default",
+		},
+		Spec: gatewayapi_v1alpha2.BackendTLSPolicySpec{
+			TargetRef: gatewayapi_v1alpha2.PolicyTargetReferenceWithSectionName{
+				PolicyTargetReference: gatewayapi_v1alpha2.PolicyTargetReference{
+					Kind: "Service",
+					Name: "backend",
+				},
+			},
+			TLS: gatewayapi_v1alpha2.BackendTLSPolicyConfig{
+				CACertRefs: []gatewayapi_v1alpha2.LocalObjectReference{{
+					Kind: "Secret",
+					Name: gatewayapi_v1.ObjectName(sec1.Name),
+				}},
+				Hostname: "subjname",
+			},
+		},
+	})
+
+	c.Request(clusterType).Equals(&envoy_service_discovery_v3.DiscoveryResponse{
+		Resources: resources(t,
+			tlsCluster(
+				cluster("default/backend/443/242c9163af", "default/backend/http", "default_backend_443"),
+				sec1,
+				"subjname",
+				"",
+				nil,
+				&dag.UpstreamTLS{
+					MinimumProtocolVersion: "1.2",
+					MaximumProtocolVersion: "1.2",
+				}),
+		),
+		TypeUrl: clusterType,
+	})
+}


### PR DESCRIPTION
BackendTLSPolicy takes precedence over the upstream-protocol annotation if both are specified. This PR adds a test to assert on this precedence.

Reading the documentation here https://projectcontour.io/docs/main/config/upstream-tls/, it seems like you can specify the protocol on the service, but the certificates for upstream tls would have been specified on HTTPProxy, which is not something that exists on HTTPRoute (because the intended way is to use BackendTLSPolicy). So the test just adds the protocol annotation, along with providing a BackendTLSPolicy, and the test will assert that the protocol is tls as well as the certificates from BackendTLSPolicy exists on the final envoy cluster.

Fixes #6138 