### PR TITLE
test/e2e: verify resource status upon creation

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -311,7 +311,7 @@ func (f *Framework) CreateHTTPProxy(proxy *contour_v1.HTTPProxy) error {
 	return f.Client.Create(context.TODO(), proxy)
 }
 
-func createAndWaitFor[T client.Object](t require.TestingT, client client.Client, obj T, condition func(T) bool, interval, timeout time.Duration) (T, bool) {
+func createAndWaitFor[T client.Object](t require.TestingT, client client.Client, obj T, condition func(T) bool, interval, timeout time.Duration) bool {
 	require.NoError(t, client.Create(context.Background(), obj))
 
 	key := types.NamespacedName{
@@ -329,11 +329,10 @@ func createAndWaitFor[T client.Object](t require.TestingT, client client.Client,
 
 		return condition(obj), nil
 	}); err != nil {
-		// return the last response for logging/debugging purposes
-		return obj, false
+		return false
 	}
 
-	return obj, true
+	return true
 }
 
 func updateAndWaitFor[T client.Object](t require.TestingT, cli client.Client, obj T, mutate func(T), condition func(T) bool, interval, timeout time.Duration) (T, bool) {
@@ -366,31 +365,31 @@ func updateAndWaitFor[T client.Object](t require.TestingT, cli client.Client, ob
 
 // CreateHTTPProxyAndWaitFor creates the provided HTTPProxy in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateHTTPProxyAndWaitFor(proxy *contour_v1.HTTPProxy, condition func(*contour_v1.HTTPProxy) bool) (*contour_v1.HTTPProxy, bool) {
+func (f *Framework) CreateHTTPProxyAndWaitFor(proxy *contour_v1.HTTPProxy, condition func(*contour_v1.HTTPProxy) bool) bool {
 	return createAndWaitFor(f.t, f.Client, proxy, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateHTTPRouteAndWaitFor creates the provided HTTPRoute in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1.HTTPRoute, condition func(*gatewayapi_v1.HTTPRoute) bool) (*gatewayapi_v1.HTTPRoute, bool) {
+func (f *Framework) CreateHTTPRouteAndWaitFor(route *gatewayapi_v1.HTTPRoute, condition func(*gatewayapi_v1.HTTPRoute) bool) bool {
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateTLSRouteAndWaitFor creates the provided TLSRoute in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateTLSRouteAndWaitFor(route *gatewayapi_v1alpha2.TLSRoute, condition func(*gatewayapi_v1alpha2.TLSRoute) bool) (*gatewayapi_v1alpha2.TLSRoute, bool) {
+func (f *Framework) CreateTLSRouteAndWaitFor(route *gatewayapi_v1alpha2.TLSRoute, condition func(*gatewayapi_v1alpha2.TLSRoute) bool) bool {
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateTCPRouteAndWaitFor creates the provided TCPRoute in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateTCPRouteAndWaitFor(route *gatewayapi_v1alpha2.TCPRoute, condition func(*gatewayapi_v1alpha2.TCPRoute) bool) (*gatewayapi_v1alpha2.TCPRoute, bool) {
+func (f *Framework) CreateTCPRouteAndWaitFor(route *gatewayapi_v1alpha2.TCPRoute, condition func(*gatewayapi_v1alpha2.TCPRoute) bool) bool {
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateBackendTLSPolicy creates the provided BackendTLSPolicy in the Kubernetes API
 // and then waits for the specified condition to be true.
-func (f *Framework) CreateBackendTLSPolicyAndWaitFor(route *gatewayapi_v1alpha2.BackendTLSPolicy, condition func(*gatewayapi_v1alpha2.BackendTLSPolicy) bool) (*gatewayapi_v1alpha2.BackendTLSPolicy, bool) {
+func (f *Framework) CreateBackendTLSPolicyAndWaitFor(route *gatewayapi_v1alpha2.BackendTLSPolicy, condition func(*gatewayapi_v1alpha2.BackendTLSPolicy) bool) bool {
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
@@ -438,13 +437,13 @@ func (f *Framework) DeleteNamespace(name string, waitForDeletion bool) {
 
 // CreateGatewayAndWaitFor creates a gateway in the
 // Kubernetes API or fails the test if it encounters an error.
-func (f *Framework) CreateGatewayAndWaitFor(gateway *gatewayapi_v1.Gateway, condition func(*gatewayapi_v1.Gateway) bool) (*gatewayapi_v1.Gateway, bool) {
+func (f *Framework) CreateGatewayAndWaitFor(gateway *gatewayapi_v1.Gateway, condition func(*gatewayapi_v1.Gateway) bool) bool {
 	return createAndWaitFor(f.t, f.Client, gateway, condition, f.RetryInterval, f.RetryTimeout)
 }
 
 // CreateGatewayClassAndWaitFor creates a GatewayClass in the
 // Kubernetes API or fails the test if it encounters an error.
-func (f *Framework) CreateGatewayClassAndWaitFor(gatewayClass *gatewayapi_v1.GatewayClass, condition func(*gatewayapi_v1.GatewayClass) bool) (*gatewayapi_v1.GatewayClass, bool) {
+func (f *Framework) CreateGatewayClassAndWaitFor(gatewayClass *gatewayapi_v1.GatewayClass, condition func(*gatewayapi_v1.GatewayClass) bool) bool {
 	return createAndWaitFor(f.t, f.Client, gatewayClass, condition, f.RetryInterval, f.RetryTimeout)
 }
 

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -135,7 +135,8 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		backendTLSPolicy := &gatewayapi_v1alpha2.BackendTLSPolicy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -163,7 +164,7 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 			},
 		}
 
-		_, ok := f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
+		_, ok = f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
 		assert.Truef(t, ok, "expected policy condition accepted on backend tls policy")
 
 		type responseTLSDetails struct {

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -135,8 +135,7 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		backendTLSPolicy := &gatewayapi_v1alpha2.BackendTLSPolicy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -164,8 +163,7 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 			},
 		}
 
-		_, ok = f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted)
-		assert.Truef(t, ok, "expected policy condition accepted on backend tls policy")
+		require.True(f.T(), f.CreateBackendTLSPolicyAndWaitFor(backendTLSPolicy, e2e.BackendTLSPolicyAccepted))
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -134,8 +134,11 @@ var _ = Describe("Gateway API", func() {
 		// or become valid.
 		gatewayClassCond := func(*gatewayapi_v1.GatewayClass) bool { return true }
 
-		f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassCond)
-		f.CreateGatewayAndWaitFor(contourGateway, e2e.GatewayProgrammed)
+		_, ok := f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassCond)
+		require.True(f.T(), ok)
+
+		_, ok = f.CreateGatewayAndWaitFor(contourGateway, e2e.GatewayProgrammed)
+		require.True(f.T(), ok)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -134,11 +134,8 @@ var _ = Describe("Gateway API", func() {
 		// or become valid.
 		gatewayClassCond := func(*gatewayapi_v1.GatewayClass) bool { return true }
 
-		_, ok := f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassCond)
-		require.True(f.T(), ok)
-
-		_, ok = f.CreateGatewayAndWaitFor(contourGateway, e2e.GatewayProgrammed)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateGatewayClassAndWaitFor(contourGatewayClass, gatewayClassCond))
+		require.True(f.T(), f.CreateGatewayAndWaitFor(contourGateway, e2e.GatewayProgrammed))
 	})
 
 	AfterEach(func() {

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -71,8 +71,7 @@ func testHostRewrite(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      string(route.Spec.Hostnames[0]),

--- a/test/e2e/gateway/host_rewrite_test.go
+++ b/test/e2e/gateway/host_rewrite_test.go
@@ -71,7 +71,8 @@ func testHostRewrite(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      string(route.Spec.Hostnames[0]),

--- a/test/e2e/gateway/http_route_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_conflict_match_test.go
@@ -57,8 +57,7 @@ func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted))
 
 		By("create httproute-2 with conflicted matches")
 		route2 := &gatewayapi_v1.HTTPRoute{
@@ -83,7 +82,6 @@ func testHTTPRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				},
 			},
 		}
-		_, ok = f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteNotAcceptedDueToConflict)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route2, e2e.HTTPRouteNotAcceptedDueToConflict))
 	})
 }

--- a/test/e2e/gateway/http_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/http_route_partially_conflict_match_test.go
@@ -57,8 +57,7 @@ func testHTTPRoutePartiallyConflictMatch(namespace string, gateway types.Namespa
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route1, e2e.HTTPRouteAccepted))
 
 		By("create httproute-2 with only partially conflicted matches")
 		route2 := &gatewayapi_v1.HTTPRoute{
@@ -90,8 +89,8 @@ func testHTTPRoutePartiallyConflictMatch(namespace string, gateway types.Namespa
 			},
 		}
 		// Partially accepted
-		f.CreateHTTPRouteAndWaitFor(route2, func(*gatewayapi_v1.HTTPRoute) bool {
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route2, func(*gatewayapi_v1.HTTPRoute) bool {
 			return e2e.HTTPRoutePartiallyInvalid(route2) && e2e.HTTPRouteAccepted(route2)
-		})
+		}))
 	})
 }

