### PR TITLE
shutdown manager: use filter on downstream_cx_active stats url

### DIFF
--- a/changelogs/unreleased/6523-therealak12-small.md
+++ b/changelogs/unreleased/6523-therealak12-small.md
@@ -1,1 +1,1 @@
-- Improve response time by utilizing a query param (`filter=http\..*\.downstream_cx_active`) when querying `/stats/prometheus` for `envoy_http_downstream_cx_active` 
+Improve response time by utilizing a query param (`filter=http\..*\.downstream_cx_active`) when querying `/stats/prometheus` for `envoy_http_downstream_cx_active` in the shutdown-manager.

--- a/changelogs/unreleased/6523-therealak12-small.md
+++ b/changelogs/unreleased/6523-therealak12-small.md
@@ -1,0 +1,1 @@
+- Improve response time by utilizing a query param (`filter=http\..*\.downstream_cx_active`) when querying `/stats/prometheus` for `envoy_http_downstream_cx_active` 

--- a/changelogs/unreleased/6523-therealak12-small.md
+++ b/changelogs/unreleased/6523-therealak12-small.md
@@ -1,1 +1,1 @@
-Improve response time by utilizing a query param (`filter=http\..*\.downstream_cx_active`) when querying `/stats/prometheus` for `envoy_http_downstream_cx_active` in the shutdown-manager.
+Improve shutdown manager query to the Envoy stats endpoint for active connections by utilizing a regex filter query param.

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	// The prometheusURL is used to fetch the envoy metrics. Note that the filter
+	// value matches Envoy's raw stat names (i.e. those on the `/stats/` endpoint).
 	prometheusURL      = "http://unix/stats/prometheus?filter=http\\..*\\.downstream_cx_active"
 	healthcheckFailURL = "http://unix/healthcheck/fail"
 	prometheusStat     = "envoy_http_downstream_cx_active"

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	prometheusURL      = "http://unix/stats/prometheus"
+	prometheusURL      = "http://unix/stats/prometheus?filter=http\\..*\\.downstream_cx_active"
 	healthcheckFailURL = "http://unix/healthcheck/fail"
 	prometheusStat     = "envoy_http_downstream_cx_active"
 )

--- a/cmd/contour/shutdownmanager.go
+++ b/cmd/contour/shutdownmanager.go
@@ -33,7 +33,7 @@ import (
 const (
 	// The prometheusURL is used to fetch the envoy metrics. Note that the filter
 	// value matches Envoy's raw stat names (i.e. those on the `/stats/` endpoint).
-	prometheusURL      = "http://unix/stats/prometheus?filter=http\\..*\\.downstream_cx_active"
+	prometheusURL      = "http://unix/stats/prometheus?filter=^http\\..*\\.downstream_cx_active$"
 	healthcheckFailURL = "http://unix/healthcheck/fail"
 	prometheusStat     = "envoy_http_downstream_cx_active"
 )


### PR DESCRIPTION
The PR adds a query param to the stats URL used in the shutdown-manager when waiting for the active connections to drain.

In clusters with a high number of routes (such as ours in Snapp with over 3000 routes), the `/stats/prometheus` response size is above 80MBs. This makes rendering and fetching the URL take a few seconds.

The introduced filter makes rendering faster and the response time shorter. Also, it reduces the time required for parsing and searching the response.

An example of the response when utilizing the filter:

![image](https://github.com/projectcontour/contour/assets/39967326/ff1ed774-f19c-48fa-9b4f-0b339131f2bc)


Comparison of total request time before and after the filter:

![image](https://github.com/projectcontour/contour/assets/39967326/1ee5654c-2b28-4185-9649-4eec6fb6f0af)

