### PR TITLE
Fix #7490: Replace cert-manager dependency in e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20241111191808-71fefeed8910
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/bombsimon/logrusr/v4 v4.1.0
-	github.com/cert-manager/cert-manager v1.18.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/envoyproxy/go-control-plane v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.18.5 h1:Gx4FSpSPYcSC4MQf43QjbxDfyTEbwZgfZQs5Lq9QlBs=
-github.com/cert-manager/cert-manager v1.18.5/go.mod h1:HbPSO5MW/44wu19t84eY/K4c4/WwyPB4bA3uffOH92s=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chigopher/pathlib v0.19.1 h1:RoLlUJc0CqBGwq239cilyhxPNLXTK+HXoASGyGznx5A=

--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -17,73 +17,192 @@ package e2e
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"sync"
 	"time"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
 	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Certs provides helpers for creating cert-manager certificates
-// and related resources.
+const (
+	e2eCertificateLifetime = 365 * 24 * time.Hour
+	e2eCertKeySize         = 2048
+	e2eCertSyncInterval    = 100 * time.Millisecond
+	selfSignedIssuerName   = "selfsigned"
+)
+
+// KeyUsage declares the X509 usage requested for a generated test certificate.
+type KeyUsage string
+
+const (
+	UsageCertSign   KeyUsage = "cert sign"
+	UsageClientAuth KeyUsage = "client auth"
+	UsageServerAuth KeyUsage = "server auth"
+	UsageSigning    KeyUsage = "signing"
+)
+
+// X509Subject defines the subset of subject fields used in the e2e suite.
+type X509Subject struct {
+	OrganizationalUnits []string
+}
+
+// CertificateSpec defines the inputs used to generate a test certificate and
+// its backing Secret.
+type CertificateSpec struct {
+	Namespace      string
+	Name           string
+	SecretName     string
+	CommonName     string
+	DNSNames       []string
+	EmailAddresses []string
+	IsCA           bool
+	Usages         []KeyUsage
+	Subject        *X509Subject
+	Issuer         string
+}
+
+type certificateMaterial struct {
+	certificate *x509.Certificate
+	privateKey  *rsa.PrivateKey
+	certPEM     []byte
+	keyPEM      []byte
+	caPEM       []byte
+}
+
+type managedCertificate struct {
+	namespace string
+	name      string
+	material  certificateMaterial
+}
+
+type managedIssuer struct {
+	selfSigned bool
+	signer     *certificateMaterial
+}
+
+// Certs provides helpers for generating TLS Secrets used by e2e tests.
 type Certs struct {
 	client        client.Client
 	retryInterval time.Duration
 	retryTimeout  time.Duration
 	t             ginkgo.GinkgoTInterface
+
+	mu           sync.RWMutex
+	issuers      map[types.NamespacedName]managedIssuer
+	certificates map[types.NamespacedName]managedCertificate
 }
 
-// CreateSelfSignedCert creates a self-signed Issuer if it doesn't already exist
-// and uses it to create a self-signed Certificate. It returns a cleanup function.
+func newCerts(cli client.Client, t ginkgo.GinkgoTInterface) *Certs {
+	c := &Certs{
+		client:        cli,
+		retryInterval: time.Second,
+		retryTimeout:  60 * time.Second,
+		t:             t,
+		issuers:       map[types.NamespacedName]managedIssuer{},
+		certificates:  map[types.NamespacedName]managedCertificate{},
+	}
+
+	go c.reconcileSecrets()
+
+	return c
+}
+
+// CreateSelfSignedCert creates a self-signed certificate Secret. It returns a
+// cleanup function that unregisters the managed Secret and removes it.
 func (c *Certs) CreateSelfSignedCert(ns, name, secretName, dnsName string) func() {
-	issuer := &certmanagerv1.Issuer{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      "selfsigned",
-		},
-		Spec: certmanagerv1.IssuerSpec{
-			IssuerConfig: certmanagerv1.IssuerConfig{
-				SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-			},
-		},
-	}
+	c.ensureSelfSignedIssuer(ns)
 
-	if err := c.client.Create(context.TODO(), issuer); err != nil && !errors.IsAlreadyExists(err) {
-		require.FailNowf(c.t, "failed creating Issuer", "error: %s", err)
-	}
-
-	cert := &certmanagerv1.Certificate{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Spec: certmanagerv1.CertificateSpec{
-			DNSNames:   []string{dnsName},
-			SecretName: secretName,
-			IssuerRef: certmanagermetav1.ObjectReference{
-				Name: "selfsigned",
-			},
-		},
-	}
-	require.NoError(c.t, c.client.Create(context.TODO(), cert))
-
-	return func() {
-		require.NoError(c.t, c.client.Delete(context.TODO(), cert))
-		require.NoError(c.t, c.client.Delete(context.TODO(), issuer))
-	}
+	return c.CreateCertificate(CertificateSpec{
+		Namespace:  ns,
+		Name:       name,
+		SecretName: secretName,
+		CommonName: dnsName,
+		DNSNames:   []string{dnsName},
+		Issuer:     selfSignedIssuerName,
+	})
 }
 
