### PR TITLE
Bump Go to 1.25 and update golangci-lint to v2.4.0

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.24.3
+  GO_VERSION: 1.25.0
 
 jobs:
   e2e-envoy-deployment:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.24.3
+  GO_VERSION: 1.25.0
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.24.3
+  GO_VERSION: 1.25.0
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.24.3
+  GO_VERSION: 1.25.0
 
 jobs:
   lint:
@@ -29,7 +29,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.6
+        version: v2.4.0
         args: --build-tags=e2e,conformance,gcp,oidc,none
   codespell:
     name: Codespell

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc
+BUILD_BASE_IMAGE ?= golang:1.25.0@sha256:9e56f0d0f043a68bb8c47c819e47dc29f6e8f5129b8885bed9d43f058f7f3ed6
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/7169-tsaarni-small.md
+++ b/changelogs/unreleased/7169-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Go to go1.25.0. See the [Go release notes](https://go.dev/doc/devel/release#go1.25.0) for more information about the content of the release.

--- a/hack/golangci-lint
+++ b/hack/golangci-lint
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 "$@"
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 "$@"

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role.go
@@ -25,7 +25,7 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/labels"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects"
-	"github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
+	rbacutil "github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
 )
 
 // EnsureClusterRole ensures a ClusterRole resource exists with the provided name
@@ -53,14 +53,14 @@ func desiredClusterRole(name string, contour *model.Contour, clusterScopedResour
 			Labels:      contour.CommonLabels(),
 			Annotations: contour.CommonAnnotations(),
 		},
-		Rules: util.ClusterScopedResourcePolicyRules(),
+		Rules: rbacutil.ClusterScopedResourcePolicyRules(),
 	}
 	if clusterScopedResourceOnly {
 		return role
 	}
 
 	// add other rules for namespacedResources, so that we can associated them with ClusterRole later
-	role.Rules = append(role.Rules, util.NamespacedResourcePolicyRules(contour.Spec.DisabledFeatures)...)
+	role.Rules = append(role.Rules, rbacutil.NamespacedResourcePolicyRules(contour.Spec.DisabledFeatures)...)
 	return role
 }
 

--- a/internal/provisioner/objects/rbac/clusterrole/cluster_role_test.go
+++ b/internal/provisioner/objects/rbac/clusterrole/cluster_role_test.go
@@ -25,7 +25,7 @@ import (
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/provisioner/model"
-	"github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
+	rbacutil "github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
 	"github.com/projectcontour/contour/internal/provisioner/slice"
 )
 
