### PR TITLE
Bump Envoy to 1.30.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.30.1
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.30.2
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/6483-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6483-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.30.2 for CVE fixes. See the v1.30.2 release notes [here](https://www.envoyproxy.io/docs/envoy/v1.30.2/version_history/v1.30/v1.30.2).

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.30.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.30.2",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.1
+        image: docker.io/envoyproxy/envoy:v1.30.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.30.1
+          image: docker.io/envoyproxy/envoy:v1.30.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9261,7 +9261,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.30.1
+          image: docker.io/envoyproxy/envoy:v1.30.2
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9065,7 +9065,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.1
+        image: docker.io/envoyproxy/envoy:v1.30.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9249,7 +9249,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.1
+        image: docker.io/envoyproxy/envoy:v1.30.2
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.30.1][53]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
+| main            | [1.30.2][56]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
 | 1.29.0          | [1.30.1][53]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.4          | [1.29.4][55]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.3          | [1.29.3][50]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
@@ -195,6 +195,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [53]: https://www.envoyproxy.io/docs/envoy/v1.30.1/version_history/v1.30/v1.30.1
 [54]: https://www.envoyproxy.io/docs/envoy/v1.28.3/version_history/v1.28/v1.28.3
 [55]: https://www.envoyproxy.io/docs/envoy/v1.29.4/version_history/v1.29/v1.29.4
+[56]: https://www.envoyproxy.io/docs/envoy/v1.30.2/version_history/v1.30/v1.30.2
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.30.1"
+      envoy: "1.30.2"
       kubernetes:
         - "1.30"
         - "1.29"


### PR DESCRIPTION
For CVE fixes

See release notes: https://www.envoyproxy.io/docs/envoy/v1.30.2/version_history/v1.30/v1.30.2