### PR TITLE
Use LinearCache to optimize StreamEndpoint discovery.

### DIFF
--- a/changelogs/unreleased/6906-tsaarni-small.md
+++ b/changelogs/unreleased/6906-tsaarni-small.md
@@ -1,0 +1,1 @@
+Improve performance in clusters with a large number of endpoints by using go-control-plane LinearCache for EDS.

--- a/internal/xdscache/v3/endpointslicetranslator.go
+++ b/internal/xdscache/v3/endpointslicetranslator.go
@@ -339,25 +339,10 @@ func (e *EndpointSliceTranslator) OnChange(root *dag.DAG) {
 	// be removed. Since we reset the cluster cache above, all
 	// the load assignments will be recalculated and we can just
 	// set the entries rather than merging them.
-	entries := e.cache.Recalculate()
+	e.entries = e.cache.Recalculate()
 
-	// Only update and notify if entries has changed.
-	changed := false
-
-	e.mu.Lock()
-	if !equal(e.entries, entries) {
-		e.entries = entries
-		changed = true
-	}
-	e.mu.Unlock()
-
-	if changed {
-		e.Debug("cluster load assignments changed, notifying waiters")
-		if e.Observer != nil {
-			e.Observer.Refresh()
-		}
-	} else {
-		e.Debug("cluster load assignments did not change")
+	if e.Observer != nil {
+		e.Observer.Refresh()
 	}
 }
 


### PR DESCRIPTION
This change attempts to improve performance in clusters with a large number of endpoints, as discussed in https://github.com/projectcontour/contour/issues/6743#issuecomment-2538586264. 

Envoy does not send a wildcard `DiscoveryRequest` (a request without a resource name) for EDS / `ClusterLoadAssignment` resources. Instead, it creates a separate EDS stream for each CDS entry and requests specific resource by name. For example, with 10000 upstream clusters, each Envoy instance sends 10000 `DiscoveryRequests`, one per endpoint, e.g. from `echoserver-0000` to `echoserver-9999`.

As a result, the SotW-style update, where full set of resources is sent at every update, is not applicable. If `echoserver-0000` changes, updates should not be sent to streams watching `echoserver-0001` - `echoserver-9999`. SotW update should consists of single update, for `echoserver-0000`.  Effectively, EDS behaves like incremental update mechanism, since each endpoint has its own stream / watch.

Using `SnapshotCache` is problematic in this scenario because it broadcasts `DiscoveryResponse` update to all EDS streams whenever any endpoint changes. Even if only `echoserver-0000` is updated, `SnapshotCache` will send 10000 updates, from `echoserver-0000` to `echoserver-9999` to each Envoy instance. In each of these updates Contour sends `DiscoveryResponse`, followed by Envoy immediately sending new `DiscoveryRequests` back to Contour to watch further updates. Since these messages are relatively heavy-weight, this creates unnecessary overhead compared to typical SotW update.

This PR replaces `SnapshotCache` with `LinearCache` for EDS. `LinearCache` addresses the issue by tracking which stream requested which resource and using versioning to ensure that updates are sent only to streams watching the specific endpoints that changed. When `echoserver-0000` is updated, only the EDS streams watching `echoserver-0000` will receive the update.

The `LinearCache` was previously considered but not adopted due to complications outlined by @skriss in a [prior PR](https://github.com/projectcontour/contour/pull/6250/files#diff-1900033d7ec953a2e318fa5369de7c7d199c4e478873a17e61b7f3776771bb1e )

> If Envoy already has config for a given resource at a particular version, then on a control plane restart, the version number of the resource in the cache will be reset to 1 (or close to 1), therefore will not be sent to Envoy since Envoy already has a "later" version of the resource. 

This PR attempts to mitigate this by generating unique version prefix at each startup.
 
Fixes #6743