@@ -134,48 +134,48 @@ func TestDesiredClusterRoleFilterResources(t *testing.T) {
 			description:               "empty disabled features",
 			disabledFeatures:          nil,
 			clusterScopedResourceOnly: false,
-			expectedGateway:           [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
-			expectedContour:           [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedGateway:           [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
+			expectedContour:           [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 		{
 			description:               "disable tlsroutes feature",
 			disabledFeatures:          []contour_v1.Feature{"tlsroutes"},
 			clusterScopedResourceOnly: false,
 			expectedGateway: [][]string{
-				removeFromStringArray(util.GatewayGroupNamespacedResource, "tlsroutes"),
-				removeFromStringArray(util.GatewayGroupNamespacedResourceStatus, "tlsroutes/status"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResource, "tlsroutes"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResourceStatus, "tlsroutes/status"),
 			},
-			expectedContour: [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedContour: [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 
 		{
 			description:               "disable extensionservices feature",
 			disabledFeatures:          []contour_v1.Feature{"extensionservices"},
 			clusterScopedResourceOnly: false,
-			expectedGateway:           [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
+			expectedGateway:           [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
 			expectedContour: [][]string{
-				removeFromStringArray(util.ContourGroupNamespacedResource, "extensionservices"),
-				removeFromStringArray(util.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResource, "extensionservices"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
 			},
 		},
 		{
 			description:               "disable non-existent features",
 			disabledFeatures:          []contour_v1.Feature{"abc", "efg"},
 			clusterScopedResourceOnly: false,
-			expectedGateway:           [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
-			expectedContour:           [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedGateway:           [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
+			expectedContour:           [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 		{
 			description:               "disable both gateway and contour features",
 			disabledFeatures:          []contour_v1.Feature{"grpcroutes", "tlsroutes", "extensionservices", "backendtlspolicies"},
 			clusterScopedResourceOnly: false,
 			expectedGateway: [][]string{
-				removeFromStringArray(util.GatewayGroupNamespacedResource, "tlsroutes", "grpcroutes", "backendtlspolicies"),
-				removeFromStringArray(util.GatewayGroupNamespacedResourceStatus, "tlsroutes/status", "grpcroutes/status", "backendtlspolicies/status"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResource, "tlsroutes", "grpcroutes", "backendtlspolicies"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResourceStatus, "tlsroutes/status", "grpcroutes/status", "backendtlspolicies/status"),
 			},
 			expectedContour: [][]string{
-				removeFromStringArray(util.ContourGroupNamespacedResource, "extensionservices"),
-				removeFromStringArray(util.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResource, "extensionservices"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
 			},
 		},
 		{

--- a/internal/provisioner/objects/rbac/role/role.go
+++ b/internal/provisioner/objects/rbac/role/role.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcontour/contour/internal/provisioner/labels"
 	"github.com/projectcontour/contour/internal/provisioner/model"
 	"github.com/projectcontour/contour/internal/provisioner/objects"
-	"github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
+	rbacutil "github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
 )
 
 // EnsureControllerRole ensures a Role resource exists with the for the Contour
@@ -109,7 +109,7 @@ func desiredRoleForResourceInNamespace(name, namespace string, contour *model.Co
 			Labels:      contour.CommonLabels(),
 			Annotations: contour.CommonAnnotations(),
 		},
-		Rules: util.NamespacedResourcePolicyRules(contour.Spec.DisabledFeatures),
+		Rules: rbacutil.NamespacedResourcePolicyRules(contour.Spec.DisabledFeatures),
 	}
 }
 

--- a/internal/provisioner/objects/rbac/role/role_test.go
+++ b/internal/provisioner/objects/rbac/role/role_test.go
@@ -24,7 +24,7 @@ import (
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/provisioner/model"
-	"github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
+	rbacutil "github.com/projectcontour/contour/internal/provisioner/objects/rbac/util"
 	"github.com/projectcontour/contour/internal/provisioner/slice"
 )
 
@@ -137,44 +137,44 @@ func TestDesiredRoleFilterResources(t *testing.T) {
 		{
 			description:      "empty disabled features",
 			disabledFeatures: nil,
-			expectedGateway:  [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
-			expectedContour:  [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedGateway:  [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
+			expectedContour:  [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 		{
 			description:      "disable tlsroutes feature",
 			disabledFeatures: []contour_v1.Feature{"tlsroutes"},
 			expectedGateway: [][]string{
-				removeFromStringArray(util.GatewayGroupNamespacedResource, "tlsroutes"),
-				removeFromStringArray(util.GatewayGroupNamespacedResourceStatus, "tlsroutes/status"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResource, "tlsroutes"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResourceStatus, "tlsroutes/status"),
 			},
-			expectedContour: [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedContour: [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 
 		{
 			description:      "disable extensionservices feature",
 			disabledFeatures: []contour_v1.Feature{"extensionservices"},
-			expectedGateway:  [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
+			expectedGateway:  [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
 			expectedContour: [][]string{
-				removeFromStringArray(util.ContourGroupNamespacedResource, "extensionservices"),
-				removeFromStringArray(util.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResource, "extensionservices"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
 			},
 		},
 		{
 			description:      "disable non-existent features",
 			disabledFeatures: []contour_v1.Feature{"abc", "efg"},
-			expectedGateway:  [][]string{util.GatewayGroupNamespacedResource, util.GatewayGroupNamespacedResourceStatus},
-			expectedContour:  [][]string{util.ContourGroupNamespacedResource, util.ContourGroupNamespacedResourceStatus},
+			expectedGateway:  [][]string{rbacutil.GatewayGroupNamespacedResource, rbacutil.GatewayGroupNamespacedResourceStatus},
+			expectedContour:  [][]string{rbacutil.ContourGroupNamespacedResource, rbacutil.ContourGroupNamespacedResourceStatus},
 		},
 		{
 			description:      "disable both gateway and contour features",
 			disabledFeatures: []contour_v1.Feature{"grpcroutes", "tlsroutes", "backendtlspolicies", "extensionservices"},
 			expectedGateway: [][]string{
-				removeFromStringArray(util.GatewayGroupNamespacedResource, "tlsroutes", "grpcroutes", "backendtlspolicies"),
-				removeFromStringArray(util.GatewayGroupNamespacedResourceStatus, "tlsroutes/status", "grpcroutes/status", "backendtlspolicies/status"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResource, "tlsroutes", "grpcroutes", "backendtlspolicies"),
+				removeFromStringArray(rbacutil.GatewayGroupNamespacedResourceStatus, "tlsroutes/status", "grpcroutes/status", "backendtlspolicies/status"),
 			},
 			expectedContour: [][]string{
-				removeFromStringArray(util.ContourGroupNamespacedResource, "extensionservices"),
-				removeFromStringArray(util.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResource, "extensionservices"),
+				removeFromStringArray(rbacutil.ContourGroupNamespacedResourceStatus, "extensionservices/status"),
 			},
 		},
 	}

--- a/internal/provisioner/objects/rbac/util/rbacutil.go
+++ b/internal/provisioner/objects/rbac/util/rbacutil.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package rbacutil
 
 import (
 	"strings"

--- a/internal/provisioner/objects/rbac/util/rbacutil_test.go
+++ b/internal/provisioner/objects/rbac/util/rbacutil_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package rbacutil
 
 import (
 	"reflect"


### PR DESCRIPTION
Updates Go to [1.25](https://go.dev/doc/go1.25) and golangci-lint to [2.4.0](https://github.com/golangci/golangci-lint/releases/tag/v2.4.0) for compiler compatibility. 

There in new (opinionated) check in revive  that caused a lint failure (`var-naming: avoid meaningless package names (revive)`) so `util` was renamed to `rbacutils`.