### PR TITLE
release-1.33: backport: Post-process HTTPProxy CRD schema to remove error as a required field

### DIFF
--- a/changelogs/unreleased/7408-tsaarni-small.md
+++ b/changelogs/unreleased/7408-tsaarni-small.md
@@ -1,0 +1,1 @@
+Fix `HTTPProxy` CRD schema incorrectly marking `status.loadBalancer.ingress[].ports[].error` as required, causing load balancer status update failures.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -8579,7 +8579,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -8798,7 +8798,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -8590,7 +8590,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -8615,7 +8615,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -8798,7 +8798,6 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
-                            - error
                             - port
                             - protocol
                             type: object

--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -24,6 +24,25 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd:crdVersions=v1 "paths=${PATHS}" "output:dir=${TEMPDIR}"
 
+# Remove "error" from required fields in load balancer status.
+# For details, see:
+# - https://github.com/projectcontour/contour/issues/7391
+# - https://github.com/kubernetes-sigs/controller-tools/pull/944#issuecomment-3314629362
+# This workaround can be removed if the upstream Kubernetes type resolves the conflicting markers.
+readonly HTTPPROXY_CRD="${TEMPDIR}/projectcontour.io_httpproxies.yaml"
+readonly PATCH_PATH="/spec/versions/0/schema/openAPIV3Schema/properties/status/properties/loadBalancer/properties/ingress/items/properties/ports/items/required/0"
+
+kubectl::patch() {
+  kubectl patch -f "$HTTPPROXY_CRD" --local --type=json -p "$1" "${@:2}"
+}
+
+kubectl::patch "[{\"op\": \"test\", \"path\": \"$PATCH_PATH\", \"value\": \"error\"}]" --dry-run=client > /dev/null || {
+  echo "Error: CRD structure has changed. The workaround for issue #7391 may no longer be needed or needs updating."
+  exit 1
+}
+
+kubectl::patch "[{\"op\": \"remove\", \"path\": \"$PATCH_PATH\"}]" -o yaml > "$HTTPPROXY_CRD.tmp" && { echo "---"; cat "$HTTPPROXY_CRD.tmp"; } > "$HTTPPROXY_CRD"
+
 # Explicitly add "preserveUnknownFields: false" to CRD specs since any CRDs created
 # as v1beta1 will have this field set to true, which we don't want going forward, and
 # it needs to be explicitly specified in order to be updated/removed. After enough time


### PR DESCRIPTION
Backport of #7408 for release-1.33 maintenance branch

Fixes #7391