### PR TITLE
Bump Go to 1.23.2

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.5
+  GO_VERSION: 1.23.2
 
 jobs:
   e2e-contour-xds:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.5
+  GO_VERSION: 1.23.2
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.5
+  GO_VERSION: 1.23.2
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.5
+  GO_VERSION: 1.23.2
 
 jobs:
   lint:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -29,8 +29,8 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
-        version: v1.56.2
-        args: --build-tags=e2e,conformance,tools,gcp,oidc,none --out-format=colored-line-number
+        version: v1.61.0
+        args: --build-tags=e2e,conformance,gcp,oidc,none --out-format=colored-line-number
   codespell:
     name: Codespell
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.22.5@sha256:829eff99a4b2abffe68f6a3847337bf6455d69d17e49ec1a97dac78834754bd6
+BUILD_BASE_IMAGE ?= golang:1.23.2@sha256:858ab89651d8a3d637da5580e71fdec40b5aefbb148ba50b9a629bd079a14bcd
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ lint-codespell:
 .PHONY: lint-golint
 lint-golint:
 	@echo Running Go linter ...
-	@./hack/golangci-lint run --build-tags=e2e,conformance,tools,gcp,oidc,none
+	@./hack/golangci-lint run --build-tags=e2e,conformance,gcp,oidc,none
 
 .PHONY: lint-yamllint
 lint-yamllint:

--- a/changelogs/unreleased/6718-tsaarni-small.md
+++ b/changelogs/unreleased/6718-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updateds to Go 1.23.2. See the [Go release notes](https://go.dev/doc/devel/release#go1.23.0) for more information.

--- a/cmd/contour/contour.go
+++ b/cmd/contour/contour.go
@@ -161,7 +161,7 @@ func main() {
 		// Reinitialize with the target debug level.
 		k8s.InitLogging(
 			k8s.LogWriterOption(log.WithField("context", "kubernetes")),
-			k8s.LogLevelOption(int(serveCtx.KubernetesDebug)),
+			k8s.LogLevelOption(int(serveCtx.KubernetesDebug)), //nolint:gosec // disable G115
 		)
 
 		log.Infof("args: %v", args)

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 "$@"
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 "$@"

--- a/internal/annotation/annotations.go
+++ b/internal/annotation/annotations.go
@@ -188,6 +188,11 @@ func NumRetries(i *networking_v1.Ingress) uint32 {
 		return 1
 	}
 
+	// If set to other negative value than 1, then fall back to Envoy default.
+	if val < 0 {
+		return 1
+	}
+
 	return uint32(val)
 }
 

--- a/internal/dag/builder_test.go
+++ b/internal/dag/builder_test.go
@@ -16164,7 +16164,7 @@ func makeHTTPRoute(name, namespace, hostname string, firstRule gatewayapi_v1.HTT
 	}
 }
 
