### PR TITLE
Introducing Contour Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contour
 
-![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Slack](https://img.shields.io/badge/slack-join%20chat-e01563.svg?logo=slack)](https://kubernetes.slack.com/messages/contour)
+![GitHub release](https://img.shields.io/github/release/projectcontour/contour.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Slack](https://img.shields.io/badge/slack-join%20chat-e01563.svg?logo=slack)](https://kubernetes.slack.com/messages/contour) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Contour%20Guru-006BFF)](https://gurubase.io/g/contour)
 
 ![Build and Test Pull Request](https://github.com/projectcontour/contour/workflows/Build%20and%20Test%20Pull%20Request/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/projectcontour/contour)](https://goreportcard.com/report/github.com/projectcontour/contour) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/projectcontour/contour/badge)](https://securityscorecards.dev/viewer/?uri=github.com/projectcontour/contour) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4141/badge)](https://bestpractices.coreinfrastructure.org/projects/4141)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Contour Guru](https://gurubase.io/g/contour) to Gurubase. Contour Guru uses the data from this repo and data from the [docs](https://projectcontour.io/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "Contour Guru", which highlights that Contour now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Contour Guru in Gurubase, just let me know that's totally fine.
