### PR TITLE
[api-gateway]: Support http(s) as AppProtocol in Kubernetes svc

### DIFF
--- a/changelogs/unreleased/6616-Krast76-small.md
+++ b/changelogs/unreleased/6616-Krast76-small.md
@@ -1,0 +1,1 @@
+Contour, support http and https as AppProtocol in k8s' services

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -110,8 +110,8 @@ func validateExternalName(svc *core_v1.Service, enableExternalNameSvc bool) erro
 const (
 	protoK8sH2C  = "kubernetes.io/h2c"
 	protoK8sWS   = "kubernetes.io/ws"
-	protoHttps   = "https"
-	protoHttp = "http"
+	protoHTTPS   = "https"
+	protoHTTP = "http"
 )
 
 func toContourProtocol(appProtocol string) (string, bool) {
@@ -119,8 +119,8 @@ func toContourProtocol(appProtocol string) (string, bool) {
 		// *NOTE: for gateway-api: the websocket is enabled by default
 		protoK8sWS:   "",
 		protoK8sH2C:  "h2c",
-		protoHttp:    "",
-		protoHttps:   "tls",
+		protoHTTP:    "",
+		protoHTTPS:   "tls",
 	}[appProtocol]
 	return proto, ok
 }

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -111,7 +111,7 @@ const (
 	protoK8sH2C  = "kubernetes.io/h2c"
 	protoK8sWS   = "kubernetes.io/ws"
 	protoHttps   = "https"
-	protoWebHttp = "http"
+	protoHttp = "http"
 )
 
 func toContourProtocol(appProtocol string) (string, bool) {

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -108,15 +108,21 @@ func validateExternalName(svc *core_v1.Service, enableExternalNameSvc bool) erro
 
 // the ServicePort's AppProtocol must be one of the these.
 const (
-	protoK8sH2C = "kubernetes.io/h2c"
-	protoK8sWS  = "kubernetes.io/ws"
+	protoK8sH2C  = "kubernetes.io/h2c"
+	protoK8sWS   = "kubernetes.io/ws"
+	protoHttp    = "www-http"
+	protoHttps   = "https"
+	protoWebHttp = "http"
 )
 
 func toContourProtocol(appProtocol string) (string, bool) {
 	proto, ok := map[string]string{
 		// *NOTE: for gateway-api: the websocket is enabled by default
-		protoK8sWS:  "",
-		protoK8sH2C: "h2c",
+		protoK8sWS:   "",
+		protoK8sH2C:  "h2c",
+		protoHttp:    "",
+		protoHttps:   "tls",
+		protoWebHttp: "",
 	}[appProtocol]
 	return proto, ok
 }

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -108,19 +108,19 @@ func validateExternalName(svc *core_v1.Service, enableExternalNameSvc bool) erro
 
 // the ServicePort's AppProtocol must be one of the these.
 const (
-	protoK8sH2C  = "kubernetes.io/h2c"
-	protoK8sWS   = "kubernetes.io/ws"
-	protoHTTPS   = "https"
-	protoHTTP = "http"
+	protoK8sH2C = "kubernetes.io/h2c"
+	protoK8sWS  = "kubernetes.io/ws"
+	protoHTTPS  = "https"
+	protoHTTP   = "http"
 )
 
 func toContourProtocol(appProtocol string) (string, bool) {
 	proto, ok := map[string]string{
 		// *NOTE: for gateway-api: the websocket is enabled by default
-		protoK8sWS:   "",
-		protoK8sH2C:  "h2c",
-		protoHTTP:    "",
-		protoHTTPS:   "tls",
+		protoK8sWS:  "",
+		protoK8sH2C: "h2c",
+		protoHTTP:   "",
+		protoHTTPS:  "tls",
 	}[appProtocol]
 	return proto, ok
 }

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -110,7 +110,6 @@ func validateExternalName(svc *core_v1.Service, enableExternalNameSvc bool) erro
 const (
 	protoK8sH2C  = "kubernetes.io/h2c"
 	protoK8sWS   = "kubernetes.io/ws"
-	protoHttp    = "www-http"
 	protoHttps   = "https"
 	protoWebHttp = "http"
 )
@@ -122,7 +121,6 @@ func toContourProtocol(appProtocol string) (string, bool) {
 		protoK8sH2C:  "h2c",
 		protoHttp:    "",
 		protoHttps:   "tls",
-		protoWebHttp: "",
 	}[appProtocol]
 	return proto, ok
 }

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -127,6 +127,18 @@ func TestBuilderLookupService(t *testing.T) {
 					AppProtocol: ptr.To("kubernetes.io/wss"),
 					Port:        8444,
 				},
+				{
+					Name:        "iana-https",
+					Protocol:    "TCP",
+					AppProtocol: ptr.To("https"),
+					Port:        8445,
+				},
+				{
+					Name:        "iana-http",
+					Protocol:    "TCP",
+					AppProtocol: ptr.To("http"),
+					Port:        8446,
+				},
 			},
 		},
 	}
@@ -217,6 +229,16 @@ func TestBuilderLookupService(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: appProtoService.Name, Namespace: appProtoService.Namespace},
 			port:           8444,
 			want:           appProtcolService(appProtoService, "", 1),
+		},
+		"lookup service by port number with supported IANA app protocol: https": {
+			NamespacedName: types.NamespacedName{Name: appProtoService.Name, Namespace: appProtoService.Namespace},
+			port:           8445,
+			want:           appProtcolService(appProtoService, "tls", 2),
+		},
+		"lookup service by port number with supported IANA app protocol: http": {
+			NamespacedName: types.NamespacedName{Name: appProtoService.Name, Namespace: appProtoService.Namespace},
+			port:           8446,
+			want:           appProtcolService(appProtoService, "", 3),
 		},
 	}
 


### PR DESCRIPTION
When contour is used as api-gateway in kubernetes clusters, appProtocol set to http or https doesn't work.
This PR, if applied, allow the following protocol (as defined by [IANA](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=https)) : 

- http and www-http
- https

That doesn't allow all the IANA services, but that'll support a common case


Fix #6560 