### PR TITLE
provisioner: Increase CPU limit for shutdown-manager

### DIFF
--- a/changelogs/unreleased/7382-tsaarni-small.md
+++ b/changelogs/unreleased/7382-tsaarni-small.md
@@ -1,0 +1,1 @@
+Gateway Provisioner: Increase the `shutdown-manager` CPU limit to 200m to reduce throttling during Envoy shutdown.

--- a/internal/provisioner/objects/dataplane/dataplane.go
+++ b/internal/provisioner/objects/dataplane/dataplane.go
@@ -61,7 +61,9 @@ const (
 	xdsResourceVersion = "v3"
 )
 
-// the default resource requirements for container: envoy-initconfig & shutdown-manager, the default value is come from:
+// the default resource requirements for container: envoy-initconfig & shutdown-manager.
+// CPU limit is generous to avoid throttling.
+// See: https://github.com/projectcontour/contour/issues/7366
 // ref: https://projectcontour.io/docs/1.25/deploy-options/#setting-resource-requests-and-limits
 var defContainerResources = core_v1.ResourceRequirements{
 	Requests: core_v1.ResourceList{
@@ -69,7 +71,7 @@ var defContainerResources = core_v1.ResourceRequirements{
 		core_v1.ResourceMemory: resource.MustParse("50Mi"),
 	},
 	Limits: core_v1.ResourceList{
-		core_v1.ResourceCPU:    resource.MustParse("50m"),
+		core_v1.ResourceCPU:    resource.MustParse("200m"),
 		core_v1.ResourceMemory: resource.MustParse("100Mi"),
 	},
 }


### PR DESCRIPTION
When using the Contour Gateway Provisioner, the `shutdown-manager` container was reported to experience CPU throttling because the default limit (`50m`) was too low for some environments.

This change increases the CPU limit to `200m`.  This hopefully fixes the throttling without needing any configuration changes from users. This limit is high, but it shouldn't cause problems because the `shutdown-manager` logic is very simple and it is unlikely to start e.g. running in a busy loop. I kept the request unchanged, so the change should not impact e.g. dimensioning of resources. 

This PR doesn't make the limits or requests configurable for users.

Updates #7366

