### PR TITLE
Add timeout setting to extensionService

### DIFF
--- a/site/content/docs/1.24/guides/external-authorization.md
+++ b/site/content/docs/1.24/guides/external-authorization.md
@@ -192,6 +192,10 @@ spec:
   services:
   - name: htpasswd
     port: 9443
+  timeoutPolicy:
+    response: 30s
+    idle: 60s 
+    idleConnection: 10m
 ```
 
 The `ExtensionService` resource must be created in the same namespace


### PR DESCRIPTION
During the grpc response process from the external authentication server to the envoy server, response code 14 and upstream server timeout need to be allowed.

```txt
[2025-03-11 01:10:16.341][13][debug][router] [source/common/router/router.cc:1551] [Tags: "ConnectionId":"67","StreamId":"11763917161951019779"] upstream headers complete: end_stream=false
[2025-03-11 01:10:16.341][13][debug][http] [source/common/http/conn_manager_impl.cc:1759] [Tags: "ConnectionId":"67","StreamId":"11763917161951019779"] closing connection due to connection close header
[2025-03-11 01:10:16.341][13][debug][http] [source/common/http/conn_manager_impl.cc:1825] [Tags: "ConnectionId":"67","StreamId":"11763917161951019779"] encoding headers via codec (end_stream=false):
':status', '200'
'content-type', 'text/plain; charset=UTF-8'
'cache-control', 'no-cache, max-age=0'
'x-content-type-options', 'nosniff'
'date', 'Tue, 11 Mar 2025 01:10:16 GMT'
'server', 'envoy'
'x-envoy-upstream-service-time', '0'
'connection', 'close'
[2025-03-11 01:10:16.341][13][debug][client] [source/common/http/codec_client.cc:129] [Tags: "ConnectionId":"2"] response complete
[2025-03-11 01:10:16.341][13][debug][http] [source/common/http/conn_manager_impl.cc:1937] [Tags: "ConnectionId":"67","StreamId":"11763917161951019779"] Codec completed encoding stream.
[2025-03-11 01:10:16.341][13][debug][connection] [source/common/network/connection_impl.cc:150] [Tags: "ConnectionId":"67"] closing data_to_write=277 type=0
[2025-03-11 01:10:16.341][13][debug][connection] [source/common/network/connection_impl_base.cc:53] [Tags: "ConnectionId":"67"] setting delayed close timer with timeout 1000 ms
[2025-03-11 01:10:16.341][13][debug][pool] [source/common/http/http1/conn_pool.cc:53] [Tags: "ConnectionId":"2"] response complete
[2025-03-11 01:10:16.341][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:215] [Tags: "ConnectionId":"2"] destroying stream: 0 remaining
[2025-03-11 01:10:16.341][13][debug][connection] [source/common/network/connection_impl.cc:788] [Tags: "ConnectionId":"67"] write flush complete
[2025-03-11 01:10:16.341][13][debug][connection] [source/common/network/connection_impl.cc:276] [Tags: "ConnectionId":"67"] closing socket: 1
[2025-03-11 01:10:16.341][13][debug][conn_handler] [source/common/listener_manager/active_stream_listener_base.cc:136] [Tags: "ConnectionId":"67"] adding to cleanup list
[2025-03-11 01:10:16.854][13][debug][filter] [source/extensions/filters/listener/tls_inspector/tls_inspector.cc:137] tls:onServerName(), requestedServerName: local.projectcontour.io
[2025-03-11 01:10:16.855][13][debug][conn_handler] [source/common/listener_manager/active_tcp_listener.cc:160] [Tags: "ConnectionId":"68"] new connection from 220.85.66.241:54758
[2025-03-11 01:10:16.864][13][debug][http] [source/common/http/conn_manager_impl.cc:385] [Tags: "ConnectionId":"68"] new stream
[2025-03-11 01:10:16.865][13][debug][http] [source/common/http/conn_manager_impl.cc:1135] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] request headers complete (end_stream=true):
':authority', 'local.projectcontour.io'
':path', '/test/26004'
':method', 'GET'
'authorization', 'Basic dXNlcjE6cGFzc3dvcmQx'
'user-agent', 'curl/8.10.1'
'accept', '*/*'
[2025-03-11 01:10:16.865][13][debug][http] [source/common/http/conn_manager_impl.cc:1118] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] request end stream
[2025-03-11 01:10:16.865][13][debug][connection] [./source/common/network/connection_impl.h:98] [Tags: "ConnectionId":"68"] current connecting state: false
[2025-03-11 01:10:16.865][13][debug][lua] [source/extensions/filters/common/lua/lua.cc:39] coroutine finished
[2025-03-11 01:10:16.865][13][debug][rbac] [source/extensions/filters/http/rbac/rbac_filter.cc:132] checking request: requestedServerName: local.projectcontour.io, sourceIP: 220.85.66.241:54758, directRemoteIP: 220.85.66.241:54758, remoteIP: 220.85.66.241:54758,localAddress: 100.66.8.179:8443, ssl: uriSanPeerCertificate: , dnsSanPeerCertificate: , subjectPeerCertificate: , headers: ':authority', 'local.projectcontour.io'
':path', '/test/26004'
':method', 'GET'
':scheme', 'https'
'authorization', 'Basic dXNlcjE6cGFzc3dvcmQx'
'user-agent', 'curl/8.10.1'
'accept', '*/*'
'x-forwarded-for', '220.85.66.241'
'x-forwarded-proto', 'https'
'x-envoy-external-address', '220.85.66.241'
'x-request-id', '7d3ad3c1-7bd9-4e9b-b71a-67c01596a46b'
, dynamicMetadata: 
[2025-03-11 01:10:16.865][13][debug][rbac] [source/extensions/filters/http/rbac/rbac_filter.cc:216] no engine, allowed by default
[2025-03-11 01:10:16.865][13][debug][router] [source/common/router/router.cc:525] [Tags: "ConnectionId":"0","StreamId":"4819276121011834334"] cluster 'extension/projectcontour-auth/htpasswd' match for URL '/envoy.service.auth.v3.Authorization/Check'
[2025-03-11 01:10:16.865][13][debug][router] [source/common/router/router.cc:750] [Tags: "ConnectionId":"0","StreamId":"4819276121011834334"] router decoding headers:
':method', 'POST'
':path', '/envoy.service.auth.v3.Authorization/Check'
':authority', 'extension.projectcontour-auth.htpasswd'
':scheme', 'http'
'te', 'trailers'
'grpc-timeout', '200m'
'content-type', 'application/grpc'
'x-envoy-internal', 'true'
'x-forwarded-for', '100.66.8.179'
'x-envoy-expected-rq-timeout-ms', '200'
[2025-03-11 01:10:16.865][13][debug][pool] [source/common/http/conn_pool_base.cc:78] queueing stream due to no available connections (ready=0 busy=0 connecting=0)
[2025-03-11 01:10:16.865][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:291] trying to create new connection
[2025-03-11 01:10:16.865][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:145] creating a new connection (connecting=0)
[2025-03-11 01:10:16.865][13][debug][http2] [source/common/http/http2/codec_impl.cc:1696] [Tags: "ConnectionId":"69"] updating connection-level initial window size to 268435456
[2025-03-11 01:10:16.865][13][debug][connection] [./source/common/network/connection_impl.h:98] [Tags: "ConnectionId":"69"] current connecting state: true
[2025-03-11 01:10:16.865][13][debug][client] [source/common/http/codec_client.cc:57] [Tags: "ConnectionId":"69"] connecting
[2025-03-11 01:10:16.865][13][debug][connection] [source/common/network/connection_impl.cc:1017] [Tags: "ConnectionId":"69"] connecting to 100.66.10.198:9443
[2025-03-11 01:10:16.865][13][debug][connection] [source/common/network/connection_impl.cc:1036] [Tags: "ConnectionId":"69"] connection in progress
[2025-03-11 01:10:16.865][13][debug][connection] [source/common/network/connection_impl.cc:746] [Tags: "ConnectionId":"69"] connected
[2025-03-11 01:10:16.865][13][debug][client] [source/common/http/codec_client.cc:88] [Tags: "ConnectionId":"69"] connected
[2025-03-11 01:10:16.866][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:328] [Tags: "ConnectionId":"69"] attaching to next stream
[2025-03-11 01:10:16.866][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:182] [Tags: "ConnectionId":"69"] creating stream
[2025-03-11 01:10:16.866][13][debug][router] [source/common/router/upstream_request.cc:595] [Tags: "ConnectionId":"0","StreamId":"4819276121011834334"] pool ready
[2025-03-11 01:10:16.866][13][debug][client] [source/common/http/codec_client.cc:142] [Tags: "ConnectionId":"69"] encode complete
[2025-03-11 01:10:16.866][13][debug][http2] [source/common/http/http2/codec_impl.cc:1803] [Tags: "ConnectionId":"69"] Http2Visitor::OnFrameHeader(0, 12, 4, 0)
[2025-03-11 01:10:17.051][13][debug][http2] [source/common/http/http2/codec_impl.cc:1803] [Tags: "ConnectionId":"69"] Http2Visitor::OnFrameHeader(0, 0, 4, 1)
[2025-03-11 01:10:17.052][13][debug][http2] [source/common/http/http2/codec_impl.cc:1803] [Tags: "ConnectionId":"69"] Http2Visitor::OnFrameHeader(0, 4, 8, 0)
[2025-03-11 01:10:17.052][13][debug][http2] [source/common/http/http2/codec_impl.cc:1803] [Tags: "ConnectionId":"69"] Http2Visitor::OnFrameHeader(0, 8, 6, 0)
[2025-03-11 01:10:17.064][18][debug][filter] [source/extensions/filters/listener/tls_inspector/tls_inspector.cc:137] tls:onServerName(), requestedServerName: dev-broker-b.deleo.co.kr
[2025-03-11 01:10:17.064][18][debug][conn_handler] [source/common/listener_manager/active_stream_listener_base.cc:45] closing connection from 43.202.119.187:36482: no matching filter chain found
[2025-03-11 01:10:17.064][13][debug][router] [source/common/router/router.cc:1104] [Tags: "ConnectionId":"0","StreamId":"4819276121011834334"] upstream timeout
[2025-03-11 01:10:17.064][13][debug][router] [source/common/router/upstream_request.cc:493] [Tags: "ConnectionId":"0","StreamId":"4819276121011834334"] resetting pool request
[2025-03-11 01:10:17.064][13][debug][client] [source/common/http/codec_client.cc:159] [Tags: "ConnectionId":"69"] request reset
[2025-03-11 01:10:17.064][13][debug][pool] [source/common/conn_pool/conn_pool_base.cc:215] [Tags: "ConnectionId":"69"] destroying stream: 0 remaining
[2025-03-11 01:10:17.064][13][debug][http2] [source/common/http/http2/codec_impl.cc:1293] [Tags: "ConnectionId":"69"] sent reset code=0
[2025-03-11 01:10:17.064][13][debug][http2] [source/common/http/http2/codec_impl.cc:1445] [Tags: "ConnectionId":"69"] stream 1 closed: 0
[2025-03-11 01:10:17.064][13][debug][http2] [source/common/http/http2/codec_impl.cc:1508] [Tags: "ConnectionId":"69"] Recouping 0 bytes of flow control window for stream 1.
[2025-03-11 01:10:17.064][13][debug][http2] [source/common/http/http2/codec_impl.cc:1930] [Tags: "ConnectionId":"69"] Http2Visitor invoking stream close listener for 1
[2025-03-11 01:10:17.064][13][debug][http] [source/common/http/async_client_impl.cc:178] async http request response headers (end_stream=true):
':status', '200'
'content-type', 'application/grpc'
'grpc-status', '14'
'grpc-message', 'upstream request timeout'
[2025-03-11 01:10:17.065][13][debug][http] [source/common/http/filter_manager.cc:1075] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] Sending local reply with details ext_authz_error
[2025-03-11 01:10:17.065][13][debug][http] [source/common/http/conn_manager_impl.cc:1825] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] encoding headers via codec (end_stream=true):
':status', '403'
'vary', 'Accept-Encoding'
'date', 'Tue, 11 Mar 2025 01:10:16 GMT'
'server', 'envoy'
[2025-03-11 01:10:17.065][13][debug][http] [source/common/http/conn_manager_impl.cc:1937] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] Codec completed encoding stream.
[2025-03-11 01:10:17.072][13][debug][connection] [source/common/network/connection_impl.cc:714] [Tags: "ConnectionId":"68"] remote close
[2025-03-11 01:10:17.072][13][debug][connection] [source/common/network/connection_impl.cc:276] [Tags: "ConnectionId":"68"] closing socket: 0
[2025-03-11 01:10:17.072][13][debug][connection] [source/common/tls/ssl_socket.cc:339] [Tags: "ConnectionId":"68"] SSL shutdown: rc=1
[2025-03-11 01:10:17.072][13][debug][conn_handler] [source/common/listener_manager/active_stream_listener_base.cc:136] [Tags: "ConnectionId":"68"] adding to cleanup list
```

```txt
[2025-03-11 01:10:17.064][13][debug][http] [source/common/http/async_client_impl.cc:178] async http request response headers (end_stream=true):
':status', '200'
'content-type', 'application/grpc'
'grpc-status', '14'
'grpc-message', 'upstream request timeout'
[2025-03-11 01:10:17.065][13][debug][http] [source/common/http/filter_manager.cc:1075] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] Sending local reply with details ext_authz_error
[2025-03-11 01:10:17.065][13][debug][http] [source/common/http/conn_manager_impl.cc:1825] [Tags: "ConnectionId":"68","StreamId":"11058351132470335050"] encoding headers via codec (end_stream=true):
':status', '403'
'vary', 'Accept-Encoding'
'date', 'Tue, 11 Mar 2025 01:10:16 GMT'
'server', 'envoy'
```
Even though I ran all the example codes in the documentation, if look at the following logs, it can see that the grpc response failed to authenticate with a timeout and finally returned a 403 code. After some trial and error, I was able to resolve the issue after setting a timeout in extensionService . I'm not sure if this timeout setting is necessary for everyone, but I think it's worth adding to the documentation for cases like mine.