### PR TITLE
release-1.28: Disable Envoy removing TE request header

### DIFF
--- a/.codespell.ignorewords
+++ b/.codespell.ignorewords
@@ -7,3 +7,4 @@ als
 wit
 aks
 immediatedly
+te

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,8 +40,13 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"re2.max_program_size.error_level": structpb.NewNumberValue(maxRegexProgramSizeError),
-			"re2.max_program_size.warn_level":  structpb.NewNumberValue(maxRegexProgramSizeWarn),
+			// Disable Envoy removing the TE/:te request header. Removing the header was
+			// added by default in Envoy v1.29.0.
+			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is backported or
+			// present in a new release of Envoy.
+			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+			"re2.max_program_size.error_level":      structpb.NewNumberValue(maxRegexProgramSizeError),
+			"re2.max_program_size.warn_level":       structpb.NewNumberValue(maxRegexProgramSizeWarn),
 		},
 	}
 }

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,9 +40,8 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			// Disable Envoy removing the client "accepted transfer encoding"
-			// request header. Removing the header was added by default in Envoy
-			// v1.29.0.
+			// Disable Envoy removing the client TE request header. Removing
+			// the header was added by default in Envoy v1.29.0.
 			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is
 			// backported or present in a new release of Envoy.
 			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,10 +40,11 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			// Disable Envoy removing the TE/:te request header. Removing the header was
-			// added by default in Envoy v1.29.0.
-			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is backported or
-			// present in a new release of Envoy.
+			// Disable Envoy removing the client "accepted transfer encoding"
+			// request header. Removing the header was added by default in Envoy
+			// v1.29.0.
+			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is
+			// backported or present in a new release of Envoy.
 			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
 			"re2.max_program_size.error_level":      structpb.NewNumberValue(maxRegexProgramSizeError),
 			"re2.max_program_size.warn_level":       structpb.NewNumberValue(maxRegexProgramSizeWarn),

--- a/internal/envoy/v3/runtime_test.go
+++ b/internal/envoy/v3/runtime_test.go
@@ -39,8 +39,9 @@ func TestRuntimeLayers(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			expectedFields := map[string]*structpb.Value{
-				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.configurableFields {
 				expectedFields[k] = v

--- a/internal/xdscache/v3/runtime_test.go
+++ b/internal/xdscache/v3/runtime_test.go
@@ -58,8 +58,9 @@ func TestRuntimeCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			rc := NewRuntimeCache(tc.runtimeSettings)
 			fields := map[string]*structpb.Value{
-				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.additionalFields {
 				fields[k] = v
@@ -82,8 +83,9 @@ func TestRuntimeCacheQuery(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 				},
 			},
 		},
@@ -148,8 +150,9 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-							"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+							"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+							"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+							"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 						},
 					},
 				},
@@ -187,6 +190,7 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
+							"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 							"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -231,6 +235,7 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
+							"envoy.reloadable_features.sanitize_te":                         structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit":  structpb.NewNumberValue(100),
 							"envoy.resource_limits.listener.ingress_https.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                              structpb.NewNumberValue(1 << 20),
@@ -298,6 +303,7 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
+					"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 					"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 					"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 					"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -312,8 +318,9 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
+					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
+					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
 				},
 			},
 		},


### PR DESCRIPTION
Removal of the header was added by default in Envoy v1.29.0. This change reverts back to prior behavior.

This change can be reverted once https://github.com/envoyproxy/envoy/pull/32255 is backported or present in a new release of Envoy.