### PR TITLE
fix: kuar-demo image is no longer available

### DIFF
--- a/changelogs/unreleased/7365-mateenali66-small.md
+++ b/changelogs/unreleased/7365-mateenali66-small.md
@@ -1,1 +1,1 @@
-Replace unavailable `gcr.io/kuar-demo/kuard-amd64:1` image with `mendhak/http-https-echo:35` in example workloads. The echo server listens on port 8080 (same as kuard) and is actively maintained.
+Replace unavailable `gcr.io/kuar-demo/kuard-amd64:1` image with `mendhak/http-https-echo:39` in example workloads. Rename example files and K8s resources from `kuard` to `demo`.

--- a/examples/example-workload/gatewayapi/demo/demo.yaml
+++ b/examples/example-workload/gatewayapi/demo/demo.yaml
@@ -2,29 +2,29 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
   namespace: default
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: kuard
+      app: demo
   template:
     metadata:
       labels:
-        app: kuard
+        app: demo
     spec:
       containers:
-      - image: mendhak/http-https-echo:35
-        name: kuard
+      - image: mendhak/http-https-echo:39
+        name: demo
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
   namespace: default
 spec:
   ports:
@@ -32,17 +32,17 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app: kuard
+    app: demo
   sessionAffinity: None
   type: ClusterIP
 ---
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: kuard
+  name: demo
   namespace: default
   labels:
-    app: kuard
+    app: demo
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -58,5 +58,5 @@ spec:
         value: /
     backendRefs:
     - kind: Service
-      name: kuard
+      name: demo
       port: 80

--- a/examples/example-workload/httpproxy/00-common/02-deployments.yaml
+++ b/examples/example-workload/httpproxy/00-common/02-deployments.yaml
@@ -14,7 +14,7 @@ spec:
         app: kuard
     spec:
       containers:
-      - image: mendhak/http-https-echo:35
+      - image: mendhak/http-https-echo:39
         name: kuard
 ---
 apiVersion: apps/v1
@@ -33,5 +33,5 @@ spec:
         app: kuard
     spec:
       containers:
-      - image: mendhak/http-https-echo:35
+      - image: mendhak/http-https-echo:39
         name: kuard

--- a/site/content/docs/main/deploy-options.md
+++ b/site/content/docs/main/deploy-options.md
@@ -106,32 +106,32 @@ _Note: We've created a public DNS record (`local.projectcontour.io`) which is co
 
 ### Test with Ingress
 
-The Contour repository contains an example deployment of the Kubernetes Up and Running demo application, [kuard][5].
-To test your Contour deployment, deploy `kuard` with the following command:
+The Contour repository contains an example deployment of a demo application.
+To test your Contour deployment, deploy the demo app with the following command:
 
 ```bash
-$ kubectl apply -f https://projectcontour.io/examples/kuard.yaml
+$ kubectl apply -f https://projectcontour.io/examples/demo.yaml
 ```
 
 Then monitor the progress of the deployment with:
 
 ```bash
-$ kubectl get po,svc,ing -l app=kuard
+$ kubectl get po,svc,ing -l app=demo
 ```
 
 You should see something like:
 
 ```
 NAME                       READY     STATUS    RESTARTS   AGE
-po/kuard-370091993-ps2gf   1/1       Running   0          4m
-po/kuard-370091993-r63cm   1/1       Running   0          4m
-po/kuard-370091993-t4dqk   1/1       Running   0          4m
+po/demo-370091993-ps2gf    1/1       Running   0          4m
+po/demo-370091993-r63cm    1/1       Running   0          4m
+po/demo-370091993-t4dqk    1/1       Running   0          4m
 
 NAME        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
-svc/kuard   10.110.67.121   <none>        80/TCP    4m
+svc/demo    10.110.67.121   <none>        80/TCP    4m
 
 NAME        HOSTS     ADDRESS     PORTS     AGE
-ing/kuard   *         10.0.0.47   80        4m
+ing/demo    *         10.0.0.47   80        4m
 ```
 
 ... showing that there are three Pods, one Service, and one Ingress that is bound to all virtual hosts (`*`).
