### PR TITLE
Gateway API: handle Route conflicts with GRPCRoute.Matches

### DIFF
--- a/changelogs/CHANGELOG-v1.29.0.md
+++ b/changelogs/CHANGELOG-v1.29.0.md
@@ -67,7 +67,7 @@ It's possible that multiple HTTPRoutes will define the same Match conditions. In
 - The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
 - The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
 
-With above ordering, any HTTPRoute that ranks lower, will be marked with below conditions accordionly
+With above ordering, any HTTPRoute that ranks lower, will be marked with below conditions accordingly
 1. If only partial rules under this HTTPRoute are conflicted, it's marked with `Accepted: True` and `PartiallyInvalid: true` Conditions and Reason: `RuleMatchPartiallyConflict`.
 2. If all the rules under this HTTPRoute are conflicted, it's marked with `Accepted: False` Condition and Reason `RuleMatchConflict`.
 

--- a/changelogs/unreleased/6566-lubronzhan-minor.md
+++ b/changelogs/unreleased/6566-lubronzhan-minor.md
@@ -5,6 +5,6 @@ It's possible that multiple GRPCRoutes will define the same Match conditions. In
 - The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
 - The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
 
-With above ordering, any GRPCRoute that ranks lower, will be marked with below conditions accordionly
+With above ordering, any GRPCRoute that ranks lower, will be marked with below conditions accordingly:
 1. If only partial rules under this GRPCRoute are conflicted, it's marked with `Accepted: True` and `PartiallyInvalid: true` Conditions and Reason: `RuleMatchPartiallyConflict`.
 2. If all the rules under this GRPCRoute are conflicted, it's marked with `Accepted: False` Condition and Reason `RuleMatchConflict`.

--- a/changelogs/unreleased/6566-lubronzhan-minor.md
+++ b/changelogs/unreleased/6566-lubronzhan-minor.md
@@ -1,0 +1,10 @@
+## Gateway API: handle Route conflicts with GRPCRoute.Matches
+
+It's possible that multiple GRPCRoutes will define the same Match conditions. In this case the following logic is applied to resolve the conflict:
+
+- The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
+- The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
+
+With above ordering, any GRPCRoute that ranks lower, will be marked with below conditions accordionly
+1. If only partial rules under this GRPCRoute are conflicted, it's marked with `Accepted: True` and `PartiallyInvalid: true` Conditions and Reason: `RuleMatchPartiallyConflict`.
+2. If all the rules under this GRPCRoute are conflicted, it's marked with `Accepted: False` Condition and Reason `RuleMatchConflict`.

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -298,7 +298,7 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 			},
 			expectConflict: true,
 		},