-// CreateCertAndWaitFor creates the provided Certificate in the Kubernetes API
-// and then waits for the specified condition to be true.
-func (c *Certs) CreateCertAndWaitFor(cert *certmanagerv1.Certificate, condition func(cert *certmanagerv1.Certificate) bool) bool {
-	return createAndWaitFor(c.t, c.client, cert, condition, c.retryInterval, c.retryTimeout)
+// CreateCA creates a root CA Secret and an issuer with the same name.
+func (c *Certs) CreateCA(ns, name string) func() {
+	return c.CreateCAWithIssuer(ns, name, name)
+}
+
+// CreateCAWithIssuer creates a root CA Secret and registers a named issuer that
+// signs future certificates with it.
+func (c *Certs) CreateCAWithIssuer(ns, secretName, issuerName string) func() {
+	c.ensureSelfSignedIssuer(ns)
+
+	spec := CertificateSpec{
+		Namespace:  ns,
+		Name:       secretName,
+		SecretName: secretName,
+		CommonName: secretName,
+		IsCA:       true,
+		Usages: []KeyUsage{
+			UsageSigning,
+			UsageCertSign,
+		},
+		Subject: &X509Subject{
+			OrganizationalUnits: []string{
+				"io",
+				"projectcontour",
+				"testsuite",
+			},
+		},
+		Issuer: selfSignedIssuerName,
+	}
+
+	material, err := c.issueCertificate(spec)
+	require.NoError(c.t, err)
+
+	c.registerIssuer(ns, issuerName, managedIssuer{
+		signer: &material,
+	})
+
+	return c.manageCertificate(spec, material, func() {
+		c.unregisterIssuer(ns, issuerName)
+	})
+}
+
+// CreateCertificate creates a certificate Secret using the named issuer.
+func (c *Certs) CreateCertificate(spec CertificateSpec) func() {
+	material, err := c.issueCertificate(spec)
+	require.NoError(c.t, err)
+
+	return c.manageCertificate(spec, material, nil)
+}
+
+// CreateCertificateAndWait creates the certificate Secret and returns true once
+// it has been persisted. Generation is synchronous, so no additional polling is
+// required beyond the initial write.
+func (c *Certs) CreateCertificateAndWait(spec CertificateSpec) bool {
+	c.CreateCertificate(spec)
+	return true
+}
+
+// CreateCert creates end-entity certificate using given CA issuer.
+func (c *Certs) CreateCert(ns, name, issuer string, dnsNames ...string) func() {
+	return c.CreateCertificate(CertificateSpec{
+		Namespace:  ns,
+		Name:       name,
+		SecretName: name,
+		CommonName: name,
+		DNSNames:   dnsNames,
+		Issuer:     issuer,
+	})
 }
 
 // GetTLSCertificate returns a tls.Certificate containing the data in the specified
@@ -106,118 +225,265 @@ func (c *Certs) GetTLSCertificate(secretNamespace, secretName string) (tls.Certi
 	return cert, caBundle
 }
 
-// ensureSelfSignedIssuer ensuers that selfsigned issuer is created.
-func (c *Certs) ensureSelfSignedIssuer(ns string) *certmanagerv1.Issuer {
-	issuer := &certmanagerv1.Issuer{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      "selfsigned",
-		},
-		Spec: certmanagerv1.IssuerSpec{
-			IssuerConfig: certmanagerv1.IssuerConfig{
-				SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-			},
-		},
+func (c *Certs) ensureSelfSignedIssuer(namespace string) {
+	c.registerIssuer(namespace, selfSignedIssuerName, managedIssuer{
+		selfSigned: true,
+	})
+}
+
+func (c *Certs) manageCertificate(spec CertificateSpec, material certificateMaterial, cleanup func()) func() {
+	name := spec.SecretName
+	if name == "" {
+		name = spec.Name
 	}
 
-	if err := c.client.Get(context.TODO(), client.ObjectKeyFromObject(issuer), issuer); err != nil {
-		if errors.IsNotFound(err) {
-			require.NoError(c.t, c.client.Create(context.TODO(), issuer))
-		} else {
+	managed := managedCertificate{
+		namespace: spec.Namespace,
+		name:      name,
+		material:  material,
+	}
+
+	c.registerManagedCertificate(managed)
+	require.NoError(c.t, c.ensureSecret(context.TODO(), managed))
+
+	return func() {
+		c.unregisterManagedCertificate(spec.Namespace, name)
+		if cleanup != nil {
+			cleanup()
+		}
+
+		secret := &core_v1.Secret{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: spec.Namespace,
+				Name:      name,
+			},
+		}
+		err := c.client.Delete(context.TODO(), secret)
+		if err != nil && !errors.IsNotFound(err) {
 			require.NoError(c.t, err)
 		}
 	}
-
-	return issuer
 }
 
-// Create CA creates root CA using selfsigned issuer.
-func (c *Certs) CreateCA(ns, name string) func() {
-	issuer := c.ensureSelfSignedIssuer(ns)
-
-	caSigningCert := &certmanagerv1.Certificate{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Spec: certmanagerv1.CertificateSpec{
-			IsCA: true,
-			Usages: []certmanagerv1.KeyUsage{
-				certmanagerv1.UsageSigning,
-				certmanagerv1.UsageCertSign,
-			},
-			Subject: &certmanagerv1.X509Subject{
-				OrganizationalUnits: []string{
-					"io",
-					"projectcontour",
-					"testsuite",
-				},
-			},
-			CommonName: name,
-			SecretName: name,
-			IssuerRef: certmanagermetav1.ObjectReference{
-				Name: "selfsigned",
-			},
-		},
-	}
-	require.NoError(c.t, c.client.Create(context.TODO(), caSigningCert))
-
-	localCAIssuer := &certmanagerv1.Issuer{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Spec: certmanagerv1.IssuerSpec{
-			IssuerConfig: certmanagerv1.IssuerConfig{
-				CA: &certmanagerv1.CAIssuer{
-					SecretName: name,
-				},
-			},
-		},
+func (c *Certs) issueCertificate(spec CertificateSpec) (certificateMaterial, error) {
+	issuer, err := c.getIssuer(spec.Namespace, spec.Issuer)
+	if err != nil {
+		return certificateMaterial{}, err
 	}
 
-	require.NoError(c.t, c.client.Create(context.TODO(), localCAIssuer))
+	privateKey, err := rsa.GenerateKey(rand.Reader, e2eCertKeySize)
+	if err != nil {
+		return certificateMaterial{}, err
+	}
 
-	return func() {
-		caSecret := &core_v1.Secret{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return certificateMaterial{}, err
+	}
+
+	subject := pkix.Name{
+		CommonName: spec.CommonName,
+	}
+	if spec.Subject != nil {
+		subject.OrganizationalUnit = append(subject.OrganizationalUnit, spec.Subject.OrganizationalUnits...)
+	}
+
+	keyUsage, extKeyUsage := x509Usages(spec)
+	template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               subject,
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(e2eCertificateLifetime),
+		BasicConstraintsValid: true,
+		IsCA:                  spec.IsCA,
+		DNSNames:              append([]string(nil), spec.DNSNames...),
+		EmailAddresses:        append([]string(nil), spec.EmailAddresses...),
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           extKeyUsage,
+	}
+
+	parent := template
+	signer := privateKey
+	caPEM := []byte(nil)
+
+	if issuer.selfSigned {
+		caPEM = make([]byte, 0)
+	} else {
+		parent = issuer.signer.certificate
+		signer = issuer.signer.privateKey
+		caPEM = append([]byte(nil), issuer.signer.caPEM...)
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, parent, &privateKey.PublicKey, signer)
+	if err != nil {
+		return certificateMaterial{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	if issuer.selfSigned {
+		caPEM = append([]byte(nil), certPEM...)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return certificateMaterial{}, err
+	}
+
+	return certificateMaterial{
+		certificate: cert,
+		privateKey:  privateKey,
+		certPEM:     certPEM,
+		keyPEM:      keyPEM,
+		caPEM:       caPEM,
+	}, nil
+}
+
+func x509Usages(spec CertificateSpec) (x509.KeyUsage, []x509.ExtKeyUsage) {
+	if !spec.IsCA && len(spec.Usages) == 0 {
+		spec.Usages = []KeyUsage{UsageServerAuth, UsageClientAuth}
+	}
+
+	keyUsage := x509.KeyUsageDigitalSignature
+	var extKeyUsage []x509.ExtKeyUsage
+
+	for _, usage := range spec.Usages {
+		switch usage {
+		case UsageCertSign, UsageSigning:
+			keyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		case UsageClientAuth:
+			extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageClientAuth)
+		case UsageServerAuth:
+			keyUsage |= x509.KeyUsageKeyEncipherment
+			extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageServerAuth)
 		}
-		require.NoError(c.t, c.client.Delete(context.TODO(), caSigningCert))
-		require.NoError(c.t, c.client.Delete(context.TODO(), localCAIssuer))
-		require.NoError(c.t, c.client.Delete(context.TODO(), issuer))
-		require.NoError(c.t, c.client.Delete(context.TODO(), caSecret))
+	}
+
+	if spec.IsCA {
+		keyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	}
+
+	return keyUsage, extKeyUsage
+}
+
+func (c *Certs) reconcileSecrets() {
+	ticker := time.NewTicker(e2eCertSyncInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		for _, cert := range c.managedCertificates() {
+			_ = c.ensureSecret(context.Background(), cert)
+		}
 	}
 }
 
-// CreateCert creates end-entity certificate using given CA issuer.
-func (c *Certs) CreateCert(ns, name, issuer string, dnsNames ...string) func() {
-	cert := &certmanagerv1.Certificate{
+func (c *Certs) ensureSecret(ctx context.Context, managed managedCertificate) error {
+	desired := &core_v1.Secret{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
+			Namespace: managed.namespace,
+			Name:      managed.name,
 		},
-		Spec: certmanagerv1.CertificateSpec{
-			CommonName: name,
-			SecretName: name,
-			DNSNames:   dnsNames,
-			IssuerRef: certmanagermetav1.ObjectReference{
-				Name: issuer,
-			},
+		Type: core_v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			core_v1.TLSCertKey:       managed.material.certPEM,
+			core_v1.TLSPrivateKeyKey: managed.material.keyPEM,
+			"ca.crt":                 managed.material.caPEM,
 		},
 	}
-	require.NoError(c.t, c.client.Create(context.TODO(), cert))
 
-	return func() {
-		secret := &core_v1.Secret{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: ns,
-				Name:      name,
-			},
+	current := &core_v1.Secret{}
+	key := client.ObjectKeyFromObject(desired)
+
+	if err := c.client.Get(ctx, key, current); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
 		}
-		require.NoError(c.t, c.client.Delete(context.TODO(), cert))
-		require.NoError(c.t, c.client.Delete(context.TODO(), secret))
+
+		if err := c.client.Create(ctx, desired); err != nil && !errors.IsAlreadyExists(err) {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		return nil
 	}
+
+	if current.Type == desired.Type &&
+		bytesEqual(current.Data[core_v1.TLSCertKey], desired.Data[core_v1.TLSCertKey]) &&
+		bytesEqual(current.Data[core_v1.TLSPrivateKeyKey], desired.Data[core_v1.TLSPrivateKeyKey]) &&
+		bytesEqual(current.Data["ca.crt"], desired.Data["ca.crt"]) {
+		return nil
+	}
+
+	current.Type = desired.Type
+	current.Data = desired.Data
+
+	return c.client.Update(ctx, current)
+}
+
+func (c *Certs) managedCertificates() []managedCertificate {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make([]managedCertificate, 0, len(c.certificates))
+	for _, cert := range c.certificates {
+		result = append(result, cert)
+	}
+
+	return result
+}
+
+func (c *Certs) registerIssuer(namespace, name string, issuer managedIssuer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.issuers[types.NamespacedName{Namespace: namespace, Name: name}] = issuer
+}
+
+func (c *Certs) unregisterIssuer(namespace, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.issuers, types.NamespacedName{Namespace: namespace, Name: name})
+}
+
+func (c *Certs) getIssuer(namespace, name string) (managedIssuer, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	issuer, ok := c.issuers[types.NamespacedName{Namespace: namespace, Name: name}]
+	if !ok {
+		return managedIssuer{}, fmt.Errorf("issuer %s/%s not found", namespace, name)
+	}
+
+	return issuer, nil
+}
+
+func (c *Certs) registerManagedCertificate(cert managedCertificate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.certificates[types.NamespacedName{Namespace: cert.namespace, Name: cert.name}] = cert
+}
+
+func (c *Certs) unregisterManagedCertificate(namespace, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.certificates, types.NamespacedName{Namespace: namespace, Name: name})
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/bombsimon/logrusr/v4"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gexec"
@@ -74,8 +73,8 @@ type Framework struct {
 	// HTTP provides helpers for making HTTP/HTTPS requests.
 	HTTP *HTTP
 
-	// Certs provides helpers for creating cert-manager certificates
-	// and related resources.
+	// Certs provides helpers for generating TLS Secrets and related
+	// certificate material for e2e tests.
 	Certs *Certs
 
 	// Deployment provides helpers for managing deploying resources that
@@ -108,7 +107,6 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 	require.NoError(t, gatewayapi_v1alpha2.Install(scheme))
 	require.NoError(t, gatewayapi_v1alpha3.Install(scheme))
 	require.NoError(t, gatewayapi_v1.Install(scheme))
-	require.NoError(t, certmanagerv1.AddToScheme(scheme))
 	require.NoError(t, apiextensions_v1.AddToScheme(scheme))
 
 	ipV6Cluster := os.Getenv("IPV6_CLUSTER") == "true"
@@ -262,12 +260,7 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 			RetryTimeout:       60 * time.Second,
 			t:                  t,
 		},
-		Certs: &Certs{
-			client:        crClient,
-			retryInterval: time.Second,
-			retryTimeout:  60 * time.Second,
-			t:             t,
-		},
+		Certs:       newCerts(crClient, t),
 		Deployment:  deployment,
 		Provisioner: provisioner,
 		Kubectl:     kubectl,

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -16,11 +16,8 @@
 package gateway
 
 import (
-	"context"
 	"encoding/json"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermeta_v1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,77 +38,18 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 		protocolVersion := "TLSv1.3"
 		t := f.T()
 
-		// Top level issuer.
-		selfSignedIssuer := &certmanagerv1.Issuer{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "selfsigned",
+		f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "backend-server-cert",
+			SecretName: "backend-server-cert",
+			CommonName: "echo-secure",
+			DNSNames:   []string{"echo-secure"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), selfSignedIssuer))
-
-		// CA to sign backend certs with.
-		caCertificate := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-cert",
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				IsCA: true,
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageSigning,
-					certmanagerv1.UsageCertSign,
-				},
-				CommonName: "ca-cert",
-				SecretName: "ca-cert",
-				IssuerRef: certmanagermeta_v1.ObjectReference{
-					Name: "selfsigned",
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), caCertificate))
-
-		// Issuer based on CA to generate new certs with.
-		basedOnCAIssuer := &certmanagerv1.Issuer{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-issuer",
-			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					CA: &certmanagerv1.CAIssuer{
-						SecretName: "ca-cert",
-					},
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), basedOnCAIssuer))
-
-		// Backend server cert signed by CA.
-		backendServerCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "backend-server-cert",
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				CommonName: "echo-secure",
-				DNSNames:   []string{"echo-secure"},
-				SecretName: "backend-server-cert",
-				IssuerRef: certmanagermeta_v1.ObjectReference{
-					Name: "ca-issuer",
-				},
-			},
-		}
-
-		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
+			Issuer: "ca-issuer",
+		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", func(_ *apps_v1.Deployment, service *core_v1.Service) {
 			delete(service.Annotations, "projectcontour.io/upstream-protocol.tls")
 		})

