### PR TITLE
Remove workaround for controller-tools typealias bug

### DIFF
--- a/apis/projectcontour/v1/zz_generated.deepcopy.go
+++ b/apis/projectcontour/v1/zz_generated.deepcopy.go
@@ -229,12 +229,16 @@ func (in *DetailedCondition) DeepCopyInto(out *DetailedCondition) {
 	if in.Errors != nil {
 		in, out := &in.Errors, &out.Errors
 		*out = make([]SubCondition, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Warnings != nil {
 		in, out := &in.Warnings, &out.Warnings
 		*out = make([]SubCondition, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/design/external-authorization-design.md
+++ b/design/external-authorization-design.md
@@ -34,7 +34,7 @@ This document describes a design for performing request authorization for virtua
 A new `ExtensionService` CRD adds a way to represent and track an authorization service.
 This CRD is relatively generic, so that it can be reused for Envoy rate limiting and logging services.
 The core of the `ExtensionService` CRD is subset of the `projectcontour.v1.HTTPProxy` `Service` specification.
-Re-using the `Service` type allows the operator to specify configuration in familiar and consistent terms, especially TLS configuration.
+Reusing the `Service` type allows the operator to specify configuration in familiar and consistent terms, especially TLS configuration.
 
 Note that only the Envoy [GRPC authorization protocol][2] will be supported.
 The GRPC protocol is a superset of the HTTP protocol and requires less configuration.

--- a/hack/generate-crd-deepcopy.sh
+++ b/hack/generate-crd-deepcopy.sh
@@ -14,10 +14,6 @@ readonly GO111MODULE=on
 
 export GO111MODULE
 
-# Workaround for https://github.com/projectcontour/contour/pull/6709#issuecomment-2466179766
-readonly GODEBUG=gotypesalias=0
-export GODEBUG
-
 boilerplate() {
     cat <<EOF
 /*

--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -11,10 +11,6 @@ readonly TEMPDIR=$(mktemp -d crd-XXXXXX)
 # Optional first arg is the paths pattern.
 readonly PATHS="${1:-"./apis/..."}"
 
-# Workaround for https://github.com/projectcontour/contour/pull/6709#issuecomment-2466179766
-readonly GODEBUG=gotypesalias=0
-export GODEBUG
-
 trap 'rm -rf "$TEMPDIR"; exit' 0 1 2 15
 
 cd "${REPO}"


### PR DESCRIPTION
This PR removes the [workaround](https://github.com/projectcontour/contour/pull/6709#issuecomment-2466179766) which was applied due to controller-tools issue https://github.com/kubernetes-sigs/controller-tools/issues/1088. The issue was fixed in [v0.17.1](https://github.com/kubernetes-sigs/controller-tools/releases/tag/v0.17.1).