### PR TITLE
Fix deepcopy generation script

### DIFF
--- a/apis/projectcontour/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/projectcontour/v1alpha1/zz_generated.deepcopy.go
@@ -187,7 +187,7 @@ func (in *ContourConfigurationSpec) DeepCopyInto(out *ContourConfigurationSpec) 
 	if in.Gateway != nil {
 		in, out := &in.Gateway, &out.Gateway
 		*out = new(GatewayConfig)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.HTTPProxy != nil {
 		in, out := &in.HTTPProxy, &out.HTTPProxy
@@ -405,6 +405,11 @@ func (in *ContourSettings) DeepCopyInto(out *ContourSettings) {
 	if in.WatchNamespaces != nil {
 		in, out := &in.WatchNamespaces, &out.WatchNamespaces
 		*out = make([]v1.Namespace, len(*in))
+		copy(*out, *in)
+	}
+	if in.DisabledFeatures != nil {
+		in, out := &in.DisabledFeatures, &out.DisabledFeatures
+		*out = make([]v1.Feature, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/hack/generate-crd-deepcopy.sh
+++ b/hack/generate-crd-deepcopy.sh
@@ -42,8 +42,8 @@ readonly HEADER=$(mktemp)
 
 boilerplate > "${HEADER}"
 
-exec echo "controller-gen version: "
-exec go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
+echo "controller-gen version: "
+go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
 
 exec go run sigs.k8s.io/controller-tools/cmd/controller-gen \
     "object:headerFile=${HEADER}" \


### PR DESCRIPTION
The script [hack/generate-crd-deepcopy.sh](https://github.com/projectcontour/contour/blob/d05f43a103e53fc21078a8dbd2daf1ac56b5e787/hack/generate-crd-deepcopy.sh) was unintentionally rendered ineffective by #6117. This occurred because `exec` replaces the current shell process with the specified binary, preventing remaining lines of the script from running.

This update restores the deepcopy generation functionality and includes the results of `make generate` to address changes missed since the last successful run.

Fixes #6790