--- a/test/e2e/httpproxy/backend_tls_protocol_version_test.go
+++ b/test/e2e/httpproxy/backend_tls_protocol_version_test.go
@@ -16,11 +16,8 @@
 package httpproxy
 
 import (
-	"context"
 	"encoding/json"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,25 +29,17 @@ import (
 
 func testBackendTLSProtocolVersion(namespace, protocolVersion string) {
 	Specify("backend connection uses configured TLS version", func() {
-		// Backend server cert signed by CA.
-		backendServerCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "backend-server-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "backend-server-cert",
+			SecretName: "backend-server-cert",
+			CommonName: "echo-secure",
+			DNSNames:   []string{"echo-secure"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				CommonName: "echo-secure",
-				DNSNames:   []string{"echo-secure"},
-				SecretName: "backend-server-cert",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-issuer",
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
+			Issuer: "ca-issuer",
+		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		p := &contour_v1.HTTPProxy{

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"time"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,25 +33,17 @@ import (
 
 func testBackendTLS(namespace string) {
 	Specify("mTLS to backends can be configured", func() {
-		// Backend server cert signed by CA.
-		backendServerCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "backend-server-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "backend-server-cert",
+			SecretName: "backend-server-cert",
+			CommonName: "echo-secure",
+			DNSNames:   []string{"echo-secure"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				CommonName: "echo-secure",
-				DNSNames:   []string{"echo-secure"},
-				SecretName: "backend-server-cert",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-issuer",
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
+			Issuer: "ca-issuer",
+		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		p := &contour_v1.HTTPProxy{

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -16,12 +16,9 @@
 package httpproxy
 
 import (
-	"context"
 	"crypto/tls"
 	"strings"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,285 +32,116 @@ func testClientCertAuth(namespace string) {
 	Specify("client requests can be authenticated", func() {
 		t := f.T()
 
-		// Create a self-signed Issuer.
-		selfSignedIssuer := &certmanagerv1.Issuer{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "selfsigned",
-			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), selfSignedIssuer))
-
-		// Using the selfsigned issuer, create a CA signing certificate for the
-		// test issuer.
-		caSigningCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-projectcontour-io",
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				IsCA: true,
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageSigning,
-					certmanagerv1.UsageCertSign,
-				},
-				Subject: &certmanagerv1.X509Subject{
-					OrganizationalUnits: []string{
-						"io",
-						"projectcontour",
-						"testsuite",
-					},
-				},
-				CommonName: "issuer",
-				SecretName: "ca-projectcontour-io",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "selfsigned",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), caSigningCert))
-
-		// Create a local CA issuer with the CA certificate that the selfsigned
-		// issuer gave us.
-		localCAIssuer := &certmanagerv1.Issuer{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-projectcontour-io",
-			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					CA: &certmanagerv1.CAIssuer{
-						SecretName: "ca-projectcontour-io",
-					},
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), localCAIssuer))
-
-		// Using the selfsigned issuer, create a CA signing certificate for another
-		// test issuer.
-		caSigningCert2 := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-notprojectcontour-io",
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				IsCA: true,
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageSigning,
-					certmanagerv1.UsageCertSign,
-				},
-				Subject: &certmanagerv1.X509Subject{
-					OrganizationalUnits: []string{
-						"io",
-						"notprojectcontour",
-						"testsuite",
-					},
-				},
-				CommonName: "issuer",
-				SecretName: "ca-notprojectcontour-io",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "selfsigned",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), caSigningCert2))
-
-		// Create a local CA issuer with the CA certificate that the selfsigned
-		// issuer gave us.
-		localCAIssuer2 := &certmanagerv1.Issuer{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "ca-notprojectcontour-io",
-			},
-			Spec: certmanagerv1.IssuerSpec{
-				IssuerConfig: certmanagerv1.IssuerConfig{
-					CA: &certmanagerv1.CAIssuer{
-						SecretName: "ca-notprojectcontour-io",
-					},
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), localCAIssuer2))
+		f.Certs.CreateCAWithIssuer(namespace, "ca-projectcontour-io", "ca-projectcontour-io")
+		f.Certs.CreateCAWithIssuer(namespace, "ca-notprojectcontour-io", "ca-notprojectcontour-io")
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-no-auth")
 
-		// Get a server certificate for echo-no-auth.
-		echoNoAuthCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-no-auth-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-no-auth-cert",
+			SecretName: "echo-no-auth",
+			DNSNames:   []string{"echo-no-auth.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-no-auth.projectcontour.io"},
-				SecretName: "echo-no-auth",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoNoAuthCert))
+			Issuer: "ca-projectcontour-io",
+		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth")
 
-		// Get a server certificate for echo-with-auth.
-		echoWithAuthCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-with-auth-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-with-auth-cert",
+			SecretName: "echo-with-auth",
+			DNSNames:   []string{"echo-with-auth.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-with-auth.projectcontour.io"},
-				SecretName: "echo-with-auth",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoWithAuthCert))
+			Issuer: "ca-projectcontour-io",
+		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth-skip-verify")
 