-func makeHTTPRouteRule(pathType gatewayapi_v1.PathMatchType, pathValue, serviceName string, port int, weight int32) gatewayapi_v1.HTTPRouteRule {
+func makeHTTPRouteRule(pathType gatewayapi_v1.PathMatchType, pathValue, serviceName string, port uint16, weight int32) gatewayapi_v1.HTTPRouteRule {
 	return gatewayapi_v1.HTTPRouteRule{
 		Matches:     gatewayapi.HTTPRouteMatch(pathType, pathValue),
 		BackendRefs: gatewayapi.HTTPBackendRef(serviceName, port, weight),

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -579,7 +579,7 @@ type HeaderValueMatchDescriptorEntry struct {
 	Value       string
 }
 
-type VhRateLimitsType int
+type VhRateLimitsType int32
 
 const (
 	// VhRateLimitsOverride (Default) will use the virtual host rate limits unless the route has a rate limit policy.

--- a/internal/dag/gatewayapi_processor.go
+++ b/internal/dag/gatewayapi_processor.go
@@ -175,7 +175,7 @@ func (p *GatewayAPIProcessor) Run(dag *DAG, source *KubernetesCache) {
 	}
 
 	for listenerName, attachedRoutes := range listenerAttachedRoutes {
-		gwAccessor.SetListenerAttachedRoutes(listenerName, attachedRoutes)
+		gwAccessor.SetListenerAttachedRoutes(listenerName, int32(attachedRoutes)) //nolint:gosec // disable G115
 	}
 
 	p.computeGatewayConditions(gwAccessor, gatewayNotProgrammedCondition)
@@ -1034,7 +1034,7 @@ func (p *GatewayAPIProcessor) computeTLSRouteForListener(route *gatewayapi_v1alp
 			// Route defaults to a weight of "1" unless otherwise specified.
 			routeWeight := uint32(1)
 			if backendRef.Weight != nil {
-				routeWeight = uint32(*backendRef.Weight)
+				routeWeight = uint32(*backendRef.Weight) //nolint:gosec // disable G115
 			}
 
 			// Keep track of all the weights for this set of backendRefs. This will be
@@ -1299,7 +1299,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 
 				var portNumber uint32
 				if filter.RequestRedirect.Port != nil {
-					portNumber = uint32(*filter.RequestRedirect.Port)
+					portNumber = uint32(*filter.RequestRedirect.Port) //nolint:gosec // disable G115
 				}
 
 				var scheme string
@@ -1440,7 +1440,7 @@ func (p *GatewayAPIProcessor) computeHTTPRouteForListener(
 		// index of the rule to ensure rules that come first have a higher
 		// priority. All dag.Routes generated from a single HTTPRoute rule have
 		// the same priority.
-		priority := uint8(ruleIndex)
+		priority := uint8(ruleIndex) //nolint:gosec // disable G115
 
 		// Get our list of routes based on whether it's a redirect or a cluster-backed route.
 		// Note that we can end up with multiple routes here since the match conditions are
@@ -1632,7 +1632,7 @@ func (p *GatewayAPIProcessor) computeGRPCRouteForListener(route *gatewayapi_v1.G
 		// index of the rule to ensure rules that come first have a higher
 		// priority. All dag.Routes generated from a single GRPCRoute rule have
 		// the same priority.
-		priority := uint8(ruleIndex)
+		priority := uint8(ruleIndex) //nolint:gosec // disable G115
 
 		// Note that we can end up with multiple routes here since the match conditions are
 		// logically "OR"-ed, which we express as multiple routes, each with one of the
@@ -1799,7 +1799,7 @@ func (p *GatewayAPIProcessor) computeTCPRouteForListener(route *gatewayapi_v1alp
 		// Route defaults to a weight of "1" unless otherwise specified.
 		routeWeight := uint32(1)
 		if backendRef.Weight != nil {
-			routeWeight = uint32(*backendRef.Weight)
+			routeWeight = uint32(*backendRef.Weight) //nolint:gosec // disable G115
 		}
 
 		// Keep track of all the weights for this set of backendRefs. This will be
@@ -2133,7 +2133,7 @@ func (p *GatewayAPIProcessor) httpClusters(routeNamespace string, backendRefs []
 		// Route defaults to a weight of "1" unless otherwise specified.
 		routeWeight := uint32(1)
 		if backendRef.Weight != nil {
-			routeWeight = uint32(*backendRef.Weight)
+			routeWeight = uint32(*backendRef.Weight) //nolint:gosec // disable G115
 		}
 
 		// Keep track of all the weights for this set of backend refs. This will be
@@ -2332,7 +2332,7 @@ func (p *GatewayAPIProcessor) grpcClusters(routeNamespace string, backendRefs []
 		// Route defaults to a weight of "1" unless otherwise specified.
 		routeWeight := uint32(1)
 		if backendRef.Weight != nil {
-			routeWeight = uint32(*backendRef.Weight)
+			routeWeight = uint32(*backendRef.Weight) //nolint:gosec // disable G115
 		}
 
 		// Keep track of all the weights for this set of backend refs. This will be

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -918,7 +918,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 
 		healthPolicy, err := httpHealthCheckPolicy(route.HealthCheckPolicy)
 		if err != nil {
-			validCond.AddErrorf(contour_v1.ConditionTypeRouteError, "HealthCheckPolicyInvalid", err.Error())
+			validCond.AddError(contour_v1.ConditionTypeRouteError, "HealthCheckPolicyInvalid", err.Error())
 			return nil
 		}
 

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1023,7 +1023,7 @@ func (p *HTTPProxyProcessor) computeRoutes(
 			c := &Cluster{
 				Upstream:                      s,
 				LoadBalancerPolicy:            lbPolicy,
-				Weight:                        uint32(service.Weight),
+				Weight:                        uint32(service.Weight), //nolint:gosec // disable G115
 				HTTPHealthCheckPolicy:         healthPolicy,
 				UpstreamValidation:            uv,
 				RequestHeadersPolicy:          reqHP,
@@ -1236,7 +1236,7 @@ func (p *HTTPProxyProcessor) processHTTPProxyTCPProxy(validCond *contour_v1.Deta
 
 			proxy.Clusters = append(proxy.Clusters, &Cluster{
 				Upstream:             s,
-				Weight:               uint32(service.Weight),
+				Weight:               uint32(service.Weight), //nolint:gosec // disable G115
 				Protocol:             protocol,
 				LoadBalancerPolicy:   lbPolicy,
 				TCPHealthCheckPolicy: healthPolicy,
@@ -1926,7 +1926,7 @@ func redirectRoutePolicy(redirect *contour_v1.HTTPRequestRedirectPolicy) (*Redir
 
 	var portNumber uint32
 	if redirect.Port != nil {
-		portNumber = uint32(*redirect.Port)
+		portNumber = uint32(*redirect.Port) //nolint:gosec // disable G115
 	}
 
 	var scheme string
@@ -1971,7 +1971,7 @@ func directResponsePolicy(direct *contour_v1.HTTPDirectResponsePolicy) *DirectRe
 		return nil
 	}
 
-	return directResponse(uint32(direct.StatusCode), direct.Body)
+	return directResponse(uint32(direct.StatusCode), direct.Body) //nolint:gosec // disable G115
 }
 
 func internalRedirectPolicy(internal *contour_v1.HTTPInternalRedirectPolicy) *InternalRedirectPolicy {

--- a/internal/dag/policy.go
+++ b/internal/dag/policy.go
@@ -93,6 +93,7 @@ func retryPolicy(rp *contour_v1.RetryPolicy) *RetryPolicy {
 	// If set to -1, then retries set to 0. If set to 0 or
 	// not supplied, the value is set to the Envoy default of 1.
 	// Otherwise the value supplied is returned.
+	// CRD validation guarantees -1 is the minimum value.
 	switch rp.NumRetries {
 	case -1:
 		numRetries = 0
@@ -103,7 +104,7 @@ func retryPolicy(rp *contour_v1.RetryPolicy) *RetryPolicy {
 	return &RetryPolicy{
 		RetryOn:              retryOn(rp.RetryOn),
 		RetriableStatusCodes: rp.RetriableStatusCodes,
-		NumRetries:           uint32(numRetries),
+		NumRetries:           uint32(numRetries), //nolint:gosec // disable G115
 		PerTryTimeout:        perTryTimeout,
 	}
 }
@@ -512,8 +513,8 @@ func httpHealthCheckPolicy(hc *contour_v1.HTTPHealthCheckPolicy) (*HTTPHealthChe
 		Host:               hc.Host,
 		Interval:           time.Duration(hc.IntervalSeconds) * time.Second,
 		Timeout:            time.Duration(hc.TimeoutSeconds) * time.Second,
-		UnhealthyThreshold: uint32(hc.UnhealthyThresholdCount),
-		HealthyThreshold:   uint32(hc.HealthyThresholdCount),
+		UnhealthyThreshold: uint32(hc.UnhealthyThresholdCount), //nolint:gosec // disable G115
+		HealthyThreshold:   uint32(hc.HealthyThresholdCount),   //nolint:gosec // disable G115
 		ExpectedStatuses:   expectedStatuses,
 	}, nil
 }

--- a/internal/dag/status_test.go
+++ b/internal/dag/status_test.go
@@ -5168,7 +5168,7 @@ func TestDAGStatus(t *testing.T) {
 	})
 }
 
-func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v1.ProtocolType, attachedRoutes int) []*status.GatewayStatusUpdate {
+func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v1.ProtocolType, attachedRoutes int32) []*status.GatewayStatusUpdate {
 	var supportedKinds []gatewayapi_v1.RouteGroupKind
 
 	switch listenerProtocol {
@@ -5218,7 +5218,7 @@ func validGatewayStatusUpdate(listenerName string, listenerProtocol gatewayapi_v
 			ListenerStatus: map[string]*gatewayapi_v1.ListenerStatus{
 				listenerName: {
 					Name:           gatewayapi_v1.SectionName(listenerName),
-					AttachedRoutes: int32(attachedRoutes),
+					AttachedRoutes: attachedRoutes,
 					SupportedKinds: supportedKinds,
 					Conditions:     listenerValidConditions(),
 				},

--- a/internal/envoy/v3/endpoint.go
+++ b/internal/envoy/v3/endpoint.go
@@ -40,7 +40,7 @@ func HealthCheckConfig(healthCheckPort int32) *envoy_config_endpoint_v3.Endpoint
 		return nil
 	}
 	return &envoy_config_endpoint_v3.Endpoint_HealthCheckConfig{
-		PortValue: uint32(healthCheckPort),
+		PortValue: uint32(healthCheckPort), //nolint:gosec // disable G115
 	}
 }
 

--- a/internal/envoy/v3/listener.go
+++ b/internal/envoy/v3/listener.go
@@ -685,6 +685,7 @@ func UnixSocketAddress(address string) *envoy_config_core_v3.Address {
 
 // SocketAddress creates a new TCP envoy_config_core_v3.Address.
 func SocketAddress(address string, port int) *envoy_config_core_v3.Address {
+	portValue := uint32(port) //nolint:gosec // disable G115
 	if address == "::" {
 		return &envoy_config_core_v3.Address{
 			Address: &envoy_config_core_v3.Address_SocketAddress{
@@ -693,7 +694,7 @@ func SocketAddress(address string, port int) *envoy_config_core_v3.Address {
 					Address:    address,
 					Ipv4Compat: true,
 					PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
-						PortValue: uint32(port),
+						PortValue: portValue,
 					},
 				},
 			},
@@ -705,7 +706,7 @@ func SocketAddress(address string, port int) *envoy_config_core_v3.Address {
 				Protocol: envoy_config_core_v3.SocketAddress_TCP,
 				Address:  address,
 				PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
-					PortValue: uint32(port),
+					PortValue: portValue,
 				},
 			},
 		},

--- a/internal/envoy/v3/ratelimit.go
+++ b/internal/envoy/v3/ratelimit.go
@@ -64,7 +64,7 @@ func LocalRateLimitConfig(config *dag.LocalRateLimitPolicy, statPrefix string) *
 
 	// Envoy defaults to 429 (Too Many Requests) if this is not specified.
 	if config.ResponseStatusCode > 0 {
-		c.Status = &envoy_type_v3.HttpStatus{Code: envoy_type_v3.StatusCode(config.ResponseStatusCode)}
+		c.Status = &envoy_type_v3.HttpStatus{Code: envoy_type_v3.StatusCode(config.ResponseStatusCode)} //nolint:gosec // disable G115
 	}
 
 	return protobuf.MustMarshalAny(c)

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -229,7 +229,7 @@ func ipFilterConfig(allow bool, rules []dag.IPFilterRule) *envoy_filter_http_rba
 		prefixLen, _ := f.CIDR.Mask.Size()
 		cidr := &envoy_config_core_v3.CidrRange{
 			AddressPrefix: f.CIDR.IP.String(),
-			PrefixLen:     wrapperspb.UInt32(uint32(prefixLen)),
+			PrefixLen:     wrapperspb.UInt32(uint32(prefixLen)), //nolint:gosec // disable G115
 		}
 
 		if f.Remote {
@@ -518,7 +518,7 @@ func mirrorPolicy(r *dag.Route) []*envoy_config_route_v3.RouteAction_RequestMirr
 			Cluster: envoy.Clustername(mp.Cluster),
 			RuntimeFraction: &envoy_config_core_v3.RuntimeFractionalPercent{
 				DefaultValue: &envoy_type_v3.FractionalPercent{
-					Numerator:   uint32(mp.Weight),
+					Numerator:   uint32(mp.Weight), //nolint:gosec // disable G115
 					Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
 				},
 			},

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -286,12 +286,12 @@ func withIdleTimeout(route *envoy_config_route_v3.Route_Route, timeout time.Dura
 	return route
 }
 
-func withMirrorPolicy(route *envoy_config_route_v3.Route_Route, mirror string, weight int64) *envoy_config_route_v3.Route_Route {
+func withMirrorPolicy(route *envoy_config_route_v3.Route_Route, mirror string, weight uint32) *envoy_config_route_v3.Route_Route {
 	route.Route.RequestMirrorPolicies = []*envoy_config_route_v3.RouteAction_RequestMirrorPolicy{{
 		Cluster: mirror,
 		RuntimeFraction: &envoy_config_core_v3.RuntimeFractionalPercent{
 			DefaultValue: &envoy_type_v3.FractionalPercent{
-				Numerator:   uint32(weight),
+				Numerator:   weight,
 				Denominator: envoy_type_v3.FractionalPercent_HUNDRED,
 			},
 		},

--- a/internal/featuretests/v3/featuretests.go
+++ b/internal/featuretests/v3/featuretests.go
@@ -321,7 +321,7 @@ func (s *StatusResult) Equals(want contour_v1.HTTPProxyStatus) *Contour {
 	// We should never get an error fetching the status for an
 	// object, so make it fatal if we do.
 	if s.Err != nil {
-		s.T.Fatalf(s.Err.Error())
+		s.T.Fatal(s.Err.Error())
 	}
 
 	assert.Equal(s.T, want, *s.Have)
@@ -336,7 +336,7 @@ func (s *StatusResult) Like(want contour_v1.HTTPProxyStatus) *Contour {
 	// We should never get an error fetching the status for an
 	// object, so make it fatal if we do.
 	if s.Err != nil {
-		s.T.Fatalf(s.Err.Error())
+		s.T.Fatal(s.Err.Error())
 	}
 
 	if len(want.CurrentStatus) > 0 {

--- a/internal/gatewayapi/helpers.go
+++ b/internal/gatewayapi/helpers.go
@@ -47,7 +47,7 @@ func GatewayParentRef(namespace, name string) gatewayapi_v1.ParentReference {
 	return parentRef
 }
 
-func GatewayListenerParentRef(namespace, name, listener string, port int) gatewayapi_v1.ParentReference {
+func GatewayListenerParentRef(namespace, name, listener string, port uint16) gatewayapi_v1.ParentReference {
 	parentRef := GatewayParentRef(namespace, name)
 
 	if listener != "" {
@@ -61,7 +61,7 @@ func GatewayListenerParentRef(namespace, name, listener string, port int) gatewa
 	return parentRef
 }
 
-func ServiceBackendObjectRef(name string, port int) gatewayapi_v1.BackendObjectReference {
+func ServiceBackendObjectRef(name string, port uint16) gatewayapi_v1.BackendObjectReference {
 	return gatewayapi_v1.BackendObjectReference{
 		Group: ptr.To(gatewayapi_v1.Group("")),
 		Kind:  ptr.To(gatewayapi_v1.Kind("Service")),
@@ -114,7 +114,7 @@ func HTTPBackendRefs(backendRefs ...[]gatewayapi_v1.HTTPBackendRef) []gatewayapi
 	return res
 }
 
-func HTTPBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1.HTTPBackendRef {
+func HTTPBackendRef(serviceName string, port uint16, weight int32) []gatewayapi_v1.HTTPBackendRef {
 	return []gatewayapi_v1.HTTPBackendRef{
 		{
 			BackendRef: gatewayapi_v1.BackendRef{
@@ -134,7 +134,7 @@ func TLSRouteBackendRefs(backendRefs ...[]gatewayapi_v1.BackendRef) []gatewayapi
 	return res
 }
 
-func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayapi_v1.BackendRef {
+func TLSRouteBackendRef(serviceName string, port uint16, weight *int32) []gatewayapi_v1.BackendRef {
 	return []gatewayapi_v1.BackendRef{
 		{
 			BackendObjectReference: gatewayapi_v1.BackendObjectReference{
@@ -148,7 +148,7 @@ func TLSRouteBackendRef(serviceName string, port int, weight *int32) []gatewayap
 	}
 }
 
-func GRPCRouteBackendRef(serviceName string, port int, weight int32) []gatewayapi_v1.GRPCBackendRef {
+func GRPCRouteBackendRef(serviceName string, port uint16, weight int32) []gatewayapi_v1.GRPCBackendRef {
 	return []gatewayapi_v1.GRPCBackendRef{
 		{
 			BackendRef: gatewayapi_v1.BackendRef{

--- a/internal/k8s/log_test.go
+++ b/internal/k8s/log_test.go
@@ -159,7 +159,7 @@ func TestLogLevelOptionKlog(t *testing.T) {
 			InitLogging(LogWriterOption(l), LogLevelOption(logLevel))
 			// Make sure log verbosity is set properly.
 			for verbosityLevel := 0; verbosityLevel <= 10; verbosityLevel++ {
-				enabled := klog.V(klog.Level(verbosityLevel)).Enabled()
+				enabled := klog.V(klog.Level(verbosityLevel)).Enabled() //nolint:gosec // disable G115
 				if verbosityLevel <= logLevel {
 					assert.True(t, enabled)
 				} else {

--- a/internal/provisioner/model/model.go
+++ b/internal/provisioner/model/model.go
@@ -136,7 +136,7 @@ func (c *Contour) EnvoyTolerationsExist() bool {
 }
 
 func (c *Contour) WatchAllNamespaces() bool {
-	return c.Spec.WatchNamespaces == nil || len(c.Spec.WatchNamespaces) == 0
+	return len(c.Spec.WatchNamespaces) == 0
 }
 
 // ContourSpec defines the desired state of Contour.

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -149,12 +149,12 @@ func desiredContainers(contour *model.Contour, contourImage, envoyImage string) 
 
 		if contour.Spec.RuntimeSettings.Envoy.Metrics != nil &&
 			contour.Spec.RuntimeSettings.Envoy.Metrics.Port > 0 {
-			metricsPort = int32(contour.Spec.RuntimeSettings.Envoy.Metrics.Port)
+			metricsPort = int32(contour.Spec.RuntimeSettings.Envoy.Metrics.Port) //nolint:gosec // disable G115
 		}
 
 		if contour.Spec.RuntimeSettings.Envoy.Health != nil &&
 			contour.Spec.RuntimeSettings.Envoy.Health.Port > 0 {
-			healthPort = contour.Spec.RuntimeSettings.Envoy.Health.Port
+			healthPort = int32(contour.Spec.RuntimeSettings.Envoy.Health.Port) //nolint:gosec // disable G115
 		}
 	}
 
@@ -235,7 +235,7 @@ func desiredContainers(contour *model.Contour, contourImage, envoyImage string) 
 					HTTPGet: &core_v1.HTTPGetAction{
 						Scheme: core_v1.URISchemeHTTP,
 						Path:   "/ready",
-						Port:   intstr.IntOrString{IntVal: int32(healthPort)},
+						Port:   intstr.IntOrString{IntVal: healthPort},
 					},
 				},
 				InitialDelaySeconds: int32(3),

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -362,7 +362,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 	checkDaemonSetHasEnvVar(t, ds, EnvoyContainerName, envoyPodEnvVar)
 	checkDaemonSetHasEnvVar(t, ds, envoyInitContainerName, envoyNsEnvVar)
 	checkDaemonSetHasLabels(t, ds, cntr.WorkloadLabels())
-	checkContainerHasPort(t, ds, int32(cntr.Spec.RuntimeSettings.Envoy.Metrics.Port))
+	checkContainerHasPort(t, ds, int32(cntr.Spec.RuntimeSettings.Envoy.Metrics.Port)) //nolint:gosec // disable G115
 
 	checkDaemonSetHasNodeSelector(t, ds, nil)
 	checkDaemonSetHasTolerations(t, ds, nil)

--- a/internal/provisioner/objects/deployment/deployment.go
+++ b/internal/provisioner/objects/deployment/deployment.go
@@ -110,7 +110,7 @@ func DesiredDeployment(contour *model.Contour, image string) *apps_v1.Deployment
 		args = append(args, fmt.Sprintf("--watch-namespaces=%s", strings.Join(ns, ",")))
 	}
 
-	if contour.Spec.DisabledFeatures != nil && len(contour.Spec.DisabledFeatures) > 0 {
+	if len(contour.Spec.DisabledFeatures) > 0 {
 		for _, f := range contour.Spec.DisabledFeatures {
 			args = append(args, fmt.Sprintf("--disable-feature=%s", string(f)))
 		}

--- a/internal/provisioner/objects/object.go
+++ b/internal/provisioner/objects/object.go
@@ -37,7 +37,7 @@ const (
 	EnvoyMetricsPort = int32(8002)
 
 	// EnvoyHealthPort is the network port number of Envoy's health listener.
-	EnvoyHealthPort = 8002
+	EnvoyHealthPort = int32(8002)
 )
 
 // NewUnprivilegedPodSecurity makes a a non-root PodSecurityContext object

--- a/internal/status/gatewaystatus.go
+++ b/internal/status/gatewaystatus.go
@@ -80,7 +80,7 @@ func (gatewayUpdate *GatewayStatusUpdate) SetListenerSupportedKinds(listenerName
 	}
 }
 
-func (gatewayUpdate *GatewayStatusUpdate) SetListenerAttachedRoutes(listenerName string, numRoutes int) {
+func (gatewayUpdate *GatewayStatusUpdate) SetListenerAttachedRoutes(listenerName string, numRoutes int32) {
 	if gatewayUpdate.ListenerStatus == nil {
 		gatewayUpdate.ListenerStatus = map[string]*gatewayapi_v1.ListenerStatus{}
 	}
@@ -90,7 +90,7 @@ func (gatewayUpdate *GatewayStatusUpdate) SetListenerAttachedRoutes(listenerName
 		}
 	}
 
-	gatewayUpdate.ListenerStatus[listenerName].AttachedRoutes = int32(numRoutes)
+	gatewayUpdate.ListenerStatus[listenerName].AttachedRoutes = numRoutes
 }
 
 // AddListenerCondition adds a Condition for the specified listener.

--- a/internal/xds/v3/callbacks_test.go
+++ b/internal/xds/v3/callbacks_test.go
@@ -15,7 +15,6 @@ package v3
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -168,7 +167,7 @@ func TestLogDiscoveryRequestDetails(t *testing.T) {
 					break
 				}
 			}
-			assert.NotNil(t, logEntry, fmt.Sprintf("no log line with expected message %q", tc.expectedLogMsg))
+			assert.NotNil(t, logEntry, "no log line with expected message %q", tc.expectedLogMsg)
 			assert.Equal(t, tc.expectedLogData, logEntry.Data)
 			logHook.Reset()
 		})

--- a/internal/xdscache/v3/endpointstranslator_test.go
+++ b/internal/xdscache/v3/endpointstranslator_test.go
@@ -1087,13 +1087,13 @@ func clusterloadassignments(clas ...*envoy_config_endpoint_v3.ClusterLoadAssignm
 	return m
 }
 
-func weightedHealthcheckEndpoints(weight uint32, healthcheckPort int32, addrs ...*envoy_config_core_v3.Address) []*envoy_config_endpoint_v3.LocalityLbEndpoints {
+func weightedHealthcheckEndpoints(weight, healthcheckPort uint32, addrs ...*envoy_config_core_v3.Address) []*envoy_config_endpoint_v3.LocalityLbEndpoints {
 	lbendpoints := healthcheckEndpoints(healthcheckPort, addrs...)
 	lbendpoints[0].LoadBalancingWeight = wrapperspb.UInt32(weight)
 	return lbendpoints
 }
 
-func healthcheckEndpoints(healthcheckPort int32, addrs ...*envoy_config_core_v3.Address) []*envoy_config_endpoint_v3.LocalityLbEndpoints {
+func healthcheckEndpoints(healthcheckPort uint32, addrs ...*envoy_config_core_v3.Address) []*envoy_config_endpoint_v3.LocalityLbEndpoints {
 	lbendpoints := make([]*envoy_config_endpoint_v3.LbEndpoint, 0, len(addrs))
 	for _, addr := range addrs {
 		lbendpoints = append(lbendpoints, healthCheckLBEndpoint(addr, healthcheckPort))
@@ -1104,11 +1104,11 @@ func healthcheckEndpoints(healthcheckPort int32, addrs ...*envoy_config_core_v3.
 }
 
 // healthCheckLBEndpoint creates a new LbEndpoint include healthCheckConfig
-func healthCheckLBEndpoint(addr *envoy_config_core_v3.Address, healthCheckPort int32) *envoy_config_endpoint_v3.LbEndpoint {
+func healthCheckLBEndpoint(addr *envoy_config_core_v3.Address, healthCheckPort uint32) *envoy_config_endpoint_v3.LbEndpoint {
 	var hc *envoy_config_endpoint_v3.Endpoint_HealthCheckConfig
 	if healthCheckPort != 0 {
 		hc = &envoy_config_endpoint_v3.Endpoint_HealthCheckConfig{
-			PortValue: uint32(healthCheckPort),
+			PortValue: healthCheckPort,
 		}
 	}
 	return &envoy_config_endpoint_v3.LbEndpoint{

--- a/pkg/certs/certgen.go
+++ b/pkg/certs/certgen.go
@@ -95,7 +95,7 @@ func GenerateCerts(config *Configuration) (*Certificates, error) {
 	}
 
 	now := time.Now()
-	expiry := now.Add(24 * time.Duration(uint32OrDefault(config.Lifetime, DefaultCertificateLifetime)) * time.Hour)
+	expiry := now.Add(24 * time.Duration(uint32OrDefault(config.Lifetime, DefaultCertificateLifetime)) * time.Hour) //nolint:gosec // disable G115
 	caCertPEM, caKeyPEM, err := newCA("Project Contour", expiry)
 	if err != nil {
 		return nil, err

--- a/pkg/certs/certgen_test.go
+++ b/pkg/certs/certgen_test.go
@@ -50,7 +50,7 @@ func TestGenerateCerts(t *testing.T) {
 			// as of an hour before the intended expiration.
 			currentTime := time.Now()
 			if tc.config.Lifetime != 0 {
-				currentTime = currentTime.Add(24 * time.Hour * time.Duration(tc.config.Lifetime)).Add(-time.Hour)
+				currentTime = currentTime.Add(24 * time.Hour * time.Duration(tc.config.Lifetime)).Add(-time.Hour) //nolint:gosec // disable G115
 			}
 
 			roots := x509.NewCertPool()

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -130,9 +130,9 @@ var _ = Describe("When upgrading", func() {
 				poller.Stop()
 				totalRequests, successfulRequests := poller.Results()
 				f.T().Logf("Total requests: %d, successful requests: %d\n", totalRequests, successfulRequests)
-				require.Greater(f.T(), totalRequests, uint(0))
+				require.Positive(f.T(), totalRequests)
 				successPercentage := 100 * float64(successfulRequests) / float64(totalRequests)
-				require.Greaterf(f.T(), successPercentage, float64(90.0), "success rate of %.2f%% less than 90%", successPercentage)
+				require.Greaterf(f.T(), successPercentage, float64(90.0), "success rate of %.2f%% less than 90%%", successPercentage)
 			})
 		})
 	})
@@ -292,7 +292,7 @@ var _ = Describe("When upgrading", func() {
 				poller.Stop()
 				totalRequests, successfulRequests := poller.Results()
 				f.T().Logf("Total requests: %d, successful requests: %d\n", totalRequests, successfulRequests)
-				require.Greater(f.T(), totalRequests, uint(0))
+				require.Positive(f.T(), totalRequests)
 				successPercentage := 100 * float64(successfulRequests) / float64(totalRequests)
 				// Success threshold is somewhat arbitrary but less than the standalone
 				// Contour upgrade threshold because the Gateway provisioner does not
@@ -300,7 +300,7 @@ var _ = Describe("When upgrading", func() {
 				// can lead to additional downtime when both are upgrading at the same
 				// time.
 				// ref. https://github.com/projectcontour/contour/issues/5375.
-				require.Greaterf(f.T(), successPercentage, float64(80.0), "success rate of %.2f%% less than 80%", successPercentage)
+				require.Greaterf(f.T(), successPercentage, float64(80.0), "success rate of %.2f%% less than 80%%", successPercentage)
 			})
 		})
 	})


### PR DESCRIPTION
This pull request includes following changes

* Updates Go major version from 1.22 to 1.23
  * See release notes: https://go.dev/doc/devel/release#go1.23.0 
* Updates golangci-lint to v1.61.0
  * [v1.60.1](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1) added Go 1.23 support
* Lint fixes.