-		"2 different routes with same path and header and query params, with same kind, expect conflict": {
+		"2 different httproutes with same path and header and query params, with same kind, expect conflict": {
 			vHost: VirtualHost{
 				Routes: map[string]*Route{},
 			},
@@ -317,6 +317,38 @@ func TestHasConflictRouteForVirtualHost(t *testing.T) {
 				},
 				{
 					Kind:               KindHTTPRoute,
+					Name:               "c",
+					Namespace:          "d",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+			},
+			expectConflict: true,
+		},
+		"2 different grpcroutes with same path and header and query params, with same kind, expect conflict": {
+			vHost: VirtualHost{
+				Routes: map[string]*Route{},
+			},
+			rs: []Route{
+				{
+					Kind:               KindGRPCRoute,
+					Name:               "a",
+					Namespace:          "b",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+				{
+					Kind:               KindGRPCRoute,
 					Name:               "c",
 					Namespace:          "d",
 					PathMatchCondition: prefixSegment("/path1"),

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -2545,8 +2545,8 @@ func addRouteNotAcceptedConditionDueToMatchConflict(routeAccessor *status.RouteP
 		status.ReasonRouteRuleMatchConflict,
 		fmt.Sprintf(status.MessageRouteRuleMatchConflict, routeKind, routeKind),
 	)
-
 }
+
 func addRoutePartiallyInvalidConditionDueToMatchPartiallyConflict(routeAccessor *status.RouteParentStatusUpdate, routeKind string) {
 	routeAccessor.AddCondition(
 		gatewayapi_v1.RouteConditionPartiallyInvalid,

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -1480,9 +1480,9 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 				timeoutPolicy)
 		}
 
-		// check all the routes whether there is conflict against previous rules
+		// Check all the routes whether there is conflict against previous rules.
 		if !p.hasConflictRoute(listener, hosts, routes) {
-			// add the route if there is conflict
+			// Add the route if there is no conflict at the same rule level.
 			// Add each route to the relevant vhost(s)/svhosts(s).
 			for host := range hosts {
 				for _, route := range routes {
@@ -1507,6 +1507,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 		// No rules under the route is valid, mark it as not accepted.
 		addRouteNotAcceptedConditionDueToMatchConflict(routeAccessor, KindHTTPRoute)
 	} else if invalidRuleCnt > 0 {
+		// Some of the rules are conflicted, mark it as partially invalid.
 		addRoutePartiallyInvalidConditionDueToMatchPartiallyConflict(routeAccessor, KindHTTPRoute)
 	}
 }
@@ -1657,9 +1658,9 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1.G
 			nil,
 		)
 
-		// check all the routes whether there is conflict against previous rules
+		// Check all the routes whether there is conflict against previous rules.
 		if !p.hasConflictRoute(listener, hosts, routes) {
-			// add the route if there is conflict
+			// Add the route if there is no conflict at the same rule level.
 			// Add each route to the relevant vhost(s)/svhosts(s).
 			for host := range hosts {
 				for _, route := range routes {
@@ -1684,6 +1685,7 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1.G
 		// No rules under the route is valid, mark it as not accepted.
 		addRouteNotAcceptedConditionDueToMatchConflict(routeAccessor, KindGRPCRoute)
 	} else if invalidRuleCnt > 0 {
+		// Some of the rules are conflicted, mark it as partially invalid.
 		addRoutePartiallyInvalidConditionDueToMatchPartiallyConflict(routeAccessor, KindGRPCRoute)
 	}
 

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -1149,7 +1149,7 @@ func TestSortGRPCRoutes(t *testing.T) {
 		expected []*gatewayapi_v1.GRPCRoute
 	}{
 		{
-			name: "3 httproutes, with different timestamp, earlier one should be first ",
+			name: "3 grpcroutes, with different timestamp, earlier one should be first ",
 			m: map[types.NamespacedName]*gatewayapi_v1.GRPCRoute{
 				{
 					Namespace: "ns", Name: "name1",
@@ -1204,7 +1204,7 @@ func TestSortGRPCRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "3 httproutes with same creation timestamps, same namespaces, smaller name comes first",
+			name: "3 grpcroutes with same creation timestamps, same namespaces, smaller name comes first",
 			m: map[types.NamespacedName]*gatewayapi_v1.GRPCRoute{
 				{
 					Namespace: "ns", Name: "name3",
@@ -1259,7 +1259,7 @@ func TestSortGRPCRoutes(t *testing.T) {
 			},
 		},
 		{
-			name: "3 httproutes with same creation timestamp, smaller namespaces comes first",
+			name: "3 grpcroutes with same creation timestamp, smaller namespaces comes first",
 			m: map[types.NamespacedName]*gatewayapi_v1.GRPCRoute{
 				{
 					Namespace: "ns3", Name: "name1",

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -1133,7 +1133,6 @@ func TestSortRoutes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			res := sortHTTPRoutes(tc.m)
 			assert.Equal(t, tc.expected, res)
 		})
@@ -1428,7 +1427,6 @@ func TestSortGRPCRoutes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			res := sortGRPCRoutes(tc.m)
 			assert.Equal(t, tc.expected, res)
 		})

--- a/internal/dag/gatewayapi_processor_test.go
+++ b/internal/dag/gatewayapi_processor_test.go
@@ -1475,7 +1475,7 @@ func TestHasConflictRoute(t *testing.T) {
 		expectedConflict bool
 	}{
 		{
-			name: "There are 2 existing route, the 3rd route to add doesn't have conflict, listen doesn't have tls, no conflict expected",
+			name: "There are 2 existing httproute, the 3rd route to add doesn't have conflict, listen doesn't have tls, no conflict expected",
 			existingRoutes: []*Route{
 				{
 					Name:               "route1",
@@ -1501,6 +1501,43 @@ func TestHasConflictRoute(t *testing.T) {
 			routes: []*Route{
 				{
 					Kind:               KindHTTPRoute,
+					Name:               "route3",
+					Namespace:          "default",
+					PathMatchCondition: prefixSegment("/path2"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: "e-tag", Value: "abc", MatchType: "contains", Invert: true},
+					},
+				},
+			},
+			listener: listener,
+		},
+		{
+			name: "There are 2 existing grpcroute, the 3rd route to add doesn't have conflict, listen doesn't have tls, no conflict expected",
+			existingRoutes: []*Route{
+				{
+					Name:               "route1",
+					Namespace:          "default",
+					PathMatchCondition: prefixSegment("/path1"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: ":authority", MatchType: HeaderMatchTypeRegex, Value: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.example\\.com(:[0-9]+)?"},
+					},
+					QueryParamMatchConditions: []QueryParamMatchCondition{
+						{Name: "param-1", Value: "value-1", MatchType: QueryParamMatchTypeExact},
+					},
+				},
+				{
+					Kind:               KindGRPCRoute,
+					Name:               "route2",
+					Namespace:          "default",
+					PathMatchCondition: prefixSegment("/path2"),
+					HeaderMatchConditions: []HeaderMatchCondition{
+						{Name: "version", Value: "2", MatchType: "exact", Invert: false},
+					},
+				},
+			},
+			routes: []*Route{
+				{
+					Kind:               KindGRPCRoute,
 					Name:               "route3",
 					Namespace:          "default",
 					PathMatchCondition: prefixSegment("/path2"),

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -40,8 +40,8 @@ const (
 	ReasonRouteRuleMatchConflict          gatewayapi_v1.RouteConditionReason = "RuleMatchConflict"
 	ReasonRouteRuleMatchPartiallyConflict gatewayapi_v1.RouteConditionReason = "RuleMatchPartiallyConflict"
 
-	MessageRouteRuleMatchConflict          string = "HTTPRoute's Match has conflict with other HTTPRoute's Match"
-	MessageRouteRuleMatchPartiallyConflict string = "Dropped Rule: HTTPRoute's rule(s) has(ve) been dropped because of conflict against other HTTPRoute's rule(s)"
+	MessageRouteRuleMatchConflict          string = "%s's Match has conflict with other %s's Match"
+	MessageRouteRuleMatchPartiallyConflict string = "Dropped Rule: %s's rule(s) has(ve) been dropped because of conflict against other %s's rule(s)"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/internal/status/routeconditions.go
+++ b/internal/status/routeconditions.go
@@ -41,7 +41,7 @@ const (
 	ReasonRouteRuleMatchPartiallyConflict gatewayapi_v1.RouteConditionReason = "RuleMatchPartiallyConflict"
 
 	MessageRouteRuleMatchConflict          string = "%s's Match has conflict with other %s's Match"
-	MessageRouteRuleMatchPartiallyConflict string = "Dropped Rule: %s's rule(s) has(ve) been dropped because of conflict against other %s's rule(s)"
+	MessageRouteRuleMatchPartiallyConflict string = "Dropped Rule: some of %s's rule(s) has(ve) been dropped because of conflict against other %s's rule(s)"
 )
 
 // RouteStatusUpdate represents an atomic update to a

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -395,6 +395,12 @@ func (f *Framework) CreateBackendTLSPolicyAndWaitFor(route *gatewayapi_v1alpha3.
 	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
 }
 
+// CreateGRPCRouteAndWaitFor creates the provided GRPCRoute in the Kubernetes API
+// and then waits for the specified condition to be true.
+func (f *Framework) CreateGRPCRouteAndWaitFor(route *gatewayapi_v1.GRPCRoute, condition func(*gatewayapi_v1.GRPCRoute) bool) bool {
+	return createAndWaitFor(f.t, f.Client, route, condition, f.RetryInterval, f.RetryTimeout)
+}
+
 // CreateNamespace creates a namespace with the given name in the
 // Kubernetes API or fails the test if it encounters an error.
 func (f *Framework) CreateNamespace(name string) {

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -185,6 +185,10 @@ var _ = Describe("Gateway API", func() {
 		f.NamespacedTest("gateway-httproute-conflict-match", testWithHTTPGateway(testHTTPRouteConflictMatch))
 
 		f.NamespacedTest("gateway-httproute-partially-conflict-match", testWithHTTPGateway(testHTTPRoutePartiallyConflictMatch))
+
+		f.NamespacedTest("gateway-grpcroute-conflict-match", testWithHTTPGateway(testGRPCRouteConflictMatch))
+
+		f.NamespacedTest("gateway-grpcroute-partially-conflict-match", testWithHTTPGateway(testGRPCRoutePartiallyConflictMatch))
 	})
 
 	Describe("Gateway with one HTTP listener and one HTTPS listener", func() {

--- a/test/e2e/gateway/grpc_route_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_conflict_match_test.go
@@ -1,0 +1,95 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+func testGRPCRouteConflictMatch(namespace string, gateway types.NamespacedName) {
+	Specify("Creates two GRPCRoutes, second one has conflict match against the first one, report Accepted: false", func() {
+		cleanup := f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+
+		By("create grpcroute-1 first")
+		route1 := &gatewayapi_v1.GRPCRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "grpcroute-1",
+			},
+			Spec: gatewayapi_v1.GRPCRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.GRPCRouteRule{{
+					Matches: []gatewayapi_v1.GRPCRouteMatch{
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "com.example.service", "Login"),
+						},
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "foo.com.example.service", "Login"),
+						},
+					},
+					BackendRefs: gatewayapi.GRPCRouteBackendRef("grpc-echo", 9000, 1),
+				}},
+			},
+		}
+		_, ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
+		require.True(f.T(), ok)
+
+		By("create grpcroute-2 with conflicted matches")
+		route2 := &gatewayapi_v1.GRPCRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "grpcroute-2",
+			},
+			Spec: gatewayapi_v1.GRPCRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.GRPCRouteRule{
+					{
+						Matches: []gatewayapi_v1.GRPCRouteMatch{
+							{
+								Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "com.example.service", "Login"),
+							},
+							{
+								Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "bar.com.example.service", "Login"),
+							},
+						},
+						BackendRefs: gatewayapi.GRPCRouteBackendRef("grpc-echo", 9000, 1),
+					},
+				},
+			},
+		}
+		_, ok = f.CreateGRPCRouteAndWaitFor(route2, e2e.GRPCRouteNotAcceptedDueToConflict)
+		require.True(f.T(), ok)
+
+		cleanup()
+	})
+}

--- a/test/e2e/gateway/grpc_route_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_conflict_match_test.go
@@ -56,7 +56,7 @@ func testGRPCRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				}},
 			},
 		}
-		_, ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
+		ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
 		require.True(f.T(), ok)
 
 		By("create grpcroute-2 with conflicted matches")
@@ -87,7 +87,7 @@ func testGRPCRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 				},
 			},
 		}
-		_, ok = f.CreateGRPCRouteAndWaitFor(route2, e2e.GRPCRouteNotAcceptedDueToConflict)
+		ok = f.CreateGRPCRouteAndWaitFor(route2, e2e.GRPCRouteNotAcceptedDueToConflict)
 		require.True(f.T(), ok)
 
 		cleanup()

--- a/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
@@ -1,0 +1,95 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package gateway
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/projectcontour/contour/internal/gatewayapi"
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+func testGRPCRoutePartiallyConflictMatch(namespace string, gateway types.NamespacedName) {
+	Specify("Creates two GRPCRoutes, second one has partial conflict match against the first one, has partially match condition", func() {
+		cleanup := f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+
+		By("create grpcroute-1 first")
+		route1 := &gatewayapi_v1.GRPCRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "grpcroute-1",
+			},
+			Spec: gatewayapi_v1.GRPCRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.GRPCRouteRule{{
+					Matches: []gatewayapi_v1.GRPCRouteMatch{
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "com.example.service", "Login"),
+						},
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "foo.com.example.service", "Login"),
+						},
+					},
+					BackendRefs: gatewayapi.GRPCRouteBackendRef("grpc-cho", 9000, 1),
+				}},
+			},
+		}
+		_, ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
+		require.True(f.T(), ok)
+
+		By("create grpcroute-2 with only partially conflicted matches")
+		route2 := &gatewayapi_v1.GRPCRoute{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "grpcroute-2",
+			},
+			Spec: gatewayapi_v1.GRPCRouteSpec{
+				Hostnames: []gatewayapi_v1.Hostname{"queryparams.gateway.projectcontour.io"},
+				CommonRouteSpec: gatewayapi_v1.CommonRouteSpec{
+					ParentRefs: []gatewayapi_v1.ParentReference{
+						gatewayapi.GatewayParentRef(gateway.Namespace, gateway.Name),
+					},
+				},
+				Rules: []gatewayapi_v1.GRPCRouteRule{{
+					Matches: []gatewayapi_v1.GRPCRouteMatch{
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "com.example.service", "Login"),
+						},
+						{
+							Method: gatewayapi.GRPCMethodMatch(gatewayapi_v1.GRPCMethodMatchExact, "foo.com.example.service", "Login"),
+						},
+					},
+					BackendRefs: gatewayapi.GRPCRouteBackendRef("grpc-cho", 9000, 1),
+				}},
+			},
+		}
+		// Partially accepted
+		f.CreateGRPCRouteAndWaitFor(route2, func(*gatewayapi_v1.GRPCRoute) bool {
+			return e2e.GRPCRoutePartiallyInvalid(route2) && e2e.GRPCRouteAccepted(route2)
+		})
+
+		cleanup()
+	})
+}