-		// Get a server certificate for echo-with-auth-skip-verify.
-		echoWithAuthSkipVerifyCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-with-auth-skip-verify-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-with-auth-skip-verify-cert",
+			SecretName: "echo-with-auth-skip-verify",
+			DNSNames:   []string{"echo-with-auth-skip-verify.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-with-auth-skip-verify.projectcontour.io"},
-				SecretName: "echo-with-auth-skip-verify",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoWithAuthSkipVerifyCert))
+			Issuer: "ca-projectcontour-io",
+		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth-skip-verify-with-ca")
 
-		// Get a server certificate for echo-with-auth-skip-verify-with-ca.
-		echoWithAuthSkipVerifyWithCACert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-with-auth-skip-verify-with-ca-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-with-auth-skip-verify-with-ca-cert",
+			SecretName: "echo-with-auth-skip-verify-with-ca",
+			DNSNames:   []string{"echo-with-auth-skip-verify-with-ca.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-with-auth-skip-verify-with-ca.projectcontour.io"},
-				SecretName: "echo-with-auth-skip-verify-with-ca",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoWithAuthSkipVerifyWithCACert))
+			Issuer: "ca-projectcontour-io",
+		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth")
 
-		// Get a server certificate for echo-with-optional-auth.
-		echoWithOptionalAuth := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-with-optional-auth-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-with-optional-auth-cert",
+			SecretName: "echo-with-optional-auth",
+			DNSNames:   []string{"echo-with-optional-auth.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-with-optional-auth.projectcontour.io"},
-				SecretName: "echo-with-optional-auth",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoWithOptionalAuth))
+			Issuer: "ca-projectcontour-io",
+		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth-no-ca")
 
