### PR TITLE
build: exclude cloud auth plugins from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ARG BUILD_GOEXPERIMENT
 ARG TARGETOS
 ARG TARGETARCH
 
+# Exclude cloud auth plugins intended for local, out-of-cluster builds.
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod make build \
+		GO_TAGS='-tags "osusergo netgo"' \
 	    CGO_ENABLED=${BUILD_CGO_ENABLED} \
 		EXTRA_GO_LDFLAGS="${BUILD_EXTRA_GO_LDFLAGS}" \
 		GOOS=${TARGETOS} \

--- a/changelogs/unreleased/7634-AkashKumar7902-small.md
+++ b/changelogs/unreleased/7634-AkashKumar7902-small.md
@@ -1,0 +1,1 @@
+Excludes the GCP and OIDC client authentication plugins from the standard Contour container image.

--- a/cmd/contour/gatewayprovisioner.go
+++ b/cmd/contour/gatewayprovisioner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/distribution/reference"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"


### PR DESCRIPTION
Fixes #5085

## What this PR does

- limits the standard container build tags to `osusergo` and `netgo`
- removes the gateway provisioner's unconditional GCP authentication plugin import
- retains the tagged GCP and OIDC plugins for normal local Makefile builds

## Why

The Dockerfile began using `make build` during an earlier refactor and consequently inherited the Makefile's local-development `gcp` and `oidc` tags. The gateway provisioner also imported the GCP plugin unconditionally, bypassing the existing `gcp` build constraint.

## Impact

The standard in-cluster Contour image no longer links the GCP or OIDC client authentication plugins. Local `make build` and `make install` builds continue to include both plugins.

## Testing

- compared dependency graphs under `osusergo netgo` and `oidc gcp osusergo netgo`
- built and tested the Contour binary with both tag sets
- ran the full Go test suite with both tag sets
- ran `go vet` with both tag sets
- built and ran the standard scratch container image, then inspected its binary for auth-plugin symbols
- ran `make lint-codespell`, `make lint-flags`, and `git diff --check`

## Release note

Requested label: `release-note/small`. The corresponding numbered changelog is included.
