### PR TITLE
Use polling during startup to wait for informers to sync

### DIFF
--- a/changelogs/unreleased/6614-tsaarni-small.md
+++ b/changelogs/unreleased/6614-tsaarni-small.md
@@ -1,0 +1,1 @@
+Fixed a bug where follower Contour instance occasionally got stuck in a non-ready state when using `--watch-namespaces` flag.


### PR DESCRIPTION
This change will use polling for  `HasSynced()` call to align with how client-go's [`WaitForCacheSync()`](https://github.com/kubernetes/client-go/blob/690fd5274dfc971dcda653e45bc6e6852ab57316/tools/cache/shared_informer.go#L327-L343) operates. Previously it was only called when we received objects from the informer. By changing to polling, we prevent a race condition where Contour fails to recognize that the final object in the initial list has been received, which would prevent the xDS server from ever starting.

Fixes #6613 

## Details 

The startup of a follower instance depends on informers signaling that they have finished synchronizing resources with the API server. We use the [`SingleFileTracker`](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L63-L66) from client-go to track the processing of initial objects. This tracker increments when processing [starts](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L100) on a resource and decrements when its [finished](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L198). 

The [`HasSynced()`](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L202) method should ideally report synchronization status `true` right after [`Finished()`](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L198) is called for the last resource in the initial list (tracker reaches zero). However, in some cases it fails to report `true` immediately, causig the [boolean trigger](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L203) that starts the xDS server to never be set.

In case of a leader instance, an [extra update](https://github.com/projectcontour/contour/blob/f9b6f6fdfdd83d3639f6e8c55836401d749c19e1/internal/contour/handler.go#L123-L127) triggered by the leader selection itself has ensured that the xDS server starts.

