### PR TITLE
[Contour Gateway Provisioner] add imagepullsecret for envoy and contour (fixes #7138)

### DIFF
--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -41,6 +41,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",
 		gatewayControllerName: "projectcontour.io/gateway-controller",
+		imagePullSecret:       "",
 	}
 
 	cmd.Flag("contour-image", "The container image used for the managed Contour.").
@@ -57,6 +58,10 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 	cmd.Flag("gateway-controller-name", "The controller string to process GatewayClasses and Gateways for.").
 		Default(provisionerConfig.gatewayControllerName).
 		StringVar(&provisionerConfig.gatewayControllerName)
+
+	cmd.Flag("image-pull-secret", "The image pull secret for the managed Envoy and Contour.").
+		Default(provisionerConfig.imagePullSecret).
+		StringVar(&provisionerConfig.imagePullSecret)
 
 	cmd.Flag("incluster", "Use in cluster configuration.").
 		Default("true").
@@ -84,6 +89,10 @@ type gatewayProvisionerConfig struct {
 	// envoyImage is the container image for the Envoy container(s) managed
 	// by the gateway provisioner.
 	envoyImage string
+
+	// imagePullSecret is the name of the image pull secret that will be used
+	// to pull the Contour and Envoy images.
+	imagePullSecret string
 
 	// metricsBindAddress is the TCP address that the gateway provisioner should bind to for
 	// serving prometheus metrics. It can be set to "0" to disable the metrics serving.
@@ -171,7 +180,7 @@ func createManager(restConfig *rest.Config, provisionerConfig *gatewayProvisione
 	if _, err := controller.NewGatewayClassController(mgr, provisionerConfig.gatewayControllerName); err != nil {
 		return nil, fmt.Errorf("failed to create gatewayclass controller: %w", err)
 	}
-	if _, err := controller.NewGatewayController(mgr, provisionerConfig.gatewayControllerName, provisionerConfig.contourImage, provisionerConfig.envoyImage); err != nil {
+	if _, err := controller.NewGatewayController(mgr, provisionerConfig.gatewayControllerName, provisionerConfig.contourImage, provisionerConfig.envoyImage, provisionerConfig.imagePullSecret); err != nil {
 		return nil, fmt.Errorf("failed to create gateway controller: %w", err)
 	}
 	return mgr, nil

--- a/internal/provisioner/equality/equality_test.go
+++ b/internal/provisioner/equality/equality_test.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	testName  = "test"
-	testNs    = testName + "-ns"
-	testImage = "test-image:main"
-	cntr      = &model.Contour{
+	testName            = "test"
+	testNs              = testName + "-ns"
+	testImage           = "test-image:main"
+	testImagePullSecret = ""
+	cntr                = &model.Contour{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      testName,
 			Namespace: testNs,
@@ -122,7 +123,7 @@ func TestDaemonSetConfigChanged(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			original := dataplane.DesiredDaemonSet(cntr, testImage, testImage)
+			original := dataplane.DesiredDaemonSet(cntr, testImage, testImage, testImagePullSecret)
 
 			mutated := original.DeepCopy()
 			tc.mutate(mutated)
@@ -218,7 +219,7 @@ func TestDeploymentConfigChanged(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		original := deployment.DesiredDeployment(cntr, testImage)
+		original := deployment.DesiredDeployment(cntr, testImage, testImagePullSecret)
 		mutated := original.DeepCopy()
 		tc.mutate(mutated)
 		if updated, changed := equality.DeploymentConfigChanged(original, mutated); changed != tc.expect {

--- a/internal/provisioner/objects/dataplane/dataplane_test.go
+++ b/internal/provisioner/objects/dataplane/dataplane_test.go
@@ -311,6 +311,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
+	testImagePullSecret := ""
 	testLogLevelArg := "--log-level debug"
 	testBaseIDArg := "--base-id 1"
 	testEnvoyMaxHeapSize := "--overload-max-heap=8000000000"
@@ -343,7 +344,7 @@ func TestDesiredDaemonSet(t *testing.T) {
 	cntr.Spec.EnvoyMaxHeapSizeBytes = 8000000000
 	cntr.Spec.EnvoyMaxDownstreamConnections = 42
 
-	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
+	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage, testImagePullSecret)
 	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)
 	checkContainerHasArg(t, container, testLogLevelArg)
 	checkContainerHasArg(t, container, testBaseIDArg)
@@ -386,7 +387,8 @@ func TestDesiredDeployment(t *testing.T) {
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
-	deploy := desiredDeployment(cntr, testContourImage, testEnvoyImage)
+	testImagePullSecret := ""
+	deploy := desiredDeployment(cntr, testContourImage, testEnvoyImage, testImagePullSecret)
 	checkDeploymentHasStrategy(t, deploy, cntr.Spec.EnvoyDeploymentStrategy)
 	checkEnvoyDeploymentHasAffinity(t, deploy, cntr)
 }
@@ -414,7 +416,8 @@ func TestNodePlacementDaemonSet(t *testing.T) {
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
-	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
+	testImagePullSecret := ""
+	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage, testImagePullSecret)
 	checkDaemonSetHasNodeSelector(t, ds, selectors)
 	checkDaemonSetHasTolerations(t, ds, tolerations)
 }
@@ -436,7 +439,8 @@ func TestEnvoyCustomPorts(t *testing.T) {
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
 	testEnvoyImage := "docker.io/envoyproxy/envoy:test"
-	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage)
+	testImagePullSecret := ""
+	ds := DesiredDaemonSet(cntr, testContourImage, testEnvoyImage, testImagePullSecret)
 	checkContainerHasPort(t, ds, int32(metricPort))
 
 	container := checkDaemonSetHasContainer(t, ds, EnvoyContainerName, true)

--- a/internal/provisioner/objects/deployment/deployment_test.go
+++ b/internal/provisioner/objects/deployment/deployment_test.go
@@ -178,7 +178,8 @@ func TestDesiredDeployment(t *testing.T) {
 	}
 
 	testContourImage := "ghcr.io/projectcontour/contour:test"
-	deploy := DesiredDeployment(cntr, testContourImage)
+	testImagePullSecret := ""
+	deploy := DesiredDeployment(cntr, testContourImage, testImagePullSecret)
 
 	container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
 	checkContainerHasImage(t, container, testContourImage)
@@ -239,7 +240,7 @@ func TestDesiredDeploymentWhenSettingWatchNamespaces(t *testing.T) {
 			cntr.Spec.IngressClassName = &icName
 			// Change the Contour watch namespaces flag
 			cntr.Spec.WatchNamespaces = tc.namespaces
-			deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test")
+			deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test", "")
 			container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
 			arg := fmt.Sprintf("--watch-namespaces=%s", strings.Join(append(model.NamespacesToStrings(tc.namespaces), cntr.Namespace), ","))
 			checkContainerHasArg(t, container, arg)
@@ -268,7 +269,7 @@ func TestNodePlacementDeployment(t *testing.T) {
 		},
 	}
 
-	deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test")
+	deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test", "")
 
 	checkDeploymentHasNodeSelector(t, deploy, selectors)
 	checkDeploymentHasTolerations(t, deploy, tolerations)
@@ -297,7 +298,7 @@ func TestDesiredDeploymentWhenSettingDisabledFeature(t *testing.T) {
 			cntr.Spec.IngressClassName = &icName
 			cntr.Spec.DisabledFeatures = tc.disabledFeatures
 			// Change the Contour watch namespaces flag
-			deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test")
+			deploy := DesiredDeployment(cntr, "ghcr.io/projectcontour/contour:test", "")
 			container := checkDeploymentHasContainer(t, deploy, contourContainerName, true)
 			for _, f := range tc.disabledFeatures {
 				arg := fmt.Sprintf("--disable-feature=%s", string(f))


### PR DESCRIPTION
add a new image-pull-secret args for Contour Gateway Provisioner to be able to use an existing secret as image-pull-secret for envoy and contour