### PR TITLE
Bumped Envoy to 1.31.6 in release-1.30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.31.5
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.31.6
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/6969-tsaarni-small.md
+++ b/changelogs/unreleased/6969-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.31.6. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.31.6/version_history/v1.31/v1.31.6) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.30.2",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.31.5",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.31.6",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.5
+        image: docker.io/envoyproxy/envoy:v1.31.6
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.31.5
+          image: docker.io/envoyproxy/envoy:v1.31.6
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9309,7 +9309,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.31.5
+          image: docker.io/envoyproxy/envoy:v1.31.6
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9113,7 +9113,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.5
+        image: docker.io/envoyproxy/envoy:v1.31.6
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9297,7 +9297,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.5
+        image: docker.io/envoyproxy/envoy:v1.31.6
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
This PR updates to [Envoy 1.31.6](https://www.envoyproxy.io/docs/envoy/v1.31.6/version_history/v1.31/v1.31.6). The update addresses [CVE-2025-30157](https://github.com/envoyproxy/envoy/security/advisories/GHSA-cf3q-gqg7-3fm9): "_Envoy crashes when HTTP ext_proc processes local replies_".