-		// Get a server certificate for echo-with-optional-auth-no-ca.
-		echoWithOptionalAuthNoCA := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-with-optional-auth-no-ca-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-with-optional-auth-no-ca-cert",
+			SecretName: "echo-with-optional-auth-no-ca",
+			DNSNames:   []string{"echo-with-optional-auth-no-ca.projectcontour.io"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				DNSNames:   []string{"echo-with-optional-auth-no-ca.projectcontour.io"},
-				SecretName: "echo-with-optional-auth-no-ca",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
-			},
-		}
-		require.NoError(t, f.Client.Create(context.TODO(), echoWithOptionalAuthNoCA))
+			Issuer: "ca-projectcontour-io",
+		})
 
-		// Get a client certificate.
-		clientCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-client-cert",
+		clientCert := e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-client-cert",
+			SecretName: "echo-client",
+			CommonName: "client",
+			EmailAddresses: []string{
+				"client@projectcontour.io",
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageClientAuth,
-				},
-				EmailAddresses: []string{
-					"client@projectcontour.io",
-				},
-				CommonName: "client",
-				SecretName: "echo-client",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-projectcontour-io",
-				},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageClientAuth,
 			},
+			Issuer: "ca-projectcontour-io",
 		}
-		// Wait for the Cert to be ready since we'll directly download
-		// the secret contents for use as a client cert later on.
-		require.True(f.T(), f.Certs.CreateCertAndWaitFor(clientCert, certIsReady))
+		require.True(f.T(), f.Certs.CreateCertificateAndWait(clientCert))
 
