### PR TITLE
Add test validating cluster name generation is unique in HTTPRoute with BackendTLSPolicy vs HTTPProxy

### DIFF
--- a/internal/featuretests/v3/backendclientauth_test.go
+++ b/internal/featuretests/v3/backendclientauth_test.go
@@ -55,6 +55,9 @@ func proxyClientCertificateOpt(t *testing.T) func(*dag.Builder) {
 				ClientCertificate: &secret,
 				FieldLogger:       log.WithField("context", "ExtensionServiceProcessor"),
 			},
+			&dag.GatewayAPIProcessor{
+				FieldLogger: log.WithField("context", "GatewayAPIProcessor"),
+			},
 		}
 
 		b.Source.ConfiguredSecretRefs = []*types.NamespacedName{

--- a/internal/k8s/statusaddress_test.go
+++ b/internal/k8s/statusaddress_test.go
@@ -14,6 +14,7 @@
 package k8s
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -325,7 +326,7 @@ func TestStatusAddressUpdater(t *testing.T) {
 
 			isu.OnAdd(tc.preop, false)
 
-			newObj := suc.Get(objName, objName)
+			newObj := suc.Get(fmt.Sprintf("%T", tc.preop), objName, objName)
 			assert.Equal(t, tc.postop, newObj)
 		})
 
@@ -344,7 +345,7 @@ func TestStatusAddressUpdater(t *testing.T) {
 
 			isu.OnUpdate(tc.preop, tc.preop)
 
-			newObj := suc.Get(objName, objName)
+			newObj := suc.Get(fmt.Sprintf("%T", tc.preop), objName, objName)
 			assert.Equal(t, tc.postop, newObj)
 		})
 	}
@@ -531,7 +532,7 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 
 			isu.OnAdd(tc.preop, false)
 
-			newObj := suc.Get(tc.preop.Name, tc.preop.Namespace)
+			newObj := suc.Get(fmt.Sprintf("%T", tc.preop), tc.preop.Name, tc.preop.Namespace)
 			assert.Equal(t, tc.postop, newObj)
 		})
 
@@ -554,7 +555,7 @@ func TestStatusAddressUpdater_Gateway(t *testing.T) {
 
 			isu.OnUpdate(tc.preop, tc.preop)
 
-			newObj := suc.Get(tc.preop.Name, tc.preop.Namespace)
+			newObj := suc.Get(fmt.Sprintf("%T", tc.preop), tc.preop.Name, tc.preop.Namespace)
 			assert.Equal(t, tc.postop, newObj)
 		})
 	}

--- a/internal/k8s/statuscache.go
+++ b/internal/k8s/statuscache.go
@@ -42,7 +42,7 @@ func (suc *StatusUpdateCacher) OnDelete(obj any) {
 	if suc.objectCache != nil {
 		switch o := obj.(type) {
 		case *contour_v1.HTTPProxy:
-			delete(suc.objectCache, suc.objKey(o.Name, o.Namespace))
+			delete(suc.objectCache, suc.objKey(fmt.Sprintf("%T", o), o.Name, o.Namespace))
 		default:
 			panic(fmt.Sprintf("status caching not supported for object type %T", obj))
 		}
@@ -57,19 +57,19 @@ func (suc *StatusUpdateCacher) OnAdd(obj any) {
 
 	switch o := obj.(type) {
 	case *contour_v1.HTTPProxy:
-		suc.objectCache[suc.objKey(o.Name, o.Namespace)] = o
+		suc.objectCache[suc.objKey(fmt.Sprintf("%T", o), o.Name, o.Namespace)] = o
 	default:
 		panic(fmt.Sprintf("status caching not supported for object type %T", obj))
 	}
 }
 
 // Get allows retrieval of objects from the cache.
-func (suc *StatusUpdateCacher) Get(name, namespace string) any {
+func (suc *StatusUpdateCacher) Get(objType, name, namespace string) any {
 	if suc.objectCache == nil {
 		suc.objectCache = make(map[string]client.Object)
 	}
 
-	obj, ok := suc.objectCache[suc.objKey(name, namespace)]
+	obj, ok := suc.objectCache[suc.objKey(objType, name, namespace)]
 	if ok {
 		return obj
 	}
@@ -81,7 +81,7 @@ func (suc *StatusUpdateCacher) Add(name, namespace string, obj client.Object) bo
 		suc.objectCache = make(map[string]client.Object)
 	}
 
-	prefix := suc.objKey(name, namespace)
+	prefix := suc.objKey(fmt.Sprintf("%T", obj), name, namespace)
 	_, ok := suc.objectCache[prefix]
 	if ok {
 		return false
@@ -95,7 +95,7 @@ func (suc *StatusUpdateCacher) Add(name, namespace string, obj client.Object) bo
 func (suc *StatusUpdateCacher) GetStatus(obj any) (*contour_v1.HTTPProxyStatus, error) {
 	switch o := obj.(type) {
 	case *contour_v1.HTTPProxy:
-		objectKey := suc.objKey(o.Name, o.Namespace)
+		objectKey := suc.objKey(fmt.Sprintf("%T", o), o.Name, o.Namespace)
 		cachedObj, ok := suc.objectCache[objectKey]
 		if ok {
 			if c, ok := cachedObj.(*contour_v1.HTTPProxy); ok {
@@ -108,8 +108,8 @@ func (suc *StatusUpdateCacher) GetStatus(obj any) (*contour_v1.HTTPProxyStatus, 
 	}
 }
 
-func (suc *StatusUpdateCacher) objKey(name, namespace string) string {
-	return fmt.Sprintf("%s/%s", namespace, name)
+func (suc *StatusUpdateCacher) objKey(objType, name, namespace string) string {
+	return fmt.Sprintf("%s/%s/%s", objType, namespace, name)
 }
 
 func (suc *StatusUpdateCacher) Send(su StatusUpdate) {
@@ -117,7 +117,7 @@ func (suc *StatusUpdateCacher) Send(su StatusUpdate) {
 		suc.objectCache = make(map[string]client.Object)
 	}
 
-	objKey := suc.objKey(su.NamespacedName.Name, su.NamespacedName.Namespace)
+	objKey := suc.objKey(fmt.Sprintf("%T", su.Resource), su.NamespacedName.Name, su.NamespacedName.Namespace)
 	obj, ok := suc.objectCache[objKey]
 	if ok {
 		suc.objectCache[objKey] = su.Mutator.Mutate(obj)


### PR DESCRIPTION
This PR validates that the cluster name generation creates unique names when the tls settings are different due to creating one cluster using HTTPRoute with BackendTLSPolicy and another with HTTPProxy.

This PR also makes a small refactor of adding the type to the `StatusUpdateCacher` to differentiate resources with the same name but different types.

Fixes #6141 