### PR TITLE
Configure dependabot cooldown to delay updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
     day: "sunday"
   cooldown:
     default-days: 3
-    semver-major-days: 15
   labels:
   - area/tooling
   - release-note/none-required

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+  cooldown:
+    default-days: 3
+    semver-major-days: 15
   labels:
   - area/dependency
   - release-note/none-required
@@ -23,6 +26,9 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+  cooldown:
+    default-days: 3
+    semver-major-days: 15
   labels:
   - area/tooling
   - release-note/none-required
@@ -39,6 +45,8 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+  cooldown:
+    default-days: 3
   ignore:
   - dependency-name: "*"
     update-types:
@@ -57,6 +65,8 @@ updates:
   schedule:
     interval: "weekly"
     day: "sunday"
+  cooldown:
+    default-days: 3
   ignore:
   - dependency-name: "*"
     update-types:


### PR DESCRIPTION
This PR configures a cooldown period for Dependabot dependency updates. The feature is introduced [here](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/). It allows updates to be delayed for a configurable number of days. I've picked 3 days for minor and patch releases, and 15 days for major versions. 

Implementing this can potentially act as a safeguard against hostile project or release takeovers that the has been seen recently in some language ecosystems:  a compromised dependency release gets quickly adopted through automated updates before anyone detects it.

Fixes #7590