### PR TITLE
internal/envoy: always set NumRetries so numRetries=-1 actually disables retries

### DIFF
--- a/changelogs/unreleased/7525-SAY-5-small.md
+++ b/changelogs/unreleased/7525-SAY-5-small.md
@@ -1,0 +1,1 @@
+Fix RetryPolicy numRetries=0 being silently coerced to 1 by populating num_retries explicitly when set, so HTTPProxy retry policies that explicitly request zero retries are honored.

--- a/internal/envoy/v3/route.go
+++ b/internal/envoy/v3/route.go
@@ -547,9 +547,14 @@ func retryPolicy(r *dag.Route) *envoy_config_route_v3.RetryPolicy {
 		RetryOn:              r.RetryPolicy.RetryOn,
 		RetriableStatusCodes: r.RetryPolicy.RetriableStatusCodes,
 	}
-	if r.RetryPolicy.NumRetries > 0 {
-		rp.NumRetries = wrapperspb.UInt32(r.RetryPolicy.NumRetries)
-	}
+	// HTTPProxy documents numRetries: -1 as "disable retries". The DAG
+	// translates -1 to 0 (internal/dag/policy.go), so the DAG value 0
+	// here uniquely means "user asked for no retries". Previously we
+	// only set NumRetries when > 0, and Envoy then defaulted to 1 --
+	// giving exactly one retry instead of none (projectcontour#5944).
+	// Always set NumRetries (including 0) so Envoy respects the
+	// documented contract.
+	rp.NumRetries = wrapperspb.UInt32(r.RetryPolicy.NumRetries)
 	rp.PerTryTimeout = envoy.Timeout(r.RetryPolicy.PerTryTimeout)
 
 	return rp

--- a/internal/featuretests/v3/envoy.go
+++ b/internal/featuretests/v3/envoy.go
@@ -313,10 +313,8 @@ func withPrefixRewrite(route *envoy_config_route_v3.Route_Route, replacement str
 
 func withRetryPolicy(route *envoy_config_route_v3.Route_Route, retryOn string, numRetries uint32, perTryTimeout time.Duration) *envoy_config_route_v3.Route_Route {
 	route.Route.RetryPolicy = &envoy_config_route_v3.RetryPolicy{
-		RetryOn: retryOn,
-	}
-	if numRetries > 0 {
-		route.Route.RetryPolicy.NumRetries = wrapperspb.UInt32(numRetries)
+		RetryOn:    retryOn,
+		NumRetries: wrapperspb.UInt32(numRetries),
 	}
 	if perTryTimeout > 0 {
 		route.Route.RetryPolicy.PerTryTimeout = durationpb.New(perTryTimeout)

--- a/internal/xdscache/v3/route_test.go
+++ b/internal/xdscache/v3/route_test.go
@@ -3896,10 +3896,8 @@ func routetimeout(cluster string, timeout time.Duration) *envoy_config_route_v3.
 func routeretry(cluster, retryOn string, numRetries uint32, perTryTimeout time.Duration) *envoy_config_route_v3.Route_Route {
 	r := routecluster(cluster)
 	r.Route.RetryPolicy = &envoy_config_route_v3.RetryPolicy{
-		RetryOn: retryOn,
-	}
-	if numRetries > 0 {
-		r.Route.RetryPolicy.NumRetries = wrapperspb.UInt32(numRetries)
+		RetryOn:    retryOn,
+		NumRetries: wrapperspb.UInt32(numRetries),
 	}
 	if perTryTimeout > 0 {
 		r.Route.RetryPolicy.PerTryTimeout = durationpb.New(perTryTimeout)


### PR DESCRIPTION
## Summary

HTTPProxy documents `numRetries: -1` as "disable retries". The DAG translator in `internal/dag/policy.go` already maps the API value `-1` to the DAG value `0` (with DAG value `1` standing for the default one-retry behaviour).

`internal/envoy/v3/route.retryPolicy`, however, only forwarded `NumRetries` to Envoy when the DAG value was `> 0`. When a user set `numRetries: -1`, the DAG value `0` silently disappeared from the Envoy `RetryPolicy`, and Envoy's documented default of `1` kicked in, giving exactly one retry instead of none.

## Fix

Always set `NumRetries` (including `0`) so the Envoy config matches what the API promised.

Fixes #5944.

## Test

- `go build ./internal/envoy/...` green.
- `go test ./internal/envoy/v3/... -count=1 -short` passes.
- `go test ./internal/xdscache/v3/... -count=1 -short` passes (TestRouteVisit goldens unchanged).

## Release Note

```release-note
Fix `numRetries: -1` on HTTPProxy retry policies so it disables retries as documented, instead of falling back to Envoy's default of one retry.
```

/kind bug
/area httpproxy