### PR TITLE
Prevent LoadBalancer updates on follower.

### DIFF
--- a/changelogs/unreleased/6872-tsaarni-small.md
+++ b/changelogs/unreleased/6872-tsaarni-small.md
@@ -1,0 +1,1 @@
+Fixed a memory leak in Contour follower instance due to unprocessed LoadBalancer status updates.

--- a/cmd/contour/serve.go
+++ b/cmd/contour/serve.go
@@ -700,34 +700,12 @@ func (s *Server) doServe() error {
 		ingressClassNames: ingressClassNames,
 		gatewayRef:        gatewayRef,
 		statusUpdater:     sh.Writer(),
+		statusAddress:     contourConfiguration.Ingress.StatusAddress,
+		serviceName:       contourConfiguration.Envoy.Service.Name,
+		serviceNamespace:  contourConfiguration.Envoy.Service.Namespace,
 	}
 	if err := s.mgr.Add(lbsw); err != nil {
 		return err
-	}
-
-	// Register an informer to watch envoy's service if we haven't been given static details.
-	if lbAddress := contourConfiguration.Ingress.StatusAddress; len(lbAddress) > 0 {
-		s.log.WithField("loadbalancer-address", lbAddress).Info("Using supplied information for Ingress status")
-		lbsw.lbStatus <- parseStatusFlag(lbAddress)
-	} else {
-		serviceHandler := &k8s.ServiceStatusLoadBalancerWatcher{
-			ServiceName: contourConfiguration.Envoy.Service.Name,
-			LBStatus:    lbsw.lbStatus,
-			Log:         s.log.WithField("context", "serviceStatusLoadBalancerWatcher"),
-		}
-
-		var handler cache.ResourceEventHandler = serviceHandler
-		if contourConfiguration.Envoy.Service.Namespace != "" {
-			handler = k8s.NewNamespaceFilter([]string{contourConfiguration.Envoy.Service.Namespace}, handler)
-		}
-
-		if err := s.informOnResource(&core_v1.Service{}, handler); err != nil {
-			s.log.WithError(err).WithField("resource", "services").Fatal("failed to create informer")
-		}
-
-		s.log.WithField("envoy-service-name", contourConfiguration.Envoy.Service.Name).
-			WithField("envoy-service-namespace", contourConfiguration.Envoy.Service.Namespace).
-			Info("Watching Service for Ingress status")
 	}
 
 	xdsServer := &xdsServer{


### PR DESCRIPTION
This PR fixes a memory leak that was triggered by LoadBalancer status updates. Only the leader instance runs `loadBalancerStatusWriter` and therefore follower does not have anyone reading from the channel that receives status updates. The LoadBalancer status updates are still watched by followers and sent to the channel, causing the go routine calling `ServiceStatusLoadBalancerWatcher.notify()` to block. This led to `LoadBalancerStatus` updates piling up and consuming memory, eventually causing an out-of-memory condition and killing the Contour process.

With this change, `Service` updates are watched only after the instance becomes the leader and starts the `loadBalancerStatusWriter`.

Fixes #6860