--- a/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
@@ -56,7 +56,7 @@ func testGRPCRoutePartiallyConflictMatch(namespace string, gateway types.Namespa
 				}},
 			},
 		}
-		_, ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
+		ok := f.CreateGRPCRouteAndWaitFor(route1, e2e.GRPCRouteAccepted)
 		require.True(f.T(), ok)
 
 		By("create grpcroute-2 with only partially conflicted matches")

--- a/test/e2e/gatewayapi_predicates.go
+++ b/test/e2e/gatewayapi_predicates.go
@@ -16,11 +16,14 @@
 package e2e
 
 import (
+	"fmt"
+
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapi_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapi_v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapi_v1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
 
+	"github.com/projectcontour/contour/internal/dag"
 	"github.com/projectcontour/contour/internal/status"
 )
 
@@ -131,7 +134,7 @@ func HTTPRouteNotAcceptedDueToConflict(route *gatewayapi_v1.HTTPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), status.MessageRouteRuleMatchConflict) {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), fmt.Sprintf(status.MessageRouteRuleMatchConflict, dag.KindHTTPRoute, dag.KindHTTPRoute)) {
 			return true
 		}
 	}
@@ -148,7 +151,7 @@ func HTTPRoutePartiallyInvalid(route *gatewayapi_v1.HTTPRoute) bool {
 	}
 
 	for _, gw := range route.Status.Parents {
-		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), status.MessageRouteRuleMatchPartiallyConflict) {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), fmt.Sprintf(status.MessageRouteRuleMatchPartiallyConflict, dag.KindHTTPRoute, dag.KindHTTPRoute)) {
 			return true
 		}
 	}
