### PR TITLE
release-main: Bump to go 1.26.4

### DIFF
--- a/.github/workflows/build_daily.yaml
+++ b/.github/workflows/build_daily.yaml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   e2e-envoy-deployment:

--- a/.github/workflows/build_tag.yaml
+++ b/.github/workflows/build_tag.yaml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GOPROXY: https://proxy.golang.org/
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64
 
 # Base build image to use.
-BUILD_BASE_IMAGE ?= golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a
+BUILD_BASE_IMAGE ?= golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479
 
 # Enable build with CGO.
 BUILD_CGO_ENABLED ?= 0

--- a/changelogs/unreleased/7523-tsaarni-small.md
+++ b/changelogs/unreleased/7523-tsaarni-small.md
@@ -1,1 +1,0 @@
-Updates Go to go1.26.2. See the [Go release notes](https://go.dev/doc/devel/release#go1.26.0) for more information about the content of the release.

--- a/changelogs/unreleased/7576-tsaarni-small.md
+++ b/changelogs/unreleased/7576-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Go to go1.26.4. See the [Go release notes](https://go.dev/doc/devel/release#go1.26.0) for more information about the content of the release.


### PR DESCRIPTION
Update Go from 1.26.3 to 1.26.4
https://go.dev/doc/devel/release#go1.26.minor