### PR TITLE
Bump Envoy to 1.34.1

### DIFF
--- a/changelogs/unreleased/7033-tsaarni-small.md
+++ b/changelogs/unreleased/7033-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.34.1. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.34.1/version_history/v1.34/v1.34.1) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.34.0",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.34.1",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.0
+        image: docker.io/envoyproxy/envoy:v1.34.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.34.0
+          image: docker.io/envoyproxy/envoy:v1.34.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9441,7 +9441,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.34.0
+          image: docker.io/envoyproxy/envoy:v1.34.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9246,7 +9246,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.0
+        image: docker.io/envoyproxy/envoy:v1.34.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9429,7 +9429,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.0
+        image: docker.io/envoyproxy/envoy:v1.34.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.34.0][66]         | 1.33, 1.32, 1.31    | [1.2.1][112]        |
+| main            | [1.34.1][72]         | 1.33, 1.32, 1.31    | [1.2.1][112]        |
 | 1.31.0          | [1.34.0][66]         | 1.32, 1.31, 1.30    | [1.2.1][112]        |
 | 1.30.3          | [1.31.6][71]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
 | 1.30.2          | [1.31.5][69]         | 1.30, 1.29, 1.28    | [1.1.0][111]        |
@@ -226,6 +226,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [69]: https://www.envoyproxy.io/docs/envoy/v1.31.5/version_history/v1.31/v1.31.5
 [70]: https://www.envoyproxy.io/docs/envoy/v1.30.10/version_history/v1.30/v1.30.10
 [71]: https://www.envoyproxy.io/docs/envoy/v1.31.6/version_history/v1.31/v1.31.6
+[72]: https://www.envoyproxy.io/docs/envoy/v1.34.1/version_history/v1.34/v1.34
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.34.0"
+      envoy: "1.34.1"
       kubernetes:
         - "1.33"
         - "1.32"


### PR DESCRIPTION
This PR updates Envoy to version 1.34.1 and addresses https://github.com/envoyproxy/envoy/security/advisories/GHSA-c7cm-838g-6g67.

Contour was not affected by this vulnerability because it does not use `uri_template` permissions with Envoy's HTTP RBAC extension.