### PR TITLE
docs: replace unavailable kuard example image with stevesloka/echo-server

### DIFF
--- a/examples/example-workload/gatewayapi/kuard/kuard.yaml
+++ b/examples/example-workload/gatewayapi/kuard/kuard.yaml
@@ -16,8 +16,19 @@ spec:
         app: kuard
     spec:
       containers:
-      - image: gcr.io/kuar-demo/kuard-amd64:1
+      # gcr.io/kuar-demo/kuard-amd64 is no longer available upstream
+      # (https://github.com/kubernetes-up-and-running/kuard/issues/59),
+      # so this example now runs a small echo server on port 8080 instead
+      # (same image already used by the blue-green example).
+      - image: stevesloka/echo-server
         name: kuard
+        command: ["echo-server"]
+        args:
+          - --echotext=kuard
+        imagePullPolicy: IfNotPresent
+        ports:
+          - name: http
+            containerPort: 8080
 ---
 apiVersion: v1
 kind: Service

--- a/examples/example-workload/httpproxy/00-common/02-deployments.yaml
+++ b/examples/example-workload/httpproxy/00-common/02-deployments.yaml
@@ -14,8 +14,17 @@ spec:
         app: kuard
     spec:
       containers:
-      - image: gcr.io/kuar-demo/kuard-amd64:1
+      # gcr.io/kuar-demo/kuard-amd64 is no longer available upstream
+      # (https://github.com/kubernetes-up-and-running/kuard/issues/59),
+      # so this example now runs a small echo server on port 8080 instead
+      # (same image already used by the blue-green example).
+      - image: stevesloka/echo-server
         name: kuard
+        command: ["echo-server"]
+        imagePullPolicy: IfNotPresent
+        ports:
+          - name: http
+            containerPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -33,5 +42,14 @@ spec:
         app: kuard
     spec:
       containers:
-      - image: gcr.io/kuar-demo/kuard-amd64:1
+      # gcr.io/kuar-demo/kuard-amd64 is no longer available upstream
+      # (https://github.com/kubernetes-up-and-running/kuard/issues/59),
+      # so this example now runs a small echo server on port 8080 instead
+      # (same image already used by the blue-green example).
+      - image: stevesloka/echo-server
         name: kuard
+        command: ["echo-server"]
+        imagePullPolicy: IfNotPresent
+        ports:
+          - name: http
+            containerPort: 8080

--- a/site/content/docs/main/guides/gateway-api.md
+++ b/site/content/docs/main/guides/gateway-api.md
@@ -159,9 +159,9 @@ $ kubectl apply -f {{< param github_raw_url>}}/{{< param branch >}}/examples/exa
 ```
 This command creates:
 
-- A Deployment named `kuard` in the default namespace to run kuard as the test application.
-- A Service named `kuard` in the default namespace to expose the kuard application on TCP port 80.
-- An HTTPRoute named `kuard` in the default namespace, attached to the `contour` Gateway, to route requests for `local.projectcontour.io` to the kuard service.
+- A Deployment named `kuard` in the default namespace to run a small echo server as the test application.
+- A Service named `kuard` in the default namespace to expose the test application on TCP port 80.
+- An HTTPRoute named `kuard` in the default namespace, attached to the `contour` Gateway, to route requests for `local.projectcontour.io` to the `kuard` service.
 
 Verify the kuard resources are available:
 ```shell


### PR DESCRIPTION
Closes #7365.

## Problem

\`gcr.io/kuar-demo/kuard-amd64:1\` is no longer pullable upstream, see [kubernetes-up-and-running/kuard#59](https://github.com/kubernetes-up-and-running/kuard/issues/59). Anyone walking through the [Gateway API guide](https://projectcontour.io/docs/1.33/guides/gateway-api/) or deploying \`examples/example-workload/httpproxy\` gets \`ErrImagePull\` on the test app.

## Fix

Swap both sample deployments to \`stevesloka/echo-server\` (already pullable and already used by \`examples/example-workload/gatewayapi/blue-green/blue-green.yaml\`, so users following the guides don't need a second image cache hit):

- \`examples/example-workload/gatewayapi/kuard/kuard.yaml\`
- \`examples/example-workload/httpproxy/00-common/02-deployments.yaml\` (both \`default\` and \`marketing\` namespace deployments)

Resource names (\`kuard\` Deployment / Service / HTTPRoute, \`app: kuard\` label) are deliberately left intact so HTTPProxy / HTTPRoute manifests that reference them, both in the docs and in any user's cluster, keep working. Only the image, command, and \`containerPort\` are touched. The existing \`s1\`, \`s2\`, \`s*-health\`, \`s*-strategy\` etc. services in \`01-services.yaml\` already target \`8080\`, which is where echo-server listens, so no \`Service\` edits were needed.

I also softened two bullets in \`site/content/docs/main/guides/gateway-api.md\` that described the deployment as running kuard specifically, since that's no longer literally true.

Left an inline comment above each swapped image so the next person wondering \"why echo-server?\" has a direct pointer to kuard#59.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>