### PR TITLE
Bump Envoy to v1.32.0

### DIFF
--- a/changelogs/unreleased/6714-tsaarni-small.md
+++ b/changelogs/unreleased/6714-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.32.0. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.32.0/version_history/v1.32/v1.32.0) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.31.0",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.32.0",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.0
+        image: docker.io/envoyproxy/envoy:v1.32.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.31.0
+          image: docker.io/envoyproxy/envoy:v1.32.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9310,7 +9310,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.31.0
+          image: docker.io/envoyproxy/envoy:v1.32.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9114,7 +9114,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.0
+        image: docker.io/envoyproxy/envoy:v1.32.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9298,7 +9298,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.0
+        image: docker.io/envoyproxy/envoy:v1.32.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.31.0][60]         | 1.31, 1.30, 1.29    | [1.1.0][111]        |
+| main            | [1.32.0][62]         | 1.31, 1.30, 1.29    | [1.1.0][111]        |
 | 1.30.0          | [1.31.0][60]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
 | 1.29.2          | [1.30.4][59]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.1          | [1.30.2][56]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
@@ -207,6 +207,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [59]: https://www.envoyproxy.io/docs/envoy/v1.30.4/version_history/v1.30/v1.30.4
 [60]: https://www.envoyproxy.io/docs/envoy/v1.31.0/version_history/v1.31/v1.31.0
 [61]: https://www.envoyproxy.io/docs/envoy/v1.29.7/version_history/v1.29/v1.29.7
+[62]: https://www.envoyproxy.io/docs/envoy/v1.32.0/version_history/v1.32/v1.32.0
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.31.0"
+      envoy: "1.32.0"
       kubernetes:
         - "1.30"
         - "1.29"
@@ -826,4 +826,3 @@ versions:
       gateway-api:
         - NA
       contour-operator: NA
-


### PR DESCRIPTION
This change updates envoy in `main` branch to v1.32.0.