### PR TITLE
Bump Go version to 1.22.12 for release-1.29

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -13,7 +13,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.22.12
 
 jobs:
   e2e-contour-xds:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -19,7 +19,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.22.12
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.22.12
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -14,7 +14,7 @@ permissions:
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GO_VERSION: 1.22.10
+  GO_VERSION: 1.22.12
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.22.10@sha256:1a6e657ab55c424c837bd3f18289092caca0a106bcd114a8997b1d7fc81565b0
+BUILD_BASE_IMAGE ?= golang:1.22.12@sha256:1f298b0c9fecdf504389a0329236f948cc04a566a2bb32337207cbaaa2f8177c
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/6972-tsaarni-small.md
+++ b/changelogs/unreleased/6972-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Go to go1.22.12. See the [Go release notes](https://go.dev/doc/devel/release#go1.22.0) for more information about the content of the release.


### PR DESCRIPTION
This PR updates Go to version [1.22.12](https://go.dev/doc/devel/release#go1.22.0) for release 1.29 branch.
