### PR TITLE
Use 1.N.P form for go directive in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectcontour/contour
 
-go 1.23
+go 1.23.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
To prevent issues with go commands and downloading correct toolchain versions.

See: https://go.dev/doc/toolchain#version

Detected locally when go tool attempted to download a new toolchain for go1.23 and was unable to.

Also see CodeQL warning:
<img width="972" alt="Screenshot 2024-11-25 at 11 42 29 AM" src="https://github.com/user-attachments/assets/34d85408-adeb-4105-8a25-d98e6b4f36a1">
