### PR TITLE
release-1.33: Bump to Envoy v1.35.13

### DIFF
--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:v1.33.5",
-		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.35.11",
+		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.35.13",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.11
+        image: docker.io/envoyproxy/envoy:distroless-v1.35.13
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.35.11
+          image: docker.io/envoyproxy/envoy:distroless-v1.35.13
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9524,7 +9524,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.35.11
+          image: docker.io/envoyproxy/envoy:distroless-v1.35.13
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9329,7 +9329,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.11
+        image: docker.io/envoyproxy/envoy:distroless-v1.35.13
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9512,7 +9512,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.35.11
+        image: docker.io/envoyproxy/envoy:distroless-v1.35.13
         imagePullPolicy: IfNotPresent
         name: envoy
         env:


### PR DESCRIPTION
Updates release-1.33 branch to Envoy v1.35.13.
For further info see https://github.com/envoyproxy/envoy/releases/tag/v1.35.13.
