### PR TITLE
internal/envoy: support AuthPolicy on direct response routes

### DIFF
--- a/changelogs/unreleased/6426-shadialtarsha-small.md
+++ b/changelogs/unreleased/6426-shadialtarsha-small.md
@@ -1,0 +1,1 @@
+Fixes bug where external authorization policy was ignored on HTTPProxy direct response routes.

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -122,6 +122,15 @@ func buildRoute(dagRoute *dag.Route, vhostName string, secure bool) *envoy_confi
 		// redirect routes to *both* the insecure and secure vhosts.
 		route.Action = UpgradeHTTPS()
 	case dagRoute.DirectResponse != nil:
+		route.TypedPerFilterConfig = map[string]*anypb.Any{}
+
+		// Apply per-route authorization policy modifications.
+		if dagRoute.AuthDisabled {
+			route.TypedPerFilterConfig["envoy.filters.http.ext_authz"] = routeAuthzDisabled()
+		} else if len(dagRoute.AuthContext) > 0 {
+			route.TypedPerFilterConfig["envoy.filters.http.ext_authz"] = routeAuthzContext(dagRoute.AuthContext)
+		}
+
 		route.Action = routeDirectResponse(dagRoute.DirectResponse)
 	case dagRoute.Redirect != nil:
 		// TODO request/response headers?

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -17,6 +17,7 @@ package httpproxy
 
 import (
 	"context"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
@@ -206,6 +207,25 @@ func testExternalAuth(namespace string) {
 							},
 						},
 					},
+					{
+						Conditions: []contour_v1.MatchCondition{
+							{Prefix: "/direct-response-auth-enabled"},
+						},
+						DirectResponsePolicy: &contour_v1.HTTPDirectResponsePolicy{
+							StatusCode: http.StatusTeapot,
+						},
+					},
+					{
+						Conditions: []contour_v1.MatchCondition{
+							{Prefix: "/direct-response-auth-disabled"},
+						},
+						DirectResponsePolicy: &contour_v1.HTTPDirectResponsePolicy{
+							StatusCode: http.StatusTeapot,
+						},
+						AuthPolicy: &contour_v1.AuthorizationPolicy{
+							Disabled: true,
+						},
+					},
 
 					{
 						AuthPolicy: &contour_v1.AuthorizationPolicy{
@@ -283,5 +303,33 @@ func testExternalAuth(namespace string) {
 		body = f.GetEchoResponseBody(res.Body)
 		assert.Equal(t, "default", body.RequestHeaders.Get("Auth-Context-Target"))
 		assert.Equal(t, "externalauth.projectcontour.io", body.RequestHeaders.Get("Auth-Context-Hostname"))
+
+		// Direct response with external auth enabled should get a 401.
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/direct-response-auth-enabled",
+			Condition: e2e.HasStatusCode(401),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 401 response code, got %d", res.StatusCode)
+
+		// Direct response with external auth enabled with "allow" in the path
+		// should succeed.
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/direct-response-auth-enabled/allow",
+			Condition: e2e.HasStatusCode(http.StatusTeapot),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 418 response code, got %d", res.StatusCode)
+
+		// Direct response with external auth disabled should succeed.
+		res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+			Host:      p.Spec.VirtualHost.Fqdn,
+			Path:      "/direct-response-auth-disabled",
+			Condition: e2e.HasStatusCode(http.StatusTeapot),
+		})
+		require.NotNil(t, res, "request never succeeded")
+		require.Truef(t, ok, "expected 418 response code, got %d", res.StatusCode)
 	})
 }


### PR DESCRIPTION
Previously, auth policies on direct response routes were ignored.

Based on #5962, included just the ExtAuth changes (will look at global rate limit E2E additions separately) and added routes/test cases to the existing ExtAuth E2E for simplicity.