### PR TITLE
Patch release updates

### DIFF
--- a/changelogs/CHANGELOG-v1.28.7.md
+++ b/changelogs/CHANGELOG-v1.28.7.md
@@ -6,7 +6,7 @@ We are delighted to present version v1.28.7 of Contour, our layer 7 HTTP reverse
 
 # All Changes
 
-- Updates Envoy to v1.29.9. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.9/version_history/v1.29/v1.29).
+- Updates Envoy to v1.29.10. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.10/version_history/v1.29/v1.29).
 - Updates Go to v1.21.13. See the release notes [here](https://go.dev/doc/devel/release#go1.21.minor).
 
 

--- a/changelogs/CHANGELOG-v1.28.7.md
+++ b/changelogs/CHANGELOG-v1.28.7.md
@@ -1,0 +1,26 @@
+We are delighted to present version v1.28.7 of Contour, our layer 7 HTTP reverse proxy for Kubernetes clusters.
+
+- [All Changes](#all-changes)
+- [Installing/Upgrading](#installing-and-upgrading)
+- [Compatible Kubernetes Versions](#compatible-kubernetes-versions)
+
+# All Changes
+
+- Updates Envoy to v1.29.9. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.29.9/version_history/v1.29/v1.29).
+- Updates Go to v1.21.13. See the release notes [here](https://go.dev/doc/devel/release#go1.21.minor).
+
+
+# Installing and Upgrading
+
+For a fresh install of Contour, consult the [getting started documentation](https://projectcontour.io/getting-started/).
+
+To upgrade an existing Contour installation, please consult the [upgrade documentation](https://projectcontour.io/resources/upgrading/).
+
+
+# Compatible Kubernetes Versions
+
+Contour v1.28.7 is tested against Kubernetes 1.27 through 1.29.
+
+
+# Are you a Contour user? We would love to know!
+If you're using Contour and want to add your organization to our adopters list, please visit this [page](https://projectcontour.io/resources/adopters/). If you prefer to keep your organization name anonymous but still give us feedback into your usage and scenarios for Contour, please post on this [GitHub thread](https://github.com/projectcontour/contour/issues/1269).

--- a/changelogs/CHANGELOG-v1.29.3.md
+++ b/changelogs/CHANGELOG-v1.29.3.md
@@ -6,7 +6,7 @@ We are delighted to present version v1.29.3 of Contour, our layer 7 HTTP reverse
 
 # All Changes
 
-- Updates Envoy to v1.30.6. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.30.6/version_history/v1.30/v1.30).
+- Updates Envoy to v1.30.7. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.30.7/version_history/v1.30/v1.30).
 - Updates Go to v1.22.8. See the release notes [here](https://go.dev/doc/devel/release#go1.22.minor).
 
 

--- a/changelogs/CHANGELOG-v1.29.3.md
+++ b/changelogs/CHANGELOG-v1.29.3.md
@@ -1,0 +1,26 @@
+We are delighted to present version v1.29.3 of Contour, our layer 7 HTTP reverse proxy for Kubernetes clusters.
+
+- [All Changes](#all-changes)
+- [Installing/Upgrading](#installing-and-upgrading)
+- [Compatible Kubernetes Versions](#compatible-kubernetes-versions)
+
+# All Changes
+
+- Updates Envoy to v1.30.6. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.30.6/version_history/v1.30/v1.30).
+- Updates Go to v1.22.8. See the release notes [here](https://go.dev/doc/devel/release#go1.22.minor).
+
+
+# Installing and Upgrading
+
+For a fresh install of Contour, consult the [getting started documentation](https://projectcontour.io/getting-started/).
+
+To upgrade an existing Contour installation, please consult the [upgrade documentation](https://projectcontour.io/resources/upgrading/).
+
+
+# Compatible Kubernetes Versions
+
+Contour v1.29.3 is tested against Kubernetes 1.27 through 1.29.
+
+
+# Are you a Contour user? We would love to know!
+If you're using Contour and want to add your organization to our adopters list, please visit this [page](https://projectcontour.io/resources/adopters/). If you prefer to keep your organization name anonymous but still give us feedback into your usage and scenarios for Contour, please post on this [GitHub thread](https://github.com/projectcontour/contour/issues/1269).

--- a/changelogs/CHANGELOG-v1.30.1.md
+++ b/changelogs/CHANGELOG-v1.30.1.md
@@ -1,0 +1,26 @@
+We are delighted to present version v1.30.1 of Contour, our layer 7 HTTP reverse proxy for Kubernetes clusters.
+
+- [All Changes](#all-changes)
+- [Installing/Upgrading](#installing-and-upgrading)
+- [Compatible Kubernetes Versions](#compatible-kubernetes-versions)
+
+# All Changes
+
+- Updates Envoy to v1.31.2. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.31.2/version_history/v1.31/v1.31).
+- Updates Go to v1.22.8. See the release notes [here](https://go.dev/doc/devel/release#go1.22.minor).
+
+
+# Installing and Upgrading
+
+For a fresh install of Contour, consult the [getting started documentation](https://projectcontour.io/getting-started/).
+
+To upgrade an existing Contour installation, please consult the [upgrade documentation](https://projectcontour.io/resources/upgrading/).
+
+
+# Compatible Kubernetes Versions
+
+Contour v1.30.1 is tested against Kubernetes 1.28 through 1.30.
+
+
+# Are you a Contour user? We would love to know!
+If you're using Contour and want to add your organization to our adopters list, please visit this [page](https://projectcontour.io/resources/adopters/). If you prefer to keep your organization name anonymous but still give us feedback into your usage and scenarios for Contour, please post on this [GitHub thread](https://github.com/projectcontour/contour/issues/1269).

--- a/changelogs/CHANGELOG-v1.30.1.md
+++ b/changelogs/CHANGELOG-v1.30.1.md
@@ -6,7 +6,7 @@ We are delighted to present version v1.30.1 of Contour, our layer 7 HTTP reverse
 
 # All Changes
 
-- Updates Envoy to v1.31.2. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.31.2/version_history/v1.31/v1.31).
+- Updates Envoy to v1.31.3. See the release notes [here](https://www.envoyproxy.io/docs/envoy/v1.31.3/version_history/v1.31/v1.31).
 - Updates Go to v1.22.8. See the release notes [here](https://go.dev/doc/devel/release#go1.22.minor).
 
 

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,11 +10,14 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.32.0][62]         | 1.31, 1.30, 1.29    | [1.1.0][111]        |
+| main            | [1.32.0][65]         | 1.31, 1.30, 1.29    | [1.1.0][111]        |
+| 1.30.1          | [1.31.2][64]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
 | 1.30.0          | [1.31.0][60]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
+| 1.29.3          | [1.30.6][63]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.2          | [1.30.4][59]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.1          | [1.30.2][56]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.0          | [1.30.1][53]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
+| 1.28.7          | [1.29.9][62]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.6          | [1.29.7][61]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.5          | [1.29.5][57]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.4          | [1.29.4][55]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
@@ -207,7 +210,10 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [59]: https://www.envoyproxy.io/docs/envoy/v1.30.4/version_history/v1.30/v1.30.4
 [60]: https://www.envoyproxy.io/docs/envoy/v1.31.0/version_history/v1.31/v1.31.0
 [61]: https://www.envoyproxy.io/docs/envoy/v1.29.7/version_history/v1.29/v1.29.7
-[62]: https://www.envoyproxy.io/docs/envoy/v1.32.0/version_history/v1.32/v1.32.0
+[62]: https://www.envoyproxy.io/docs/envoy/v1.29.9/version_history/v1.29/v1.29
+[63]: https://www.envoyproxy.io/docs/envoy/v1.30.6/version_history/v1.30/v1.30
+[64]: https://www.envoyproxy.io/docs/envoy/v1.31.2/version_history/v1.31/v1.31
+[65]: https://www.envoyproxy.io/docs/envoy/v1.32.0/version_history/v1.32/v1.32
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -11,13 +11,13 @@ These combinations of versions are specifically tested in CI and supported by th
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
 | main            | [1.32.0][65]         | 1.31, 1.30, 1.29    | [1.1.0][111]        |
-| 1.30.1          | [1.31.2][64]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
+| 1.30.1          | [1.31.3][64]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
 | 1.30.0          | [1.31.0][60]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
-| 1.29.3          | [1.30.6][63]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
+| 1.29.3          | [1.30.7][63]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.2          | [1.30.4][59]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.1          | [1.30.2][56]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.29.0          | [1.30.1][53]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
-| 1.28.7          | [1.29.9][62]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
+| 1.28.7          | [1.29.10][62]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.6          | [1.29.7][61]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.5          | [1.29.5][57]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
 | 1.28.4          | [1.29.4][55]         | 1.29, 1.28, 1.27    | [1.0.0][110]        |
@@ -210,9 +210,9 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [59]: https://www.envoyproxy.io/docs/envoy/v1.30.4/version_history/v1.30/v1.30.4
 [60]: https://www.envoyproxy.io/docs/envoy/v1.31.0/version_history/v1.31/v1.31.0
 [61]: https://www.envoyproxy.io/docs/envoy/v1.29.7/version_history/v1.29/v1.29.7
-[62]: https://www.envoyproxy.io/docs/envoy/v1.29.9/version_history/v1.29/v1.29
-[63]: https://www.envoyproxy.io/docs/envoy/v1.30.6/version_history/v1.30/v1.30
-[64]: https://www.envoyproxy.io/docs/envoy/v1.31.2/version_history/v1.31/v1.31
+[62]: https://www.envoyproxy.io/docs/envoy/v1.29.10/version_history/v1.29/v1.29
+[63]: https://www.envoyproxy.io/docs/envoy/v1.30.7/version_history/v1.30/v1.30
+[64]: https://www.envoyproxy.io/docs/envoy/v1.31.3/version_history/v1.31/v1.31
 [65]: https://www.envoyproxy.io/docs/envoy/v1.32.0/version_history/v1.32/v1.32
 
 [98]: https://github.com/kubernetes/client-go

--- a/versions.yaml
+++ b/versions.yaml
@@ -17,7 +17,7 @@ versions:
   - version: v1.30.1
     supported: "true"
     dependencies:
-      envoy: "1.31.2"
+      envoy: "1.31.3"
       kubernetes:
         - "1.30"
         - "1.29"
@@ -37,7 +37,7 @@ versions:
   - version: v1.29.3
     supported: "true"
     dependencies:
-      envoy: "1.30.6"
+      envoy: "1.30.7"
       kubernetes:
         - "1.29"
         - "1.28"
@@ -77,7 +77,7 @@ versions:
   - version: v1.28.7
     supported: "true"
     dependencies:
-      envoy: "1.29.9"
+      envoy: "1.29.10"
       kubernetes:
         - "1.29"
         - "1.28"

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,8 +14,18 @@ versions:
         - "1.28"
       gateway-api:
         - "1.1.0"
-  - version: v1.30.0
+  - version: v1.30.1
     supported: "true"
+    dependencies:
+      envoy: "1.31.2"
+      kubernetes:
+        - "1.30"
+        - "1.29"
+        - "1.28"
+      gateway-api:
+        - "1.1.0"
+  - version: v1.30.0
+    supported: "false"
     dependencies:
       envoy: "1.31.0"
       kubernetes:
@@ -24,8 +34,18 @@ versions:
         - "1.28"
       gateway-api:
         - "1.1.0"
-  - version: v1.29.2
+  - version: v1.29.3
     supported: "true"
+    dependencies:
+      envoy: "1.30.6"
+      kubernetes:
+        - "1.29"
+        - "1.28"
+        - "1.27"
+      gateway-api:
+        - "1.0.0"
+  - version: v1.29.2
+    supported: "false"
     dependencies:
       envoy: "1.30.4"
       kubernetes:
@@ -54,8 +74,18 @@ versions:
         - "1.27"
       gateway-api:
         - "1.0.0"
-  - version: v1.28.6
+  - version: v1.28.7
     supported: "true"
+    dependencies:
+      envoy: "1.29.9"
+      kubernetes:
+        - "1.29"
+        - "1.28"
+        - "1.27"
+      gateway-api:
+        - "1.0.0"
+  - version: v1.28.6
+    supported: "false"
     dependencies:
       envoy: "1.29.7"
       kubernetes:


### PR DESCRIPTION
This PR updates the `main` branch with information for the patch releases v1.30.1, v1.29.3 and v1.28.7, along with an Envoy version bump in `main`.

Unlike before, I’ve linked the Envoy changelog index pages that contain the changelogs for each minor version. This is because we may skip certain Envoy releases, as in this case, so readers will need to refer to multiple changelogs anyway. Additionally, it may help reduce the effort required to update the links.

Related PRs
* `main`: https://github.com/projectcontour/contour/pull/6714
* https://github.com/projectcontour/contour/pull/6715
* https://github.com/projectcontour/contour/pull/6716
* https://github.com/projectcontour/contour/pull/6717