### PR TITLE
Use certyaml to issue certs in e2e suite

### DIFF
--- a/test/e2e/certs.go
+++ b/test/e2e/certs.go
@@ -17,192 +17,67 @@ package e2e
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"fmt"
-	"math/big"
-	"sync"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	core_v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	e2eCertificateLifetime = 365 * 24 * time.Hour
-	e2eCertKeySize         = 2048
-	e2eCertSyncInterval    = 100 * time.Millisecond
-	selfSignedIssuerName   = "selfsigned"
-)
-
-// KeyUsage declares the X509 usage requested for a generated test certificate.
-type KeyUsage string
-
-const (
-	UsageCertSign   KeyUsage = "cert sign"
-	UsageClientAuth KeyUsage = "client auth"
-	UsageServerAuth KeyUsage = "server auth"
-	UsageSigning    KeyUsage = "signing"
-)
-
-// X509Subject defines the subset of subject fields used in the e2e suite.
-type X509Subject struct {
-	OrganizationalUnits []string
-}
-
-// CertificateSpec defines the inputs used to generate a test certificate and
-// its backing Secret.
-type CertificateSpec struct {
-	Namespace      string
-	Name           string
-	SecretName     string
-	CommonName     string
-	DNSNames       []string
-	EmailAddresses []string
-	IsCA           bool
-	Usages         []KeyUsage
-	Subject        *X509Subject
-	Issuer         string
-}
-
-type certificateMaterial struct {
-	certificate *x509.Certificate
-	privateKey  *rsa.PrivateKey
-	certPEM     []byte
-	keyPEM      []byte
-	caPEM       []byte
-}
-
-type managedCertificate struct {
-	namespace string
-	name      string
-	material  certificateMaterial
-}
-
-type managedIssuer struct {
-	selfSigned bool
-	signer     *certificateMaterial
-}
-
 // Certs provides helpers for generating TLS Secrets used by e2e tests.
 type Certs struct {
-	client        client.Client
-	retryInterval time.Duration
-	retryTimeout  time.Duration
-	t             ginkgo.GinkgoTInterface
-
-	mu           sync.RWMutex
-	issuers      map[types.NamespacedName]managedIssuer
-	certificates map[types.NamespacedName]managedCertificate
+	client client.Client
+	t      ginkgo.GinkgoTInterface
 }
 
 func newCerts(cli client.Client, t ginkgo.GinkgoTInterface) *Certs {
-	c := &Certs{
-		client:        cli,
-		retryInterval: time.Second,
-		retryTimeout:  60 * time.Second,
-		t:             t,
-		issuers:       map[types.NamespacedName]managedIssuer{},
-		certificates:  map[types.NamespacedName]managedCertificate{},
-	}
-
-	go c.reconcileSecrets()
-
-	return c
+	return &Certs{client: cli, t: t}
 }
 
