### PR TITLE
test/e2e: add flake attempts for gRPC plaintext E2E

### DIFF
--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -41,7 +41,8 @@ import (
 )
 
 func testGRPCServicePlaintext(namespace string) {
-	Specify("requests to a gRPC service configured with plaintext work as expected", func() {
+	// Flake tracking issue: https://github.com/projectcontour/contour/issues/6092
+	Specify("requests to a gRPC service configured with plaintext work as expected", FlakeAttempts(3), func() {
 		t := f.T()
 
 		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")


### PR DESCRIPTION
Updates #6092.

https://github.com/projectcontour/contour/actions/runs/8087545863/attempts/1 hit the flake.