### PR TITLE
Add ECDSA P-521 support for XDS interface

### DIFF
--- a/changelogs/unreleased/6996-tsaarni-small.md
+++ b/changelogs/unreleased/6996-tsaarni-small.md
@@ -1,0 +1,1 @@
+Add support for the SECP521R1 curve, enabling the use of EC certificates with 521-bit private keys in the xDS gRPC interface between Envoy and Contour.

--- a/internal/envoy/v3/bootstrap.go
+++ b/internal/envoy/v3/bootstrap.go
@@ -360,6 +360,22 @@ func upstreamSdsTLSContext(certificateSdsFile, validationSdsFile string) *envoy_
 		CommonTlsContext: &envoy_transport_socket_tls_v3.CommonTlsContext{
 			TlsParams: &envoy_transport_socket_tls_v3.TlsParameters{
 				TlsMaximumProtocolVersion: envoy_transport_socket_tls_v3.TlsParameters_TLSv1_3,
+				// To allow use of ECDSA P-521 certs for xDS the default signature algorithms list is overridden.
+				// This override is a temporary workaround until BoringSSL includes "ecdsa_secp521r1_sha512" in the default list.
+				// The default list can be found here:
+				// https://github.com/google/boringssl/blob/45a865d6682a7bc989143d73466ade7728959324/ssl/extensions.cc#L275-L293
+				SignatureAlgorithms: []string{
+					"ecdsa_secp256r1_sha256",
+					"rsa_pss_rsae_sha256",
+					"rsa_pkcs1_sha256",
+					"ecdsa_secp384r1_sha384",
+					"rsa_pss_rsae_sha384",
+					"rsa_pkcs1_sha384",
+					"ecdsa_secp521r1_sha512",
+					"rsa_pss_rsae_sha512",
+					"rsa_pkcs1_sha512",
+					"rsa_pkcs1_sha1",
+				},
 			},
 			TlsCertificateSdsSecretConfigs: []*envoy_transport_socket_tls_v3.SdsSecretConfig{{
 				Name: "contour_xds_tls_certificate",

--- a/internal/envoy/v3/bootstrap_test.go
+++ b/internal/envoy/v3/bootstrap_test.go
@@ -1595,7 +1595,19 @@ func TestBootstrap(t *testing.T) {
                   "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
                   "common_tls_context": {
                     "tls_params": {
-                      "tls_maximum_protocol_version": "TLSv1_3"
+                      "tls_maximum_protocol_version": "TLSv1_3",
+                      "signature_algorithms": [
+                        "ecdsa_secp256r1_sha256",
+                        "rsa_pss_rsae_sha256",
+                        "rsa_pkcs1_sha256",
+                        "ecdsa_secp384r1_sha384",
+                        "rsa_pss_rsae_sha384",
+                        "rsa_pkcs1_sha384",
+                        "ecdsa_secp521r1_sha512",
+                        "rsa_pss_rsae_sha512",
+                        "rsa_pkcs1_sha512",
+                        "rsa_pkcs1_sha1"
+                      ]
                     },
                     "tls_certificate_sds_secret_configs": [
                       {


### PR DESCRIPTION
When Envoy connects to Contour over the xDS gRPC interface, it doesn't include `secp521r1` in the TLS `signature_algorithms` extension because of BoringSSL’s default settings. As a result, the TLS handshake fails when using EC certificates with 521-bit private keys for the xDS interface.  

This PR updates the Envoy bootstrap configuration to explicitly specify the list of supported signature algorithms, including `secp521r1`, enabling compatibility with these certificates.

Fixes #6997