### PR TITLE
Bump go to 1.22.5

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -13,7 +13,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.22.5
 
 jobs:
   e2e-contour-xds:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -19,7 +19,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.22.5
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.22.5
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.4
+  GO_VERSION: 1.22.5
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.22.4@sha256:969349b8121a56d51c74f4c273ab974c15b3a8ae246a5cffc1df7d28b66cf978
+BUILD_BASE_IMAGE ?= golang:1.22.5@sha256:829eff99a4b2abffe68f6a3847337bf6455d69d17e49ec1a97dac78834754bd6
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/6499-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6499-sunjayBhatia-small.md
@@ -1,1 +1,0 @@
-Updates to Go 1.22.4. See the [Go release notes](https://go.dev/doc/devel/release#go1.22.minor) for more information.

--- a/changelogs/unreleased/6563-sunjayBhatia-small.md
+++ b/changelogs/unreleased/6563-sunjayBhatia-small.md
@@ -1,0 +1,1 @@
+Updates to Go 1.22.5. See the [Go release notes](https://go.dev/doc/devel/release#go1.22.minor) for more information.


### PR DESCRIPTION
See release notes: https://go.dev/doc/devel/release#go1.22.minor