### PR TITLE
Ignore all loopback IPs in local ip grep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{pri
 # Used to supply a local Envoy docker container an IP to connect to that is running
 # 'contour serve'. On MacOS this will work, but may not on other OSes. Defining
 # LOCALIP as an env var before running 'make local' will solve that.
-LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v 127.0.0.1 | head -n1 | awk '{print $$2}')
+LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v '127.' | head -n1 | awk '{print $$2}')
 
 # Variables needed for running e2e tests.
 CONTOUR_E2E_LOCAL_HOST ?= $(LOCALIP)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{pri
 # Used to supply a local Envoy docker container an IP to connect to that is running
 # 'contour serve'. On MacOS this will work, but may not on other OSes. Defining
 # LOCALIP as an env var before running 'make local' will solve that.
-LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v '127.' | head -n1 | awk '{print $$2}')
+LOCALIP ?= $(shell ifconfig | grep inet | grep -v '::' | grep -v 'inet 127.' | head -n1 | awk '{print $$2}')
 
 # Variables needed for running e2e tests.
 CONTOUR_E2E_LOCAL_HOST ?= $(LOCALIP)


### PR DESCRIPTION
## Overview
I found that when running [Cloudflare WARP](https://developers.cloudflare.com/warp-client/) it adds DNS server listening two new loopback interface IPs, `127.0.2.2` and `127.0.2.3`. This broke the envoy xDS configuration because the it was trying to use `127.0.2.2:8001`.

This grep change should just remove all IPs in the loopback CIDR block since they all start with `127.`