### PR TITLE
docs: update outdated reference to bitnami

### DIFF
--- a/SITE_CONTRIBUTION.md
+++ b/SITE_CONTRIBUTION.md
@@ -58,8 +58,7 @@ A reference table, located at the end of the Markdown file, uses the following f
 [4]: https://httpbin.org/
 [5]: https://github.com/projectcontour/community/wiki/Office-Hours
 [6]: {{< param slack_url >}}
-[7]: https://github.com/bitnami/charts/tree/master/bitnami/contour
-[8]: https://www.youtube.com/watch?v=xUJbTnN3Dmw
+[7]: https://www.youtube.com/watch?v=xUJbTnN3Dmw
 ```
 
 ## Using URL parameters

--- a/site/content/getting-started/_index.md
+++ b/site/content/getting-started/_index.md
@@ -47,7 +47,7 @@ You should see the following:
 ### Option 2: Helm
 This option requires [Helm to be installed locally][29].
 
-Add the bitnami chart repository (which contains the Contour chart) by running the following:
+Add projectcontour's chart repository by running the following:
 
 ```bash
 $ helm repo add contour https://projectcontour.github.io/helm-charts/
@@ -232,8 +232,6 @@ If you encounter issues, review the [troubleshooting][17] page, [file an issue][
 [12]: {{< param slack_url >}}
 [13]: https://projectcontour.io/resources/deprecation-policy/
 [14]: /docs/{{< param latest_version >}}/guides/gateway-api
-[15]: https://github.com/bitnami/charts/tree/master/bitnami/contour
-[16]: https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice
 [17]: /docs/{{< param latest_version >}}/troubleshooting
 [18]: /docs/{{< param latest_version >}}/architecture
 [19]: https://youtu.be/YA82A4Rcs_A


### PR DESCRIPTION
As part of https://github.com/projectcontour/contour/pull/7290, the helm chart repo was changed, but the bitnami reference wasn't. This PR fixes that documentation, removes another example references to bitnami, and removes a unused link.