### PR TITLE
Added missing retryOn conditions

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1146,7 +1146,7 @@ type TimeoutPolicy struct {
 }
 
 // RetryOn is a string type alias with validation to ensure that the value is valid.
-// +kubebuilder:validation:Enum="5xx";gateway-error;reset;connect-failure;retriable-4xx;refused-stream;retriable-status-codes;retriable-headers;cancelled;deadline-exceeded;internal;resource-exhausted;unavailable
+// +kubebuilder:validation:Enum="5xx";gateway-error;reset;reset-before-request;connect-failure;envoy-ratelimited;retriable-4xx;refused-stream;retriable-status-codes;retriable-headers;http3-post-connect-failure;cancelled;deadline-exceeded;internal;resource-exhausted;unavailable
 type RetryOn string
 
 // RetryPolicy defines the attributes associated with retrying policy.
@@ -1171,11 +1171,14 @@ type RetryPolicy struct {
 	// - `5xx`
 	// - `gateway-error`
 	// - `reset`
+	// - `reset-before-request`
 	// - `connect-failure`
+	// - `envoy-ratelimited`
 	// - `retriable-4xx`
 	// - `refused-stream`
 	// - `retriable-status-codes`
 	// - `retriable-headers`
+	// - `http3-post-connect-failure`
 	//
 	// Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
 	//

--- a/changelogs/unreleased/6772-tsaarni-small.md
+++ b/changelogs/unreleased/6772-tsaarni-small.md
@@ -1,0 +1,1 @@
+Added conditions `reset-before-request`, `envoy-ratelimited` and `http3-post-connect-failure` for `httpproxy.spec.routes.retryPolicy.retryOn`, see Envoy [documentation](https://www.envoyproxy.io/docs/envoy/v1.32.0/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on) for more details.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -6702,11 +6702,14 @@ spec:
                             - `5xx`
                             - `gateway-error`
                             - `reset`
+                            - `reset-before-request`
                             - `connect-failure`
+                            - `envoy-ratelimited`
                             - `retriable-4xx`
                             - `refused-stream`
                             - `retriable-status-codes`
                             - `retriable-headers`
+                            - `http3-post-connect-failure`
                             Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             - `cancelled`
                             - `deadline-exceeded`
@@ -6720,11 +6723,14 @@ spec:
                             - 5xx
                             - gateway-error
                             - reset
+                            - reset-before-request
                             - connect-failure
+                            - envoy-ratelimited
                             - retriable-4xx
                             - refused-stream
                             - retriable-status-codes
                             - retriable-headers
+                            - http3-post-connect-failure
                             - cancelled
                             - deadline-exceeded
                             - internal

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -6922,11 +6922,14 @@ spec:
                             - `5xx`
                             - `gateway-error`
                             - `reset`
+                            - `reset-before-request`
                             - `connect-failure`
+                            - `envoy-ratelimited`
                             - `retriable-4xx`
                             - `refused-stream`
                             - `retriable-status-codes`
                             - `retriable-headers`
+                            - `http3-post-connect-failure`
                             Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             - `cancelled`
                             - `deadline-exceeded`
@@ -6940,11 +6943,14 @@ spec:
                             - 5xx
                             - gateway-error
                             - reset
+                            - reset-before-request
                             - connect-failure
+                            - envoy-ratelimited
                             - retriable-4xx
                             - refused-stream
                             - retriable-status-codes
                             - retriable-headers
+                            - http3-post-connect-failure
                             - cancelled
                             - deadline-exceeded
                             - internal

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -6713,11 +6713,14 @@ spec:
                             - `5xx`
                             - `gateway-error`
                             - `reset`
+                            - `reset-before-request`
                             - `connect-failure`
+                            - `envoy-ratelimited`
                             - `retriable-4xx`
                             - `refused-stream`
                             - `retriable-status-codes`
                             - `retriable-headers`
+                            - `http3-post-connect-failure`
                             Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             - `cancelled`
                             - `deadline-exceeded`
@@ -6731,11 +6734,14 @@ spec:
                             - 5xx
                             - gateway-error
                             - reset
+                            - reset-before-request
                             - connect-failure
+                            - envoy-ratelimited
                             - retriable-4xx
                             - refused-stream
                             - retriable-status-codes
                             - retriable-headers
+                            - http3-post-connect-failure
                             - cancelled
                             - deadline-exceeded
                             - internal

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -6738,11 +6738,14 @@ spec:
                             - `5xx`
                             - `gateway-error`
                             - `reset`
+                            - `reset-before-request`
                             - `connect-failure`
+                            - `envoy-ratelimited`
                             - `retriable-4xx`
                             - `refused-stream`
                             - `retriable-status-codes`
                             - `retriable-headers`
+                            - `http3-post-connect-failure`
                             Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             - `cancelled`
                             - `deadline-exceeded`
@@ -6756,11 +6759,14 @@ spec:
                             - 5xx
                             - gateway-error
                             - reset
+                            - reset-before-request
                             - connect-failure
+                            - envoy-ratelimited
                             - retriable-4xx
                             - refused-stream
                             - retriable-status-codes
                             - retriable-headers
+                            - http3-post-connect-failure
                             - cancelled
                             - deadline-exceeded
                             - internal

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -6922,11 +6922,14 @@ spec:
                             - `5xx`
                             - `gateway-error`
                             - `reset`
+                            - `reset-before-request`
                             - `connect-failure`
+                            - `envoy-ratelimited`
                             - `retriable-4xx`
                             - `refused-stream`
                             - `retriable-status-codes`
                             - `retriable-headers`
+                            - `http3-post-connect-failure`
                             Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             - `cancelled`
                             - `deadline-exceeded`
@@ -6940,11 +6943,14 @@ spec:
                             - 5xx
                             - gateway-error
                             - reset
+                            - reset-before-request
                             - connect-failure
+                            - envoy-ratelimited
                             - retriable-4xx
                             - refused-stream
                             - retriable-status-codes
                             - retriable-headers
+                            - http3-post-connect-failure
                             - cancelled
                             - deadline-exceeded
                             - internal

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -3518,11 +3518,14 @@ Ignored if NumRetries is not supplied.</p>
 <li><code>5xx</code></li>
 <li><code>gateway-error</code></li>
 <li><code>reset</code></li>
+<li><code>reset-before-request</code></li>
 <li><code>connect-failure</code></li>
+<li><code>envoy-ratelimited</code></li>
 <li><code>retriable-4xx</code></li>
 <li><code>refused-stream</code></li>
 <li><code>retriable-status-codes</code></li>
 <li><code>retriable-headers</code></li>
+<li><code>http3-post-connect-failure</code></li>
 </ul>
 <p>Supported <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on">gRPC conditions</a>:</p>
 <ul>


### PR DESCRIPTION
This change adds missing route config retry-on conditions that are available in Envoy 1.32.

Fixes #6770