### PR TITLE
Change CodeQL action name back to CodeQL-Build:

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ env:
   GO_VERSION: 1.26.0
 
 jobs:
-  CodeQL-for-Go:
+  CodeQL-Build:
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
Since PR #7445 added `CodeQL-for-Actions` and renamed `CodeQL-Build` to `CodeQL-Go`, the pull request checks have remained stuck. They stay in a pending state while waiting for the non-existent `CodeQL-Build` job to complete. I cannot find any remaining references to the old name, so it is unclear why this is happening.

As a workaround, I am renaming the job back to `CodeQL-Build`.

Edit: 

Besides the name I had changed also the category for the Go scan by adding https://github.com/projectcontour/contour/blob/5bee8ea58698f26b0c479245138eda9c33eaafec/.github/workflows/codeql-analysis.yml#L56-L57

This left GitHub to wait results for the old configuration (now third category: one for go, one for actions and the third one default). Old configuration needed to be removed from project Settings / Advanced Security / [CodeQL](https://github.com/projectcontour/contour/security/code-scanning/tools/CodeQL/status), click "..." and select View setup type. Then select the stale configuration (without language), click "..." and select Delete configuration.