### PR TITLE
internal/dag: basic Gateway API Timeouts.BackendRequest impl

### DIFF
--- a/changelogs/unreleased/6335-skriss-small.md
+++ b/changelogs/unreleased/6335-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: add support for HTTPRoute's Timeouts.BackendRequest field.

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -9441,7 +9441,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		},
 	})
 
-	run(t, "route rule with timeouts.request and timeouts.backendRequest specified", testcase{
+	run(t, "route rule with timeouts.backendRequest greater than timeouts.request", testcase{
 		objs: []any{
 			kuardService,
 			&gatewayapi_v1.HTTPRoute{
@@ -9462,7 +9462,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 							Timeouts: &gatewayapi_v1.HTTPRouteTimeouts{
 								Request:        ptr.To(gatewayapi_v1.Duration("30s")),
-								BackendRequest: ptr.To(gatewayapi_v1.Duration("30s")),
+								BackendRequest: ptr.To(gatewayapi_v1.Duration("60s")),
 							},
 						},
 					},
@@ -9477,7 +9477,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
 						routeResolvedRefsCondition(),
-						routeAcceptedFalse(gatewayapi_v1.RouteReasonUnsupportedValue, "HTTPRoute.Spec.Rules.Timeouts.BackendRequest is not supported, use HTTPRoute.Spec.Rules.Timeouts.Request instead"),
+						routeAcceptedFalse(gatewayapi_v1.RouteReasonUnsupportedValue, "HTTPRoute.Spec.Rules.Timeouts.BackendRequest must be less than/equal to HTTPRoute.Spec.Rules.Timeouts.Request when both are specified"),
 					},
 				},
 			},
@@ -9486,7 +9486,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 		wantGatewayStatusUpdate: validGatewayStatusUpdate("http", gatewayapi_v1.HTTPProtocolType, 1),
 	})
 
-	run(t, "route rule with only timeouts.backendRequest specified", testcase{
+	run(t, "route rule with invalid timeouts.backendRequest specified", testcase{
 		objs: []any{
 			kuardService,
 			&gatewayapi_v1.HTTPRoute{
@@ -9506,7 +9506,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 							Matches:     gatewayapi.HTTPRouteMatch(gatewayapi_v1.PathMatchPathPrefix, "/"),
 							BackendRefs: gatewayapi.HTTPBackendRef("kuard", 8080, 1),
 							Timeouts: &gatewayapi_v1.HTTPRouteTimeouts{
-								BackendRequest: ptr.To(gatewayapi_v1.Duration("30s")),
+								BackendRequest: ptr.To(gatewayapi_v1.Duration("invalid")),
 							},
 						},
 					},
@@ -9520,7 +9520,7 @@ func TestGatewayAPIHTTPRouteDAGStatus(t *testing.T) {
 					ParentRef: gatewayapi.GatewayParentRef("projectcontour", "contour"),
 					Conditions: []meta_v1.Condition{
 						routeResolvedRefsCondition(),
-						routeAcceptedFalse(gatewayapi_v1.RouteReasonUnsupportedValue, "HTTPRoute.Spec.Rules.Timeouts.BackendRequest is not supported, use HTTPRoute.Spec.Rules.Timeouts.Request instead"),
+						routeAcceptedFalse(gatewayapi_v1.RouteReasonUnsupportedValue, "invalid HTTPRoute.Spec.Rules.Timeouts.BackendRequest: unable to parse timeout string \"invalid\": time: invalid duration \"invalid\""),
 					},
 				},
 			},

--- a/test/conformance/gatewayapi/gateway_conformance_test.go
+++ b/test/conformance/gatewayapi/gateway_conformance_test.go
@@ -74,12 +74,6 @@ func TestGatewayConformance(t *testing.T) {
 			// See: https://github.com/envoyproxy/envoy/issues/17318
 			tests.HTTPRouteRedirectPortAndScheme.ShortName,
 
-			// Not implemented yet since it's functionally equivalent
-			// to Timeouts.Request, to be enabled once Gateway API
-			// supports retries.
-			// See: https://github.com/projectcontour/contour/issues/6000
-			tests.HTTPRouteTimeoutBackendRequest.ShortName,
-
 			// Contour supports the positive-case functionality,
 			// but there are some negative cases that aren't fully
 			// implemented plus complications with the test setup itself.

--- a/test/scripts/run-gateway-conformance.sh
+++ b/test/scripts/run-gateway-conformance.sh
@@ -58,7 +58,7 @@ GO_MOD_GATEWAY_API_VERSION=$(grep "sigs.k8s.io/gateway-api" go.mod | awk '{print
 
 if [ "$GATEWAY_API_VERSION" = "$GO_MOD_GATEWAY_API_VERSION" ]; then
   go test -timeout=40m -tags conformance ./test/conformance/gatewayapi --gateway-class=contour
-else 
+else
   cd $(mktemp -d)
   git clone https://github.com/kubernetes-sigs/gateway-api
   cd gateway-api
@@ -67,5 +67,5 @@ else
   # test/conformance/gatewayapi/gateway_conformance_test.go.
   go test -timeout=40m ./conformance -run TestConformance -gateway-class=contour -all-features \
     -exempt-features=Mesh \
-    -skip-tests=HTTPRouteRedirectPortAndScheme,HTTPRouteTimeoutBackendRequest,GatewayStaticAddresses
+    -skip-tests=HTTPRouteRedirectPortAndScheme,GatewayStaticAddresses
 fi


### PR DESCRIPTION
Implements the Gateway API BackendRequest timeout in a way that satisfies current conformance. Since retries do not exist yet in Gateway API, BackendRequest is functionally equivalent to Request timeout, but according to the API spec must be less than/equal to Request timeout if both are specified.

(Yes, I know I was the one who originally suggested we don't implement this field yet, but since it's the only blocker to our conformance report showing full success for both core and extended, it seemed worth doing the simple/conformant implementation for now).