-		// Get another client certificate.
-		clientCertInvalid := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "echo-client-cert-invalid",
+		clientCertInvalid := e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "echo-client-cert-invalid",
+			SecretName: "echo-client-invalid",
+			CommonName: "badclient",
+			EmailAddresses: []string{
+				"badclient@projectcontour.io",
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageClientAuth,
-				},
-				EmailAddresses: []string{
-					"badclient@projectcontour.io",
-				},
-				CommonName: "badclient",
-				SecretName: "echo-client-invalid",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-notprojectcontour-io",
-				},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageClientAuth,
 			},
+			Issuer: "ca-notprojectcontour-io",
 		}
-		// Wait for the Cert to be ready since we'll directly download
-		// the secret contents for use as a client cert later on.
-		require.True(f.T(), f.Certs.CreateCertAndWaitFor(clientCertInvalid, certIsReady))
+		require.True(f.T(), f.Certs.CreateCertificateAndWait(clientCertInvalid))
 
 		// This proxy does not require client certificate auth.
 		noAuthProxy := &contour_v1.HTTPProxy{
@@ -496,8 +324,8 @@ func testClientCertAuth(namespace string) {
 		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid))
 
 		// get the valid & invalid client certs
-		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.Spec.SecretName)
-		invalidClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCertInvalid.Spec.SecretName)
+		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.SecretName)
+		invalidClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCertInvalid.SecretName)
 
 		cases := map[string]struct {
 			host       string
@@ -641,13 +469,4 @@ func optUseClientCert(cert *tls.Certificate) func(*tls.Config) {
 			return cert, nil
 		}
 	}
