### PR TITLE
bump Envoy to v1.29.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.29.2
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.29.3
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.29.2",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.29.3",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.2
+        image: docker.io/envoyproxy/envoy:v1.29.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.29.2
+          image: docker.io/envoyproxy/envoy:v1.29.3
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9178,7 +9178,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.29.2
+          image: docker.io/envoyproxy/envoy:v1.29.3
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8982,7 +8982,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.2
+        image: docker.io/envoyproxy/envoy:v1.29.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9166,7 +9166,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.29.2
+        image: docker.io/envoyproxy/envoy:v1.29.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/internal/envoy/v3/runtime.go
+++ b/internal/envoy/v3/runtime.go
@@ -40,13 +40,8 @@ func RuntimeLayers(configurableRuntimeFields map[string]*structpb.Value) []*envo
 func baseRuntimeLayer() *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			// Disable Envoy removing the client TE request header. Removing
-			// the header was added by default in Envoy v1.29.0.
-			// Can remove once https://github.com/envoyproxy/envoy/pull/32255 is
-			// backported or present in a new release of Envoy.
-			"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-			"re2.max_program_size.error_level":      structpb.NewNumberValue(maxRegexProgramSizeError),
-			"re2.max_program_size.warn_level":       structpb.NewNumberValue(maxRegexProgramSizeWarn),
+			"re2.max_program_size.error_level": structpb.NewNumberValue(maxRegexProgramSizeError),
+			"re2.max_program_size.warn_level":  structpb.NewNumberValue(maxRegexProgramSizeWarn),
 		},
 	}
 }

--- a/internal/envoy/v3/runtime_test.go
+++ b/internal/envoy/v3/runtime_test.go
@@ -39,9 +39,8 @@ func TestRuntimeLayers(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			expectedFields := map[string]*structpb.Value{
-				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
+				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.configurableFields {
 				expectedFields[k] = v

--- a/internal/xdscache/v3/runtime_test.go
+++ b/internal/xdscache/v3/runtime_test.go
@@ -59,9 +59,8 @@ func TestRuntimeCacheContents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			rc := NewRuntimeCache(tc.runtimeSettings)
 			fields := map[string]*structpb.Value{
-				"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-				"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
-				"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
+				"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+				"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
 			}
 			for k, v := range tc.additionalFields {
 				fields[k] = v
@@ -84,9 +83,8 @@ func TestRuntimeCacheQuery(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
+					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
 				},
 			},
 		},
@@ -151,9 +149,8 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-							"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
-							"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
+							"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+							"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
 						},
 					},
 				},
@@ -191,7 +188,6 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 							"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -236,7 +232,6 @@ func TestRuntimeVisit(t *testing.T) {
 					Name: "dynamic",
 					Layer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"envoy.reloadable_features.sanitize_te":                         structpb.NewBoolValue(false),
 							"envoy.resource_limits.listener.ingress_http.connection_limit":  structpb.NewNumberValue(100),
 							"envoy.resource_limits.listener.ingress_https.connection_limit": structpb.NewNumberValue(100),
 							"re2.max_program_size.error_level":                              structpb.NewNumberValue(1 << 20),
@@ -304,7 +299,6 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"envoy.reloadable_features.sanitize_te":                        structpb.NewBoolValue(false),
 					"envoy.resource_limits.listener.ingress_http.connection_limit": structpb.NewNumberValue(100),
 					"re2.max_program_size.error_level":                             structpb.NewNumberValue(1 << 20),
 					"re2.max_program_size.warn_level":                              structpb.NewNumberValue(1000),
@@ -319,9 +313,8 @@ func TestRuntimeCacheOnChangeDelete(t *testing.T) {
 			Name: "dynamic",
 			Layer: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"envoy.reloadable_features.sanitize_te": structpb.NewBoolValue(false),
-					"re2.max_program_size.error_level":      structpb.NewNumberValue(1 << 20),
-					"re2.max_program_size.warn_level":       structpb.NewNumberValue(1000),
+					"re2.max_program_size.error_level": structpb.NewNumberValue(1 << 20),
+					"re2.max_program_size.warn_level":  structpb.NewNumberValue(1000),
 				},
 			},
 		},

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.29.2][49]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
+| main            | [1.29.3][50]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.2          | [1.29.2][49]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.1          | [1.29.1][46]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.0          | [1.29.1][46]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
@@ -183,6 +183,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [47]: https://www.envoyproxy.io/docs/envoy/v1.28.1/version_history/v1.28/v1.28.1
 [48]: https://www.envoyproxy.io/docs/envoy/v1.27.3/version_history/v1.27/v1.27.3
 [49]: https://www.envoyproxy.io/docs/envoy/v1.29.2/version_history/v1.29/v1.29.2
+[50]: https://www.envoyproxy.io/docs/envoy/v1.29.3/version_history/v1.29/v1.29.3
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.29.2"
+      envoy: "1.29.3"
       kubernetes:
         - "1.29"
         - "1.28"


### PR DESCRIPTION
Also removes setting the envoy.reloadable_features.sanitize_te runtime flag to false since Envoy's behavior is now correct.