### PR TITLE
use a go-control-plane linear cache for EDS

### DIFF
--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	envoy_cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	envoy_server_v3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -510,11 +509,7 @@ func (s *Server) doServe() error {
 	var snapshotHandler *xdscache_v3.SnapshotHandler
 
 	if contourConfiguration.XDSServer.Type == contour_v1alpha1.EnvoyServerType {
-		snapshotHandler = xdscache_v3.NewSnapshotHandler(
-			resources,
-			envoy_cache_v3.NewSnapshotCache(false, &contour_xds_v3.Hash, s.log.WithField("context", "snapshotCache")),
-			s.log.WithField("context", "snapshotHandler"),
-		)
+		snapshotHandler = xdscache_v3.NewSnapshotHandler(resources, s.log.WithField("context", "snapshotHandler"))
 
 		// register observer for endpoints updates.
 		endpointHandler.SetObserver(contour.ComposeObservers(snapshotHandler))
@@ -929,7 +924,7 @@ func (x *xdsServer) Start(ctx context.Context) error {
 
 	switch x.config.Type {
 	case contour_v1alpha1.EnvoyServerType:
-		contour_xds_v3.RegisterServer(envoy_server_v3.NewServer(ctx, x.snapshotHandler.SnapshotCache, contour_xds_v3.NewRequestLoggingCallbacks(log)), grpcServer)
+		contour_xds_v3.RegisterServer(envoy_server_v3.NewServer(ctx, x.snapshotHandler.GetCache(), contour_xds_v3.NewRequestLoggingCallbacks(log)), grpcServer)
 	case contour_v1alpha1.ContourServerType:
 		contour_xds_v3.RegisterServer(contour_xds_v3.NewContourServer(log, xdscache.ResourcesOf(x.resources)...), grpcServer)
 	default:

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -925,6 +925,9 @@ func (x *xdsServer) Start(ctx context.Context) error {
 	switch x.config.Type {
 	case contour_v1alpha1.EnvoyServerType:
 		contour_xds_v3.RegisterServer(envoy_server_v3.NewServer(ctx, x.snapshotHandler.GetCache(), contour_xds_v3.NewRequestLoggingCallbacks(log)), grpcServer)
+
+		// Generate a snapshot based on the initial DAG build.
+		x.snapshotHandler.OnChange(nil)
 	case contour_v1alpha1.ContourServerType:
 		contour_xds_v3.RegisterServer(contour_xds_v3.NewContourServer(log, xdscache.ResourcesOf(x.resources)...), grpcServer)
 	default:

--- a/cmd/contour/servecontext_test.go
+++ b/cmd/contour/servecontext_test.go
@@ -379,7 +379,7 @@ func TestConvertServeContext(t *testing.T) {
 	defaultContourConfiguration := func() contour_v1alpha1.ContourConfigurationSpec {
 		return contour_v1alpha1.ContourConfigurationSpec{
 			XDSServer: &contour_v1alpha1.XDSServerConfig{
-				Type:    contour_v1alpha1.ContourServerType,
+				Type:    contour_v1alpha1.EnvoyServerType,
 				Address: "127.0.0.1",
 				Port:    8001,
 				TLS: &contour_v1alpha1.TLS{

--- a/internal/contourconfig/contourconfiguration.go
+++ b/internal/contourconfig/contourconfiguration.go
@@ -41,7 +41,7 @@ func OverlayOnDefaults(spec contour_v1alpha1.ContourConfigurationSpec) (contour_
 func Defaults() contour_v1alpha1.ContourConfigurationSpec {
 	return contour_v1alpha1.ContourConfigurationSpec{
 		XDSServer: &contour_v1alpha1.XDSServerConfig{
-			Type:    contour_v1alpha1.ContourServerType,
+			Type:    contour_v1alpha1.EnvoyServerType,
 			Address: "0.0.0.0",
 			Port:    8001,
 			TLS: &contour_v1alpha1.TLS{

--- a/internal/protobuf/helpers.go
+++ b/internal/protobuf/helpers.go
@@ -15,8 +15,6 @@
 package protobuf
 
 import (
-	"reflect"
-
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -42,22 +40,34 @@ func UInt32OrNil(val uint32) *wrapperspb.UInt32Value {
 	}
 }
 
-// AsMessages casts the given slice of values (that implement the proto.Message
+// AsMessages converts the given slice of values (that implement the proto.Message
 // interface) to a slice of proto.Message. If the length of the slice is 0, it
 // returns nil.
-func AsMessages(messages any) []proto.Message {
-	v := reflect.ValueOf(messages)
-	if v.Len() == 0 {
+func AsMessages[T proto.Message](messages []T) []proto.Message {
+	if len(messages) == 0 {
 		return nil
 	}
 
-	protos := make([]proto.Message, v.Len())
+	protos := make([]proto.Message, len(messages))
+	for i, message := range messages {
+		protos[i] = message
+	}
+	return protos
+}
 
-	for i := range protos {
-		protos[i] = v.Index(i).Interface().(proto.Message)
+// AsMessagesByName converts the given map of values (that implement the proto.Message
+// interface) to a map of proto.Message. If the length of the map is 0, it
+// returns nil.
+func AsMessagesByName[T proto.Message](messages map[string]T) map[string]proto.Message {
+	if len(messages) == 0 {
+		return nil
 	}
 
-	return protos
+	protosByName := make(map[string]proto.Message, len(messages))
+	for name, msg := range messages {
+		protosByName[name] = msg
+	}
+	return protosByName
 }
 
 // MustMarshalAny marshals a protobuf into an any.Any type, panicking

--- a/internal/protobuf/helpers_test.go
+++ b/internal/protobuf/helpers_test.go
@@ -16,7 +16,9 @@ package protobuf
 import (
 	"testing"
 
+	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -28,4 +30,38 @@ func TestU32Nil(t *testing.T) {
 func TestU32Default(t *testing.T) {
 	assert.Equal(t, wrapperspb.UInt32(99), UInt32OrDefault(0, 99))
 	assert.Equal(t, wrapperspb.UInt32(1), UInt32OrDefault(1, 99))
+}
+
+func TestAsMessages(t *testing.T) {
+	assert.Nil(t, AsMessages([]*envoy_config_cluster_v3.Cluster{}))
+
+	in := []*envoy_config_cluster_v3.Cluster{
+		{Name: "cluster-1"},
+		{Name: "cluster-2"},
+		{Name: "cluster-3"},
+		{Name: "cluster-4"},
+	}
+	out := AsMessages(in)
+
+	require.Len(t, out, len(in))
+	for i := range in {
+		assert.EqualValues(t, in[i], out[i])
+	}
+}
+
+func TestAsMessagesByName(t *testing.T) {
+	assert.Nil(t, AsMessagesByName(map[string]*envoy_config_cluster_v3.Cluster{}))
+
+	in := map[string]*envoy_config_cluster_v3.Cluster{
+		"cluster-1": {Name: "cluster-1"},
+		"cluster-2": {Name: "cluster-2"},
+		"cluster-3": {Name: "cluster-3"},
+		"cluster-4": {Name: "cluster-4"},
+	}
+	out := AsMessagesByName(in)
+
+	require.Len(t, out, len(in))
+	for name := range in {
+		assert.EqualValues(t, in[name], out[name])
+	}
 }

--- a/internal/xds/resource.go
+++ b/internal/xds/resource.go
@@ -25,6 +25,10 @@ type Resource interface {
 	// Contents returns the contents of this resource.
 	Contents() []proto.Message
 
+	// ContentsByName returns the contents of this resource,
+	// indexed by name.
+	ContentsByName() map[string]proto.Message
+
 	// Query returns an entry for each resource name supplied.
 	Query(names []string) []proto.Message
 

--- a/internal/xds/v3/contour_test.go
+++ b/internal/xds/v3/contour_test.go
@@ -228,6 +228,7 @@ type mockResource struct {
 }
 
 func (m *mockResource) Contents() []proto.Message                   { return m.contents() }
+func (m *mockResource) ContentsByName() map[string]proto.Message    { panic("not implemented") }
 func (m *mockResource) Query(names []string) []proto.Message        { return m.query(names) }
 func (m *mockResource) Register(ch chan int, last int, _ ...string) { m.register(ch, last) }
 func (m *mockResource) TypeURL() string                             { return m.typeurl() }

--- a/internal/xdscache/v3/cluster.go
+++ b/internal/xdscache/v3/cluster.go
@@ -57,6 +57,13 @@ func (c *ClusterCache) Contents() []proto.Message {
 	return protobuf.AsMessages(values)
 }
 
+func (c *ClusterCache) ContentsByName() map[string]proto.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return protobuf.AsMessagesByName(c.values)
+}
+
 func (c *ClusterCache) Query(names []string) []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/xdscache/v3/endpointslicetranslator.go
+++ b/internal/xdscache/v3/endpointslicetranslator.go
@@ -351,6 +351,9 @@ func (e *EndpointSliceTranslator) OnChange(root *dag.DAG) {
 	if changed {
 		e.Debug("cluster load assignments changed, notifying waiters")
 		e.Notify()
+		if e.Observer != nil {
+			e.Observer.Refresh()
+		}
 	} else {
 		e.Debug("cluster load assignments did not change")
 	}
@@ -443,6 +446,13 @@ func (e *EndpointSliceTranslator) Contents() []proto.Message {
 
 	sort.Stable(sorter.For(values))
 	return protobuf.AsMessages(values)
+}
+
+func (e *EndpointSliceTranslator) ContentsByName() map[string]proto.Message {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return protobuf.AsMessagesByName(e.entries)
 }
 
 func (e *EndpointSliceTranslator) Query(names []string) []proto.Message {

--- a/internal/xdscache/v3/endpointslicetranslator_test.go
+++ b/internal/xdscache/v3/endpointslicetranslator_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	core_v1 "k8s.io/api/core/v1"
@@ -59,6 +60,27 @@ func TestEndpointSliceTranslatorContents(t *testing.T) {
 			got := endpointSliceTranslator.Contents()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
+	}
+}
+
+func TestEndpointSliceTranslatorContentsByName(t *testing.T) {
+	var est EndpointSliceTranslator
+
+	assert.Nil(t, est.ContentsByName())
+
+	contents := map[string]*envoy_config_endpoint_v3.ClusterLoadAssignment{
+		"default/httpbin-org": envoy_v3.ClusterLoadAssignment("default/httpbin-org",
+			envoy_v3.SocketAddress("10.10.10.10", 80),
+		),
+	}
+
+	est.entries = contents
+
+	got := est.ContentsByName()
+
+	require.Equal(t, len(contents), len(got))
+	for name, val := range contents {
+		protobuf.ExpectEqual(t, val, got[name])
 	}
 }
 

--- a/internal/xdscache/v3/endpointstranslator.go
+++ b/internal/xdscache/v3/endpointstranslator.go
@@ -326,6 +326,9 @@ func (e *EndpointsTranslator) OnChange(root *dag.DAG) {
 	if changed {
 		e.Debug("cluster load assignments changed, notifying waiters")
 		e.Notify()
+		if e.Observer != nil {
+			e.Observer.Refresh()
+		}
 	} else {
 		e.Debug("cluster load assignments did not change")
 	}
@@ -438,6 +441,13 @@ func (e *EndpointsTranslator) Contents() []proto.Message {
 
 	sort.Stable(sorter.For(values))
 	return protobuf.AsMessages(values)
+}
+
+func (e *EndpointsTranslator) ContentsByName() map[string]proto.Message {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return protobuf.AsMessagesByName(e.entries)
 }
 
 func (e *EndpointsTranslator) Query(names []string) []proto.Message {

--- a/internal/xdscache/v3/endpointstranslator_test.go
+++ b/internal/xdscache/v3/endpointstranslator_test.go
@@ -63,6 +63,27 @@ func TestEndpointsTranslatorContents(t *testing.T) {
 	}
 }
 
+func TestEndpointsTranslatorContentsByName(t *testing.T) {
+	var et EndpointsTranslator
+
+	assert.Nil(t, et.ContentsByName())
+
+	contents := map[string]*envoy_config_endpoint_v3.ClusterLoadAssignment{
+		"default/httpbin-org": envoy_v3.ClusterLoadAssignment("default/httpbin-org",
+			envoy_v3.SocketAddress("10.10.10.10", 80),
+		),
+	}
+
+	et.entries = contents
+
+	got := et.ContentsByName()
+
+	require.Equal(t, len(contents), len(got))
+	for name, val := range contents {
+		protobuf.ExpectEqual(t, val, got[name])
+	}
+}
+
 func TestEndpointCacheQuery(t *testing.T) {
 	tests := map[string]struct {
 		contents map[string]*envoy_config_endpoint_v3.ClusterLoadAssignment

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -335,6 +335,13 @@ func (c *ListenerCache) Contents() []proto.Message {
 	return protobuf.AsMessages(values)
 }
 
+func (c *ListenerCache) ContentsByName() map[string]proto.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return protobuf.AsMessagesByName(c.values)
+}
+
 // Query returns the proto.Messages in the ListenerCache that match
 // a slice of strings
 func (c *ListenerCache) Query(names []string) []proto.Message {

--- a/internal/xdscache/v3/route.go
+++ b/internal/xdscache/v3/route.go
@@ -59,6 +59,13 @@ func (c *RouteCache) Contents() []proto.Message {
 	return protobuf.AsMessages(values)
 }
 
+func (c *RouteCache) ContentsByName() map[string]proto.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return protobuf.AsMessagesByName(c.values)
+}
+
 // Query searches the RouteCache for the named RouteConfiguration entries.
 func (c *RouteCache) Query(names []string) []proto.Message {
 	c.mu.Lock()

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -25,6 +25,7 @@ import (
 	envoy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -80,6 +81,27 @@ func TestRouteCacheContents(t *testing.T) {
 			got := rc.Contents()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
+	}
+}
+
+func TestRouteCacheContentsByName(t *testing.T) {
+	var rc RouteCache
+
+	assert.Nil(t, rc.ContentsByName())
+
+	contents := map[string]*envoy_config_route_v3.RouteConfiguration{
+		"ingress_http": {
+			Name: "ingress_http",
+		},
+	}
+
+	rc.Update(contents)
+
+	got := rc.ContentsByName()
+
+	require.Equal(t, len(contents), len(got))
+	for name, val := range contents {
+		protobuf.ExpectEqual(t, val, got[name])
 	}
 }
 

--- a/internal/xdscache/v3/runtime_test.go
+++ b/internal/xdscache/v3/runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	envoy_service_runtime_v3 "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	core_v1 "k8s.io/api/core/v1"
@@ -74,6 +75,29 @@ func TestRuntimeCacheContents(t *testing.T) {
 				},
 			}, rc.Contents())
 		})
+	}
+}
+
+func TestRuntimeCacheContentsByName(t *testing.T) {
+	var rc RuntimeCache
+
+	want := map[string]*envoy_service_runtime_v3.Runtime{
+		"dynamic": {
+			Name: "dynamic",
+			Layer: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+				},
+			},
+		},
+	}
+
+	got := rc.ContentsByName()
+
+	require.Equal(t, len(want), len(got))
+	for name, val := range want {
+		protobuf.ExpectEqual(t, val, got[name])
 	}
 }
 

--- a/internal/xdscache/v3/secret.go
+++ b/internal/xdscache/v3/secret.go
@@ -72,6 +72,13 @@ func (c *SecretCache) Contents() []proto.Message {
 	return protobuf.AsMessages(values)
 }
 
+func (c *SecretCache) ContentsByName() map[string]proto.Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return protobuf.AsMessagesByName(c.values)
+}
+
 func (c *SecretCache) Query(names []string) []proto.Message {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/xdscache/v3/secret_test.go
+++ b/internal/xdscache/v3/secret_test.go
@@ -18,6 +18,8 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_transport_socket_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	core_v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
@@ -57,6 +59,25 @@ func TestSecretCacheContents(t *testing.T) {
 			got := sc.Contents()
 			protobuf.ExpectEqual(t, tc.want, got)
 		})
+	}
+}
+
+func TestSecretCacheContentsByName(t *testing.T) {
+	var sc SecretCache
+
+	assert.Nil(t, sc.ContentsByName())
+
+	contents := map[string]*envoy_transport_socket_tls_v3.Secret{
+		"default/secret/0567f551af": secret("default/secret/0567f551af", secretdata(CERTIFICATE, RSA_PRIVATE_KEY)),
+	}
+
+	sc.Update(contents)
+
+	got := sc.ContentsByName()
+
+	require.Equal(t, len(contents), len(got))
+	for name, val := range contents {
+		protobuf.ExpectEqual(t, val, got[name])
 	}
 }
 

--- a/internal/xdscache/v3/snapshot.go
+++ b/internal/xdscache/v3/snapshot.go
@@ -15,13 +15,14 @@ package v3
 
 import (
 	"context"
-	"reflect"
 
+	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	envoy_cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	envoy_resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/projectcontour/contour/internal/dag"
 	contour_xds_v3 "github.com/projectcontour/contour/internal/xds/v3"
@@ -29,46 +30,75 @@ import (
 )
 
 // SnapshotHandler responds to DAG builds via the OnChange()
-// event and generates and caches go-control-plane Snapshots.
+// event and Endpoint updates via the Refresh() event and
+// generates and caches go-control-plane Snapshots.
 type SnapshotHandler struct {
-	// SnapshotCache contains go-control-plane Snapshots
-	// and is used by the go-control-plane xDS server.
-	SnapshotCache envoy_cache_v3.SnapshotCache
-
-	// resources contains the Contour xDS resource caches.
-	resources map[envoy_resource_v3.Type]xdscache.ResourceCache
-	log       logrus.FieldLogger
+	resources     map[envoy_resource_v3.Type]xdscache.ResourceCache
+	snapshotCache envoy_cache_v3.SnapshotCache
+	edsCache      *envoy_cache_v3.LinearCache
+	muxCache      *envoy_cache_v3.MuxCache
+	log           logrus.FieldLogger
 }
 
 // NewSnapshotHandler returns an instance of SnapshotHandler.
-func NewSnapshotHandler(resources []xdscache.ResourceCache, snapshotCache envoy_cache_v3.SnapshotCache, logger logrus.FieldLogger) *SnapshotHandler {
+func NewSnapshotHandler(resources []xdscache.ResourceCache, log logrus.FieldLogger) *SnapshotHandler {
+	var (
+		snapshotCache = envoy_cache_v3.NewSnapshotCache(false, &contour_xds_v3.Hash, log.WithField("context", "snapshotCache"))
+		edsCache      = envoy_cache_v3.NewLinearCache(envoy_resource_v3.EndpointType, envoy_cache_v3.WithLogger(log.WithField("context", "edsCache")))
+
+		muxCache = &envoy_cache_v3.MuxCache{
+			Caches: map[string]envoy_cache_v3.Cache{
+				envoy_resource_v3.ListenerType: snapshotCache,
+				envoy_resource_v3.ClusterType:  snapshotCache,
+				envoy_resource_v3.RouteType:    snapshotCache,
+				envoy_resource_v3.SecretType:   snapshotCache,
+				envoy_resource_v3.RuntimeType:  snapshotCache,
+				envoy_resource_v3.EndpointType: edsCache,
+			},
+			Classify: func(req *envoy_service_discovery_v3.DiscoveryRequest) string {
+				return req.GetTypeUrl()
+			},
+			ClassifyDelta: func(dr *envoy_cache_v3.DeltaRequest) string {
+				return dr.GetTypeUrl()
+			},
+		}
+	)
+
 	return &SnapshotHandler{
 		resources:     parseResources(resources),
-		SnapshotCache: snapshotCache,
-		log:           logger,
+		snapshotCache: snapshotCache,
+		edsCache:      edsCache,
+		muxCache:      muxCache,
+		log:           log,
 	}
 }
 
+func (s *SnapshotHandler) GetCache() envoy_cache_v3.Cache {
+	return s.muxCache
+}
+
 // Refresh is called when the EndpointsTranslator updates values
-// in its cache.
+// in its cache. It updates the ClusterLoadAssignments linear cache.
 func (s *SnapshotHandler) Refresh() {
-	s.generateNewSnapshot()
+	endpoints := s.resources[envoy_resource_v3.EndpointType].ContentsByName()
+
+	resources := make(map[string]envoy_types.Resource, len(endpoints))
+	for name, val := range endpoints {
+		resources[name] = val
+	}
+
+	s.edsCache.SetResources(resources)
 }
 
 // OnChange is called when the DAG is rebuilt and a new snapshot is needed.
+// It creates and caches a new go-control-plane Snapshot based on the
+// contents of the Contour xDS resource caches.
 func (s *SnapshotHandler) OnChange(*dag.DAG) {
-	s.generateNewSnapshot()
-}
-
-// generateNewSnapshot creates and caches a new go-control-plane
-// Snapshot based on the contents of the Contour xDS resource caches.
-func (s *SnapshotHandler) generateNewSnapshot() {
 	// Generate new snapshot version.
 	version := uuid.NewString()
 
 	// Convert caches to envoy xDS Resources.
 	resources := map[envoy_resource_v3.Type][]envoy_types.Resource{
-		envoy_resource_v3.EndpointType: asResources(s.resources[envoy_resource_v3.EndpointType].Contents()),
 		envoy_resource_v3.ClusterType:  asResources(s.resources[envoy_resource_v3.ClusterType].Contents()),
 		envoy_resource_v3.RouteType:    asResources(s.resources[envoy_resource_v3.RouteType].Contents()),
 		envoy_resource_v3.ListenerType: asResources(s.resources[envoy_resource_v3.ListenerType].Contents()),
@@ -82,25 +112,24 @@ func (s *SnapshotHandler) generateNewSnapshot() {
 		return
 	}
 
-	if err := s.SnapshotCache.SetSnapshot(context.Background(), contour_xds_v3.Hash.String(), snapshot); err != nil {
+	if err := s.snapshotCache.SetSnapshot(context.Background(), contour_xds_v3.Hash.String(), snapshot); err != nil {
 		s.log.Errorf("failed to store snapshot version %q: %s", version, err)
 		return
 	}
 }
 
-// asResources casts the given slice of values (that implement the envoy_types.Resource
+// asResources converts the given slice of values (that implement the envoy_types.Resource
 // interface) to a slice of envoy_types.Resource. If the length of the slice is 0, it
 // returns nil.
-func asResources(messages any) []envoy_types.Resource {
-	v := reflect.ValueOf(messages)
-	if v.Len() == 0 {
+func asResources[T proto.Message](messages []T) []envoy_types.Resource {
+	if len(messages) == 0 {
 		return nil
 	}
 
-	protos := make([]envoy_types.Resource, v.Len())
+	protos := make([]envoy_types.Resource, len(messages))
 
-	for i := range protos {
-		protos[i] = v.Index(i).Interface().(envoy_types.Resource)
+	for i, resource := range messages {
+		protos[i] = resource
 	}
 
 	return protos

--- a/internal/xdscache/v3/snapshot.go
+++ b/internal/xdscache/v3/snapshot.go
@@ -64,13 +64,19 @@ func NewSnapshotHandler(resources []xdscache.ResourceCache, log logrus.FieldLogg
 		}
 	)
 
-	return &SnapshotHandler{
+	sh := &SnapshotHandler{
 		resources:     parseResources(resources),
 		snapshotCache: snapshotCache,
 		edsCache:      edsCache,
 		muxCache:      muxCache,
 		log:           log,
 	}
+
+	// Trigger an initial snapshot, based on any static values
+	// present in the resource caches.
+	sh.OnChange(nil)
+
+	return sh
 }
 
 func (s *SnapshotHandler) GetCache() envoy_cache_v3.Cache {

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -1036,7 +1036,7 @@ func Defaults() Parameters {
 		InCluster:  false,
 		Kubeconfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
 		Server: ServerParameters{
-			XDSServerType: ContourServerType,
+			XDSServerType: EnvoyServerType,
 		},
 		IngressStatusAddress:       "",
 		AccessLogFormat:            DEFAULT_ACCESS_LOG_TYPE,

--- a/pkg/config/parameters_test.go
+++ b/pkg/config/parameters_test.go
@@ -48,7 +48,7 @@ func TestParseDefaults(t *testing.T) {
 debug: false
 kubeconfig: TestParseDefaults/.kube/config
 server:
-    xds-server-type: contour
+    xds-server-type: envoy
 accesslog-format: envoy
 json-fields:
     - '@timestamp'

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -369,6 +369,10 @@ func (d *Deployment) EnsureEnvoyDeployment() error {
 	return d.ensureResource(d.EnvoyDeployment, new(apps_v1.Deployment))
 }
 
+func (d *Deployment) RestartEnvoy() error {
+	return d.client.DeleteAllOf(context.Background(), &core_v1.Pod{}, client.InNamespace(d.Namespace.Name), client.MatchingLabels{"app": "envoy"})
+}
+
 func (d *Deployment) WaitForEnvoyUpdated() error {
 	if d.EnvoyDeploymentMode == DaemonsetMode {
 		return WaitForEnvoyDaemonSetUpdated(d.EnvoyDaemonSet, d.client, d.contourImage)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -641,7 +641,7 @@ func DefaultContourConfiguration() *contour_v1alpha1.ContourConfiguration {
 
 func XDSServerTypeFromEnv() contour_v1alpha1.XDSServerType {
 	// Default to contour if not provided.
-	serverType := contour_v1alpha1.ContourServerType
+	serverType := contour_v1alpha1.EnvoyServerType
 	typeFromEnv, found := os.LookupEnv("CONTOUR_E2E_XDS_SERVER_TYPE")
 	if found {
 		serverType = contour_v1alpha1.XDSServerType(typeFromEnv)

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Gateway API", func() {
 	AfterEach(func() {
 		require.NoError(f.T(), f.DeleteGatewayClass(contourGatewayClass, false))
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 
 	Describe("Gateway with one HTTP listener", func() {

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -106,6 +106,7 @@ var _ = Describe("HTTPProxy", func() {
 
 	AfterEach(func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 	f.NamespacedTest("httpproxy-direct-response-policy", testDirectResponseRule)
 

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Infra", func() {
 	AfterEach(func() {
 		f.Kubectl.StopKubectlPortForward(kubectlCmd)
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
-		// Not restarting Envoy here becaue it causes the subsequent port-forward
+		// Not restarting Envoy here because it causes the subsequent port-forward
 		// to be flaky, and it does not appear to be needed here. Could be added
 		// later if the port-forward is de-flaked (possibly need to do a better
 		// job of waiting for new pod(s) to be running before starting the port

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -121,6 +121,11 @@ var _ = Describe("Infra", func() {
 	AfterEach(func() {
 		f.Kubectl.StopKubectlPortForward(kubectlCmd)
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		// Not restarting Envoy here becaue it causes the subsequent port-forward
+		// to be flaky, and it does not appear to be needed here. Could be added
+		// later if the port-forward is de-flaked (possibly need to do a better
+		// job of waiting for new pod(s) to be running before starting the port
+		// forward).
 	})
 
 	f.Test(testMetrics)

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Ingress", func() {
 
 	AfterEach(func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 
 	f.NamespacedTest("ingress-tls-wildcard-host", testTLSWildcardHost)


### PR DESCRIPTION
- Triggers only EDS updates when endpoints change
- Does not trigger EDS updates when only non-endpoints change

Seems like until we get to implementing ADS, keeping endpoint updates independent is a good idea so that endpoint changes (which in general probably happen more frequently than other xDS updates) don't trigger all xDS resources to be updated.