### PR TITLE
internal/dag: 0s HTTPRoute timeout disables the timeout

### DIFF
--- a/changelogs/unreleased/6375-skriss-small.md
+++ b/changelogs/unreleased/6375-skriss-small.md
@@ -1,0 +1,1 @@
+Gateway API: a timeout value of `0s` disables the timeout.

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -3393,6 +3393,30 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 				},
 			),
 		},
+		"HTTPRoute rule with 0s (disabled) request timeout": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []any{
+				kuardService,
+				makeHTTPRouteWithTimeouts("0s", ""),
+			},
+			want: listeners(
+				&Listener{
+					Name: "http-80",
+					VirtualHosts: virtualhosts(
+						virtualhost("test.projectcontour.io",
+							&Route{
+								PathMatchCondition: prefixString("/"),
+								Clusters:           clustersWeight(service(kuardService)),
+								TimeoutPolicy: RouteTimeoutPolicy{
+									ResponseTimeout: timeout.DisabledSetting(),
+								},
+							},
+						),
+					),
+				},
+			),
+		},
 		"HTTPRoute rule with request and backendRequest timeout": {
 			gatewayclass: validClass,
 			gateway:      gatewayHTTPAllNamespaces,
@@ -3435,6 +3459,30 @@ func TestDAGInsertGatewayAPI(t *testing.T) {
 								Clusters:           clustersWeight(service(kuardService)),
 								TimeoutPolicy: RouteTimeoutPolicy{
 									ResponseTimeout: timeout.DurationSetting(5 * time.Second),
+								},
+							},
+						),
+					),
+				},
+			),
+		},
+		"HTTPRoute rule with 0s (disabled) backendRequest timeout": {
+			gatewayclass: validClass,
+			gateway:      gatewayHTTPAllNamespaces,
+			objs: []any{
+				kuardService,
+				makeHTTPRouteWithTimeouts("", "0s"),
+			},
+			want: listeners(
+				&Listener{
+					Name: "http-80",
+					VirtualHosts: virtualhosts(
+						virtualhost("test.projectcontour.io",
+							&Route{
+								PathMatchCondition: prefixString("/"),
+								Clusters:           clustersWeight(service(kuardService)),
+								TimeoutPolicy: RouteTimeoutPolicy{
+									ResponseTimeout: timeout.DisabledSetting(),
 								},
 							},
 						),

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1131,6 +1131,11 @@ func parseHTTPRouteTimeouts(httpRouteTimeouts *gatewayapi_v1.HTTPRouteTimeouts) 
 			return nil, fmt.Errorf("invalid HTTPRoute.Spec.Rules.Timeouts.Request: %v", err)
 		}
 
+		// For Gateway API a zero-valued timeout means disable the timeout.
+		if requestTimeout.Duration() == 0 {
+			requestTimeout = timeout.DisabledSetting()
+		}
+
 		responseTimeout = requestTimeout
 	}
 
@@ -1142,6 +1147,11 @@ func parseHTTPRouteTimeouts(httpRouteTimeouts *gatewayapi_v1.HTTPRouteTimeouts) 
 		backendRequestTimeout, err := timeout.Parse(string(*httpRouteTimeouts.BackendRequest))
 		if err != nil {
 			return nil, fmt.Errorf("invalid HTTPRoute.Spec.Rules.Timeouts.BackendRequest: %v", err)
+		}
+
+		// For Gateway API a zero-valued timeout means disable the timeout.
+		if backendRequestTimeout.Duration() == 0 {
+			backendRequestTimeout = timeout.DisabledSetting()
 		}
 
 		// If Timeouts.Request was specified, then Timeouts.BackendRequest must be


### PR DESCRIPTION
In Gateway API, a timeout specified as 0s (or any
other explicitly zero-valued duration string) should disable the timeout rather than use the default
value.

Closes #6373.