--- a/test/e2e/gateway/multiple_https_listeners_test.go
+++ b/test/e2e/gateway/multiple_https_listeners_test.go
@@ -58,8 +58,8 @@ func testMultipleHTTPSListeners(namespace string) {
 					},
 				},
 			}
-			_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-			require.True(t, ok, "expected HTTPRoute to be accepted")
+			require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
+
 		}
 
 		// Make requests to each listener hostname and validate the response

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -64,7 +64,8 @@ func testGatewayMultipleQueryParamMatch(namespace string, gateway types.Namespac
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			// These test cases are for documenting Envoy's behavior when

--- a/test/e2e/gateway/query_param_match_test.go
+++ b/test/e2e/gateway/query_param_match_test.go
@@ -64,8 +64,7 @@ func testGatewayMultipleQueryParamMatch(namespace string, gateway types.Namespac
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		cases := map[string]string{
 			// These test cases are for documenting Envoy's behavior when

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -80,8 +80,7 @@ func testRequestHeaderModifierBackendRef(namespace string, gateway types.Namespa
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		// Check the route with the RequestHeaderModifier filter.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/request_header_modifier_test.go
+++ b/test/e2e/gateway/request_header_modifier_test.go
@@ -80,7 +80,8 @@ func testRequestHeaderModifierBackendRef(namespace string, gateway types.Namespa
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		// Check the route with the RequestHeaderModifier filter.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -66,8 +66,7 @@ func testRequestRedirectRule(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		// /complex-redirect specifies a host name,
 		// scheme, port and response code for the

--- a/test/e2e/gateway/request_redirect_test.go
+++ b/test/e2e/gateway/request_redirect_test.go
@@ -66,7 +66,8 @@ func testRequestRedirectRule(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		// /complex-redirect specifies a host name,
 		// scheme, port and response code for the

--- a/test/e2e/gateway/response_header_modifier_test.go
+++ b/test/e2e/gateway/response_header_modifier_test.go
@@ -81,8 +81,7 @@ func testResponseHeaderModifierBackendRef(namespace string, gateway types.Namesp
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		// Check the route is available.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/response_header_modifier_test.go
+++ b/test/e2e/gateway/response_header_modifier_test.go
@@ -81,7 +81,8 @@ func testResponseHeaderModifierBackendRef(namespace string, gateway types.Namesp
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		// Check the route is available.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/tcproute_test.go
+++ b/test/e2e/gateway/tcproute_test.go
@@ -58,9 +58,7 @@ func testTCPRoute(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		route, ok := f.CreateTCPRouteAndWaitFor(route, e2e.TCPRouteAccepted)
-		require.True(t, ok)
-		require.NotNil(t, route)
+		require.True(f.T(), f.CreateTCPRouteAndWaitFor(route, e2e.TCPRouteAccepted))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Condition: e2e.HasStatusCode(200),

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -59,7 +59,8 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		route = &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -85,7 +86,8 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok = f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		// Ensure http (insecure) request routes to echo-insecure.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/tls_gateway_test.go
+++ b/test/e2e/gateway/tls_gateway_test.go
@@ -59,8 +59,7 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		route = &gatewayapi_v1.HTTPRoute{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -86,8 +85,7 @@ func testTLSGateway(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		// Ensure http (insecure) request routes to echo-insecure.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -60,7 +60,8 @@ func testTLSWildcardHost(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
+		require.True(f.T(), ok)
 
 		cases := []struct {
 			hostname   string

--- a/test/e2e/gateway/tls_wildcard_host_test.go
+++ b/test/e2e/gateway/tls_wildcard_host_test.go
@@ -60,8 +60,7 @@ func testTLSWildcardHost(namespace string, gateway types.NamespacedName) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 		cases := []struct {
 			hostname   string

--- a/test/e2e/httpproxy/backend_tls_protocol_version_test.go
+++ b/test/e2e/httpproxy/backend_tls_protocol_version_test.go
@@ -78,7 +78,8 @@ func testBackendTLSProtocolVersion(namespace, protocolVersion string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/httpproxy/backend_tls_protocol_version_test.go
+++ b/test/e2e/httpproxy/backend_tls_protocol_version_test.go
@@ -78,8 +78,7 @@ func testBackendTLSProtocolVersion(namespace, protocolVersion string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -81,7 +81,8 @@ func testBackendTLS(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -81,8 +81,7 @@ func testBackendTLS(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		type responseTLSDetails struct {
 			TLS struct {

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -289,8 +289,7 @@ func testClientCertAuth(namespace string) {
 		}
 		// Wait for the Cert to be ready since we'll directly download
 		// the secret contents for use as a client cert later on.
-		_, ok := f.Certs.CreateCertAndWaitFor(clientCert, certIsReady)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.Certs.CreateCertAndWaitFor(clientCert, certIsReady))
 
 		// Get another client certificate.
 		clientCertInvalid := &certmanagerv1.Certificate{
@@ -314,8 +313,7 @@ func testClientCertAuth(namespace string) {
 		}
 		// Wait for the Cert to be ready since we'll directly download
 		// the secret contents for use as a client cert later on.
-		_, ok = f.Certs.CreateCertAndWaitFor(clientCertInvalid, certIsReady)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.Certs.CreateCertAndWaitFor(clientCertInvalid, certIsReady))
 
 		// This proxy does not require client certificate auth.
 		noAuthProxy := &contour_v1.HTTPProxy{
@@ -342,8 +340,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(noAuthProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(noAuthProxy, e2e.HTTPProxyValid))
 
 		// This proxy requires client certificate auth.
 		authProxy := &contour_v1.HTTPProxy{
@@ -373,8 +370,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(authProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(authProxy, e2e.HTTPProxyValid))
 
 		// This proxy does not verify client certs.
 		authSkipVerifyProxy := &contour_v1.HTTPProxy{
@@ -404,8 +400,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(authSkipVerifyProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(authSkipVerifyProxy, e2e.HTTPProxyValid))
 
 		// This proxy requires a client certificate but does not verify it.
 		authSkipVerifyWithCAProxy := &contour_v1.HTTPProxy{
@@ -436,8 +431,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(authSkipVerifyWithCAProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(authSkipVerifyWithCAProxy, e2e.HTTPProxyValid))
 
 		// This proxy requests a client certificate but only verifies it if sent.
 		optionalAuthProxy := &contour_v1.HTTPProxy{
@@ -468,8 +462,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(optionalAuthProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(optionalAuthProxy, e2e.HTTPProxyValid))
 
 		// This proxy requests a client certificate but doesn't verify it if sent.
 		optionalAuthNoCAProxy := &contour_v1.HTTPProxy{
@@ -500,8 +493,7 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid))
 
 		// get the valid & invalid client certs
 		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.Spec.SecretName)

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -289,7 +289,8 @@ func testClientCertAuth(namespace string) {
 		}
 		// Wait for the Cert to be ready since we'll directly download
 		// the secret contents for use as a client cert later on.
-		f.Certs.CreateCertAndWaitFor(clientCert, certIsReady)
+		_, ok := f.Certs.CreateCertAndWaitFor(clientCert, certIsReady)
+		require.True(f.T(), ok)
 
 		// Get another client certificate.
 		clientCertInvalid := &certmanagerv1.Certificate{
@@ -313,7 +314,8 @@ func testClientCertAuth(namespace string) {
 		}
 		// Wait for the Cert to be ready since we'll directly download
 		// the secret contents for use as a client cert later on.
-		f.Certs.CreateCertAndWaitFor(clientCertInvalid, certIsReady)
+		_, ok = f.Certs.CreateCertAndWaitFor(clientCertInvalid, certIsReady)
+		require.True(f.T(), ok)
 
 		// This proxy does not require client certificate auth.
 		noAuthProxy := &contour_v1.HTTPProxy{
@@ -340,7 +342,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(noAuthProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(noAuthProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// This proxy requires client certificate auth.
 		authProxy := &contour_v1.HTTPProxy{
@@ -370,7 +373,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(authProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(authProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// This proxy does not verify client certs.
 		authSkipVerifyProxy := &contour_v1.HTTPProxy{
@@ -400,7 +404,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(authSkipVerifyProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(authSkipVerifyProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// This proxy requires a client certificate but does not verify it.
 		authSkipVerifyWithCAProxy := &contour_v1.HTTPProxy{
@@ -431,7 +436,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(authSkipVerifyWithCAProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(authSkipVerifyWithCAProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// This proxy requests a client certificate but only verifies it if sent.
 		optionalAuthProxy := &contour_v1.HTTPProxy{
@@ -462,7 +468,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(optionalAuthProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(optionalAuthProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// This proxy requests a client certificate but doesn't verify it if sent.
 		optionalAuthNoCAProxy := &contour_v1.HTTPProxy{
@@ -493,7 +500,8 @@ func testClientCertAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// get the valid & invalid client certs
 		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.Spec.SecretName)

--- a/test/e2e/httpproxy/client_cert_crl_test.go
+++ b/test/e2e/httpproxy/client_cert_crl_test.go
@@ -181,7 +181,8 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(proxyWithFullCRLCheck, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWithFullCRLCheck, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Create HTTPProxy that does CRL check for leaf-certificates only.
 		proxyWithCRLLeafOnly := &contour_v1.HTTPProxy{
@@ -213,7 +214,8 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(proxyWithCRLLeafOnly, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(proxyWithCRLLeafOnly, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// HTTPProxy with full chain revocation but refers to Secret with only partial set of CRLs.
 		proxyWithCRLMissing := &contour_v1.HTTPProxy{
@@ -244,7 +246,8 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(proxyWithCRLMissing, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(proxyWithCRLMissing, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]struct {
 			host       string
@@ -407,7 +410,8 @@ func testClientCertRevocation(namespace string) {
 		}
 
 		// HTTPProxy should be invalid since CertificateRevocationList refers to non-existent Secret.
-		f.CreateHTTPProxyAndWaitFor(proxyWithCRLCheck, e2e.HTTPProxyInvalid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWithCRLCheck, e2e.HTTPProxyInvalid)
+		require.True(f.T(), ok)
 
 		// Create Secret with CRL where client certificate is revoked.
 		require.NoError(t, f.Client.Create(context.TODO(),

--- a/test/e2e/httpproxy/client_cert_crl_test.go
+++ b/test/e2e/httpproxy/client_cert_crl_test.go
@@ -181,8 +181,7 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWithFullCRLCheck, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyWithFullCRLCheck, e2e.HTTPProxyValid))
 
 		// Create HTTPProxy that does CRL check for leaf-certificates only.
 		proxyWithCRLLeafOnly := &contour_v1.HTTPProxy{
@@ -214,8 +213,7 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(proxyWithCRLLeafOnly, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyWithCRLLeafOnly, e2e.HTTPProxyValid))
 
 		// HTTPProxy with full chain revocation but refers to Secret with only partial set of CRLs.
 		proxyWithCRLMissing := &contour_v1.HTTPProxy{
@@ -246,8 +244,7 @@ func testClientCertRevocation(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(proxyWithCRLMissing, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyWithCRLMissing, e2e.HTTPProxyValid))
 
 		cases := map[string]struct {
 			host       string
@@ -410,8 +407,7 @@ func testClientCertRevocation(namespace string) {
 		}
 
 		// HTTPProxy should be invalid since CertificateRevocationList refers to non-existent Secret.
-		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWithCRLCheck, e2e.HTTPProxyInvalid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyWithCRLCheck, e2e.HTTPProxyInvalid))
 
 		// Create Secret with CRL where client certificate is revoked.
 		require.NoError(t, f.Client.Create(context.TODO(),

--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -347,8 +347,7 @@ func testAppCookieRewrite(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// No rewrite rule on route, nothing should change.
 		headers := requestSetCookieHeader(false, p.Spec.VirtualHost.Fqdn, "/no-rewrite", "no-rewrite=foo; Path=/nrw; Domain=nrw.com; SameSite=Strict; Secure")
@@ -470,8 +469,7 @@ func testHeaderGlobalRewriteCookieRewrite(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Path:      "/global",
@@ -610,8 +608,7 @@ func testHeaderRewriteCookieRewrite(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Path:      "/cookie-lb",
@@ -698,8 +695,7 @@ func testCookieRewriteTLS(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		headers := requestSetCookieHeader(true, p.Spec.VirtualHost.Fqdn, "/", "a-cookie=bar; Domain=cookie-rewrite-tls.projectcontour.io; Path=/; SameSite=Strict; Secure")
 		checkReturnedSetCookieHeader(headers, "a-cookie", "bar", "/", "cookie-rewrite-tls.projectcontour.io", "Strict", true, nil)

--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -347,7 +347,8 @@ func testAppCookieRewrite(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// No rewrite rule on route, nothing should change.
 		headers := requestSetCookieHeader(false, p.Spec.VirtualHost.Fqdn, "/no-rewrite", "no-rewrite=foo; Path=/nrw; Domain=nrw.com; SameSite=Strict; Secure")
@@ -469,7 +470,8 @@ func testHeaderGlobalRewriteCookieRewrite(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Path:      "/global",
@@ -608,7 +610,8 @@ func testHeaderRewriteCookieRewrite(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Path:      "/cookie-lb",
@@ -695,7 +698,8 @@ func testCookieRewriteTLS(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		headers := requestSetCookieHeader(true, p.Spec.VirtualHost.Fqdn, "/", "a-cookie=bar; Domain=cookie-rewrite-tls.projectcontour.io; Path=/; SameSite=Strict; Secure")
 		checkReturnedSetCookieHeader(headers, "a-cookie", "bar", "/", "cookie-rewrite-tls.projectcontour.io", "Strict", true, nil)

--- a/test/e2e/httpproxy/default_global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/default_global_rate_limiting_test.go
@@ -56,7 +56,8 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.
@@ -104,7 +105,8 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -176,7 +178,8 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Make requests against the proxy, confirm a 429 response
 		// is now gotten since we've exceeded the rate limit.
@@ -220,7 +223,8 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.
@@ -272,7 +276,8 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -349,7 +354,8 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Make requests against the proxy, confirm a 429 response
 		// is now gotten since we've exceeded the rate limit.
@@ -399,7 +405,8 @@ func testDefaultGlobalRateLimitingWithVhRateLimitsIgnore(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.

--- a/test/e2e/httpproxy/default_global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/default_global_rate_limiting_test.go
@@ -56,8 +56,7 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.
@@ -105,8 +104,7 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -178,8 +176,7 @@ func testDefaultGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Make requests against the proxy, confirm a 429 response
 		// is now gotten since we've exceeded the rate limit.
@@ -223,8 +220,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.
@@ -276,8 +272,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -354,8 +349,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Make requests against the proxy, confirm a 429 response
 		// is now gotten since we've exceeded the rate limit.
@@ -405,8 +399,7 @@ func testDefaultGlobalRateLimitingWithVhRateLimitsIgnore(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 429 from the proxy confirming
 		// that we've exceeded the rate limit.

--- a/test/e2e/httpproxy/direct_response_test.go
+++ b/test/e2e/httpproxy/direct_response_test.go
@@ -36,8 +36,7 @@ func testDirectResponseRule(namespace string) {
 func doDirectTest(namespace string, proxy *contour_v1.HTTPProxy, t GinkgoTInterface) {
 	f.Fixtures.Echo.Deploy(namespace, "echo")
 
-	_, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid)
-	require.True(f.T(), ok)
+	require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid))
 
 	assertDirectResponseRequest(t, proxy.Spec.VirtualHost.Fqdn, "/directresponse-nobody",
 		"", 200)

--- a/test/e2e/httpproxy/dynamic_headers_test.go
+++ b/test/e2e/httpproxy/dynamic_headers_test.go
@@ -144,8 +144,7 @@ func testDynamicHeaders(namespace string) {
 			p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set = append(p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set, hv)
 		}
 
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/dynamic_headers_test.go
+++ b/test/e2e/httpproxy/dynamic_headers_test.go
@@ -144,7 +144,8 @@ func testDynamicHeaders(namespace string) {
 			p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set = append(p.Spec.Routes[0].Services[0].ResponseHeadersPolicy.Set, hv)
 		}
 
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/exact_path_condition_match_test.go
+++ b/test/e2e/httpproxy/exact_path_condition_match_test.go
@@ -19,6 +19,7 @@ package httpproxy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -128,7 +129,8 @@ func testExactPathCondition(namespace string) {
 			},
 		}
 
-		f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/":                        "echo-default", // Condition matched: "Prefix: /"

--- a/test/e2e/httpproxy/exact_path_condition_match_test.go
+++ b/test/e2e/httpproxy/exact_path_condition_match_test.go
@@ -129,8 +129,7 @@ func testExactPathCondition(namespace string) {
 			},
 		}
 
-		_, ok := f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid))
 
 		cases := map[string]string{
 			"/":                        "echo-default", // Condition matched: "Prefix: /"

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -223,7 +223,8 @@ func testExternalAuth(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -223,8 +223,7 @@ func testExternalAuth(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{

--- a/test/e2e/httpproxy/external_name_test.go
+++ b/test/e2e/httpproxy/external_name_test.go
@@ -82,10 +82,7 @@ func testExternalNameServiceInsecure(namespace string) {
 				},
 			},
 		}
-		proxy, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		if !ok {
-			t.Fatalf("The HTTPProxy did not become valid, here are the Valid condition's Errors: %s", e2e.HTTPProxyErrors(proxy))
-		}
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -153,10 +150,7 @@ func testExternalNameServiceTLS(namespace string) {
 				},
 			},
 		}
-		proxy, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		if !ok {
-			t.Fatalf("The HTTPProxy did not become valid, here are the Valid condition's Errors: %s", e2e.HTTPProxyErrors(proxy))
-		}
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -225,7 +219,7 @@ func testExternalNameServiceLocalhostInvalid(namespace string) {
 
 		// The HTTPProxy should be marked invalid due to the service
 		// using localhost.localdomain.
-		_, invalid := f.CreateHTTPProxyAndWaitFor(p, func(proxy *contour_v1.HTTPProxy) bool {
+		require.Truef(f.T(), f.CreateHTTPProxyAndWaitFor(p, func(proxy *contour_v1.HTTPProxy) bool {
 			validCond := proxy.Status.GetConditionFor(contour_v1.ValidConditionType)
 			if validCond == nil {
 				return false
@@ -243,7 +237,6 @@ func testExternalNameServiceLocalhostInvalid(namespace string) {
 			}
 
 			return false
-		})
-		require.Truef(t, invalid, "ExternalName with hostname %s was accepted by Contour.", externalNameService.Spec.ExternalName)
+		}), "ExternalName with hostname %s was accepted by Contour.", externalNameService.Spec.ExternalName)
 	})
 }

--- a/test/e2e/httpproxy/fqdn_test.go
+++ b/test/e2e/httpproxy/fqdn_test.go
@@ -122,9 +122,14 @@ func testWildcardSubdomainFQDN(namespace string) {
 				}},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(proxyWildcard, e2e.HTTPProxyValid)
-		f.CreateHTTPProxyAndWaitFor(proxyFullFQDN, e2e.HTTPProxyValid)
-		f.CreateHTTPProxyAndWaitFor(proxyFullFQDNSubdomain, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWildcard, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
+
+		_, ok = f.CreateHTTPProxyAndWaitFor(proxyFullFQDN, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
+
+		_, ok = f.CreateHTTPProxyAndWaitFor(proxyFullFQDNSubdomain, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]struct {
 			ServiceName   string
@@ -240,7 +245,8 @@ func testIngressWildcardSubdomainFQDN(namespace string) {
 				}},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(proxySubdomain, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(proxySubdomain, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      "www.wildcard-override.projectcontour.io",

--- a/test/e2e/httpproxy/fqdn_test.go
+++ b/test/e2e/httpproxy/fqdn_test.go
@@ -122,14 +122,9 @@ func testWildcardSubdomainFQDN(namespace string) {
 				}},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(proxyWildcard, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
-
-		_, ok = f.CreateHTTPProxyAndWaitFor(proxyFullFQDN, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
-
-		_, ok = f.CreateHTTPProxyAndWaitFor(proxyFullFQDNSubdomain, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyWildcard, e2e.HTTPProxyValid))
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyFullFQDN, e2e.HTTPProxyValid))
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxyFullFQDNSubdomain, e2e.HTTPProxyValid))
 
 		cases := map[string]struct {
 			ServiceName   string
@@ -245,8 +240,7 @@ func testIngressWildcardSubdomainFQDN(namespace string) {
 				}},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(proxySubdomain, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxySubdomain, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      "www.wildcard-override.projectcontour.io",

--- a/test/e2e/httpproxy/global_external_auth_test.go
+++ b/test/e2e/httpproxy/global_external_auth_test.go
@@ -86,7 +86,8 @@ func testGlobalExternalAuthVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
@@ -184,7 +185,8 @@ func testGlobalExternalAuthTLS(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
@@ -275,7 +277,8 @@ func testGlobalExternalAuthNonTLSAuthDisabled(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -367,7 +370,8 @@ func testGlobalExternalAuthTLSAuthDisabled(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/global_external_auth_test.go
+++ b/test/e2e/httpproxy/global_external_auth_test.go
@@ -86,8 +86,7 @@ func testGlobalExternalAuthVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
@@ -185,8 +184,7 @@ func testGlobalExternalAuthTLS(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// By default requests to /first should not be authorized.
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
@@ -277,8 +275,7 @@ func testGlobalExternalAuthNonTLSAuthDisabled(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -370,8 +367,7 @@ func testGlobalExternalAuthTLSAuthDisabled(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -55,7 +55,8 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -151,7 +152,8 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -249,7 +251,8 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -349,7 +352,8 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -447,7 +451,8 @@ func testDisableVirtualHostGlobalRateLimitingOnRoute(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -549,7 +554,8 @@ func testDisableVirtualHostGlobalRateLimitingOnRoute(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -55,8 +55,7 @@ func testGlobalRateLimitingVirtualHostNonTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -152,8 +151,7 @@ func testGlobalRateLimitingRouteNonTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -251,8 +249,7 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -352,8 +349,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -451,8 +447,7 @@ func testDisableVirtualHostGlobalRateLimitingOnRoute(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -554,8 +549,7 @@ func testDisableVirtualHostGlobalRateLimitingOnRoute(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -80,8 +80,7 @@ func testGRPCServicePlaintext(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(t, ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		insecureAddr := strings.TrimPrefix(f.HTTP.HTTPURLBase, "http://")
 		secureAddr := strings.TrimPrefix(f.HTTP.HTTPSURLBase, "https://")
@@ -156,8 +155,7 @@ func testGRPCWeb(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(t, ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// One byte marker that this is a data frame, and 4 bytes
 		// for the length (we can use 0 since the yages.Empty message

--- a/test/e2e/httpproxy/header_condition_match_test.go
+++ b/test/e2e/httpproxy/header_condition_match_test.go
@@ -243,8 +243,7 @@ func testHeaderConditionMatch(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		type scenario struct {
 			headers        map[string]string

--- a/test/e2e/httpproxy/header_condition_match_test.go
+++ b/test/e2e/httpproxy/header_condition_match_test.go
@@ -243,7 +243,8 @@ func testHeaderConditionMatch(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		type scenario struct {
 			headers        map[string]string

--- a/test/e2e/httpproxy/host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/host_header_rewrite_test.go
@@ -64,8 +64,7 @@ func testHostRewriteLiteral(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -119,8 +118,7 @@ func testHostRewriteHeaderHTTPService(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,
@@ -179,8 +177,7 @@ func testHostRewriteHeaderHTTPSService(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,
@@ -254,8 +251,7 @@ func testHostRewriteHeaderExternalNameService(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/host_header_rewrite_test.go
@@ -64,7 +64,8 @@ func testHostRewriteLiteral(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,
@@ -118,7 +119,8 @@ func testHostRewriteHeaderHTTPService(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,
@@ -177,7 +179,8 @@ func testHostRewriteHeaderHTTPSService(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,
@@ -251,7 +254,8 @@ func testHostRewriteHeaderExternalNameService(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:        p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/http_health_checks_test.go
+++ b/test/e2e/httpproxy/http_health_checks_test.go
@@ -55,7 +55,8 @@ func testHTTPHealthChecks(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/http_health_checks_test.go
+++ b/test/e2e/httpproxy/http_health_checks_test.go
@@ -55,8 +55,7 @@ func testHTTPHealthChecks(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/https_fallback_certificate_test.go
@@ -59,8 +59,7 @@ func testHTTPSFallbackCertificate(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Send a request that includes a valid SNI, confirm a 200 is
 		// returned.

--- a/test/e2e/httpproxy/https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/https_fallback_certificate_test.go
@@ -59,7 +59,8 @@ func testHTTPSFallbackCertificate(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Send a request that includes a valid SNI, confirm a 200 is
 		// returned.

--- a/test/e2e/httpproxy/https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/https_misdirected_request_test.go
@@ -58,7 +58,8 @@ func testHTTPSMisdirectedRequest(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/https_misdirected_request_test.go
@@ -58,8 +58,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/https_sni_enforcement_test.go
@@ -58,7 +58,8 @@ func testHTTPSSNIEnforcement(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(echoOneProxy, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(echoOneProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      echoOneProxy.Spec.VirtualHost.Fqdn,
@@ -98,7 +99,8 @@ func testHTTPSSNIEnforcement(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(echoTwoProxy, e2e.HTTPProxyValid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(echoTwoProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      echoTwoProxy.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/https_sni_enforcement_test.go
@@ -58,8 +58,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(echoOneProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(echoOneProxy, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      echoOneProxy.Spec.VirtualHost.Fqdn,
@@ -99,8 +98,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 				},
 			},
 		}
-		_, ok = f.CreateHTTPProxyAndWaitFor(echoTwoProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(echoTwoProxy, e2e.HTTPProxyValid))
 
 		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host:      echoTwoProxy.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/include_exact_condition_test.go
+++ b/test/e2e/httpproxy/include_exact_condition_test.go
@@ -186,8 +186,10 @@ func testIncludeExactCondition(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
-		f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
+		_, ok = f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/app/foo":      "echo-app",   // Condition matched: "Prefix: /app"   +  "Exact:  /foo"    = "Exact:  /app/foo"

--- a/test/e2e/httpproxy/include_exact_condition_test.go
+++ b/test/e2e/httpproxy/include_exact_condition_test.go
@@ -186,10 +186,8 @@ func testIncludeExactCondition(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
-		_, ok = f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid))
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid))
 
 		cases := map[string]string{
 			"/app/foo":      "echo-app",   // Condition matched: "Prefix: /app"   +  "Exact:  /foo"    = "Exact:  /app/foo"

--- a/test/e2e/httpproxy/include_prefix_condition_test.go
+++ b/test/e2e/httpproxy/include_prefix_condition_test.go
@@ -118,8 +118,7 @@ func testIncludePrefixCondition(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid))
 
 		cases := map[string]string{
 			"/":          "echo-app",

--- a/test/e2e/httpproxy/include_prefix_condition_test.go
+++ b/test/e2e/httpproxy/include_prefix_condition_test.go
@@ -118,7 +118,8 @@ func testIncludePrefixCondition(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(baseProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/":          "echo-app",

--- a/test/e2e/httpproxy/include_regex_path_condition_test.go
+++ b/test/e2e/httpproxy/include_regex_path_condition_test.go
@@ -175,11 +175,8 @@ func testIncludeRegexCondition(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(rootProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
-
-		_, ok = f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(rootProxy, e2e.HTTPProxyValid))
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid))
 
 		cases := map[string]string{
 			"/echo2/":               "echo-2", // "Prefix: / with included Prefix: echo2/"

--- a/test/e2e/httpproxy/include_regex_path_condition_test.go
+++ b/test/e2e/httpproxy/include_regex_path_condition_test.go
@@ -175,9 +175,11 @@ func testIncludeRegexCondition(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(rootProxy, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(rootProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
-		f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
+		_, ok = f.CreateHTTPProxyAndWaitFor(invalidRootProxy, e2e.HTTPProxyInvalid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/echo2/":               "echo-2", // "Prefix: / with included Prefix: echo2/"

--- a/test/e2e/httpproxy/internal_redirect_test.go
+++ b/test/e2e/httpproxy/internal_redirect_test.go
@@ -122,10 +122,7 @@ func doInternalRedirectTest(namespace string, proxy *contour_v1.HTTPProxy, t Gin
 	}
 	require.NoError(t, f.Client.Create(context.TODO(), envoyService))
 
-	p, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid)
-	if !ok {
-		t.Fatalf("The HTTPProxy did not become valid, here are the Valid condition's Errors: %s", e2e.HTTPProxyErrors(p))
-	}
+	require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid))
 
 	// /redirect ensure the redirect works as expected.
 	assertInternalRedirectRequest(t, proxy.Spec.VirtualHost.Fqdn, "/redirect",

--- a/test/e2e/httpproxy/ip_filtering_test.go
+++ b/test/e2e/httpproxy/ip_filtering_test.go
@@ -59,7 +59,8 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -171,7 +172,8 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -280,7 +282,8 @@ func testIPFilterPolicy(namespace string) {
 			},
 		}
 		// root will be missing an include when created
-		r, _ = f.CreateHTTPProxyAndWaitFor(r, e2e.HTTPProxyInvalid)
+		r, ok := f.CreateHTTPProxyAndWaitFor(r, e2e.HTTPProxyInvalid)
+		require.True(f.T(), ok)
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -300,7 +303,8 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/ip_filtering_test.go
+++ b/test/e2e/httpproxy/ip_filtering_test.go
@@ -59,8 +59,7 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -172,8 +171,7 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -282,8 +280,7 @@ func testIPFilterPolicy(namespace string) {
 			},
 		}
 		// root will be missing an include when created
-		r, ok := f.CreateHTTPProxyAndWaitFor(r, e2e.HTTPProxyInvalid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(r, e2e.HTTPProxyInvalid))
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -303,8 +300,7 @@ func testIPFilterPolicy(namespace string) {
 				},
 			},
 		}
-		p, ok = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/local_rate_limiting_test.go
+++ b/test/e2e/httpproxy/local_rate_limiting_test.go
@@ -55,8 +55,7 @@ func testLocalRateLimitingVirtualHost(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -143,8 +142,7 @@ func testLocalRateLimitingRoute(namespace string) {
 				},
 			},
 		}
-		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/local_rate_limiting_test.go
+++ b/test/e2e/httpproxy/local_rate_limiting_test.go
@@ -55,7 +55,8 @@ func testLocalRateLimitingVirtualHost(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.
@@ -142,7 +143,8 @@ func testLocalRateLimitingRoute(namespace string) {
 				},
 			},
 		}
-		p, _ = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		p, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		// Wait until we get a 200 from the proxy confirming
 		// the pods are up and serving traffic.

--- a/test/e2e/httpproxy/merge_slash_test.go
+++ b/test/e2e/httpproxy/merge_slash_test.go
@@ -84,8 +84,7 @@ func testDisableMergeSlashes(disableMergeSlashes bool) e2e.NamespacedTestBody {
 					},
 				},
 			}
-			_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-			require.True(t, ok)
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 			var testCases map[string]string
 			if disableMergeSlashes {

--- a/test/e2e/httpproxy/multiple_ingress_classes_test.go
+++ b/test/e2e/httpproxy/multiple_ingress_classes_test.go
@@ -56,10 +56,7 @@ func testMultipleIngressClassesField(namespace string) {
 				p.Spec.IngressClassName = class
 			}
 
-			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-			if !valid {
-				t.Fatalf("The HTTPProxy did not become valid: %+v", proxy)
-			}
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,
@@ -105,10 +102,7 @@ func testMultipleIngressClassesAnnotation(namespace string) {
 				}
 			}
 
-			proxy, valid := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-			if !valid {
-				t.Fatalf("The HTTPProxy did not become valid - %+v", proxy)
-			}
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/namespaces_test.go
+++ b/test/e2e/httpproxy/namespaces_test.go
@@ -35,7 +35,8 @@ func testWatchNamespaces(namespaces []string) e2e.NamespacedTestBody {
 			for _, ns := range namespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("proxy", ns)
-				f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				require.True(f.T(), ok)
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,
@@ -68,7 +69,8 @@ func testWatchAndRootNamespaces(rootNamespaces []string, nonRootNamespace string
 			for _, ns := range rootNamespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("root-proxy", ns)
-				f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				require.True(f.T(), ok)
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,
@@ -123,7 +125,8 @@ func testWatchAndRootNamespaces(rootNamespaces []string, nonRootNamespace string
 			}
 			err := f.CreateHTTPProxy(lp)
 			require.NoError(f.T(), err, "could not create leaf httpproxy")
-			f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			_, ok = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			require.True(f.T(), ok)
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,
 				Condition: e2e.HasStatusCode(200),
@@ -154,7 +157,8 @@ func testRootNamespaces(namespaces []string) e2e.NamespacedTestBody {
 			for _, ns := range namespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("root-proxy", ns)
-				f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+				require.True(f.T(), ok)
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/namespaces_test.go
+++ b/test/e2e/httpproxy/namespaces_test.go
@@ -35,8 +35,7 @@ func testWatchNamespaces(namespaces []string) e2e.NamespacedTestBody {
 			for _, ns := range namespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("proxy", ns)
-				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-				require.True(f.T(), ok)
+				require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,
@@ -69,8 +68,7 @@ func testWatchAndRootNamespaces(rootNamespaces []string, nonRootNamespace string
 			for _, ns := range rootNamespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("root-proxy", ns)
-				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-				require.True(f.T(), ok)
+				require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,
@@ -84,8 +82,7 @@ func testWatchAndRootNamespaces(rootNamespaces []string, nonRootNamespace string
 
 			// Root proxy in non-root namespace should fail
 			p := newEchoProxy("root-proxy", nonRootNamespace)
-			_, ok := f.CreateHTTPProxyAndWaitFor(p, httpProxyRootNotAllowedInNS)
-			require.Truef(f.T(), ok, "expected HTTPProxy to have status RootNamespaceError")
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, httpProxyRootNotAllowedInNS), "expected HTTPProxy to have status RootNamespaceError")
 
 			// Leaf proxy in non-root (but watched) namespace should succeed
 			lp := &contour_v1.HTTPProxy{
@@ -125,8 +122,8 @@ func testWatchAndRootNamespaces(rootNamespaces []string, nonRootNamespace string
 			}
 			err := f.CreateHTTPProxy(lp)
 			require.NoError(f.T(), err, "could not create leaf httpproxy")
-			_, ok = f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
+
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,
 				Condition: e2e.HasStatusCode(200),
@@ -157,8 +154,7 @@ func testRootNamespaces(namespaces []string) e2e.NamespacedTestBody {
 			for _, ns := range namespaces {
 				deployEchoServer(f.T(), f.Client, ns, "echo")
 				p := newEchoProxy("root-proxy", ns)
-				_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-				require.True(f.T(), ok)
+				require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 				res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 					Host:      p.Spec.VirtualHost.Fqdn,
@@ -171,8 +167,7 @@ func testRootNamespaces(namespaces []string) e2e.NamespacedTestBody {
 			// Root proxy in non-root namespace should fail
 			deployEchoServer(f.T(), f.Client, nonrootNS, "echo")
 			p := newEchoProxy("root-proxy", nonrootNS)
-			_, ok := f.CreateHTTPProxyAndWaitFor(p, httpProxyRootNotAllowedInNS)
-			require.Truef(f.T(), ok, "expected HTTPProxy to have status RootNamespaceError")
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, httpProxyRootNotAllowedInNS), "expected HTTPProxy to have status RootNamespaceError")
 		})
 	}
 }

--- a/test/e2e/httpproxy/path_condition_match_test.go
+++ b/test/e2e/httpproxy/path_condition_match_test.go
@@ -18,6 +18,7 @@ package httpproxy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -79,7 +80,8 @@ func testPathConditionMatch(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/":                "echo-slash-default",

--- a/test/e2e/httpproxy/path_condition_match_test.go
+++ b/test/e2e/httpproxy/path_condition_match_test.go
@@ -80,8 +80,7 @@ func testPathConditionMatch(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		cases := map[string]string{
 			"/":                "echo-slash-default",

--- a/test/e2e/httpproxy/path_rewrite_test.go
+++ b/test/e2e/httpproxy/path_rewrite_test.go
@@ -18,6 +18,7 @@ package httpproxy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -100,7 +101,8 @@ func testPathPrefixRewrite(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := []struct {
 			path            string

--- a/test/e2e/httpproxy/path_rewrite_test.go
+++ b/test/e2e/httpproxy/path_rewrite_test.go
@@ -101,8 +101,7 @@ func testPathPrefixRewrite(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		cases := []struct {
 			path            string

--- a/test/e2e/httpproxy/pod_restart_test.go
+++ b/test/e2e/httpproxy/pod_restart_test.go
@@ -58,7 +58,8 @@ func testPodRestart(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/pod_restart_test.go
+++ b/test/e2e/httpproxy/pod_restart_test.go
@@ -58,8 +58,7 @@ func testPodRestart(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 			Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/httpproxy/query_parameter_condition_match_test.go
+++ b/test/e2e/httpproxy/query_parameter_condition_match_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -218,7 +219,8 @@ func testQueryParameterConditionMatch(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		type scenario struct {
 			queryParams    map[string]string
@@ -400,7 +402,8 @@ func testQueryParameterConditionMultiple(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		type scenario struct {
 			path           string

--- a/test/e2e/httpproxy/query_parameter_condition_match_test.go
+++ b/test/e2e/httpproxy/query_parameter_condition_match_test.go
@@ -219,8 +219,7 @@ func testQueryParameterConditionMatch(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		type scenario struct {
 			queryParams    map[string]string
@@ -402,8 +401,7 @@ func testQueryParameterConditionMultiple(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		type scenario struct {
 			path           string

--- a/test/e2e/httpproxy/regex_path_condition_test.go
+++ b/test/e2e/httpproxy/regex_path_condition_test.go
@@ -18,6 +18,7 @@ package httpproxy
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -127,7 +128,8 @@ func testRegexPathCondition(namespace string) {
 			},
 		}
 
-		f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		cases := map[string]string{
 			"/":                      "echo-1", // Regex Pattern /

--- a/test/e2e/httpproxy/regex_path_condition_test.go
+++ b/test/e2e/httpproxy/regex_path_condition_test.go
@@ -128,8 +128,7 @@ func testRegexPathCondition(namespace string) {
 			},
 		}
 
-		_, ok := f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(serviceProxy, e2e.HTTPProxyValid))
 
 		cases := map[string]string{
 			"/":                      "echo-1", // Regex Pattern /

--- a/test/e2e/httpproxy/request_redirect_test.go
+++ b/test/e2e/httpproxy/request_redirect_test.go
@@ -47,16 +47,14 @@ func testRequestRedirectRuleInvalid(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 		proxy := getRedirectHTTPProxyInvalid(namespace)
 
-		_, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyInvalid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyInvalid))
 	})
 }
 
 func doRedirectTest(namespace string, proxy *contour_v1.HTTPProxy, t GinkgoTInterface) {
 	f.Fixtures.Echo.Deploy(namespace, "echo")
 
-	_, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid)
-	require.True(f.T(), ok)
+	require.True(f.T(), f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid))
 
 	// /basic-redirect only specifies a host name to redirect to.
 	assertRequest(t, proxy.Spec.VirtualHost.Fqdn, "/basic-redirect",

--- a/test/e2e/httpproxy/request_redirect_test.go
+++ b/test/e2e/httpproxy/request_redirect_test.go
@@ -47,14 +47,16 @@ func testRequestRedirectRuleInvalid(namespace string) {
 		f.Fixtures.Echo.Deploy(namespace, "echo")
 		proxy := getRedirectHTTPProxyInvalid(namespace)
 
-		f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyInvalid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyInvalid)
+		require.True(f.T(), ok)
 	})
 }
 
 func doRedirectTest(namespace string, proxy *contour_v1.HTTPProxy, t GinkgoTInterface) {
 	f.Fixtures.Echo.Deploy(namespace, "echo")
 
-	f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid)
+	_, ok := f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid)
+	require.True(f.T(), ok)
 
 	// /basic-redirect only specifies a host name to redirect to.
 	assertRequest(t, proxy.Spec.VirtualHost.Fqdn, "/basic-redirect",

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -58,8 +58,7 @@ func testTCPRouteHTTPSTermination(namespace string) {
 				},
 			},
 		}
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		certSecret := &core_v1.Secret{}
 		key := client.ObjectKey{Namespace: namespace, Name: "echo-cert"}

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -58,7 +58,8 @@ func testTCPRouteHTTPSTermination(namespace string) {
 				},
 			},
 		}
-		f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+		require.True(f.T(), ok)
 
 		certSecret := &core_v1.Secret{}
 		key := client.ObjectKey{Namespace: namespace, Name: "echo-cert"}

--- a/test/e2e/incluster/memory_usage_test.go
+++ b/test/e2e/incluster/memory_usage_test.go
@@ -89,8 +89,7 @@ func testHeaderMatchIncludesMemoryUsage(namespace string) {
 		}
 
 		// Wait for root to be valid.
-		_, valid := f.CreateHTTPProxyAndWaitFor(root, e2e.HTTPProxyValid)
-		require.True(f.T(), valid)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(root, e2e.HTTPProxyValid))
 
 		// Ensure there are no container restarts.
 		require.Never(f.T(), func() bool {

--- a/test/e2e/incluster/rbac_test.go
+++ b/test/e2e/incluster/rbac_test.go
@@ -80,8 +80,7 @@ func testProjectcontourResourcesRBAC(namespace string) {
 				},
 			},
 		}
-		_, success := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyInvalid)
-		assert.True(f.T(), success)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyInvalid))
 
 		// Update HTTPProxy to valid service.
 		require.NoError(f.T(), retry.RetryOnConflict(retry.DefaultBackoff, func() error {

--- a/test/e2e/incluster/smoke_test.go
+++ b/test/e2e/incluster/smoke_test.go
@@ -57,8 +57,7 @@ func testSimpleSmoke(namespace string) {
 					},
 				},
 			}
-			_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/incluster/smoke_test.go
+++ b/test/e2e/incluster/smoke_test.go
@@ -57,7 +57,8 @@ func testSimpleSmoke(namespace string) {
 					},
 				},
 			}
-			f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
+			require.True(f.T(), ok)
 
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				Host:      p.Spec.VirtualHost.Fqdn,

--- a/test/e2e/infra/endpointslice_test.go
+++ b/test/e2e/infra/endpointslice_test.go
@@ -60,8 +60,7 @@ func testSimpleEndpointSlice(namespace string) {
 			},
 		}
 
-		_, ok := f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)
-		require.True(f.T(), ok)
+		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		require.Eventually(f.T(), func() bool {
 			return IsEnvoyProgrammedWithAllPodIPs(namespace)

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -85,8 +85,7 @@ var _ = BeforeSuite(func() {
 		}
 	}
 
-	_, ok := f.CreateGatewayClassAndWaitFor(gc, e2e.GatewayClassAccepted)
-	require.True(f.T(), ok)
+	require.True(f.T(), f.CreateGatewayClassAndWaitFor(gc, e2e.GatewayClassAccepted))
 
 	paramsEnvoyDeployment := &contour_v1alpha1.ContourDeployment{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -116,8 +115,7 @@ var _ = BeforeSuite(func() {
 			},
 		},
 	}
-	_, ok = f.CreateGatewayClassAndWaitFor(gcWithEnvoyDeployment, e2e.GatewayClassAccepted)
-	require.True(f.T(), ok)
+	require.True(f.T(), f.CreateGatewayClassAndWaitFor(gcWithEnvoyDeployment, e2e.GatewayClassAccepted))
 })
 
 var _ = AfterSuite(func() {
@@ -180,8 +178,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok := f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted))
 
 			// Create a Gateway using that GatewayClass, it should not be accepted
 			// since the GatewayClass is not accepted.
@@ -277,10 +274,9 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
+			require.True(f.T(), f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
-			})
-			require.True(f.T(), ok)
+			}))
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
@@ -304,8 +300,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok = f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
 
 			res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 				OverrideURL: "http://" + net.JoinHostPort(gateway.Status.Addresses[0].Value, "80"),
@@ -385,7 +380,7 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
+			require.True(f.T(), f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				if !(e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)) {
 					return false
 				}
@@ -397,8 +392,7 @@ var _ = Describe("Gateway provisioner", func() {
 				}
 
 				return true
-			})
-			require.True(f.T(), ok)
+			}))
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
 
@@ -422,8 +416,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok = f.CreateHTTPRouteAndWaitFor(httpRoute, e2e.HTTPRouteAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateHTTPRouteAndWaitFor(httpRoute, e2e.HTTPRouteAccepted))
 
 			for _, tc := range []struct {
 				name   string
@@ -485,8 +478,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok = f.CreateTCPRouteAndWaitFor(tcpRoute, e2e.TCPRouteAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateTCPRouteAndWaitFor(tcpRoute, e2e.TCPRouteAccepted))
 
 			for _, tc := range []struct {
 				name string
@@ -533,8 +525,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok := f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted))
 
 			// Now create the ContourDeployment to match the parametersRef.
 			params := &contour_v1alpha1.ContourDeployment{
@@ -595,10 +586,10 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
+			require.True(f.T(), f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
-			})
-			require.True(f.T(), ok, fmt.Sprintf("gateway is %v", gateway))
+			}))
+
 			type testObj struct {
 				expectReconcile bool
 				namespace       string
@@ -650,9 +641,8 @@ var _ = Describe("Gateway provisioner", func() {
 					route.Spec.Hostnames = []gatewayapi_v1.Hostname{gatewayapi_v1.Hostname("provisioner.projectcontour.io." + t.namespace)}
 
 					By(fmt.Sprintf("Expect namespace %s to be watched by contour", t.namespace))
-					hr, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted)
-					By(fmt.Sprintf("Expect httproute under namespace %s is accepted", t.namespace))
-					require.True(f.T(), ok, fmt.Sprintf("httproute is %v", hr))
+					require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteAccepted))
+
 					res, ok := f.HTTP.RequestUntil(&e2e.HTTPRequestOpts{
 						OverrideURL: "http://" + net.JoinHostPort(gateway.Status.Addresses[0].Value, "80"),
 						Host:        string(route.Spec.Hostnames[0]),
@@ -668,17 +658,16 @@ var _ = Describe("Gateway provisioner", func() {
 				} else {
 					// Root proxy in non-watched namespace should fail
 					By(fmt.Sprintf("Expect namespace %s not to be watched by contour", t.namespace))
-					hr, ok := f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteIgnoredByContour)
-					require.True(f.T(), ok, fmt.Sprintf("httproute's is %v", hr))
+					require.True(f.T(), f.CreateHTTPRouteAndWaitFor(route, e2e.HTTPRouteIgnoredByContour))
 
 					By(fmt.Sprintf("Expect httproute under namespace %s is not accepted for a period of time", t.namespace))
 					require.Never(f.T(), func() bool {
-						hr = &gatewayapi_v1.HTTPRoute{}
-						if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(hr), hr); err != nil {
+						hr := &gatewayapi_v1.HTTPRoute{}
+						if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(route), hr); err != nil {
 							return false
 						}
 						return e2e.HTTPRouteAccepted(hr)
-					}, 20*time.Second, time.Second, hr)
+					}, 20*time.Second, time.Second)
 				}
 			}
 		})
@@ -701,8 +690,7 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			_, ok := f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted)
-			require.True(f.T(), ok)
+			require.True(f.T(), f.CreateGatewayClassAndWaitFor(gatewayClass, e2e.GatewayClassNotAccepted))
 
 			// Now create the ContourDeployment to match the parametersRef.
 			params := &contour_v1alpha1.ContourDeployment{
@@ -763,10 +751,9 @@ var _ = Describe("Gateway provisioner", func() {
 				},
 			}
 
-			gateway, ok := f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
+			require.True(f.T(), f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 				return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
-			})
-			require.True(f.T(), ok, fmt.Sprintf("gateway is %v", gateway))
+			}))
 
 			By("Skip reconciling the TLSRoute if disabledFeatures includes it")
 			f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
@@ -792,16 +779,16 @@ var _ = Describe("Gateway provisioner", func() {
 					},
 				},
 			}
-			tr, ok := f.CreateTLSRouteAndWaitFor(route, e2e.TLSRouteIgnoredByContour)
-			require.True(f.T(), ok, fmt.Sprintf("tlsroute's is %v", tr))
+			require.True(f.T(), f.CreateTLSRouteAndWaitFor(route, e2e.TLSRouteIgnoredByContour))
+
 			By("Expect tlsroute not to be accepted")
 			require.Never(f.T(), func() bool {
-				tr = &gatewayapi_v1alpha2.TLSRoute{}
-				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(tr), tr); err != nil {
+				tr := &gatewayapi_v1alpha2.TLSRoute{}
+				if err := f.Client.Get(context.Background(), k8s.NamespacedNameOf(route), tr); err != nil {
 					return false
 				}
 				return e2e.TLSRouteAccepted(tr)
-			}, 20*time.Second, time.Second, tr)
+			}, 20*time.Second, time.Second)
 		})
 	})
 })

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -204,7 +204,7 @@ var _ = Describe("When upgrading", func() {
 
 				f.Fixtures.Echo.DeployN(namespace, "echo", 2)
 
-				f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1.HTTPRoute{
+				_, ok = f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: namespace,
 						Name:      "echo",
@@ -244,6 +244,7 @@ var _ = Describe("When upgrading", func() {
 						},
 					},
 				}, e2e.HTTPRouteAccepted)
+				require.True(f.T(), ok)
 
 				By("ensuring it is routable")
 				checkRoutability(appHost)

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -147,17 +147,14 @@ var _ = Describe("When upgrading", func() {
 
 			Eventually(sess, f.RetryTimeout, f.RetryInterval).Should(gexec.Exit(0))
 
-			gc, ok := f.CreateGatewayClassAndWaitFor(&gatewayapi_v1.GatewayClass{
+			require.True(f.T(), f.CreateGatewayClassAndWaitFor(&gatewayapi_v1.GatewayClass{
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: gatewayClassName,
 				},
 				Spec: gatewayapi_v1.GatewayClassSpec{
 					ControllerName: gatewayapi_v1.GatewayController("projectcontour.io/gateway-controller"),
 				},
-			}, e2e.GatewayClassAccepted)
-
-			require.True(f.T(), ok)
-			require.NotNil(f.T(), gc)
+			}, e2e.GatewayClassAccepted))
 		})
 
 		AfterEach(func() {
@@ -178,7 +175,7 @@ var _ = Describe("When upgrading", func() {
 
 				appHost := "upgrade.provisioner.projectcontour.io"
 
-				gateway, ok := f.CreateGatewayAndWaitFor(&gatewayapi_v1.Gateway{
+				gateway := &gatewayapi_v1.Gateway{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: namespace,
 						Name:      "upgrade-gateway",
@@ -194,17 +191,19 @@ var _ = Describe("When upgrading", func() {
 							},
 						},
 					},
-				}, func(gw *gatewayapi_v1.Gateway) bool {
+				}
+
+				require.True(f.T(), f.CreateGatewayAndWaitFor(gateway, func(gw *gatewayapi_v1.Gateway) bool {
 					return e2e.GatewayProgrammed(gw) && e2e.GatewayHasAddress(gw)
-				})
-				require.True(t, ok)
-				require.NotNil(t, gateway)
+				}))
+
+				require.NoError(f.T(), f.Client.Get(context.Background(), k8s.NamespacedNameOf(gateway), gateway))
 
 				f.HTTP.HTTPURLBase = "http://" + gateway.Status.Addresses[0].Value
 
 				f.Fixtures.Echo.DeployN(namespace, "echo", 2)
 
-				_, ok = f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1.HTTPRoute{
+				require.True(f.T(), f.CreateHTTPRouteAndWaitFor(&gatewayapi_v1.HTTPRoute{
 					ObjectMeta: meta_v1.ObjectMeta{
 						Namespace: namespace,
 						Name:      "echo",
@@ -243,8 +242,7 @@ var _ = Describe("When upgrading", func() {
 							},
 						},
 					},
-				}, e2e.HTTPRouteAccepted)
-				require.True(f.T(), ok)
+				}, e2e.HTTPRouteAccepted))
 
 				By("ensuring it is routable")
 				checkRoutability(appHost)


### PR DESCRIPTION
Adds checks to verify resources are eventually
created with the expected status, where missing.
Without these checks, it's unknown whether the
"CreateAndWaitFor" method was successful or timed
out waiting for the desired condition.