### PR TITLE
docs: add method matching example for HTTPProxy using Envoy pseudo-headers

### DIFF
--- a/site/content/docs/main/config/request-routing.md
+++ b/site/content/docs/main/config/request-routing.md
@@ -128,7 +128,7 @@ Modifiers:
 
 #### Method Matching
 
-HTTPProxy currently does not provide a dedicated field for matching HTTP methods. However, you can achieve method-based routing using **header conditions** with the Envoy pseudo-header `:method`. This allows routing requests based on HTTP methods such as `GET`, `POST`, `PUT`, etc.
+HTTPProxy currently does not provide a dedicated field for matching HTTP methods. However, you can achieve method-based routing using **header conditions** with the HTTP/2 pseudo-header formatted`:method` header match. This allows routing requests based on HTTP methods such as `GET`, `POST`, `PUT`, etc.
 
 ```yaml
 apiVersion: projectcontour.io/v1


### PR DESCRIPTION
## Overview

This PR adds documentation for **HTTP method-based routing** in `HTTPProxy` objects using Envoy pseudo-headers (`:method`). While Contour supports routing based on path, headers, and query parameters, method matching was not clearly documented. This update provides guidance for users who want to route requests based on HTTP methods such as GET, POST, PUT, etc.

## What was changed

- Added a **Method Matching** section under **Route Conditions** in `request-routing.md`.
- Included a **YAML example** demonstrating routing GET and POST requests to different backend services.
- Explained how to use Envoy pseudo-header `:method` with header conditions to implement method-based routing.
- Positioned the new section logically after **Header Conditions** so users can understand it in the context of existing routing options.

## Why this change is needed

- Existing documentation does not cover method matching in `HTTPProxy`, even though it is supported via Envoy pseudo-headers.
- Users currently may be unaware of how to implement method-based routing.
- Improves Contour documentation completeness and user experience.

## Example

```yaml
apiVersion: projectcontour.io/v1
kind: HTTPProxy
metadata:
  name: method-routing
  namespace: default
spec:
  virtualhost:
    fqdn: example.bar.com
  routes:
    - conditions:
        - header:
            name: ":method"
            exact: GET
      services:
        - name: get-service
          port: 80
    - conditions:
        - header:
            name: ":method"
            exact: POST
      services:
        - name: post-service
          port: 80
```
This example demonstrates routing GET requests to get-service and POST requests to post-service.

## Related Issue
Closes #5753 - Document how to do method matching in HTTPProxy