### PR TITLE
main: Bump to Envoy v1.38.3

### DIFF
--- a/changelogs/unreleased/7583-tsaarni-small.md
+++ b/changelogs/unreleased/7583-tsaarni-small.md
@@ -1,1 +1,0 @@
-Updates Envoy to v1.38.1. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1) for more information about the content of the release.

--- a/changelogs/unreleased/7609-tsaarni-small.md
+++ b/changelogs/unreleased/7609-tsaarni-small.md
@@ -1,0 +1,1 @@
+Updates Envoy to v1.38.3. See the [Envoy release notes](https://www.envoyproxy.io/docs/envoy/v1.38.3/version_history/v1.38/v1.38.3) for more information about the content of the release.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -36,7 +36,7 @@ func registerGatewayProvisioner(app *kingpin.Application) (*kingpin.CmdClause, *
 
 	provisionerConfig := &gatewayProvisionerConfig{
 		contourImage:          "ghcr.io/projectcontour/contour:main",
-		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.38.2",
+		envoyImage:            "docker.io/envoyproxy/envoy:distroless-v1.38.3",
 		metricsBindAddress:    ":8080",
 		leaderElection:        false,
 		leaderElectionID:      "0d879e31.projectcontour.io",

--- a/examples/contour/03-envoy.yaml
+++ b/examples/contour/03-envoy.yaml
@@ -46,7 +46,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.38.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/deployment/03-envoy-deployment.yaml
+++ b/examples/deployment/03-envoy-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.38.2
+          image: docker.io/envoyproxy/envoy:distroless-v1.38.3
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -9902,7 +9902,7 @@ spec:
             - --log-level info
           command:
             - envoy
-          image: docker.io/envoyproxy/envoy:distroless-v1.38.2
+          image: docker.io/envoyproxy/envoy:distroless-v1.38.3
           imagePullPolicy: IfNotPresent
           name: envoy
           env:

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -9707,7 +9707,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.38.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -9890,7 +9890,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:distroless-v1.38.2
+        image: docker.io/envoyproxy/envoy:distroless-v1.38.3
         imagePullPolicy: IfNotPresent
         name: envoy
         env:

--- a/site/content/resources/compatibility-matrix.md
+++ b/site/content/resources/compatibility-matrix.md
@@ -10,7 +10,7 @@ These combinations of versions are specifically tested in CI and supported by th
 
 | Contour Version | Envoy Version        | Kubernetes Versions | Gateway API Version |
 | --------------- | :------------------- | ------------------- | --------------------|
-| main            | [1.38.1][77]         | 1.36, 1.35, 1.34    | [1.3.0][113]        |
+| main            | [1.38.3][77]         | 1.36, 1.35, 1.34    | [1.3.0][113]        |
 | 1.33.5          | [1.35.10][80]        | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.4          | [1.35.10][80]        | 1.34, 1.33, 1.32    | [1.3.0][113]        |
 | 1.33.3          | [1.35.9][78]         | 1.34, 1.33, 1.32    | [1.3.0][113]        |
@@ -251,7 +251,7 @@ __Note:__ This list of extensions was last verified to be complete with Envoy v1
 [74]: https://www.envoyproxy.io/docs/envoy/v1.35.8/version_history/v1.35/v1.35
 [75]: https://www.envoyproxy.io/docs/envoy/v1.34.12/version_history/v1.34/v1.34
 [76]: https://www.envoyproxy.io/docs/envoy/v1.31.10/version_history/v1.31/v1.31
-[77]: https://www.envoyproxy.io/docs/envoy/v1.38.1/version_history/v1.38/v1.38.1
+[77]: https://www.envoyproxy.io/docs/envoy/v1.38.3/version_history/v1.38/v1.38.3
 [78]: https://www.envoyproxy.io/docs/envoy/v1.35.9/version_history/v1.35/v1.35.9
 [79]: https://www.envoyproxy.io/docs/envoy/v1.34.13/version_history/v1.34/v1.34.13
 [80]: https://www.envoyproxy.io/docs/envoy/v1.35.10/version_history/v1.35/v1.35.10

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,7 +7,7 @@ versions:
   - version: main
     supported: "false"
     dependencies:
-      envoy: "1.38.1"
+      envoy: "1.38.3"
       kubernetes:
         - "1.36"
         - "1.35"


### PR DESCRIPTION
Updates to Envoy v1.38.3
For further info see https://github.com/envoyproxy/envoy/releases/tag/v1.38.3