### PR TITLE
Bump Envoy to v1.34.4 for release track 1.32

### DIFF
--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.32.0",
-		envoyImage:            "docker.io/envoyproxy/envoy:v1.34.1",
+		envoyImage:            "docker.io/envoyproxy/envoy:v1.34.4",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.1
+        image: docker.io/envoyproxy/envoy:v1.34.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.34.1
+          image: docker.io/envoyproxy/envoy:v1.34.4
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9440,7 +9440,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:v1.34.1
+          image: docker.io/envoyproxy/envoy:v1.34.4
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9245,7 +9245,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.1
+        image: docker.io/envoyproxy/envoy:v1.34.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9428,7 +9428,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.34.1
+        image: docker.io/envoyproxy/envoy:v1.34.4
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
Bump Envoy version from v1.34.1 to v1.34.4.

Changes 

* https://www.envoyproxy.io/docs/envoy/v1.34.4/version_history/v1.34/v1.34.4
* https://www.envoyproxy.io/docs/envoy/v1.34.3/version_history/v1.34/v1.34.3
* https://www.envoyproxy.io/docs/envoy/v1.34.2/version_history/v1.34/v1.34.2