-// CreateSelfSignedCert creates a self-signed certificate Secret. It returns a
-// cleanup function that unregisters the managed Secret and removes it.
-func (c *Certs) CreateSelfSignedCert(ns, name, secretName, dnsName string) func() {
-	c.ensureSelfSignedIssuer(ns)
-
-	return c.CreateCertificate(CertificateSpec{
-		Namespace:  ns,
-		Name:       name,
-		SecretName: secretName,
-		CommonName: dnsName,
-		DNSNames:   []string{dnsName},
-		Issuer:     selfSignedIssuerName,
+// CreateSelfSignedCert creates a self-signed certificate Secret.
+func (c *Certs) CreateSelfSignedCert(ns, secretName, dnsName string) {
+	isCA := false
+	c.CreateCertificate(ns, secretName, &certyaml.Certificate{
+		Subject:         "cn=" + dnsName,
+		SubjectAltNames: []string{"DNS:" + dnsName},
+		IsCA:            &isCA,
 	})
 }
 
-// CreateCA creates a root CA Secret and an issuer with the same name.
-func (c *Certs) CreateCA(ns, name string) func() {
-	return c.CreateCAWithIssuer(ns, name, name)
+// CreateCA creates a root CA Secret and returns the CA for use as Issuer.
+func (c *Certs) CreateCA(ns, secretName string) *certyaml.Certificate {
+	ca := &certyaml.Certificate{Subject: "cn=" + secretName}
+	c.CreateCertificate(ns, secretName, ca)
+	return ca
 }
 
-// CreateCAWithIssuer creates a root CA Secret and registers a named issuer that
-// signs future certificates with it.
-func (c *Certs) CreateCAWithIssuer(ns, secretName, issuerName string) func() {
-	c.ensureSelfSignedIssuer(ns)
-
-	spec := CertificateSpec{
-		Namespace:  ns,
-		Name:       secretName,
-		SecretName: secretName,
-		CommonName: secretName,
-		IsCA:       true,
-		Usages: []KeyUsage{
-			UsageSigning,
-			UsageCertSign,
-		},
-		Subject: &X509Subject{
-			OrganizationalUnits: []string{
-				"io",
-				"projectcontour",
-				"testsuite",
-			},
-		},
-		Issuer: selfSignedIssuerName,
-	}
-
-	material, err := c.issueCertificate(spec)
+// CreateCertificate creates a TLS Secret from a certyaml.Certificate.
+func (c *Certs) CreateCertificate(ns, secretName string, cert *certyaml.Certificate) {
+	certPEM, keyPEM, err := cert.PEM()
 	require.NoError(c.t, err)
 
-	c.registerIssuer(ns, issuerName, managedIssuer{
-		signer: &material,
-	})
+	var caPEM []byte
+	if cert.Issuer != nil {
+		caPEM, _, err = cert.Issuer.PEM()
+		require.NoError(c.t, err)
+	} else {
+		caPEM = certPEM
+	}
 
-	return c.manageCertificate(spec, material, func() {
-		c.unregisterIssuer(ns, issuerName)
-	})
-}
-
-// CreateCertificate creates a certificate Secret using the named issuer.
-func (c *Certs) CreateCertificate(spec CertificateSpec) func() {
-	material, err := c.issueCertificate(spec)
-	require.NoError(c.t, err)
-
-	return c.manageCertificate(spec, material, nil)
-}
-
-// CreateCertificateAndWait creates the certificate Secret and returns true once
-// it has been persisted. Generation is synchronous, so no additional polling is
-// required beyond the initial write.
-func (c *Certs) CreateCertificateAndWait(spec CertificateSpec) bool {
-	c.CreateCertificate(spec)
-	return true
-}
-
-// CreateCert creates end-entity certificate using given CA issuer.
-func (c *Certs) CreateCert(ns, name, issuer string, dnsNames ...string) func() {
-	return c.CreateCertificate(CertificateSpec{
-		Namespace:  ns,
-		Name:       name,
-		SecretName: name,
-		CommonName: name,
-		DNSNames:   dnsNames,
-		Issuer:     issuer,
-	})
+	secret := &core_v1.Secret{
+		ObjectMeta: meta_v1.ObjectMeta{Namespace: ns, Name: secretName},
+		Type:       core_v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			core_v1.TLSCertKey:       certPEM,
+			core_v1.TLSPrivateKeyKey: keyPEM,
+			"ca.crt":                 caPEM,
+		},
+	}
+	require.NoError(c.t, c.client.Create(context.TODO(), secret))
 }
 
 // GetTLSCertificate returns a tls.Certificate containing the data in the specified
@@ -223,267 +98,4 @@ func (c *Certs) GetTLSCertificate(secretNamespace, secretName string) (tls.Certi
 	}
 
 	return cert, caBundle
-}
-
-func (c *Certs) ensureSelfSignedIssuer(namespace string) {
-	c.registerIssuer(namespace, selfSignedIssuerName, managedIssuer{
-		selfSigned: true,
-	})
-}
-
-func (c *Certs) manageCertificate(spec CertificateSpec, material certificateMaterial, cleanup func()) func() {
-	name := spec.SecretName
-	if name == "" {
-		name = spec.Name
-	}
-
-	managed := managedCertificate{
-		namespace: spec.Namespace,
-		name:      name,
-		material:  material,
-	}
-
-	c.registerManagedCertificate(managed)
-	require.NoError(c.t, c.ensureSecret(context.TODO(), managed))
-
-	return func() {
-		c.unregisterManagedCertificate(spec.Namespace, name)
-		if cleanup != nil {
-			cleanup()
-		}
-
-		secret := &core_v1.Secret{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Namespace: spec.Namespace,
-				Name:      name,
-			},
-		}
-		err := c.client.Delete(context.TODO(), secret)
-		if err != nil && !errors.IsNotFound(err) {
-			require.NoError(c.t, err)
-		}
-	}
-}
-
-func (c *Certs) issueCertificate(spec CertificateSpec) (certificateMaterial, error) {
-	issuer, err := c.getIssuer(spec.Namespace, spec.Issuer)
-	if err != nil {
-		return certificateMaterial{}, err
-	}
-
-	privateKey, err := rsa.GenerateKey(rand.Reader, e2eCertKeySize)
-	if err != nil {
-		return certificateMaterial{}, err
-	}
-
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		return certificateMaterial{}, err
-	}
-
-	subject := pkix.Name{
-		CommonName: spec.CommonName,
-	}
-	if spec.Subject != nil {
-		subject.OrganizationalUnit = append(subject.OrganizationalUnit, spec.Subject.OrganizationalUnits...)
-	}
-
-	keyUsage, extKeyUsage := x509Usages(spec)
-	template := &x509.Certificate{
-		SerialNumber:          serialNumber,
-		Subject:               subject,
-		NotBefore:             time.Now().Add(-time.Minute),
-		NotAfter:              time.Now().Add(e2eCertificateLifetime),
-		BasicConstraintsValid: true,
-		IsCA:                  spec.IsCA,
-		DNSNames:              append([]string(nil), spec.DNSNames...),
-		EmailAddresses:        append([]string(nil), spec.EmailAddresses...),
-		KeyUsage:              keyUsage,
-		ExtKeyUsage:           extKeyUsage,
-	}
-
-	parent := template
-	signer := privateKey
-	caPEM := []byte(nil)
-
-	if issuer.selfSigned {
-		caPEM = make([]byte, 0)
-	} else {
-		parent = issuer.signer.certificate
-		signer = issuer.signer.privateKey
-		caPEM = append([]byte(nil), issuer.signer.caPEM...)
-	}
-
-	certDER, err := x509.CreateCertificate(rand.Reader, template, parent, &privateKey.PublicKey, signer)
-	if err != nil {
-		return certificateMaterial{}, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-	if issuer.selfSigned {
-		caPEM = append([]byte(nil), certPEM...)
-	}
-
-	cert, err := x509.ParseCertificate(certDER)
-	if err != nil {
-		return certificateMaterial{}, err
-	}
-
-	return certificateMaterial{
-		certificate: cert,
-		privateKey:  privateKey,
-		certPEM:     certPEM,
-		keyPEM:      keyPEM,
-		caPEM:       caPEM,
-	}, nil
-}
-
-func x509Usages(spec CertificateSpec) (x509.KeyUsage, []x509.ExtKeyUsage) {
-	if !spec.IsCA && len(spec.Usages) == 0 {
-		spec.Usages = []KeyUsage{UsageServerAuth, UsageClientAuth}
-	}
-
-	keyUsage := x509.KeyUsageDigitalSignature
-	var extKeyUsage []x509.ExtKeyUsage
-
-	for _, usage := range spec.Usages {
-		switch usage {
-		case UsageCertSign, UsageSigning:
-			keyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
-		case UsageClientAuth:
-			extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageClientAuth)
-		case UsageServerAuth:
-			keyUsage |= x509.KeyUsageKeyEncipherment
-			extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageServerAuth)
-		}
-	}
-
-	if spec.IsCA {
-		keyUsage |= x509.KeyUsageCertSign | x509.KeyUsageCRLSign
-	}
-
-	return keyUsage, extKeyUsage
-}
-
-func (c *Certs) reconcileSecrets() {
-	ticker := time.NewTicker(e2eCertSyncInterval)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		for _, cert := range c.managedCertificates() {
-			_ = c.ensureSecret(context.Background(), cert)
-		}
-	}
-}
-
-func (c *Certs) ensureSecret(ctx context.Context, managed managedCertificate) error {
-	desired := &core_v1.Secret{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: managed.namespace,
-			Name:      managed.name,
-		},
-		Type: core_v1.SecretTypeTLS,
-		Data: map[string][]byte{
-			core_v1.TLSCertKey:       managed.material.certPEM,
-			core_v1.TLSPrivateKeyKey: managed.material.keyPEM,
-			"ca.crt":                 managed.material.caPEM,
-		},
-	}
-
-	current := &core_v1.Secret{}
-	key := client.ObjectKeyFromObject(desired)
-
-	if err := c.client.Get(ctx, key, current); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-
-		if err := c.client.Create(ctx, desired); err != nil && !errors.IsAlreadyExists(err) {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		return nil
-	}
-
-	if current.Type == desired.Type &&
-		bytesEqual(current.Data[core_v1.TLSCertKey], desired.Data[core_v1.TLSCertKey]) &&
-		bytesEqual(current.Data[core_v1.TLSPrivateKeyKey], desired.Data[core_v1.TLSPrivateKeyKey]) &&
-		bytesEqual(current.Data["ca.crt"], desired.Data["ca.crt"]) {
-		return nil
-	}
-
-	current.Type = desired.Type
-	current.Data = desired.Data
-
-	return c.client.Update(ctx, current)
-}
-
-func (c *Certs) managedCertificates() []managedCertificate {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	result := make([]managedCertificate, 0, len(c.certificates))
-	for _, cert := range c.certificates {
-		result = append(result, cert)
-	}
-
-	return result
-}
-
-func (c *Certs) registerIssuer(namespace, name string, issuer managedIssuer) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.issuers[types.NamespacedName{Namespace: namespace, Name: name}] = issuer
-}
-
-func (c *Certs) unregisterIssuer(namespace, name string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	delete(c.issuers, types.NamespacedName{Namespace: namespace, Name: name})
-}
-
-func (c *Certs) getIssuer(namespace, name string) (managedIssuer, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	issuer, ok := c.issuers[types.NamespacedName{Namespace: namespace, Name: name}]
-	if !ok {
-		return managedIssuer{}, fmt.Errorf("issuer %s/%s not found", namespace, name)
-	}
-
-	return issuer, nil
-}
-
-func (c *Certs) registerManagedCertificate(cert managedCertificate) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.certificates[types.NamespacedName{Namespace: cert.namespace, Name: cert.name}] = cert
-}
-
-func (c *Certs) unregisterManagedCertificate(namespace, name string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	delete(c.certificates, types.NamespacedName{Namespace: namespace, Name: name})
-}
-
-func bytesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
 }

