### PR TITLE
deprecate xDS server type field

### DIFF
--- a/apis/projectcontour/v1alpha1/contourconfig.go
+++ b/apis/projectcontour/v1alpha1/contourconfig.go
@@ -129,6 +129,9 @@ type XDSServerConfig struct {
 	// Values: `envoy` (default), `contour (deprecated)`.
 	//
 	// Other values will produce an error.
+	//
+	// Deprecated: this field will be removed in a future release when
+	// the `contour` xDS server implementation is removed.
 	// +optional
 	Type XDSServerType `json:"type,omitempty"`
 

--- a/changelogs/unreleased/6561-skriss-deprecation.md
+++ b/changelogs/unreleased/6561-skriss-deprecation.md
@@ -1,0 +1,4 @@
+## xDS server type fields in config file and ContourConfiguration CRD are deprecated
+
+These fields are officially deprecated now that the `contour` xDS server implementation is deprecated.
+They are planned to be removed in the 1.31 release, along with the `contour` xDS server implementation.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -509,6 +509,7 @@ func (s *Server) doServe() error {
 	// the contents of the Contour xDS caches after the DAG is built.
 	var snapshotHandler *xdscache_v3.SnapshotHandler
 
+	// nolint:staticcheck
 	if contourConfiguration.XDSServer.Type == contour_v1alpha1.EnvoyServerType {
 		snapshotHandler = xdscache_v3.NewSnapshotHandler(resources, s.log.WithField("context", "snapshotHandler"))
 
@@ -923,6 +924,7 @@ func (x *xdsServer) Start(ctx context.Context) error {
 
 	grpcServer := xds.NewServer(x.registry, grpcOptions(log, x.config.TLS)...)
 
+	// nolint:staticcheck
 	switch x.config.Type {
 	case contour_v1alpha1.EnvoyServerType:
 		contour_xds_v3.RegisterServer(envoy_server_v3.NewServer(ctx, x.snapshotHandler.GetCache(), contour_xds_v3.NewRequestLoggingCallbacks(log)), grpcServer)
@@ -930,6 +932,7 @@ func (x *xdsServer) Start(ctx context.Context) error {
 		contour_xds_v3.RegisterServer(contour_xds_v3.NewContourServer(log, xdscache.ResourcesOf(x.resources)...), grpcServer)
 	default:
 		// This can't happen due to config validation.
+		// nolint:staticcheck
 		log.Fatalf("invalid xDS server type %q", x.config.Type)
 	}
 
@@ -944,6 +947,7 @@ func (x *xdsServer) Start(ctx context.Context) error {
 		log = log.WithField("insecure", true)
 	}
 
+	// nolint:staticcheck
 	log.Infof("started xDS server type: %q", x.config.Type)
 	defer log.Info("stopped xDS server")
 

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1143,6 +1143,8 @@ spec:
                       Defines the XDSServer to use for `contour serve`.
                       Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
+                      Deprecated: this field will be removed in a future release when
+                      the `contour` xDS server implementation is removed.
                     type: string
                 type: object
             type: object
@@ -4919,6 +4921,8 @@ spec:
                           Defines the XDSServer to use for `contour serve`.
                           Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
+                          Deprecated: this field will be removed in a future release when
+                          the `contour` xDS server implementation is removed.
                         type: string
                     type: object
                 type: object

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1363,6 +1363,8 @@ spec:
                       Defines the XDSServer to use for `contour serve`.
                       Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
+                      Deprecated: this field will be removed in a future release when
+                      the `contour` xDS server implementation is removed.
                     type: string
                 type: object
             type: object
@@ -5139,6 +5141,8 @@ spec:
                           Defines the XDSServer to use for `contour serve`.
                           Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
+                          Deprecated: this field will be removed in a future release when
+                          the `contour` xDS server implementation is removed.
                         type: string
                     type: object
                 type: object

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -1154,6 +1154,8 @@ spec:
                       Defines the XDSServer to use for `contour serve`.
                       Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
+                      Deprecated: this field will be removed in a future release when
+                      the `contour` xDS server implementation is removed.
                     type: string
                 type: object
             type: object
@@ -4930,6 +4932,8 @@ spec:
                           Defines the XDSServer to use for `contour serve`.
                           Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
+                          Deprecated: this field will be removed in a future release when
+                          the `contour` xDS server implementation is removed.
                         type: string
                     type: object
                 type: object

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1179,6 +1179,8 @@ spec:
                       Defines the XDSServer to use for `contour serve`.
                       Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
+                      Deprecated: this field will be removed in a future release when
+                      the `contour` xDS server implementation is removed.
                     type: string
                 type: object
             type: object
@@ -4955,6 +4957,8 @@ spec:
                           Defines the XDSServer to use for `contour serve`.
                           Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
+                          Deprecated: this field will be removed in a future release when
+                          the `contour` xDS server implementation is removed.
                         type: string
                     type: object
                 type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1363,6 +1363,8 @@ spec:
                       Defines the XDSServer to use for `contour serve`.
                       Values: `envoy` (default), `contour (deprecated)`.
                       Other values will produce an error.
+                      Deprecated: this field will be removed in a future release when
+                      the `contour` xDS server implementation is removed.
                     type: string
                 type: object
             type: object
@@ -5139,6 +5141,8 @@ spec:
                           Defines the XDSServer to use for `contour serve`.
                           Values: `envoy` (default), `contour (deprecated)`.
                           Other values will produce an error.
+                          Deprecated: this field will be removed in a future release when
+                          the `contour` xDS server implementation is removed.
                         type: string
                     type: object
                 type: object

--- a/internal/contourconfig/contourconfiguration_test.go
+++ b/internal/contourconfig/contourconfiguration_test.go
@@ -206,12 +206,12 @@ func TestOverlayOnDefaults(t *testing.T) {
 		"ContourConfig with single non-default field is overlaid correctly": {
 			contourConfig: contour_v1alpha1.ContourConfigurationSpec{
 				XDSServer: &contour_v1alpha1.XDSServerConfig{
-					Type: contour_v1alpha1.EnvoyServerType,
+					Port: 7777,
 				},
 			},
 			want: func() contour_v1alpha1.ContourConfigurationSpec {
 				res := contourconfig.Defaults()
-				res.XDSServer.Type = contour_v1alpha1.EnvoyServerType
+				res.XDSServer.Port = 7777
 				return res
 			},
 		},

--- a/pkg/config/parameters.go
+++ b/pkg/config/parameters.go
@@ -242,6 +242,8 @@ func (t ProtocolParameters) Validate() error {
 type ServerParameters struct {
 	// Defines the XDSServer to use for `contour serve`.
 	// Defaults to "envoy"
+	// Deprecated: this field will be removed in a future release when
+	// the `contour` xDS server implementation is removed.
 	XDSServerType ServerType `yaml:"xds-server-type,omitempty"`
 }
 

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -9031,6 +9031,8 @@ XDSServerType
 <p>Defines the XDSServer to use for <code>contour serve</code>.</p>
 <p>Values: <code>envoy</code> (default), <code>contour (deprecated)</code>.</p>
 <p>Other values will produce an error.</p>
+<p>Deprecated: this field will be removed in a future release when
+the <code>contour</code> xDS server implementation is removed.</p>
 </td>
 </tr>
 <tr>

--- a/site/content/docs/main/configuration.md
+++ b/site/content/docs/main/configuration.md
@@ -206,7 +206,7 @@ The server configuration block can be used to configure various settings for the
 
 | Field Name      | Type   | Default | Description                                                                   |
 | --------------- | ------ | ------- | ----------------------------------------------------------------------------- |
-| xds-server-type | string | envoy   | This field specifies the xDS Server to use. Options are `envoy` or `contour` (deprecated). |
+| xds-server-type | string | envoy   | This field specifies the xDS Server to use. Options are `envoy` or `contour` (deprecated). **This field is deprecated** and will be removed in a future release when the `contour` xDS server implementation is removed. |
 
 ### Gateway Configuration
 


### PR DESCRIPTION
Fields are planned to be removed in the 1.31 release.

Updates #2134.