### PR TITLE
test/scripts: reuse development image tag

### DIFF
--- a/test/scripts/install-contour-working.sh
+++ b/test/scripts/install-contour-working.sh
@@ -44,9 +44,8 @@ if ! kind::cluster::exists "$CLUSTERNAME" ; then
     exit 2
 fi
 
-# Set (pseudo) random image tag to trigger restarts at every deployment.
-# TODO: Come up with a scheme that doesn't fill up the dev environment with randomly-tagged images.
-VERSION="v$$"
+# Reuse a single development tag so repeated builds do not leave uniquely-tagged images behind.
+readonly VERSION="dev"
 
 # Build the image.
 make -C ${REPO} container IMAGE=ghcr.io/projectcontour/contour VERSION=${VERSION}
@@ -75,6 +74,10 @@ for file in ${REPO}/examples/contour/02-job-certgen.yaml ${REPO}/examples/contou
     "$file" | \
   ${KUBECTL} apply -f -
 done
+
+# The image tag does not change, so explicitly restart workloads that use the Contour image.
+${KUBECTL} rollout restart -n projectcontour deployment/contour
+${KUBECTL} rollout restart -n projectcontour daemonset/envoy
 
 # Wait for Contour and Envoy to report "Ready" status.
 ${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l app=contour deployments --for=condition=Available

--- a/test/scripts/install-provisioner-working.sh
+++ b/test/scripts/install-provisioner-working.sh
@@ -28,9 +28,8 @@ if ! kind::cluster::exists "$CLUSTERNAME" ; then
     exit 2
 fi
 
-# Set (pseudo) random image tag to trigger restarts at every deployment.
-# TODO: Come up with a scheme that doesn't fill up the dev environment with randomly-tagged images.
-VERSION="v$$"
+# Reuse a single development tag so repeated builds do not leave uniquely-tagged images behind.
+readonly VERSION="dev"
 
 # Build the Contour Provisioner image.
 make -C ${REPO} container IMAGE=ghcr.io/projectcontour/contour VERSION=${VERSION}
@@ -48,6 +47,21 @@ ${KUBECTL} apply -f <(cat examples/gateway-provisioner/03-gateway-provisioner.ya
     yq eval '.spec.template.spec.containers[0].image = env(CONTOUR_IMG)' - | \
     yq eval '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' - | \
     yq eval '.spec.template.spec.containers[0].args += "--contour-image="+env(CONTOUR_IMG)' -)
+
+# The image tag does not change, so explicitly restart the provisioner and its managed workloads.
+${KUBECTL} rollout restart -n projectcontour deployment/contour-gateway-provisioner
+
+managed_workloads=$(
+    ${KUBECTL} get deployments,daemonsets \
+        --all-namespaces \
+        --selector=app.kubernetes.io/managed-by=contour-gateway-provisioner \
+        --output=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.kind}{"/"}{.metadata.name}{"\n"}{end}'
+)
+while read -r namespace workload ; do
+    if [[ -n "${workload}" ]]; then
+        ${KUBECTL} rollout restart -n "${namespace}" "${workload}"
+    fi
+done <<< "${managed_workloads}"
 
 # Wait for the provisioner to report "Ready" status.
 ${KUBECTL} wait --timeout="${WAITTIME}" -n projectcontour -l control-plane=contour-gateway-provisioner deployments --for=condition=Available


### PR DESCRIPTION
Fixes #5277

## What this PR does

- reuses the `ghcr.io/projectcontour/contour:dev` image tag in both working-install scripts
- explicitly restarts the standalone Contour Deployment and Envoy DaemonSet after loading a rebuilt image
- restarts the Gateway provisioner and its managed Deployments and DaemonSets across namespaces

## Why

The scripts currently generate a process-specific image tag for every run. That
forces Kubernetes to deploy the new build, but it also accumulates uniquely
tagged images in the local development environment.

## Developer impact

Repeated working-tree deployments now reuse one development tag while still
restarting every long-running workload that embeds the rebuilt Contour binary.

## Prior work

This is a fresh implementation of the approach discussed in #5854. Thanks to
@harshil1973 for the earlier implementation and to the maintainers who recorded
the expected restart behavior there.

## Release note

Requested label: `release-note/none-required`. This changes local contributor
tooling only, so no changelog file is required for that category.

## Testing

- `bash -n test/scripts/install-contour-working.sh test/scripts/install-provisioner-working.sh`
- `git diff --check`
- `make lint-codespell`
- disposable mock execution covering rendered images, cross-namespace Deployment/DaemonSet restarts, empty results, and `kubectl get` failure propagation
- two consecutive real Kind v0.32.0 / Kubernetes v1.36.1 runs of each working-install script, verifying the stable `:dev` tag, changed image digests/IDs and pod UIDs, and final workload convergence
