### PR TITLE
daily build: run E2E's against endpoints translator

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -127,7 +127,7 @@ jobs:
         steps: ${{ toJson(steps) }}
         channel: '#contour-ci-notifications'
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
-  e2e-endpoint-slices:
+  e2e-endpoints:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -154,7 +154,7 @@ jobs:
     - name: e2e tests
       env:
         CONTOUR_E2E_IMAGE: ghcr.io/projectcontour/contour:main
-        CONTOUR_E2E_USE_ENDPOINT_SLICES: true
+        CONTOUR_E2E_USE_ENDPOINTS: true
       run: |
         make setup-kind-cluster run-e2e cleanup-kind
     - uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -651,9 +651,9 @@ func XDSServerTypeFromEnv() contour_v1alpha1.XDSServerType {
 
 func UseFeatureFlagsFromEnv() []string {
 	flags := make([]string, 0)
-	_, found := os.LookupEnv("CONTOUR_E2E_USE_ENDPOINT_SLICES")
+	_, found := os.LookupEnv("CONTOUR_E2E_USE_ENDPOINTS")
 	if found {
-		flags = append(flags, "useEndpointSlices")
+		flags = append(flags, "useEndpointSlices=false")
 	}
 	return flags
 }


### PR DESCRIPTION
Now that using EndpointSlices is the default behavior, flip the daily build to continue running E2E's with the Endpoints translator for coverage until it's
removed.