### PR TITLE
Bump to golang 1.24.0 and golangci-lint v1.64.5

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.23.4
+  GO_VERSION: 1.24.0
 
 jobs:
   e2e-envoy-deployment:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.23.4
+  GO_VERSION: 1.24.0
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.23.4
+  GO_VERSION: 1.24.0
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.23.4
+  GO_VERSION: 1.24.0
 
 jobs:
   lint:
@@ -29,7 +29,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
       with:
-        version: v1.61.0
+        version: v1.64.5
         args: --build-tags=e2e,conformance,gcp,oidc,none --out-format=colored-line-number
   codespell:
     name: Codespell

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.23.4@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041
+BUILD_BASE_IMAGE ?= golang:1.24.0@sha256:cd0c949a4709ef70a8dad14274f09bd07b25542de5a1c4812f217087737efd17
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/apis/projectcontour/v1alpha1/contourconfig_helpers.go
+++ b/apis/projectcontour/v1alpha1/contourconfig_helpers.go
@@ -145,7 +145,7 @@ func (e *EnvoyConfig) Validate() error {
 	return nil
 }
 
-func ValidateTLSProtocolVersions(min, max string) error {
+func ValidateTLSProtocolVersions(minVersion, maxVersion string) error {
 	parseVersion := func(version, tip, defVal string) (string, error) {
 		switch version {
 		case "":
@@ -157,12 +157,12 @@ func ValidateTLSProtocolVersions(min, max string) error {
 		}
 	}
 
-	minVer, err := parseVersion(min, "minimum", "1.2")
+	minVer, err := parseVersion(minVersion, "minimum", "1.2")
 	if err != nil {
 		return err
 	}
 
-	maxVer, err := parseVersion(max, "maximum", "1.3")
+	maxVer, err := parseVersion(maxVersion, "maximum", "1.3")
 	if err != nil {
 		return err
 	}

--- a/changelogs/unreleased/6918-tsaarni-small.md
+++ b/changelogs/unreleased/6918-tsaarni-small.md
@@ -1,0 +1,1 @@
+Update to Go 1.24.0. See the [Go release notes](https://go.dev/doc/devel/release#go1.24.0) for more information.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectcontour/contour
 
-go 1.23.0
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.1

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 "$@"
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5 "$@"

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -266,22 +266,22 @@ func (d *Deployment) UnmarshalResources() error {
 }
 
 // Common case of updating object if exists, create otherwise.
-func (d *Deployment) ensureResource(new, existing client.Object) error {
-	if err := d.client.Get(context.TODO(), client.ObjectKeyFromObject(new), existing); err != nil {
+func (d *Deployment) ensureResource(newResource, existingResource client.Object) error {
+	if err := d.client.Get(context.TODO(), client.ObjectKeyFromObject(newResource), existingResource); err != nil {
 		if api_errors.IsNotFound(err) {
-			return d.client.Create(context.TODO(), new)
+			return d.client.Create(context.TODO(), newResource)
 		}
 		return err
 	}
-	new.SetResourceVersion(existing.GetResourceVersion())
+	newResource.SetResourceVersion(existingResource.GetResourceVersion())
 	// If a core_v1.Service, pass along existing cluster IP and healthcheck node port.
-	if newS, ok := new.(*core_v1.Service); ok {
-		existingS := existing.(*core_v1.Service)
+	if newS, ok := newResource.(*core_v1.Service); ok {
+		existingS := existingResource.(*core_v1.Service)
 		newS.Spec.ClusterIP = existingS.Spec.ClusterIP
 		newS.Spec.ClusterIPs = existingS.Spec.ClusterIPs
 		newS.Spec.HealthCheckNodePort = existingS.Spec.HealthCheckNodePort
 	}
-	return d.client.Update(context.TODO(), new)
+	return d.client.Update(context.TODO(), newResource)
 }
 
 func (d *Deployment) EnsureNamespace() error {

--- a/test/e2e/provisioner.go
+++ b/test/e2e/provisioner.go
@@ -108,22 +108,22 @@ func (p *Provisioner) UnmarshalResources() error {
 }
 
 // Common case of updating object if exists, create otherwise.
-func (p *Provisioner) ensureResource(new, existing client.Object) error {
-	if err := p.client.Get(context.TODO(), client.ObjectKeyFromObject(new), existing); err != nil {
+func (p *Provisioner) ensureResource(newResource, existingResource client.Object) error {
+	if err := p.client.Get(context.TODO(), client.ObjectKeyFromObject(newResource), existingResource); err != nil {
 		if api_errors.IsNotFound(err) {
-			return p.client.Create(context.TODO(), new)
+			return p.client.Create(context.TODO(), newResource)
 		}
 		return err
 	}
-	new.SetResourceVersion(existing.GetResourceVersion())
+	newResource.SetResourceVersion(existingResource.GetResourceVersion())
 	// If a core_v1.Service, pass along existing cluster IP and healthcheck node port.
-	if newS, ok := new.(*core_v1.Service); ok {
-		existingS := existing.(*core_v1.Service)
+	if newS, ok := newResource.(*core_v1.Service); ok {
+		existingS := existingResource.(*core_v1.Service)
 		newS.Spec.ClusterIP = existingS.Spec.ClusterIP
 		newS.Spec.ClusterIPs = existingS.Spec.ClusterIPs
 		newS.Spec.HealthCheckNodePort = existingS.Spec.HealthCheckNodePort
 	}
-	return p.client.Update(context.TODO(), new)
+	return p.client.Update(context.TODO(), newResource)
 }
 
 // Convenience method for deploying the pieces of the deployment needed for


### PR DESCRIPTION
This change updates to Go 1.24.0. See https://go.dev/doc/devel/release#go1.24.0 for details.

The PR also updates golangci-lint to v1.64.5 for Go 1.24 support and fixes lint errors reported by new linter version

```
apis/projectcontour/v1alpha1/contourconfig_helpers.go:148:34: redefines-builtin-id: redefinition of the built-in function min (revive)
func ValidateTLSProtocolVersions(min, max string) error {
                                 ^
test/e2e/provisioner.go:111:38: redefines-builtin-id: redefinition of the built-in function new (revive)
func (p *Provisioner) ensureResource(new, existing client.Object) error {
                                     ^
test/e2e/deployment.go:269:37: redefines-builtin-id: redefinition of the built-in function new (revive)
func (d *Deployment) ensureResource(new, existing client.Object) error {
```
