### PR TITLE
release-1.27: Bump golang to 1.21.11

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -10,7 +10,8 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.21.11
+
 jobs:
   e2e-envoy-xds:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -15,7 +15,8 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.21.11
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -11,7 +11,7 @@ on:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.21.11
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.21.9
+BUILD_BASE_IMAGE ?= golang:1.21.11@sha256:a8edec58ba598e2f1259f4ec4ca1b06358468214225e73d7c841ab0980c12367
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0


### PR DESCRIPTION
See release notes: https://go.dev/doc/devel/release#go1.21.minor