### PR TITLE
release-main: Bump to Envoy v1.38.0

### DIFF
--- a/changelogs/unreleased/7566-tsaarni-small.md
+++ b/changelogs/unreleased/7566-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.38.0. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.38.0/version_history/v1.38/v1.38.0) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.37.2",
+		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.38.0",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.37.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.37.2
+          image: docker.io/envoyproxy/envoy:distroless-v1.38.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9556,7 +9556,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.37.2
+          image: docker.io/envoyproxy/envoy:distroless-v1.38.0
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9361,7 +9361,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.37.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9544,7 +9544,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.37.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.0
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.37.2][77]         | 1.35, 1.34, 1.33    | [1.3.0][113]        |
+| main            | [1.38.0][77]         | 1.35, 1.34, 1.33    | [1.3.0][113]        |
 | 1.33.4          | [1.35.10][80]        | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.3          | [1.35.9][78]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.2          | [1.35.8][74]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
@@ -250,7 +250,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [74]: https://www.envoyproxy.io/docs/envoy/v1.35.8/version_history/v1.35/v1.35
 [75]: https://www.envoyproxy.io/docs/envoy/v1.34.12/version_history/v1.34/v1.34
 [76]: https://www.envoyproxy.io/docs/envoy/v1.31.10/version_history/v1.31/v1.31
-[77]: https://www.envoyproxy.io/docs/envoy/v1.37.2/version_history/v1.37/v1.37.2
+[77]: https://www.envoyproxy.io/docs/envoy/v1.38.0/version_history/v1.38/v1.38.0
 [78]: https://www.envoyproxy.io/docs/envoy/v1.35.9/version_history/v1.35/v1.35.9
 [79]: https://www.envoyproxy.io/docs/envoy/v1.34.13/version_history/v1.34/v1.34.13
 [80]: https://www.envoyproxy.io/docs/envoy/v1.35.10/version_history/v1.35/v1.35.10

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.37.2"
+      envoy: "1.38.0"
       kubernetes:
         - "1.35"
         - "1.34"


### PR DESCRIPTION
Update from Envoy 1.37.2 to 1.38.0
https://www.envoyproxy.io/docs/envoy/v1.38.0/version_history/v1.38/v1.38.0