### PR TITLE
fix: update Go version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectcontour/contour
 
-go 1.24.0
+go 1.25.7
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Fixes CVE-2025-68121 (CRITICAL) and other Go stdlib vulnerabilities.