### PR TITLE
test/e2e: restart Envoy pods in between tests

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -369,6 +369,10 @@ func (d *Deployment) EnsureEnvoyDeployment() error {
 	return d.ensureResource(d.EnvoyDeployment, new(apps_v1.Deployment))
 }
 
+func (d *Deployment) RestartEnvoy() error {
+	return d.client.DeleteAllOf(context.Background(), &core_v1.Pod{}, client.InNamespace(d.Namespace.Name), client.MatchingLabels{"app": "envoy"})
+}
+
 func (d *Deployment) WaitForEnvoyUpdated() error {
 	if d.EnvoyDeploymentMode == DaemonsetMode {
 		return WaitForEnvoyDaemonSetUpdated(d.EnvoyDaemonSet, d.client, d.contourImage)

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Gateway API", func() {
 	AfterEach(func() {
 		require.NoError(f.T(), f.DeleteGatewayClass(contourGatewayClass, false))
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 
 	Describe("Gateway with one HTTP listener", func() {

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -106,6 +106,7 @@ var _ = Describe("HTTPProxy", func() {
 
 	AfterEach(func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 	f.NamespacedTest("httpproxy-direct-response-policy", testDirectResponseRule)
 

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -121,6 +121,11 @@ var _ = Describe("Infra", func() {
 	AfterEach(func() {
 		f.Kubectl.StopKubectlPortForward(kubectlCmd)
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		// Not restarting Envoy here because it causes the subsequent port-forward
+		// to be flaky, and it does not appear to be needed here. Could be added
+		// later if the port-forward is de-flaked (possibly need to do a better
+		// job of waiting for new pod(s) to be running before starting the port
+		// forward).
 	})
 
 	f.Test(testMetrics)

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Ingress", func() {
 
 	AfterEach(func() {
 		require.NoError(f.T(), f.Deployment.StopLocalContour(contourCmd, contourConfigFile))
+		require.NoError(f.T(), f.Deployment.RestartEnvoy())
 	})
 
 	f.NamespacedTest("ingress-tls-wildcard-host", testTLSWildcardHost)


### PR DESCRIPTION
This allows each test to run with a "clean" set of Envoys that haven't been configured with resources from previous tests.