--- a/test/e2e/gateway/backend_tls_policy_test.go
+++ b/test/e2e/gateway/backend_tls_policy_test.go
@@ -16,11 +16,13 @@
 package gateway
 
 import (
+	"crypto/x509"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,17 +40,12 @@ func testBackendTLSPolicy(namespace string, gateway types.NamespacedName) {
 		protocolVersion := "TLSv1.3"
 		t := f.T()
 
-		f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "backend-server-cert",
-			SecretName: "backend-server-cert",
-			CommonName: "echo-secure",
-			DNSNames:   []string{"echo-secure"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-issuer",
+		ca := f.Certs.CreateCA(namespace, "ca-cert")
+		f.Certs.CreateCertificate(namespace, "backend-server-cert", &certyaml.Certificate{
+			Subject:         "cn=echo-secure",
+			SubjectAltNames: []string{"DNS:echo-secure"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          ca,
 		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", func(_ *apps_v1.Deployment, service *core_v1.Service) {
 			delete(service.Annotations, "projectcontour.io/upstream-protocol.tls")

--- a/test/e2e/gateway/gateway_test.go
+++ b/test/e2e/gateway/gateway_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Gateway API", func() {
 			return testWithGateway(gw, gatewayClass, func(namespace string, gateway types.NamespacedName) {
 				Context(fmt.Sprintf("with TLS secret %s/tlscert for hostname %s", namespace, hostname), func() {
 					BeforeEach(func() {
-						f.Certs.CreateSelfSignedCert(namespace, "tlscert", "tlscert", hostname)
+						f.Certs.CreateSelfSignedCert(namespace, "tlscert", hostname)
 					})
 
 					body(namespace, gateway)
@@ -325,9 +325,9 @@ var _ = Describe("Gateway API", func() {
 
 			return testWithGateway(gateway, gatewayClass, func(namespace string, _ types.NamespacedName) {
 				BeforeEach(func() {
-					f.Certs.CreateSelfSignedCert(namespace, "tlscert-1", "tlscert-1", "https-1.gateway.projectcontour.io")
-					f.Certs.CreateSelfSignedCert(namespace, "tlscert-2", "tlscert-2", "https-2.gateway.projectcontour.io")
-					f.Certs.CreateSelfSignedCert(namespace, "tlscert-3", "tlscert-3", "https-3.gateway.projectcontour.io")
+					f.Certs.CreateSelfSignedCert(namespace, "tlscert-1", "https-1.gateway.projectcontour.io")
+					f.Certs.CreateSelfSignedCert(namespace, "tlscert-2", "https-2.gateway.projectcontour.io")
+					f.Certs.CreateSelfSignedCert(namespace, "tlscert-3", "https-3.gateway.projectcontour.io")
 				})
 
 				body(namespace)

--- a/test/e2e/httpproxy/backend_tls_protocol_version_test.go
+++ b/test/e2e/httpproxy/backend_tls_protocol_version_test.go
@@ -16,29 +16,26 @@
 package httpproxy
 
 import (
+	"crypto/x509"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-func testBackendTLSProtocolVersion(namespace, protocolVersion string) {
+func testBackendTLSProtocolVersion(namespace, protocolVersion string, ca func() *certyaml.Certificate) {
 	Specify("backend connection uses configured TLS version", func() {
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "backend-server-cert",
-			SecretName: "backend-server-cert",
-			CommonName: "echo-secure",
-			DNSNames:   []string{"echo-secure"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-issuer",
+		f.Certs.CreateCertificate(namespace, "backend-server-cert", &certyaml.Certificate{
+			Subject:         "cn=echo-secure",
+			SubjectAltNames: []string{"DNS:echo-secure"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          ca(),
 		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 

--- a/test/e2e/httpproxy/backend_tls_test.go
+++ b/test/e2e/httpproxy/backend_tls_test.go
@@ -17,12 +17,14 @@ package httpproxy
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,18 +33,13 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-func testBackendTLS(namespace string) {
+func testBackendTLS(namespace string, ca func() *certyaml.Certificate) {
 	Specify("mTLS to backends can be configured", func() {
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "backend-server-cert",
-			SecretName: "backend-server-cert",
-			CommonName: "echo-secure",
-			DNSNames:   []string{"echo-secure"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-issuer",
+		f.Certs.CreateCertificate(namespace, "backend-server-cert", &certyaml.Certificate{
+			Subject:         "cn=echo-secure",
+			SubjectAltNames: []string{"DNS:echo-secure"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          ca(),
 		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 
@@ -100,15 +97,14 @@ func testBackendTLS(namespace string) {
 		assert.Equal(f.T(), tlsInfo.TLS.PeerCertificates[0], string(clientSecret.Data["tls.crt"]))
 
 		// Delete client cert so it is rotated.
-		oldUID := clientSecret.UID
 		require.NoError(f.T(), f.Client.Delete(context.TODO(), clientSecret))
-		// Make sure the cert is rotated.
-		require.Eventually(f.T(), func() bool {
-			if err := f.Client.Get(context.TODO(), clientSecretKey, clientSecret); err != nil {
-				return false
-			}
-			return clientSecret.UID != oldUID
-		}, time.Second*10, time.Millisecond*50)
+		// Rotate cert by re-creating the secret with same name but different cert.
+		f.Certs.CreateCertificate(namespace, "backend-client-cert", &certyaml.Certificate{
+			Subject:     "cn=client",
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			Issuer:      ca(),
+		})
+		require.NoError(f.T(), f.Client.Get(context.TODO(), clientSecretKey, clientSecret))
 
 		// Send HTTP request again until we get a 200 and new cert is presented.
 		require.Eventually(f.T(), func() bool {

--- a/test/e2e/httpproxy/client_cert_auth_test.go
+++ b/test/e2e/httpproxy/client_cert_auth_test.go
@@ -17,11 +17,13 @@ package httpproxy
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -32,116 +34,76 @@ func testClientCertAuth(namespace string) {
 	Specify("client requests can be authenticated", func() {
 		t := f.T()
 
-		f.Certs.CreateCAWithIssuer(namespace, "ca-projectcontour-io", "ca-projectcontour-io")
-		f.Certs.CreateCAWithIssuer(namespace, "ca-notprojectcontour-io", "ca-notprojectcontour-io")
+		caProjectcontour := f.Certs.CreateCA(namespace, "ca-projectcontour-io")
+		caNotProjectcontour := f.Certs.CreateCA(namespace, "ca-notprojectcontour-io")
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-no-auth")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-no-auth-cert",
-			SecretName: "echo-no-auth",
-			DNSNames:   []string{"echo-no-auth.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-no-auth", &certyaml.Certificate{
+			Subject:         "cn=echo-no-auth-cert",
+			SubjectAltNames: []string{"DNS:echo-no-auth.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-with-auth-cert",
-			SecretName: "echo-with-auth",
-			DNSNames:   []string{"echo-with-auth.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-with-auth", &certyaml.Certificate{
+			Subject:         "cn=echo-with-auth-cert",
+			SubjectAltNames: []string{"DNS:echo-with-auth.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth-skip-verify")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-with-auth-skip-verify-cert",
-			SecretName: "echo-with-auth-skip-verify",
-			DNSNames:   []string{"echo-with-auth-skip-verify.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-with-auth-skip-verify", &certyaml.Certificate{
+			Subject:         "cn=echo-with-auth-skip-verify-cert",
+			SubjectAltNames: []string{"DNS:echo-with-auth-skip-verify.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-auth-skip-verify-with-ca")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-with-auth-skip-verify-with-ca-cert",
-			SecretName: "echo-with-auth-skip-verify-with-ca",
-			DNSNames:   []string{"echo-with-auth-skip-verify-with-ca.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-with-auth-skip-verify-with-ca", &certyaml.Certificate{
+			Subject:         "cn=echo-with-auth-skip-verify-with-ca-cert",
+			SubjectAltNames: []string{"DNS:echo-with-auth-skip-verify-with-ca.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-with-optional-auth-cert",
-			SecretName: "echo-with-optional-auth",
-			DNSNames:   []string{"echo-with-optional-auth.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-with-optional-auth", &certyaml.Certificate{
+			Subject:         "cn=echo-with-optional-auth-cert",
+			SubjectAltNames: []string{"DNS:echo-with-optional-auth.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-with-optional-auth-no-ca")
 
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-with-optional-auth-no-ca-cert",
-			SecretName: "echo-with-optional-auth-no-ca",
-			DNSNames:   []string{"echo-with-optional-auth-no-ca.projectcontour.io"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-projectcontour-io",
+		f.Certs.CreateCertificate(namespace, "echo-with-optional-auth-no-ca", &certyaml.Certificate{
+			Subject:         "cn=echo-with-optional-auth-no-ca-cert",
+			SubjectAltNames: []string{"DNS:echo-with-optional-auth-no-ca.projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          caProjectcontour,
 		})
 
-		clientCert := e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-client-cert",
-			SecretName: "echo-client",
-			CommonName: "client",
-			EmailAddresses: []string{
-				"client@projectcontour.io",
-			},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageClientAuth,
-			},
-			Issuer: "ca-projectcontour-io",
-		}
-		require.True(f.T(), f.Certs.CreateCertificateAndWait(clientCert))
+		f.Certs.CreateCertificate(namespace, "echo-client", &certyaml.Certificate{
+			Subject:         "cn=client",
+			SubjectAltNames: []string{"email:client@projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			Issuer:          caProjectcontour,
+		})
 
-		clientCertInvalid := e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "echo-client-cert-invalid",
-			SecretName: "echo-client-invalid",
-			CommonName: "badclient",
-			EmailAddresses: []string{
-				"badclient@projectcontour.io",
-			},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageClientAuth,
-			},
-			Issuer: "ca-notprojectcontour-io",
-		}
-		require.True(f.T(), f.Certs.CreateCertificateAndWait(clientCertInvalid))
+		f.Certs.CreateCertificate(namespace, "echo-client-invalid", &certyaml.Certificate{
+			Subject:         "cn=badclient",
+			SubjectAltNames: []string{"email:badclient@projectcontour.io"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			Issuer:          caNotProjectcontour,
+		})
 
 		// This proxy does not require client certificate auth.
 		noAuthProxy := &contour_v1.HTTPProxy{
@@ -324,8 +286,8 @@ func testClientCertAuth(namespace string) {
 		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(optionalAuthNoCAProxy, e2e.HTTPProxyValid))
 
 		// get the valid & invalid client certs
-		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCert.SecretName)
-		invalidClientCert, _ := f.Certs.GetTLSCertificate(namespace, clientCertInvalid.SecretName)
+		validClientCert, _ := f.Certs.GetTLSCertificate(namespace, "echo-client")
+		invalidClientCert, _ := f.Certs.GetTLSCertificate(namespace, "echo-client-invalid")
 
 		cases := map[string]struct {
 			host       string

--- a/test/e2e/httpproxy/cookie_rewrite_test.go
+++ b/test/e2e/httpproxy/cookie_rewrite_test.go
@@ -709,7 +709,7 @@ func testHeaderRewriteCookieRewrite(namespace string) {
 func testCookieRewriteTLS(namespace string) {
 	Specify("cookies rewrites work on TLS vhosts", func() {
 		deployEchoServer(f.T(), f.Client, namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "cookie-rewrite-tls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "cookie-rewrite-tls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/default_global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/default_global_rate_limiting_test.go
@@ -194,7 +194,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitvhosttls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "globalratelimitvhosttls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -241,7 +241,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitroutetls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "globalratelimitroutetls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -307,7 +307,7 @@ func testDefaultGlobalRateLimitingVirtualHostTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitroutetls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "globalratelimitroutetls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/external_auth_http_test.go
+++ b/test/e2e/httpproxy/external_auth_http_test.go
@@ -38,7 +38,7 @@ import (
 func testExternalAuthzHTTP(namespace string) {
 	Specify("external HTTP auth can be configured on an HTTPProxy", func() {
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "externalauthhttp.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "externalauthhttp.projectcontour.io")
 
 		setHandler := e2e.StartLocalHTTPService(GinkgoT(), f.Client, namespace, "http-auth-mock")
 
@@ -260,7 +260,7 @@ var _ = Describe("httpproxy-ext-auth-http-global", func() {
 
 		Specify("global HTTP ext auth applies to virtual hosts", func() {
 			f.Fixtures.Echo.Deploy(namespace, "echo")
-			f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "globalexternalauthhttp.projectcontour.io")
+			f.Certs.CreateSelfSignedCert(namespace, "echo", "globalexternalauthhttp.projectcontour.io")
 
 			p := &contour_v1.HTTPProxy{
 				ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/external_auth_test.go
+++ b/test/e2e/httpproxy/external_auth_test.go
@@ -37,9 +37,9 @@ func testExternalAuth(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "externalauth.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "externalauth.projectcontour.io")
 
-		f.Certs.CreateSelfSignedCert(namespace, "testserver-cert", "testserver-cert", "testserver")
+		f.Certs.CreateSelfSignedCert(namespace, "testserver-cert", "testserver")
 
 		// auth testserver
 		deployment := &apps_v1.Deployment{

--- a/test/e2e/httpproxy/external_name_test.go
+++ b/test/e2e/httpproxy/external_name_test.go
@@ -97,7 +97,7 @@ func testExternalNameServiceTLS(namespace string) {
 	Specify("external name services work over https", func() {
 		t := f.T()
 
-		f.Certs.CreateSelfSignedCert(namespace, "backend-server-cert", "backend-server-cert", "echo")
+		f.Certs.CreateSelfSignedCert(namespace, "backend-server-cert", "echo")
 
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-tls", nil)
 

--- a/test/e2e/httpproxy/global_external_auth_test.go
+++ b/test/e2e/httpproxy/global_external_auth_test.go
@@ -124,7 +124,7 @@ func testGlobalExternalAuthTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "https.globalexternalauth.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "https.globalexternalauth.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -310,7 +310,7 @@ func testGlobalExternalAuthTLSAuthDisabled(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "disabled.https.globalexternalauth.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "disabled.https.globalexternalauth.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/global_rate_limiting_test.go
+++ b/test/e2e/httpproxy/global_rate_limiting_test.go
@@ -223,7 +223,7 @@ func testGlobalRateLimitingVirtualHostTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitvhosttls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "globalratelimitvhosttls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -310,7 +310,7 @@ func testGlobalRateLimitingRouteTLS(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "globalratelimitroutetls.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "globalratelimitroutetls.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -46,7 +46,7 @@ func testGRPCServicePlaintext(namespace string) {
 		t := f.T()
 
 		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "grpc-echo-plaintext.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "grpc-echo-plaintext.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -128,7 +128,7 @@ func testGRPCWeb(namespace string) {
 		t := f.T()
 
 		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo", "echo", "grpc-web.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "grpc-web.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/host_header_rewrite_test.go
+++ b/test/e2e/httpproxy/host_header_rewrite_test.go
@@ -143,7 +143,7 @@ func testHostRewriteHeaderHTTPSService(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
-		f.Certs.CreateSelfSignedCert(namespace, "ingress-conformance-echo", "ingress-conformance-echo", "https.hostheaderrewrite.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "ingress-conformance-echo", "https.hostheaderrewrite.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -16,6 +16,7 @@
 package httpproxy
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	"k8s.io/utils/ptr"
 
 	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -184,7 +186,7 @@ var _ = Describe("HTTPProxy", func() {
 					Namespace: namespace,
 				}
 
-				f.Certs.CreateSelfSignedCert(namespace, "fallback-cert", "fallback-cert", "fallback.projectcontour.io")
+				f.Certs.CreateSelfSignedCert(namespace, "fallback-cert", "fallback.projectcontour.io")
 			})
 
 			testHTTPSFallbackCertificate(namespace)
@@ -193,17 +195,14 @@ var _ = Describe("HTTPProxy", func() {
 
 	f.NamespacedTest("httpproxy-backend-tls", func(namespace string) {
 		Context("with backend tls", func() {
+			var backendTLSCA *certyaml.Certificate
+
 			BeforeEach(func() {
-				f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
-				f.Certs.CreateCertificate(e2e.CertificateSpec{
-					Namespace:  namespace,
-					Name:       "backend-client-cert",
-					SecretName: "backend-client-cert",
-					CommonName: "client",
-					Usages: []e2e.KeyUsage{
-						e2e.UsageClientAuth,
-					},
-					Issuer: "ca-issuer",
+				backendTLSCA = f.Certs.CreateCA(namespace, "ca-cert")
+				f.Certs.CreateCertificate(namespace, "backend-client-cert", &certyaml.Certificate{
+					Subject:     "cn=client",
+					ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+					Issuer:      backendTLSCA,
 				})
 
 				contourConfig.TLS = config.TLSParameters{
@@ -219,22 +218,19 @@ var _ = Describe("HTTPProxy", func() {
 				}
 			})
 
-			testBackendTLS(namespace)
+			testBackendTLS(namespace, func() *certyaml.Certificate { return backendTLSCA })
 		})
 	})
 
 	f.NamespacedTest("httpproxy-backend-tls-version", func(namespace string) {
+		var backendTLSCA *certyaml.Certificate
+
 		BeforeEach(func() {
-			f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
-			f.Certs.CreateCertificate(e2e.CertificateSpec{
-				Namespace:  namespace,
-				Name:       "backend-client-cert",
-				SecretName: "backend-client-cert",
-				CommonName: "client",
-				Usages: []e2e.KeyUsage{
-					e2e.UsageClientAuth,
-				},
-				Issuer: "ca-issuer",
+			backendTLSCA = f.Certs.CreateCA(namespace, "ca-cert")
+			f.Certs.CreateCertificate(namespace, "backend-client-cert", &certyaml.Certificate{
+				Subject:     "cn=client",
+				ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				Issuer:      backendTLSCA,
 			})
 
 			contourConfig.TLS = config.TLSParameters{
@@ -264,7 +260,7 @@ var _ = Describe("HTTPProxy", func() {
 				}
 			})
 
-			testBackendTLSProtocolVersion(namespace, expectedProtocolVersion)
+			testBackendTLSProtocolVersion(namespace, expectedProtocolVersion, func() *certyaml.Certificate { return backendTLSCA })
 		})
 	})
 

--- a/test/e2e/httpproxy/https_fallback_certificate_test.go
+++ b/test/e2e/httpproxy/https_fallback_certificate_test.go
@@ -32,7 +32,7 @@ func testHTTPSFallbackCertificate(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "fallback-cert-echo.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "fallback-cert-echo.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/https_misdirected_request_test.go
+++ b/test/e2e/httpproxy/https_misdirected_request_test.go
@@ -32,7 +32,7 @@ func testHTTPSMisdirectedRequest(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo", "https-misdirected-request.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo", "https-misdirected-request.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/https_sni_enforcement_test.go
+++ b/test/e2e/httpproxy/https_sni_enforcement_test.go
@@ -32,7 +32,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "echo-one")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-one-cert", "echo-one", "sni-enforcement-echo-one.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo-one", "sni-enforcement-echo-one.projectcontour.io")
 
 		echoOneProxy := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -72,7 +72,7 @@ func testHTTPSSNIEnforcement(namespace string) {
 
 		// echo-two
 		f.Fixtures.Echo.Deploy(namespace, "echo-two")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-two-cert", "echo-two", "sni-enforcement-echo-two.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo-two", "sni-enforcement-echo-two.projectcontour.io")
 
 		echoTwoProxy := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/jwt_verification_test.go
+++ b/test/e2e/httpproxy/jwt_verification_test.go
@@ -138,7 +138,7 @@ func testJWTVerification(setupProvider func(namespace string, jwksJSON []byte) c
 			require.NoError(t, err)
 
 			f.Fixtures.Echo.Deploy(namespace, "echo")
-			f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "echo-tls", "jwt.projectcontour.io")
+			f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "jwt.projectcontour.io")
 
 			bearerToken := func(token string) func(*http.Request) {
 				return func(r *http.Request) {
@@ -302,7 +302,7 @@ func testJWTVerificationRemoteJWKSRotation(namespace string) {
 		})
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "echo-tls", "jwt-rotation.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "jwt-rotation.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
@@ -409,7 +409,7 @@ func testJWTVerificationLocalJWKSRotation(namespace string) {
 		require.NoError(t, f.Client.Create(context.TODO(), secret))
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "echo-tls", "jwt-rotation-local.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo-tls", "jwt-rotation-local.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/httpproxy/tcproute_https_termination_test.go
+++ b/test/e2e/httpproxy/tcproute_https_termination_test.go
@@ -34,7 +34,7 @@ func testTCPRouteHTTPSTermination(namespace string) {
 		t := f.T()
 
 		f.Fixtures.Echo.Deploy(namespace, "ingress-conformance-echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "echo-cert", "tcp-route-https-termination.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(namespace, "echo-cert", "tcp-route-https-termination.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/incluster/rbac_test.go
+++ b/test/e2e/incluster/rbac_test.go
@@ -40,7 +40,7 @@ func testProjectcontourResourcesRBAC(namespace string) {
 		otherNS := "another-" + namespace
 		f.CreateNamespace(otherNS)
 		defer f.DeleteNamespace(otherNS, false)
-		f.Certs.CreateSelfSignedCert(otherNS, "delegated-cert", "delegated-cert", "rbac-test.projectcontour.io")
+		f.Certs.CreateSelfSignedCert(otherNS, "delegated-cert", "rbac-test.projectcontour.io")
 
 		// HTTPProxy and TLSCertificateDelegation
 		t := &contour_v1.TLSCertificateDelegation{

--- a/test/e2e/infra/infra_test.go
+++ b/test/e2e/infra/infra_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	core_v1 "k8s.io/api/core/v1"
 
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -29,12 +30,7 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-var (
-	f = e2e.NewFramework(false)
-
-	// Functions called after suite to clean up resources.
-	cleanup []func()
-)
+var f = e2e.NewFramework(false)
 
 func TestInfra(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,20 +56,22 @@ var _ = BeforeSuite(func() {
 	require.NoError(f.T(), f.Deployment.EnsureResourcesForLocalContour())
 
 	// Create certificate and key for metrics over HTTPS.
-	cleanup = append(cleanup,
-		f.Certs.CreateCA("projectcontour", "metrics-ca"),
-		f.Certs.CreateCert("projectcontour", "metrics-server", "metrics-ca", "localhost"),
-		f.Certs.CreateCert("projectcontour", "metrics-client", "metrics-ca"),
-	)
+	metricsCA := f.Certs.CreateCA("projectcontour", "metrics-ca")
+	f.Certs.CreateCertificate("projectcontour", "metrics-server", &certyaml.Certificate{
+		Subject:         "cn=metrics-server",
+		SubjectAltNames: []string{"DNS:localhost"},
+		Issuer:          metricsCA,
+	})
+	f.Certs.CreateCertificate("projectcontour", "metrics-client", &certyaml.Certificate{
+		Subject: "cn=metrics-client",
+		Issuer:  metricsCA,
+	})
 })
 
 var _ = AfterSuite(func() {
 	// Delete resources individually instead of deleting the entire contour
 	// namespace as a performance optimization, because deleting non-empty
 	// namespaces can take up to a couple of minutes to complete.
-	for _, c := range cleanup {
-		c()
-	}
 	require.NoError(f.T(), f.Deployment.DeleteResourcesForLocalContour())
 	gexec.CleanupBuildArtifacts()
 })

--- a/test/e2e/ingress/backend_tls_test.go
+++ b/test/e2e/ingress/backend_tls_test.go
@@ -17,11 +17,13 @@ package ingress
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	core_v1 "k8s.io/api/core/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,18 +33,13 @@ import (
 	"github.com/projectcontour/contour/test/e2e"
 )
 
-func testBackendTLS(namespace string) {
+func testBackendTLS(namespace string, ca func() *certyaml.Certificate) {
 	Specify("simple TLS to backends can be configured", func() {
-		f.Certs.CreateCertificate(e2e.CertificateSpec{
-			Namespace:  namespace,
-			Name:       "backend-server-cert",
-			SecretName: "backend-server-cert",
-			CommonName: "echo-secure",
-			DNSNames:   []string{"echo-secure"},
-			Usages: []e2e.KeyUsage{
-				e2e.UsageServerAuth,
-			},
-			Issuer: "ca-issuer",
+		f.Certs.CreateCertificate(namespace, "backend-server-cert", &certyaml.Certificate{
+			Subject:         "cn=echo-secure",
+			SubjectAltNames: []string{"DNS:echo-secure"},
+			ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			Issuer:          ca(),
 		})
 		f.Fixtures.EchoSecure.Deploy(namespace, "echo-secure", nil)
 

--- a/test/e2e/ingress/ingress_test.go
+++ b/test/e2e/ingress/ingress_test.go
@@ -16,12 +16,14 @@
 package ingress
 
 import (
+	"crypto/x509"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/stretchr/testify/require"
+	"github.com/tsaarni/certyaml"
 	"k8s.io/utils/ptr"
 
 	contour_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
@@ -90,17 +92,14 @@ var _ = Describe("Ingress", func() {
 
 	f.NamespacedTest("backend-tls", func(namespace string) {
 		Context("with backend tls", func() {
+			var backendTLSCA *certyaml.Certificate
+
 			BeforeEach(func() {
-				f.Certs.CreateCAWithIssuer(namespace, "ca-cert", "ca-issuer")
-				f.Certs.CreateCertificate(e2e.CertificateSpec{
-					Namespace:  namespace,
-					Name:       "backend-client-cert",
-					SecretName: "backend-client-cert",
-					CommonName: "client",
-					Usages: []e2e.KeyUsage{
-						e2e.UsageClientAuth,
-					},
-					Issuer: "ca-issuer",
+				backendTLSCA = f.Certs.CreateCA(namespace, "ca-cert")
+				f.Certs.CreateCertificate(namespace, "backend-client-cert", &certyaml.Certificate{
+					Subject:     "cn=client",
+					ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+					Issuer:      backendTLSCA,
 				})
 
 				contourConfig.TLS = config.TLSParameters{
@@ -115,7 +114,7 @@ var _ = Describe("Ingress", func() {
 				}
 			})
 
-			testBackendTLS(namespace)
+			testBackendTLS(namespace, func() *certyaml.Certificate { return backendTLSCA })
 		})
 	})
 

--- a/test/e2e/ingress/tls_wildcard_host_test.go
+++ b/test/e2e/ingress/tls_wildcard_host_test.go
@@ -34,7 +34,7 @@ func testTLSWildcardHost(namespace string) {
 		hostSuffix := "wildcardhost.ingress.projectcontour.io"
 
 		f.Fixtures.Echo.Deploy(namespace, "echo")
-		f.Certs.CreateSelfSignedCert(namespace, "echo-one-cert", "echo-one-cert", "*."+hostSuffix)
+		f.Certs.CreateSelfSignedCert(namespace, "echo-one-cert", "*."+hostSuffix)
 
 		i := &networking_v1.Ingress{
 			ObjectMeta: meta_v1.ObjectMeta{

--- a/test/e2e/provisioner/provisioner_test.go
+++ b/test/e2e/provisioner/provisioner_test.go
@@ -319,8 +319,8 @@ var _ = Describe("Gateway provisioner", func() {
 
 	f.NamespacedTest("gateway-with-many-listeners", func(namespace string) {
 		Specify("A gateway with many Listeners for different protocols can be provisioned and routes correctly", func() {
-			f.Certs.CreateSelfSignedCert(namespace, "https-1-cert", "https-1-cert", "https-1.provisioner.projectcontour.io")
-			f.Certs.CreateSelfSignedCert(namespace, "https-2-cert", "https-2-cert", "https-2.provisioner.projectcontour.io")
+			f.Certs.CreateSelfSignedCert(namespace, "https-1-cert", "https-1.provisioner.projectcontour.io")
+			f.Certs.CreateSelfSignedCert(namespace, "https-2-cert", "https-2.provisioner.projectcontour.io")
 
 			gateway := &gatewayapi_v1.Gateway{
 				ObjectMeta: meta_v1.ObjectMeta{


### PR DESCRIPTION
This PR removes duplication in the e2e test framework. It now utilizes [certyaml](https://github.com/tsaarni/certyaml) to issue certificates, which was already a dependency and is currently used in other parts of the tests.

Fixes #7584 