### PR TITLE
Allow follower to start with empty initial resource list

### DIFF
--- a/changelogs/unreleased/6295-tsaarni-small.md
+++ b/changelogs/unreleased/6295-tsaarni-small.md
@@ -1,0 +1,1 @@
+If there were no relevant resources for Contour in the watched namespaces during the startup of a follower instance of Contour, it did not reach a ready state.


### PR DESCRIPTION
This change fixes a bug that caused follower instance of Contour not reach the ready state when started under following condition:

1. Namespace(s) configured with `--watched-namespaces` do not contain any resources.
2. Resources that informer sends during initial synchronization are not triggering DAG rebuild because Contour decides those resources were not relevant.

As result, XDS server is not started at all and those Contour instances will not reach ready state.

Note that leader instance still worked correctly even when the conditions were true. This is because leader election triggers "fake" DAG update and therefore the same code path gets executed as if informer delivered some relevant resources that necessitated DAG rebuild - and therefore XDS server start. 

The change adds explicit checks to cover the conditions (1) and (2).

Background:

Prior to #5672 we had hardcoded timer that triggered start of XDS server regardless of DAG rebuild status - even if it was not built at all. Starting from 1.27.0 we wait until all relevant resources have been received from the API server and then build the initial DAG. Back then it was not considered that there might not be initial resources and no initial DAG to build at all.

Fixes #6291