### PR TITLE
release-1.33: backport: Remove envoy stats hostPort from example manifests (#7476)

### DIFF
--- a/changelogs/unreleased/7476-tsaarni-small.md
+++ b/changelogs/unreleased/7476-tsaarni-small.md
@@ -1,0 +1,1 @@
+Remove the Envoy stats `hostPort` from the example manifests. This port is typically needed only for in-cluster access and should not be exposed on the host network.

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -70,7 +70,6 @@ spec:
           name: https
           protocol: TCP
         - containerPort: 8002
-          hostPort: 8002
           name: metrics
           protocol: TCP
         readinessProbe:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -82,7 +82,6 @@ spec:
               name: https
               protocol: TCP
             - containerPort: 8002
-              hostPort: 8002
               name: metrics
               protocol: TCP
           readinessProbe:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9548,7 +9548,6 @@ spec:
               name: https
               protocol: TCP
             - containerPort: 8002
-              hostPort: 8002
               name: metrics
               protocol: TCP
           readinessProbe:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9353,7 +9353,6 @@ spec:
           name: https
           protocol: TCP
         - containerPort: 8002
-          hostPort: 8002
           name: metrics
           protocol: TCP
         readinessProbe:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9536,7 +9536,6 @@ spec:
           name: https
           protocol: TCP
         - containerPort: 8002
-          hostPort: 8002
           name: metrics
           protocol: TCP
         readinessProbe:

--- a/test/e2e/bench/bench_test.go
+++ b/test/e2e/bench/bench_test.go
@@ -83,16 +83,6 @@ var _ = BeforeSuite(func() {
 			core_v1.ResourceMemory: resource.MustParse("2Gi"),
 		},
 	}
-	// Add metrics port to Envoy DaemonSet.
-	f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.Containers[1].Ports = append(
-		f.Deployment.EnvoyDaemonSet.Spec.Template.Spec.Containers[1].Ports,
-		core_v1.ContainerPort{
-			Name:          "metrics",
-			HostPort:      8002,
-			ContainerPort: 8002,
-			Protocol:      core_v1.ProtocolTCP,
-		},
-	)
 
 	require.NoError(f.T(), f.Deployment.EnsureResourcesForInclusterContour(true))
 

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -524,10 +524,12 @@ func (d *Deployment) EnsureResourcesForLocalContour() error {
 
 	if d.EnvoyDeploymentMode == DaemonsetMode {
 		d.EnvoyDaemonSet.Spec.Template = d.mutatePodTemplate(d.EnvoyDaemonSet.Spec.Template)
+		d.addMetricsHostPort(&d.EnvoyDaemonSet.Spec.Template.Spec)
 		return d.EnsureEnvoyDaemonSet()
 	}
 
 	d.EnvoyDeployment.Spec.Template = d.mutatePodTemplate(d.EnvoyDeployment.Spec.Template)
+	d.addMetricsHostPort(&d.EnvoyDeployment.Spec.Template.Spec)
 
 	// The envoy deployment uses host ports, so can have at most
 	// one replica per node, and our cluster only has one worker
@@ -828,6 +830,8 @@ func (d *Deployment) EnsureResourcesForInclusterContour(startContourDeployment b
 	envoyPodSpec.Containers[0].Image = d.contourImage
 	envoyPodSpec.Containers[0].ImagePullPolicy = core_v1.PullIfNotPresent
 
+	d.addMetricsHostPort(envoyPodSpec)
+
 	if d.EnvoyDeploymentMode == DeploymentMode {
 		// The envoy deployment uses host ports, so can have at most
 		// one replica per node, and our cluster only has one worker
@@ -980,6 +984,21 @@ func (d *Deployment) EnvoyResourceAndName() string {
 	}
 
 	return "daemonset/envoy"
+}
+
+// addMetricsHostPort exposes the Envoy stats port via hostPort.
+func (d *Deployment) addMetricsHostPort(podSpec *core_v1.PodSpec) {
+	for i, c := range podSpec.Containers {
+		if c.Name != "envoy" {
+			continue
+		}
+		for j, p := range c.Ports {
+			if p.Name == "metrics" {
+				podSpec.Containers[i].Ports[j].HostPort = 8002
+				return
+			}
+		}
+	}
 }
 
 func randomString(n int) string {


### PR DESCRIPTION
Backport of #7476 for release-1.33 maintenance branch.

This PR removes the Envoy stats (metrics) hostPort 8002 from the example deployment manifests in [examples](https://github.com/projectcontour/contour/tree/main/examples). Since this configuration is not recommended for general deployments, the examples should not include it.

Since the e2e test suite uses these manifests but still requires port access for stats, this PR also updates the suite to expose the port programmatically.

Fixes #7475