@@ -199,6 +202,56 @@ func TLSRouteAccepted(route *gatewayapi_v1alpha2.TLSRoute) bool {
 
 	for _, gw := range route.Status.Parents {
 		if conditionExists(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionTrue) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GRPCRouteAccepted returns true if the route has a .status.conditions
+// entry of "Accepted: true".
+func GRPCRouteAccepted(route *gatewayapi_v1.GRPCRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		if conditionExists(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionTrue) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GRPCRouteNotAcceptedDueToConflict returns true if the route has a .status.conditions
+// entry of "Accepted: false" && "Reason: RouteMatchConflict" && "Message: GRPCRoute's Match has
+// conflict with other GRPCRoute's Match".
+func GRPCRouteNotAcceptedDueToConflict(route *gatewayapi_v1.GRPCRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionAccepted), meta_v1.ConditionFalse, string(status.ReasonRouteRuleMatchConflict), fmt.Sprintf(status.MessageRouteRuleMatchConflict, dag.KindGRPCRoute, dag.KindGRPCRoute)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GRPCRoutePartiallyInvalid returns true if the route has a .status.conditions
+// entry of "PartiallyInvalid: true" && "Reason: RuleMatchPartiallyConflict" && "Message:
+// GRPCRoute's Match has partial conflict with other GRPCRoute's Match".
+func GRPCRoutePartiallyInvalid(route *gatewayapi_v1.GRPCRoute) bool {
+	if route == nil {
+		return false
+	}
+
+	for _, gw := range route.Status.Parents {
+		if conditionExistsWithAllKeys(gw.Conditions, string(gatewayapi_v1.RouteConditionPartiallyInvalid), meta_v1.ConditionTrue, string(status.ReasonRouteRuleMatchPartiallyConflict), fmt.Sprintf(status.MessageRouteRuleMatchPartiallyConflict, dag.KindGRPCRoute, dag.KindGRPCRoute)) {
 			return true
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/projectcontour/contour/issues/6267
Handle the match conflict of grpcroutes

It's possible that multiple GRPCRoutes will define the same Match conditions. In this case the following logic is applied to resolve the conflict:

- The oldest Route based on creation timestamp. For example, a Route with a creation timestamp of “2020-09-08 01:02:03” is given precedence over a Route with a creation timestamp of “2020-09-08 01:02:04”.
- The Route appearing first in alphabetical order (namespace/name) for example, foo/bar is given precedence over foo/baz.
