### PR TITLE
Bump Envoy to v1.29.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.29.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.29.2
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/6283-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/6283-sunjayBhatia-minor.md
@@ -1,0 +1,5 @@
+## Update Envoy to v1.29.2
+
+See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2).
+
+Note that this Envoy version reverts the HTTP/2 codec back to `nghttp2` from `oghttp2`.

--- a/changelogs/unreleased/6283-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6283-sunjayBhatia-small.md
@@ -1,1 +1,0 @@
-Updates Envoy to v1.29.2. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2).

--- a/changelogs/unreleased/6283-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6283-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.29.2. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.29.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.29.2",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.1
+        image: docker.io/envoyproxy/envoy:v1.29.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.29.1
+          image: docker.io/envoyproxy/envoy:v1.29.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9178,7 +9178,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.29.1
+          image: docker.io/envoyproxy/envoy:v1.29.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8982,7 +8982,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.1
+        image: docker.io/envoyproxy/envoy:v1.29.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9166,7 +9166,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.1
+        image: docker.io/envoyproxy/envoy:v1.29.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.29.1][46]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
+| main            | [1.29.2][49]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.1          | [1.29.1][46]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.0          | [1.29.1][46]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.27.1          | [1.28.1][47]         | 1.28, 1.27, 1.26    | [0.8.1][109]        |
@@ -181,6 +181,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [46]: https://www.envoyproxy.io/docs/envoy/v1.29.1/version_history/v1.29/v1.29.1
 [47]: https://www.envoyproxy.io/docs/envoy/v1.28.1/version_history/v1.28/v1.28.1
 [48]: https://www.envoyproxy.io/docs/envoy/v1.27.3/version_history/v1.27/v1.27.3
+[49]: https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.29.1"
+      envoy: "1.29.2"
       kubernetes:
         - "1.29"
         - "1.28"


### PR DESCRIPTION
See release notes: https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2