@@ -143,28 +143,28 @@ In your browser, navigate your browser to the IP or DNS address of the Contour S
 To test your Contour deployment with [HTTPProxy][9], run the following command:
 
 ```sh
-$ kubectl apply -f https://projectcontour.io/examples/kuard-httpproxy.yaml
+$ kubectl apply -f https://projectcontour.io/examples/demo-httpproxy.yaml
 ```
 
 Then monitor the progress of the deployment with:
 
 ```sh
-$ kubectl get po,svc,httpproxy -l app=kuard
+$ kubectl get po,svc,httpproxy -l app=demo
 ```
 
 You should see something like:
 
 ```sh
 NAME                        READY     STATUS    RESTARTS   AGE
-pod/kuard-bcc7bf7df-9hj8d   1/1       Running   0          1h
-pod/kuard-bcc7bf7df-bkbr5   1/1       Running   0          1h
-pod/kuard-bcc7bf7df-vkbtl   1/1       Running   0          1h
+pod/demo-bcc7bf7df-9hj8d    1/1       Running   0          1h
+pod/demo-bcc7bf7df-bkbr5    1/1       Running   0          1h
+pod/demo-bcc7bf7df-vkbtl    1/1       Running   0          1h
 
 NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-service/kuard   ClusterIP   10.102.239.168   <none>        80/TCP    1h
+service/demo    ClusterIP   10.102.239.168   <none>        80/TCP    1h
 
 NAME                                    FQDN                TLS SECRET                  FIRST ROUTE  STATUS  STATUS DESCRIPT
-httpproxy.projectcontour.io/kuard      kuard.local         <SECRET NAME IF TLS USED>                valid   valid HTTPProxy
+httpproxy.projectcontour.io/demo       demo.local          <SECRET NAME IF TLS USED>                valid   valid HTTPProxy
 ```
 
 ... showing that there are three Pods, one Service, and one HTTPProxy .
@@ -172,7 +172,7 @@ httpproxy.projectcontour.io/kuard      kuard.local         <SECRET NAME IF TLS U
 In your terminal, use curl with the IP or DNS address of the Contour Service to send a request to the demo application:
 
 ```sh
-$ curl -H 'Host: kuard.local' ${CONTOUR_IP}
+$ curl -H 'Host: demo.local' ${CONTOUR_IP}
 ```
 
 ## Running without a Kubernetes LoadBalancer
@@ -367,7 +367,7 @@ $ kubectl delete ns projectcontour
 [2]: {{< param github_url>}}/tree/{{< param branch >}}/examples/render/contour.yaml
 [3]: #host-networking
 [4]: guides/proxy-proto.md
-[5]: https://github.com/kubernetes-up-and-running/kuard
+[5]: https://github.com/mendhak/docker-http-https-echo
 [7]: {{< param github_url>}}/tree/{{< param branch >}}/examples/contour/02-service-envoy.yaml
 [8]: /getting-started
 [9]: config/fundamentals.md

