### PR TITLE
Update Envoy from 1.35 to 1.37 release track (v1.37.1)

### DIFF
--- a/changelogs/unreleased/7454-tsaarni-small.md
+++ b/changelogs/unreleased/7454-tsaarni-small.md
@@ -1,1 +1,0 @@
-Updates Envoy to v1.35.9. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.35.9/version_history/v1.35/v1.35) for more information about the content of the release.

--- a/changelogs/unreleased/7459-tsaarni-small.md
+++ b/changelogs/unreleased/7459-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.37.1 (from the 1.35 track). See the [Envoy 1.36 release notes](https://www.envoyproxy.io/docs/envoy/v1.36.5/version_history/v1.36/v1.36) and [Envoy 1.37 release notes](https://www.envoyproxy.io/docs/envoy/v1.37.1/version_history/v1.37/v1.37.1) for more information about the content of the releases.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.35.9",
+		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.37.1",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.9
+        image: docker.io/envoyproxy/envoy:distroless-v1.37.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.35.9
+          image: docker.io/envoyproxy/envoy:distroless-v1.37.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9557,7 +9557,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.35.9
+          image: docker.io/envoyproxy/envoy:distroless-v1.37.1
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9362,7 +9362,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.9
+        image: docker.io/envoyproxy/envoy:distroless-v1.37.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9545,7 +9545,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.9
+        image: docker.io/envoyproxy/envoy:distroless-v1.37.1
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.35.8][74]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
+| main            | [1.37.1][77]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.2          | [1.35.8][74]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.1          | [1.35.8][74]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.0          | [1.35.2][74]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
@@ -244,6 +244,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [74]: https://www.envoyproxy.io/docs/envoy/v1.35.8/version_history/v1.35/v1.35
 [75]: https://www.envoyproxy.io/docs/envoy/v1.34.12/version_history/v1.34/v1.34
 [76]: https://www.envoyproxy.io/docs/envoy/v1.31.10/version_history/v1.31/v1.31
+[77]: https://www.envoyproxy.io/docs/envoy/v1.37.1/version_history/v1.37/v1.37.1
 
 [98]: https://github.com/kubernetes/client-go
 [99]: https://github.com/kubernetes/client-go#compatibility-matrix

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.35.8"
+      envoy: "1.37.1"
       kubernetes:
         - "1.34"
         - "1.33"


### PR DESCRIPTION
Updates the main branch to the latest Envoy minor version release track (1.37).