### PR TITLE
Bump golang to 1.22.1 for CVEs

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -13,7 +13,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.22.1
 
 jobs:
   e2e-envoy-xds:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -19,7 +19,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.22.1
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.22.1
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.0
+  GO_VERSION: 1.22.1
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.22.0@sha256:7b297d9abee021bab9046e492506b3c2da8a3722cbf301653186545ecc1e00bb
+BUILD_BASE_IMAGE ?= golang:1.22.1@sha256:34ce21a9696a017249614876638ea37ceca13cdd88f582caad06f87a8aa45bf3
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/6181-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6181-sunjayBhatia-small.md
@@ -1,1 +1,0 @@
-Updates to Go 1.22.0. See the [Go release notes](https://go.dev/doc/go1.22) for more information.

--- a/changelogs/unreleased/6265-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6265-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates to Go 1.22.1. See the [Go release notes](https://go.dev/doc/devel/release#go1.22.minor) for more information.


### PR DESCRIPTION
See release notes: https://go.dev/doc/devel/release#go1.22.0

https://github.com/golang/go/issues/65831 is the most relevant CVE backport for Contour