### PR TITLE
Disable Envoy removing TE request header

### DIFF
--- a/.codespell.ignorewords
+++ b/.codespell.ignorewords
@@ -7,3 +7,4 @@ als
 wit
 aks
 immediatedly
+te

--- a/changelogs/unreleased/6288-sunjayBhatia-minor.md
+++ b/changelogs/unreleased/6288-sunjayBhatia-minor.md
@@ -1,0 +1,7 @@
+## Disable Envoy removing TE header
+
+As of version v1.29.0, Envoy removes the hop-by-hop TE header.
+However, this causes issues with HTTP/2, particularly gRPC, with implementations expecting the header to be present (and set to `trailers`).
+Contour disables this via Envoy runtime setting and reverts to the v1.28.x and prior behavior of allowing the header to be proxied.
+
+Once [this Envoy PR that enables the TE header including `trailers` to be forwarded](https://github.com/envoyproxy/envoy/pull/32255) is backported to a release or a new minor is cut, Contour will no longer set the aforementioned runtime key.

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,8 +40,13 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"re2.max_program_size.error_level": structpb.NewNumberValue(maxRegexProgramSizeError),
-			"re2.max_program_size.warn_level":  structpb.NewNumberValue(maxRegexProgramSizeWarn),
+			// Disable Envoy removing the TE/:te request header. Removing the header was
+			// added by default in Envoy v1.29.0.
+			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is backported or
+			// present in a new release of Envoy.
+			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+			"re2.max_program_size.error_level":      structpb.NewNumberValue(maxRegexProgramSizeError),
+			"re2.max_program_size.warn_level":       structpb.NewNumberValue(maxRegexProgramSizeWarn),
 		},
 	}
 }

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,9 +40,8 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			// Disable Envoy removing the client "accepted transfer encoding"
-			// request header. Removing the header was added by default in Envoy
-			// v1.29.0.
+			// Disable Envoy removing the client TE request header. Removing
+			// the header was added by default in Envoy v1.29.0.
 			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is
 			// backported or present in a new release of Envoy.
 			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,10 +40,11 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			// Disable Envoy removing the TE/:te request header. Removing the header was
-			// added by default in Envoy v1.29.0.
-			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is backported or
-			// present in a new release of Envoy.
+			// Disable Envoy removing the client "accepted transfer encoding"
+			// request header. Removing the header was added by default in Envoy
+			// v1.29.0.
+			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is
+			// backported or present in a new release of Envoy.
 			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
 			"re2.max_program_size.error_level":      structpb.NewNumberValue(maxRegexProgramSizeError),
 			"re2.max_program_size.warn_level":       structpb.NewNumberValue(maxRegexProgramSizeWarn),

--- a/internal/envoy/v3/runtime_test.go
+++ b/internal/envoy/v3/runtime_test.go
@@ -39,8 +39,9 @@ func TestRuntimeLayers(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			expectedFields := map[string]*structpb.Value{
-				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.configurableFields {
 				expectedFields[k] = v

--- a/internal/xdscache/v3/runtime_test.go
+++ b/internal/xdscache/v3/runtime_test.go
@@ -59,8 +59,9 @@ func TestRuntimeCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			rc := NewRuntimeCache(tc.runtimeSettings)
 			fields := map[string]*structpb.Value{
-				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.additionalFields {
 				fields[k] = v
@@ -83,8 +84,9 @@ func TestRuntimeCacheQuery(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 				},
 			},
 		},
@@ -149,8 +151,9 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-							"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+							"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+							"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+							"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 						},
 					},
 				},
@@ -188,6 +191,7 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
+							"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 							"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -232,6 +236,7 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
+							"envoy.reloadable_features.sanitize_te":                         structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit":  structpb.NewNumberValue(100),
 							"envoy.resource_limits.listener.ingress_https.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                              structpb.NewNumberValue(1 << 20),
@@ -299,6 +304,7 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
+					"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 					"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 					"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 					"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -313,8 +319,9 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 				},
 			},
 		},


### PR DESCRIPTION
Removal of the header was added by default in Envoy v1.29.0. This change reverts back to prior behavior.

This change can be reverted once https://github.com/envoyproxy/envoy/pull/32255 is backported or present in a new release of Envoy.