### PR TITLE
Sync ext auth server config into envoy when virtualhost authPolicy is disabled

### DIFF
--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1452,7 +1452,7 @@ func determineExternalAuthTimeout(responseTimeout string, validCond *contour_v1.
 }
 
 func (p *HTTPProxyProcessor) computeSecureVirtualHostAuthorization(validCond *contour_v1.DetailedCondition, httpproxy *contour_v1.HTTPProxy, svhost *SecureVirtualHost) bool {
-	if httpproxy.Spec.VirtualHost.AuthorizationConfigured() && !httpproxy.Spec.VirtualHost.DisableAuthorization() && httpproxy.Spec.VirtualHost.Authorization.ExtensionServiceRef.IsConfigured() {
+	if httpproxy.Spec.VirtualHost.AuthorizationConfigured() && httpproxy.Spec.VirtualHost.Authorization.ExtensionServiceRef.IsConfigured() {
 		authorization := p.computeVirtualHostAuthorization(httpproxy.Spec.VirtualHost.Authorization, validCond, httpproxy)
 		if authorization == nil {
 			return false


### PR DESCRIPTION
## problem

When setting external auth server in virtualhost. Under this virtualhost, there are many service under this virtualhost, and we just want to set up auth server for one service

the root httpproxy:
```yaml
  virtualhost:
    authorization:
      authPolicy:
        disabled: true
      extensionRef:
        name: authserver
        namespace: projectcontour
      failOpen: true
```
the route level:
```yaml
    routes:
    - authPolicy:
        disabled: false
```

After this config, we found auth service config didn't sync auth server config to envoy when the `httpproxy.Spec.VirtualHost.Authorization.disabled==true`

From [route config](https://github.com/projectcontour/contour/blob/180d62fa8d6c024d4d00d0e2caa2ed20d927563d/internal/dag/httpproxy_processor.go#L880) Contour support to use route level config overwrite virtualhost or global config. 
But it only support when virtualhost is disabled:false, and route disabled:true.

## Solution

remove this `httpproxy.Spec.VirtualHost.Authorization.disabled==true` check to allow contour always sync ext auth server config into envoy. And route can overwrite this disabled flag when aythorization is disbaled in vistualhost .