--- a/site/content/docs/main/guides/gateway-api.md
+++ b/site/content/docs/main/guides/gateway-api.md
@@ -155,27 +155,27 @@ See the next section ([Testing the Gateway API](#test-routing)) for how to deplo
 
 Deploy the test application:
 ```shell
-$ kubectl apply -f {{< param github_raw_url>}}/{{< param branch >}}/examples/example-workload/gatewayapi/kuard/kuard.yaml
+$ kubectl apply -f {{< param github_raw_url>}}/{{< param branch >}}/examples/example-workload/gatewayapi/demo/demo.yaml
 ```
 This command creates:
 
-- A Deployment named `kuard` in the default namespace to run kuard as the test application.
-- A Service named `kuard` in the default namespace to expose the kuard application on TCP port 80.
-- An HTTPRoute named `kuard` in the default namespace, attached to the `contour` Gateway, to route requests for `local.projectcontour.io` to the kuard service.
+- A Deployment named `demo` in the default namespace to run the demo application.
+- A Service named `demo` in the default namespace to expose the demo application on TCP port 80.
+- An HTTPRoute named `demo` in the default namespace, attached to the `contour` Gateway, to route requests for `local.projectcontour.io` to the demo service.
 
-Verify the kuard resources are available:
+Verify the demo resources are available:
 ```shell
-$ kubectl get po,svc,httproute -l app=kuard
-NAME                         READY   STATUS    RESTARTS   AGE
-pod/kuard-798585497b-78x6x   1/1     Running   0          21s
-pod/kuard-798585497b-7gktg   1/1     Running   0          21s
-pod/kuard-798585497b-zw42m   1/1     Running   0          21s
+$ kubectl get po,svc,httproute -l app=demo
+NAME                        READY   STATUS    RESTARTS   AGE
+pod/demo-798585497b-78x6x   1/1     Running   0          21s
+pod/demo-798585497b-7gktg   1/1     Running   0          21s
+pod/demo-798585497b-zw42m   1/1     Running   0          21s
 
 NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
-service/kuard   ClusterIP   172.30.168.168   <none>        80/TCP    21s
+service/demo    ClusterIP   172.30.168.168   <none>        80/TCP    21s
 
-NAME                                        HOSTNAMES
-httproute.gateway.networking.k8s.io/kuard   ["local.projectcontour.io"]
+NAME                                       HOSTNAMES
+httproute.gateway.networking.k8s.io/demo   ["local.projectcontour.io"]
 ```
 
 ## Test Routing
@@ -195,7 +195,7 @@ In another terminal, make a request to the application via the forwarded port (n
 ```shell
 $ curl -i http://local.projectcontour.io:8888
 ```
-You should receive a 200 response code along with the HTML body of the main `kuard` page.
+You should receive a 200 response code along with the response body from the demo application.
 
 You can also open http://local.projectcontour.io:8888/ in a browser.
 

--- a/site/content/examples/demo-httpproxy.yaml
+++ b/site/content/examples/demo-httpproxy.yaml
@@ -2,35 +2,35 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: kuard
+      app: demo
   template:
     metadata:
       labels:
-        app: kuard
+        app: demo
     spec:
       containers:
-      - image: mendhak/http-https-echo:35
-        name: kuard
+      - image: mendhak/http-https-echo:39
+        name: demo
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
 spec:
   ports:
   - port: 80
     protocol: TCP
     targetPort: 8080
   selector:
-    app: kuard
+    app: demo
   sessionAffinity: None
   type: ClusterIP
 ---
@@ -38,15 +38,15 @@ apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata: 
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
   namespace: default
 spec: 
   virtualhost:
-    fqdn: kuard.local
+    fqdn: demo.local
   routes: 
     - conditions:
       - prefix: /
       services:
-        - name: kuard
+        - name: demo
           port: 80

--- a/site/content/examples/demo.yaml
+++ b/site/content/examples/demo.yaml
@@ -2,47 +2,47 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: kuard
+      app: demo
   template:
     metadata:
       labels:
-        app: kuard
+        app: demo
     spec:
       containers:
-      - image: mendhak/http-https-echo:35
-        name: kuard
+      - image: mendhak/http-https-echo:39
+        name: demo
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: kuard
-  name: kuard
+    app: demo
+  name: demo
 spec:
   ports:
   - port: 80
     protocol: TCP
     targetPort: 8080
   selector:
-    app: kuard
+    app: demo
   sessionAffinity: None
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: kuard
+  name: demo
   labels:
-    app: kuard
+    app: demo
 spec:
   defaultBackend:
     service:
-      name: kuard
+      name: demo
       port:
         number: 80


### PR DESCRIPTION
## Summary

Fixes #7365

The `gcr.io/kuar-demo/kuard-amd64:1` image is no longer available due to GCR deprecation. This PR:

1. Replaces the image with `mendhak/http-https-echo:39`, an actively maintained echo server that listens on port 8080 (same as kuard), making it a drop-in replacement
2. Renames all `kuard` example files, directories, and K8s resource names to neutral `demo` name
3. Updates documentation references in `deploy-options.md` and `gateway-api.md`

## Changes

- `examples/example-workload/gatewayapi/kuard/` → `examples/example-workload/gatewayapi/demo/`
- `site/content/examples/kuard.yaml` → `site/content/examples/demo.yaml`
- `site/content/examples/kuard-httpproxy.yaml` → `site/content/examples/demo-httpproxy.yaml`
- `examples/example-workload/httpproxy/00-common/02-deployments.yaml` — image updated
- `site/content/docs/main/deploy-options.md` — references updated
- `site/content/docs/main/guides/gateway-api.md` — references updated
- `changelogs/unreleased/7365-mateenali66-small.md` — changelog entry