### PR TITLE
Enable admin route for `stats/prometheus`

### DIFF
--- a/changelogs/unreleased/6503-clayton-gonsalves-small.md
+++ b/changelogs/unreleased/6503-clayton-gonsalves-small.md
@@ -1,0 +1,1 @@
+allow `/stats/prometheus` route on the `admin` listener.

--- a/internal/envoy/v3/stats.go
+++ b/internal/envoy/v3/stats.go
@@ -50,7 +50,7 @@ func StatsListeners(metrics contour_v1alpha1.MetricsConfig, health contour_v1alp
 			SocketOptions: NewSocketOptions().TCPKeepalive().Build(),
 			FilterChains: filterChain("stats",
 				DownstreamTLSTransportSocket(
-					downstreamTLSContext(metrics.TLS.CAFile != "")), routeForAdminInterface("/stats")),
+					downstreamTLSContext(metrics.TLS.CAFile != "")), routeForAdminInterface("/stats", "/stats/prometheus")),
 		}, {
 			Name:          "health",
 			Address:       SocketAddress(health.Address, health.Port),
@@ -65,7 +65,11 @@ func StatsListeners(metrics contour_v1alpha1.MetricsConfig, health contour_v1alp
 			Name:          "stats-health",
 			Address:       SocketAddress(metrics.Address, metrics.Port),
 			SocketOptions: NewSocketOptions().TCPKeepalive().Build(),
-			FilterChains:  filterChain("stats", nil, routeForAdminInterface("/ready", "/stats")),
+			FilterChains: filterChain("stats", nil, routeForAdminInterface(
+				"/ready",
+				"/stats",
+				"/stats/prometheus",
+			)),
 		}}
 
 	// Create separate HTTP listeners for metrics and health.
@@ -74,7 +78,7 @@ func StatsListeners(metrics contour_v1alpha1.MetricsConfig, health contour_v1alp
 			Name:          "stats",
 			Address:       SocketAddress(metrics.Address, metrics.Port),
 			SocketOptions: NewSocketOptions().TCPKeepalive().Build(),
-			FilterChains:  filterChain("stats", nil, routeForAdminInterface("/stats")),
+			FilterChains:  filterChain("stats", nil, routeForAdminInterface("/stats", "/stats/prometheus")),
 		}, {
 			Name:          "health",
 			Address:       SocketAddress(health.Address, health.Port),

--- a/internal/envoy/v3/stats_test.go
+++ b/internal/envoy/v3/stats_test.go
@@ -87,6 +87,34 @@ func TestStatsListeners(t *testing.T) {
 		},
 	}
 
+	prometheusStatsRoute := &envoy_config_route_v3.Route{
+		Match: &envoy_config_route_v3.RouteMatch{
+			PathSpecifier: &envoy_config_route_v3.RouteMatch_Path{
+				Path: "/stats/prometheus",
+			},
+			Headers: []*envoy_config_route_v3.HeaderMatcher{
+				{
+					Name: ":method",
+					HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+						StringMatch: &envoy_matcher_v3.StringMatcher{
+							IgnoreCase: true,
+							MatchPattern: &envoy_matcher_v3.StringMatcher_Exact{
+								Exact: "GET",
+							},
+						},
+					},
+				},
+			},
+		},
+		Action: &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{
+				ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
+					Cluster: "envoy-admin",
+				},
+			},
+		},
+	}
+
 	type testcase struct {
 		metrics contour_v1alpha1.MetricsConfig
 		health  contour_v1alpha1.HealthConfig
@@ -119,7 +147,7 @@ func TestStatsListeners(t *testing.T) {
 									VirtualHosts: []*envoy_config_route_v3.VirtualHost{{
 										Name:    "backend",
 										Domains: []string{"*"},
-										Routes:  []*envoy_config_route_v3.Route{readyRoute, statsRoute},
+										Routes:  []*envoy_config_route_v3.Route{readyRoute, statsRoute, prometheusStatsRoute},
 									}},
 								},
 							},
@@ -165,7 +193,7 @@ func TestStatsListeners(t *testing.T) {
 									VirtualHosts: []*envoy_config_route_v3.VirtualHost{{
 										Name:    "backend",
 										Domains: []string{"*"},
-										Routes:  []*envoy_config_route_v3.Route{statsRoute},
+										Routes:  []*envoy_config_route_v3.Route{statsRoute, prometheusStatsRoute},
 									}},
 								},
 							},
@@ -256,7 +284,7 @@ func TestStatsListeners(t *testing.T) {
 									VirtualHosts: []*envoy_config_route_v3.VirtualHost{{
 										Name:    "backend",
 										Domains: []string{"*"},
-										Routes:  []*envoy_config_route_v3.Route{statsRoute},
+										Routes:  []*envoy_config_route_v3.Route{statsRoute, prometheusStatsRoute},
 									}},
 								},
 							},
@@ -349,7 +377,7 @@ func TestStatsListeners(t *testing.T) {
 									VirtualHosts: []*envoy_config_route_v3.VirtualHost{{
 										Name:    "backend",
 										Domains: []string{"*"},
-										Routes:  []*envoy_config_route_v3.Route{statsRoute},
+										Routes:  []*envoy_config_route_v3.Route{statsRoute, prometheusStatsRoute},
 									}},
 								},
 							},


### PR DESCRIPTION
As part of the changes made in https://github.com/projectcontour/contour/pull/6447
the admin endpoint was tightened to only allow `GET` requests with path matches as `exact`.
This change blocked the `stats/prometheus` endpoint which is used by prometheus to scrape metrics. 

Note: If not fixed, this will lead to loss of all prometheus based metrics. 

