### PR TITLE
Parse equal-preference cipher groups

### DIFF
--- a/.codespell.ignorewords
+++ b/.codespell.ignorewords
@@ -8,3 +8,4 @@ wit
 aks
 immediatedly
 te
+NotIn

--- a/apis/projectcontour/v1alpha1/ciphersuites.go
+++ b/apis/projectcontour/v1alpha1/ciphersuites.go
@@ -18,6 +18,9 @@ package v1alpha1
 // - most of the clients that might need to use the commented ciphers are
 // unable to connect without TLS 1.0, which contour never enables.
 //
+// Ciphers are listed in order of preference.
+// [cipher1|cipher2|...] defines an equal-preference group of ciphers.
+//
 // This list is ignored if the client and server negotiate TLS 1.3.
 //
 // The commented ciphers are left in place to simplify updating this list for future
@@ -41,18 +44,18 @@ var DefaultTLSCiphers = []string{
 // See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
 // Note: This list is a superset of what is valid for stock Envoy builds and those using BoringSSL FIPS.
 var ValidTLSCiphers = map[string]struct{}{
-	"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]": {},
-	"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]":     {},
-	"ECDHE-ECDSA-AES128-GCM-SHA256":                                 {},
-	"ECDHE-RSA-AES128-GCM-SHA256":                                   {},
-	"ECDHE-ECDSA-AES128-SHA":                                        {},
-	"ECDHE-RSA-AES128-SHA":                                          {},
-	"AES128-GCM-SHA256":                                             {},
-	"AES128-SHA":                                                    {},
-	"ECDHE-ECDSA-AES256-GCM-SHA384":                                 {},
-	"ECDHE-RSA-AES256-GCM-SHA384":                                   {},
-	"ECDHE-ECDSA-AES256-SHA":                                        {},
-	"ECDHE-RSA-AES256-SHA":                                          {},
-	"AES256-GCM-SHA384":                                             {},
-	"AES256-SHA":                                                    {},
+	"ECDHE-ECDSA-CHACHA20-POLY1305": {},
+	"ECDHE-RSA-CHACHA20-POLY1305":   {},
+	"ECDHE-ECDSA-AES128-GCM-SHA256": {},
+	"ECDHE-RSA-AES128-GCM-SHA256":   {},
+	"ECDHE-ECDSA-AES128-SHA":        {},
+	"ECDHE-RSA-AES128-SHA":          {},
+	"AES128-GCM-SHA256":             {},
+	"AES128-SHA":                    {},
+	"ECDHE-ECDSA-AES256-GCM-SHA384": {},
+	"ECDHE-RSA-AES256-GCM-SHA384":   {},
+	"ECDHE-ECDSA-AES256-SHA":        {},
+	"ECDHE-RSA-AES256-SHA":          {},
+	"AES256-GCM-SHA384":             {},
+	"AES256-SHA":                    {},
 }

--- a/apis/projectcontour/v1alpha1/contourconfig_helpers_test.go
+++ b/apis/projectcontour/v1alpha1/contourconfig_helpers_test.go
@@ -141,8 +141,10 @@ func TestContourConfigurationSpecValidate(t *testing.T) {
 		c.Envoy.Listener.TLS.CipherSuites = []string{
 			"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]",
 			"ECDHE-ECDSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-CHACHA20-POLY1305",
 			"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
 			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-CHACHA20-POLY1305",
 			"ECDHE-ECDSA-AES128-SHA",
 			"AES128-GCM-SHA256",
 			"AES128-SHA",
@@ -159,6 +161,20 @@ func TestContourConfigurationSpecValidate(t *testing.T) {
 			"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]",
 			"NOTAVALIDCIPHER",
 			"AES128-GCM-SHA256",
+		}
+		require.Error(t, c.Validate())
+
+		// Equal-preference group with invalid cipher.
+		c.Envoy.Listener.TLS.CipherSuites = []string{
+			"[ECDHE-ECDSA-AES128-GCM-SHA256|NOTAVALIDCIPHER]",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
+		}
+		require.Error(t, c.Validate())
+
+		// Unmatched brackets.
+		c.Envoy.Listener.TLS.CipherSuites = []string{
+			"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
 		}
 		require.Error(t, c.Validate())
 	})

--- a/changelogs/unreleased/6461-tsaarni-small.md
+++ b/changelogs/unreleased/6461-tsaarni-small.md
@@ -1,0 +1,1 @@
+Add support for defining equal-preference cipher groups ([cipher1|cipher2|...]) and permit `ECDHE-ECDSA-CHACHA20-POLY1305` and `ECDHE-RSA-CHACHA20-POLY1305` to be used separately.

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -280,7 +280,7 @@ func TestDesiredDeploymentWhenSettingDisabledFeature(t *testing.T) {
 		disabledFeatures []contour_v1.Feature
 	}{
 		{
-			description:      "disable 2 featuers",
+			description:      "disable 2 features",
 			disabledFeatures: []contour_v1.Feature{"tlsroutes", "grpcroutes"},
 		},
 		{


### PR DESCRIPTION
This change corrects the parsing of cipher configuration by adding support for equal-preference cipher groups `[cipher1|cipher2|...]`:

- The `ValidTLSCiphers` list now contains only individual cipher names, not groups.
- When configuring a group, the group is split into individual ciphers before comparing against cipher names in valid TLS cipher list.
- User is now able to configure ciphers `ECDHE-ECDSA-CHACHA20-POLY1305` and `ECDHE-RSA-CHACHA20-POLY1305` individually, whereas previously they were only accepted as part of the hardcoded groups.
- User can now define their own equal-preference ciphers groups.

Fixes #6380

**Background:**

Prior this change the list of valid TLS ciphers had hardcoded ciphers in bracketed format https://github.com/projectcontour/contour/blob/0796cd9d76578f147db9715046874d06d4581208/apis/projectcontour/v1alpha1/ciphersuites.go#L44-L45

This is simply a copy from Envoy documentation ([link](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites)) but on further inspection Boringssl doc ([link](https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Cipher-suite-configuration)) says:

> An equal-preference is specified with square brackets, combining multiple selectors separated by `|`. For example:
`[TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256]`

We should not use the hardcoded groups when validating user's cipher configuration, instead we should parse the groups into individual cipher names and validate them.
