### PR TITLE
release-1.28: provisioner: Use separate flag for each disabled feature

### DIFF
--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -111,7 +111,9 @@ func DesiredDeployment(contour *model.Contour, image string) *appsv1.Deployment 
 	}
 
 	if contour.Spec.DisabledFeatures != nil && len(contour.Spec.DisabledFeatures) > 0 {
-		args = append(args, fmt.Sprintf("--disable-feature=%s", strings.Join(model.FeaturesToStrings(contour.Spec.DisabledFeatures), ",")))
+		for _, f := range contour.Spec.DisabledFeatures {
+			args = append(args, fmt.Sprintf("--disable-feature=%s", string(f)))
+		}
 	}
 
 	// Pass the insecure/secure flags to Contour if using non-default ports.

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -297,8 +297,10 @@ func TestDesiredDeploymentWhenSettingDisabledFeature(t *testing.T) {
 			// Change the Contour watch namespaces flag
 			deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test")
 			container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
-			arg := fmt.Sprintf("--disable-feature=%s", strings.Join(model.FeaturesToStrings(tc.disabledFeatures), ","))
-			checkContainerHasArg(t, container, arg)
+			for _, f := range tc.disabledFeatures {
+				arg := fmt.Sprintf("--disable-feature=%s", string(f))
+				checkContainerHasArg(t, container, arg)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Flags on Contour Deployment should be separate, not comma separated list