-}
-
-func certIsReady(cert *certmanagerv1.Certificate) bool {
-	for _, cond := range cert.Status.Conditions {
-		if cond.Type == certmanagerv1.CertificateConditionReady && cond.Status == certmanagermetav1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -16,18 +16,14 @@
 package httpproxy
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/require"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -198,75 +194,17 @@ var _ = Describe("HTTPProxy", func() {
 	f.NamespacedTest("httpproxy-backend-tls", func(namespace string) {
 		Context("with backend tls", func() {
 			BeforeEach(func() {
-				// Top level issuer.
-				selfSignedIssuer := &certmanagerv1.Issuer{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "selfsigned",
+				f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
+				f.Certs.CreateCertificate(e2e.CertificateSpec{
+					Namespace:  namespace,
+					Name:       "backend-client-cert",
+					SecretName: "backend-client-cert",
+					CommonName: "client",
+					Usages: []e2e.KeyUsage{
+						e2e.UsageClientAuth,
 					},
-					Spec: certmanagerv1.IssuerSpec{
-						IssuerConfig: certmanagerv1.IssuerConfig{
-							SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), selfSignedIssuer))
-
-				// CA to sign backend certs with.
-				caCertificate := &certmanagerv1.Certificate{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "ca-cert",
-					},
-					Spec: certmanagerv1.CertificateSpec{
-						IsCA: true,
-						Usages: []certmanagerv1.KeyUsage{
-							certmanagerv1.UsageSigning,
-							certmanagerv1.UsageCertSign,
-						},
-						CommonName: "ca-cert",
-						SecretName: "ca-cert",
-						IssuerRef: certmanagermetav1.ObjectReference{
-							Name: "selfsigned",
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), caCertificate))
-
-				// Issuer based on CA to generate new certs with.
-				basedOnCAIssuer := &certmanagerv1.Issuer{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "ca-issuer",
-					},
-					Spec: certmanagerv1.IssuerSpec{
-						IssuerConfig: certmanagerv1.IssuerConfig{
-							CA: &certmanagerv1.CAIssuer{
-								SecretName: "ca-cert",
-							},
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), basedOnCAIssuer))
-
-				// Backend client cert, can use for upstream validation as well.
-				backendClientCert := &certmanagerv1.Certificate{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "backend-client-cert",
-					},
-					Spec: certmanagerv1.CertificateSpec{
-						Usages: []certmanagerv1.KeyUsage{
-							certmanagerv1.UsageClientAuth,
-						},
-						CommonName: "client",
-						SecretName: "backend-client-cert",
-						IssuerRef: certmanagermetav1.ObjectReference{
-							Name: "ca-issuer",
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), backendClientCert))
+					Issuer: "ca-issuer",
+				})
 
 				contourConfig.TLS = config.TLSParameters{
 					ClientCertificate: config.NamespacedName{
@@ -287,75 +225,17 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-backend-tls-version", func(namespace string) {
 		BeforeEach(func() {
-			// Top level issuer.
-			selfSignedIssuer := &certmanagerv1.Issuer{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "selfsigned",
+			f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
+			f.Certs.CreateCertificate(e2e.CertificateSpec{
+				Namespace:  namespace,
+				Name:       "backend-client-cert",
+				SecretName: "backend-client-cert",
+				CommonName: "client",
+				Usages: []e2e.KeyUsage{
+					e2e.UsageClientAuth,
 				},
-				Spec: certmanagerv1.IssuerSpec{
-					IssuerConfig: certmanagerv1.IssuerConfig{
-						SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-					},
-				},
-			}
-			require.NoError(f.T(), f.Client.Create(context.TODO(), selfSignedIssuer))
-
-			// CA to sign backend certs with.
-			caCertificate := &certmanagerv1.Certificate{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "ca-cert",
-				},
-				Spec: certmanagerv1.CertificateSpec{
-					IsCA: true,
-					Usages: []certmanagerv1.KeyUsage{
-						certmanagerv1.UsageSigning,
-						certmanagerv1.UsageCertSign,
-					},
-					CommonName: "ca-cert",
-					SecretName: "ca-cert",
-					IssuerRef: certmanagermetav1.ObjectReference{
-						Name: "selfsigned",
-					},
-				},
-			}
-			require.NoError(f.T(), f.Client.Create(context.TODO(), caCertificate))
-
-			// Issuer based on CA to generate new certs with.
-			basedOnCAIssuer := &certmanagerv1.Issuer{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "ca-issuer",
-				},
-				Spec: certmanagerv1.IssuerSpec{
-					IssuerConfig: certmanagerv1.IssuerConfig{
-						CA: &certmanagerv1.CAIssuer{
-							SecretName: "ca-cert",
-						},
-					},
-				},
-			}
-			require.NoError(f.T(), f.Client.Create(context.TODO(), basedOnCAIssuer))
-
-			// Backend client cert, can use for upstream validation as well.
-			backendClientCert := &certmanagerv1.Certificate{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Namespace: namespace,
-					Name:      "backend-client-cert",
-				},
-				Spec: certmanagerv1.CertificateSpec{
-					Usages: []certmanagerv1.KeyUsage{
-						certmanagerv1.UsageClientAuth,
-					},
-					CommonName: "client",
-					SecretName: "backend-client-cert",
-					IssuerRef: certmanagermetav1.ObjectReference{
-						Name: "ca-issuer",
-					},
-				},
-			}
-			require.NoError(f.T(), f.Client.Create(context.TODO(), backendClientCert))
+				Issuer: "ca-issuer",
+			})
 
 			contourConfig.TLS = config.TLSParameters{
 				ClientCertificate: config.NamespacedName{

--- a/test/e2e/ingress/backend_tls_test.go
+++ b/test/e2e/ingress/backend_tls_test.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"encoding/json"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,25 +33,17 @@ import (
 
 func testBackendTLS(namespace string) {
 	Specify("simple TLS to backends can be configured", func() {
-		// Backend server cert signed by CA.
-		backendServerCert := &certmanagerv1.Certificate{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: namespace,
-				Name:      "backend-server-cert",
+		f.Certs.CreateCertificate(e2e.CertificateSpec{
+			Namespace:  namespace,
+			Name:       "backend-server-cert",
+			SecretName: "backend-server-cert",
+			CommonName: "echo-secure",
+			DNSNames:   []string{"echo-secure"},
+			Usages: []e2e.KeyUsage{
+				e2e.UsageServerAuth,
 			},
-			Spec: certmanagerv1.CertificateSpec{
-				Usages: []certmanagerv1.KeyUsage{
-					certmanagerv1.UsageServerAuth,
-				},
-				CommonName: "echo-secure",
-				DNSNames:   []string{"echo-secure"},
-				SecretName: "backend-server-cert",
-				IssuerRef: certmanagermetav1.ObjectReference{
-					Name: "ca-issuer",
-				},
-			},
-		}
-		require.NoError(f.T(), f.Client.Create(context.TODO(), backendServerCert))
+			Issuer: "ca-issuer",
+		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
 		i := &networking_v1.Ingress{

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -16,16 +16,12 @@
 package ingress
 
 import (
-	"context"
 	"testing"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/require"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -95,75 +91,17 @@ var _ = Describe("Ingress", func() {
 	f.NamespacedTest("backend-tls", func(namespace string) {
 		Context("with backend tls", func() {
 			BeforeEach(func() {
-				// Top level issuer.
-				selfSignedIssuer := &certmanagerv1.Issuer{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "selfsigned",
+				f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
+				f.Certs.CreateCertificate(e2e.CertificateSpec{
+					Namespace:  namespace,
+					Name:       "backend-client-cert",
+					SecretName: "backend-client-cert",
+					CommonName: "client",
+					Usages: []e2e.KeyUsage{
+						e2e.UsageClientAuth,
 					},
-					Spec: certmanagerv1.IssuerSpec{
-						IssuerConfig: certmanagerv1.IssuerConfig{
-							SelfSigned: &certmanagerv1.SelfSignedIssuer{},
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), selfSignedIssuer))
-
-				// CA to sign backend certs with.
-				caCertificate := &certmanagerv1.Certificate{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "ca-cert",
-					},
-					Spec: certmanagerv1.CertificateSpec{
-						IsCA: true,
-						Usages: []certmanagerv1.KeyUsage{
-							certmanagerv1.UsageSigning,
-							certmanagerv1.UsageCertSign,
-						},
-						CommonName: "ca-cert",
-						SecretName: "ca-cert",
-						IssuerRef: certmanagermetav1.ObjectReference{
-							Name: "selfsigned",
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), caCertificate))
-
-				// Issuer based on CA to generate new certs with.
-				basedOnCAIssuer := &certmanagerv1.Issuer{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "ca-issuer",
-					},
-					Spec: certmanagerv1.IssuerSpec{
-						IssuerConfig: certmanagerv1.IssuerConfig{
-							CA: &certmanagerv1.CAIssuer{
-								SecretName: "ca-cert",
-							},
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), basedOnCAIssuer))
-
-				// Backend client cert, can use for upstream validation as well.
-				backendClientCert := &certmanagerv1.Certificate{
-					ObjectMeta: meta_v1.ObjectMeta{
-						Namespace: namespace,
-						Name:      "backend-client-cert",
-					},
-					Spec: certmanagerv1.CertificateSpec{
-						Usages: []certmanagerv1.KeyUsage{
-							certmanagerv1.UsageClientAuth,
-						},
-						CommonName: "client",
-						SecretName: "backend-client-cert",
-						IssuerRef: certmanagermetav1.ObjectReference{
-							Name: "ca-issuer",
-						},
-					},
-				}
-				require.NoError(f.T(), f.Client.Create(context.TODO(), backendClientCert))
+					Issuer: "ca-issuer",
+				})
 
 				contourConfig.TLS = config.TLSParameters{
 					ClientCertificate: config.NamespacedName{

--- a/test/scripts/README.md
+++ b/test/scripts/README.md
@@ -4,8 +4,8 @@
 The [make-kind-cluster.sh](./make-kind-cluster.sh) script will bring up
 a local kind cluster. This underlying VM [config](./kind-expose-port.yaml)
 forwards the Envoy ports 80 and 443 locally as port 9080 and 9443.
-The script installs [cert-manager](https://cert-manager.io), which is
-needed for tests that use TLS.
+TLS assets needed by the e2e suite are generated directly by the test
+framework, so no extra certificate controller is required in the cluster.
 
 The [install-contour-working.sh](.install-contour-working.sh) script
 builds and installs Contour from the working repository.

--- a/test/scripts/make-kind-cluster.sh
+++ b/test/scripts/make-kind-cluster.sh
@@ -125,13 +125,6 @@ if [ $success != "true" ]; then
   exit 1
 fi
 
-# Install cert-manager.
-CERT_MANAGER_VERSION=$(go list -m all | grep github.com/cert-manager/cert-manager | awk '{print $2}')
-
-${KUBECTL} apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
-${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=cert-manager deployments --for=condition=Available
-${KUBECTL} wait --timeout="${WAITTIME}" -n cert-manager -l app=webhook deployments --for=condition=Available
-
 if [[ "${SKIP_GATEWAY_API_INSTALL}" != "true" ]]; then
   # Install Gateway API CRDs.
   ${KUBECTL} apply -f "${REPO}/examples/gateway/00-crds.yaml"


### PR DESCRIPTION
## Overview

This PR removes the dependency on cert-manager in the e2e test suite and replaces it with a lightweight in-process certificate generation helper.

Previously, the e2e suite relied on cert-manager CRDs to generate test certificates. Although cert-manager was only used for testing, it was included in go.mod, causing its transitive dependencies (notably gateway-api) to affect Contour’s build.

When cert-manager updated its gateway-api dependency to a newer version, it introduced version conflicts with Contour’s own Gateway API usage, resulting in compilation failures.

## What this PR does

- Introduces a local certificate helper (`test/e2e/certs.go`) that:
  - Generates X.509 certificates using Go’s crypto libraries
  - Tracks issuers in memory
  - Creates TLS Secrets (`kubernetes.io/tls`) directly
  - Reconciles managed Secrets to preserve behavior like cert rotation

- Refactors e2e tests to use the new helper via the shared framework
- Removes cert-manager usage from e2e tests
- Removes cert-manager dependency from `go.mod`
- Removes cert-manager installation from `test/scripts/make-kind-cluster.sh`
- Updates `test/scripts/README.md` to reflect the new test flow

## Why this change

- Avoids dependency leakage from test-only dependencies
- Eliminates gateway-api version conflicts introduced by cert-manager
- Simplifies e2e test setup (no external controller required)
- Improves test determinism and reduces cluster complexity

## Behavior parity

The new helper preserves key behaviors previously provided by cert-manager:
- Certificate issuance via issuers
- CA-based signing
- Secret regeneration when deleted (important for rotation-related tests)

## Testing

- Ran full e2e test suite locally
- Verified TLS-related tests (backend TLS, mTLS, protocol versions)
- Confirmed no dependency conflicts remain in module graph

## Related Issue

Fixes #7490