### PR TITLE
release-main: Bump to go 1.26.3

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.2
+  GO_VERSION: 1.26.3
 
 jobs:
   e2e-envoy-deployment:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.2
+  GO_VERSION: 1.26.3
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.2
+  GO_VERSION: 1.26.3
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.2
+  GO_VERSION: 1.26.3
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.26.2@sha256:5f3787b7f902c07c7ec4f3aa91a301a3eda8133aa32661a3b3a3a86ab3a68a36
+BUILD_BASE_IMAGE ?= golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0


### PR DESCRIPTION
Update Go from 1.26.2 to 1.26.3
https://go.dev/doc/devel/release#go1.26.minor