### PR TITLE
main: Bump to go 1.26.2

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
 
 jobs:
   e2e-envoy-deployment:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.2
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.26.0@sha256:c83e68f3ebb6943a2904fa66348867d108119890a2c6a2e6f07b38d0eb6c25c5
+BUILD_BASE_IMAGE ?= golang:1.26.2@sha256:5f3787b7f902c07c7ec4f3aa91a301a3eda8133aa32661a3b3a3a86ab3a68a36
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/7416-tsaarni-small.md
+++ b/changelogs/unreleased/7416-tsaarni-small.md
@@ -1,1 +1,0 @@
-Updates Go to go1.26.0. See the [Go release notes](https://go.dev/doc/devel/release#go1.26.0) for more information about the content of the release.

--- a/changelogs/unreleased/7523-tsaarni-small.md
+++ b/changelogs/unreleased/7523-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Go to go1.26.2. See the [Go release notes](https://go.dev/doc/devel/release#go1.26.0) for more information about the content of the release.


### PR DESCRIPTION
https://go.dev/doc/devel/release#go1.26.0