### PR TITLE
Post-process HTTPProxy CRD schema to remove error as a required field

### DIFF
--- a/changelogs/unreleased/7408-tsaarni-small.md
+++ b/changelogs/unreleased/7408-tsaarni-small.md
@@ -1,0 +1,1 @@
+Fix `HTTPProxy` CRD schema incorrectly marking `status.loadBalancer.ingress[].ports[].error` as required, causing load balancer status update failures.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -8595,7 +8595,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -8814,7 +8814,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -8606,7 +8606,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8631,7 +8631,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -8814,7 +8814,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -24,4 +24,23 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd:crdVersions=v1 "paths=${PATHS}" "output:dir=${TEMPDIR}"
 
+# Remove "error" from required fields in load balancer status.
+# For details, see:
+# - https://github.com/projectcontour/contour/issues/7391
+# - https://github.com/kubernetes-sigs/controller-tools/pull/944#issuecomment-3314629362
+# This workaround can be removed if the upstream Kubernetes type resolves the conflicting markers.
+readonly HTTPPROXY_CRD="${TEMPDIR}/projectcontour.io_httpproxies.yaml"
+readonly PATCH_PATH="/spec/versions/0/schema/openAPIV3Schema/properties/status/properties/loadBalancer/properties/ingress/items/properties/ports/items/required/0"
+
+kubectl::patch() {
+  kubectl patch -f "$HTTPPROXY_CRD" --local --type=json -p "$1" "${@:2}"
+}
+
+kubectl::patch "[{\"op\": \"test\", \"path\": \"$PATCH_PATH\", \"value\": \"error\"}]" --dry-run=client > /dev/null || {
+  echo "Error: CRD structure has changed. The workaround for issue #7391 may no longer be needed or needs updating."
+  exit 1
+}
+
+kubectl::patch "[{\"op\": \"remove\", \"path\": \"$PATCH_PATH\"}]" -o yaml > "$HTTPPROXY_CRD.tmp" && { echo "---"; cat "$HTTPPROXY_CRD.tmp"; } > "$HTTPPROXY_CRD"
+
 ls "${TEMPDIR}"/*.yaml | xargs cat | sed '/^$/d' > "${REPO}/examples/contour/01-crds.yaml"


### PR DESCRIPTION
This PR adds a post-processing step to `make generate` to prevent `status.loadBalancer.ingress[].ports[].error` from being incorrectly marked as `required` in the `HTTPProxy` CRD schema, which caused load balancer status update failures.

The issue happens because the [`HTTPProxy`](https://github.com/projectcontour/contour/blob/d368385f0facc965051d129d8fdd95784de85a91/apis/projectcontour/v1/httpproxy.go#L1434-L1435) embeds the Kubernetes `core_v1.LoadBalancerStatus`. This type contains [`PortStatus`](https://github.com/kubernetes/api/blob/fd489ea10e70d7ea2926c58431153438f6408d80/core/v1/types.go#L8430-L8442) struct with some conflicting markers, and controller-tools v0.16.x changed how it handles conflicting `+optional` and `+kubebuilder:validation:Required marker`. Rewriting the status struct to remove its dependency on the external package would be best solution, but it would break Go API compatibility for `HTTPProxy`.

The modification uses `kubectl patch` with the exact path to the data structure and includes test for recognizing if the field is still there before processing. This approach should be robust and not affect wrong fields.

Fixes #7391