### PR TITLE
Bumped Envoy to 1.30.10 in release-1.29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE := $(REGISTRY)/$(PROJECT)
 SRCDIRS := ./cmd ./internal ./apis
 LOCAL_BOOTSTRAP_CONFIG = localenvoyconfig.yaml
 SECURE_LOCAL_BOOTSTRAP_CONFIG = securelocalenvoyconfig.yaml
-ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.30.9
+ENVOY_IMAGE = docker.io/envoyproxy/envoy:v1.30.10
 GATEWAY_API_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}')
 
 # Used to supply a local Envoy docker container an IP to connect to that is running

--- a/changelogs/unreleased/6970-tsaarni-small.md
+++ b/changelogs/unreleased/6970-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.30.10. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.30.10/version_history/v1.30/v1.30.10) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.29.4",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.30.9",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.30.10",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -50,7 +50,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.9
+        image: docker.io/envoyproxy/envoy:v1.30.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.30.9
+          image: docker.io/envoyproxy/envoy:v1.30.10
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9267,7 +9267,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.30.9
+          image: docker.io/envoyproxy/envoy:v1.30.10
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9071,7 +9071,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.9
+        image: docker.io/envoyproxy/envoy:v1.30.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9255,7 +9255,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.30.9
+        image: docker.io/envoyproxy/envoy:v1.30.10
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
This PR updates to [Envoy 1.30.10](https://www.envoyproxy.io/docs/envoy/v1.30.10/version_history/v1.30/v1.30.10). The update addresses [CVE-2025-30157](https://github.com/envoyproxy/envoy/security/advisories/GHSA-cf3q-gqg7-3fm9): "_Envoy crashes when HTTP ext_proc processes local replies_".