### PR TITLE
fix: semgrep-allow-privilege-escalation-no-securitycontext #1

### DIFF
--- a/site/content/examples/proxydemo/01-prereq.yaml
+++ b/site/content/examples/proxydemo/01-prereq.yaml
@@ -112,6 +112,8 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
# Fix: Semgrep allow-privilege-escalation-no-securitycontext

## Summary
This pull request resolves the Semgrep finding `allow-privilege-escalation-no-securitycontext`, which identifies Kubernetes container specs lacking an explicit `securityContext` with `allowPrivilegeEscalation` disabled. Without this setting, a container may inherit binaries or permissions that allow unintended privilege escalation.

## Change Details
### Modified File
`site/content/examples/proxydemo/01-prereq.yaml`

### Updates
- Added a `securityContext` block to the affected container definition.
- Explicitly set:
`allowPrivilegeEscalation: false`
- Ensures the container cannot elevate privileges even if setuid/setgid binaries exist.

## Rationale
Containers without a security context may be susceptible to privilege escalation attacks. Kubernetes best practices recommend disabling privilege escalation to provide stronger security boundaries. This update aligns the pod specification with those standards and resolves the Semgrep-reported issue.

## Verification
- Confirmed that the YAML now includes `securityContext.allowPrivilegeEscalation: false`.
- Semgrep rule warning is fully addressed.
- Resource spec remains valid and deployable.