### PR TITLE
Add fsnotify to monitor the configMap path

### DIFF
--- a/changelogs/unreleased/6196-lubronzhan-small.md
+++ b/changelogs/unreleased/6196-lubronzhan-small.md
@@ -1,0 +1,1 @@
+Add filesystem notifier (fsnotify) to watch the path where configMap of contour is mounted to, so that if there is update to the configMap, contour can automatically restart.

--- a/cmd/contour/filewatcher.go
+++ b/cmd/contour/filewatcher.go
@@ -35,7 +35,7 @@ func initializeWatch(path string, log logrus.FieldLogger) (*fsnotify.Watcher, er
 				log.Warningf("watcher receives err: %v\n", err)
 			case event := <-watch.Events:
 				if event.Op != fsnotify.Chmod {
-					log.Fatalf("restarting contour because received event %v on file %s\n", event.Op, path)
+					log.Fatalf("restarting contour because received event %v on file %s\n", event.Op.String(), path)
 				} else {
 					log.Printf("watcher receives %s on the mounted file %s\n", event.Op.String(), event.Name)
 				}

--- a/cmd/contour/filewatcher.go
+++ b/cmd/contour/filewatcher.go
@@ -35,7 +35,7 @@ func initializeWatch(path string, log logrus.FieldLogger) (*fsnotify.Watcher, er
 				log.Warningf("watcher receives err: %v\n", err)
 			case event := <-watch.Events:
 				if event.Op != fsnotify.Chmod {
-					log.Fatalf("restarting contour because received event %v on file %s\n", event.Op, defaultConfigPath)
+					log.Fatalf("restarting contour because received event %v on file %s\n", event.Op, path)
 				} else {
 					log.Printf("watcher receives %s on the mounted file %s\n", event.Op.String(), event.Name)
 				}

--- a/cmd/contour/filewatcher.go
+++ b/cmd/contour/filewatcher.go
@@ -1,0 +1,50 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+)
+
+const defaultConfigPath = "/config"
+
+// set up a filesystem watcher for the mounted files
+// right now just the configMap
+// reboot the app whenever there is an update via the returned stopCh.
+func initializeWatch(path string, log logrus.FieldLogger) (*fsnotify.Watcher, error) {
+	watch, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatalln("fail to setup config watcher")
+	}
+	go func() {
+		for {
+			select {
+			case err := <-watch.Errors:
+				log.Warningf("watcher receives err: %v\n", err)
+			case event := <-watch.Events:
+				if event.Op != fsnotify.Chmod {
+					log.Fatalf("restarting contour because received event %v on file %s\n", event.Op, defaultConfigPath)
+				} else {
+					log.Printf("watcher receives %s on the mounted file %s\n", event.Op.String(), event.Name)
+				}
+			}
+		}
+	}()
+
+	if err := watch.Add(path); err != nil {
+		log.Fatalf("fail to watch contour config file %s\n", path)
+	}
+	return watch, err
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.5.0
 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240111020705-5401a878d8bb
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v48 v48.2.0
@@ -63,7 +64,6 @@ require (
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-fonts/liberation v0.3.1 // indirect

--- a/test/e2e/filewatcher/filewatcher_test.go
+++ b/test/e2e/filewatcher/filewatcher_test.go
@@ -1,0 +1,102 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package filewatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	apps_v1 "k8s.io/api/apps/v1"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+var f = e2e.NewFramework(true)
+
+func TestFileWatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "File Watcher tests")
+}
+
+var _ = BeforeSuite(func() {
+	// just need 1 contour pod
+	f.Deployment.ContourDeployment.Spec.Replicas = ptr.To(int32(1))
+	require.NoError(f.T(), f.Deployment.EnsureResourcesForInclusterContour(true))
+})
+
+var _ = Describe("Contour file watcher", func() {
+	Context("Update configMap of contour", func() {
+		Specify("Contour should restart after configMap is restarted", func() {
+			By("Get Contour pod's restart time")
+			cd := &apps_v1.Deployment{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      f.Deployment.ContourDeployment.Name,
+					Namespace: f.Deployment.ContourDeployment.Namespace,
+				},
+			}
+			require.NoError(f.T(), f.Client.Get(context.TODO(), client.ObjectKeyFromObject(cd), cd))
+
+			labelSelector := cd.Spec.Selector
+			require.Len(f.T(), labelSelector.MatchLabels, 1)
+
+			var podList core_v1.PodList
+			require.NoError(f.T(), f.Client.List(context.TODO(), &podList, client.MatchingLabels(labelSelector.MatchLabels)))
+			require.NotNil(f.T(), podList)
+			require.Len(f.T(), podList.Items, 1)
+			require.Len(f.T(), podList.Items[0].Status.ContainerStatuses, 1)
+
+			previousRestartCount := podList.Items[0].Status.ContainerStatuses[0].RestartCount
+
+			By("Get ConfigMap")
+			cm := &core_v1.ConfigMap{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      f.Deployment.ContourConfigMap.Name,
+					Namespace: f.Deployment.ContourConfigMap.Namespace,
+				},
+			}
+			require.NoError(f.T(), f.Client.Get(context.TODO(), client.ObjectKeyFromObject(cm), cm))
+
+			By("Update configmap's content")
+			newConfigMapContent := `
+accesslog-format: envoy`
+			cm.Data["contour.yaml"] = newConfigMapContent
+
+			require.NoError(f.T(), f.Client.Update(context.TODO(), cm))
+
+			By("Contour pod's restartCount should get larger")
+			require.Eventually(f.T(), func() bool {
+				var podList core_v1.PodList
+				require.NoError(f.T(), f.Client.List(context.TODO(), &podList, client.MatchingLabels(labelSelector.MatchLabels)))
+				require.NotNil(f.T(), podList)
+				require.Len(f.T(), podList.Items, 1)
+				require.Len(f.T(), podList.Items[0].Status.ContainerStatuses, 1)
+				return podList.Items[0].Status.ContainerStatuses[0].RestartCount > previousRestartCount
+			}, time.Minute*2, time.Second)
+		})
+	})
+})
+
+var _ = AfterSuite(func() {
+	require.NoError(f.T(), f.Deployment.DeleteResourcesForInclusterContour())
+})


### PR DESCRIPTION
Fix https://github.com/projectcontour/contour/issues/2491

Add file system notifier to monitor the path to which the confgMap of contour deployment is mounted. So that if user updates the contour's ConfigMap, the contour deployment will be restarted

TODO:
- [x]  E2E test