### PR TITLE
Update README.md to be more helpful

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,5 @@
 # Contour Documentation
 
-The contents of this directory have moved to [projectcontour.io](https://projectcontour.io/).
-Specifically;
+The contents of this directory have moved to corresponding directories in [../site/content](../site/content).
 
-* Guides and How-to's have moved to [projectcontour.io/guides](https://projectcontour.io/guides)
-* Versioned release documentation has moved to [projectcontour.io/docs](https://projectcontour.io/docs)
-* Project related and non-versioned documentation has moved to [projectcontour.io/resources](https://projectcontour.io/resources/) 
-
-For more about how we're thinking of Contour's future, check out [the design docs](../design/).
+For more information on how to contribute to the Contour documentation, see the [Contour Technical Documentation Contributing Guide](https://projectcontour.io/resources/contributing-docs/).


### PR DESCRIPTION
The docs/README.md made no sense. Anyone reading it in GitHub clearly wants to contribute to the documentation, that's why they're in the source code of Contour, why else would they have found their way to the source repository? So, it should point to where the documentation lives in the git repository, not to the website where it's served.