### PR TITLE
contour: adds global ext auth support to fallback certificates

### DIFF
--- a/changelogs/unreleased/6558-erikflores7-minor.md
+++ b/changelogs/unreleased/6558-erikflores7-minor.md
@@ -1,0 +1,3 @@
+## Fallback Certificate: Add Global Ext Auth support
+
+Applies Global Auth filters to Fallback certificate

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -543,8 +543,14 @@ func (c *ListenerCache) OnChange(root *dag.DAG) {
 					alpnProtos...,
 				)
 
+				var authzFilter *envoy_filter_network_http_connection_manager_v3.HttpFilter
+				if vh.ExternalAuthorization != nil {
+					authzFilter = envoy_v3.FilterExternalAuthz(vh.ExternalAuthorization)
+				}
+
 				cm := envoy_v3.HTTPConnectionManagerBuilder().
 					DefaultFilters().
+					AddFilter(authzFilter).
 					RouteConfigName(fallbackCertRouteConfigName(listener)).
 					MetricsPrefix(listener.Name).
 					AccessLoggers(cfg.newSecureAccessLog()).


### PR DESCRIPTION
When using IP to connect, no SNI is sent so the Fallback certificate has to be used in these cases. But when using Fallback certificate, there is currently no support for auth. This change adds the auth filter to add support for the fallback certificate.

 Fixes #6512 
 
 
  Signed-off-by: Erik Flores eflores@anduril.com