### PR TITLE
Update website footer to align with CNCF guidelines

### DIFF
--- a/site/themes/contour/layouts/partials/footer.html
+++ b/site/themes/contour/layouts/partials/footer.html
@@ -12,9 +12,9 @@
 		</div>
 		<div class="bottom-links">
 			<div class="copywrite">
-				&copy; Project Contour Authors
+				Copyright Project Contour a Series of LF Projects, LLC
 				<br />
-				&copy; {{ now.Year }} <a href="https://linuxfoundation.org" target="_blank">The Linux Foundation</a>. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
+				For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank">lfprojects.org/policies/</a>.
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Update the website footer to use the LF Projects, LLC disclaimer per CNCF website guidelines.

Fixes #7527