### PR TITLE
apis/projectcontour/v1: require non-empty name for header match and include

### DIFF
--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -66,6 +66,7 @@ type Namespace string
 // Include describes a set of policies that can be applied to an HTTPProxy in a namespace.
 type Include struct {
 	// Name of the HTTPProxy
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 	// Namespace of the HTTPProxy to include. Defaults to the current namespace if not supplied.
 	// +optional
@@ -117,6 +118,7 @@ type MatchCondition struct {
 type HeaderMatchCondition struct {
 	// Name is the name of the header to match against. Name is required.
 	// Header names are case insensitive.
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
 	// Present specifies that condition is true when the named header
@@ -400,6 +402,7 @@ type VirtualHost struct {
 	// all leaves of the DAG rooted at this object relate to the fqdn.
 	//
 	// +kubebuilder:validation:Pattern="^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+	// +kubebuilder:validation:MinLength=1
 	Fqdn string `json:"fqdn"`
 
 	// If present the fields describes TLS properties of the virtual

--- a/changelogs/unreleased/7641-pujitha24-small.md
+++ b/changelogs/unreleased/7641-pujitha24-small.md
@@ -1,0 +1,1 @@
+HTTPProxy `HeaderMatchCondition.name` and `Include.name` now require a non-empty value, matching their documented required status.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1102,6 +1102,7 @@ spec:
                                               description: |-
                                                 Name is the name of the header to match against. Name is required.
                                                 Header names are case insensitive.
+                                              minLength: 1
                                               type: string
                                             notcontains:
                                               description: |-
@@ -5190,6 +5191,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-
@@ -6067,6 +6069,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6164,6 +6167,7 @@ spec:
                       type: array
                     name:
                       description: Name of the HTTPProxy
+                      minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the HTTPProxy to include. Defaults
@@ -6247,6 +6251,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6845,6 +6850,7 @@ spec:
                                                     description: |-
                                                       Name is the name of the header to match against. Name is required.
                                                       Header names are case insensitive.
+                                                    minLength: 1
                                                     type: string
                                                   notcontains:
                                                     description: |-
@@ -8110,6 +8116,7 @@ spec:
                     description: |-
                       The fully qualified domain name of the root of the ingress tree
                       all leaves of the DAG rooted at this object relate to the fqdn.
+                    minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   ipAllowPolicy:
@@ -8430,6 +8437,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1321,6 +1321,7 @@ spec:
                                               description: |-
                                                 Name is the name of the header to match against. Name is required.
                                                 Header names are case insensitive.
+                                              minLength: 1
                                               type: string
                                             notcontains:
                                               description: |-
@@ -5409,6 +5410,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-
@@ -6286,6 +6288,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6383,6 +6386,7 @@ spec:
                       type: array
                     name:
                       description: Name of the HTTPProxy
+                      minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the HTTPProxy to include. Defaults
@@ -6466,6 +6470,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -7064,6 +7069,7 @@ spec:
                                                     description: |-
                                                       Name is the name of the header to match against. Name is required.
                                                       Header names are case insensitive.
+                                                    minLength: 1
                                                     type: string
                                                   notcontains:
                                                     description: |-
@@ -8329,6 +8335,7 @@ spec:
                     description: |-
                       The fully qualified domain name of the root of the ingress tree
                       all leaves of the DAG rooted at this object relate to the fqdn.
+                    minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   ipAllowPolicy:
@@ -8649,6 +8656,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -1113,6 +1113,7 @@ spec:
                                               description: |-
                                                 Name is the name of the header to match against. Name is required.
                                                 Header names are case insensitive.
+                                              minLength: 1
                                               type: string
                                             notcontains:
                                               description: |-
@@ -5201,6 +5202,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-
@@ -6078,6 +6080,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6175,6 +6178,7 @@ spec:
                       type: array
                     name:
                       description: Name of the HTTPProxy
+                      minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the HTTPProxy to include. Defaults
@@ -6258,6 +6262,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6856,6 +6861,7 @@ spec:
                                                     description: |-
                                                       Name is the name of the header to match against. Name is required.
                                                       Header names are case insensitive.
+                                                    minLength: 1
                                                     type: string
                                                   notcontains:
                                                     description: |-
@@ -8121,6 +8127,7 @@ spec:
                     description: |-
                       The fully qualified domain name of the root of the ingress tree
                       all leaves of the DAG rooted at this object relate to the fqdn.
+                    minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   ipAllowPolicy:
@@ -8441,6 +8448,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1138,6 +1138,7 @@ spec:
                                               description: |-
                                                 Name is the name of the header to match against. Name is required.
                                                 Header names are case insensitive.
+                                              minLength: 1
                                               type: string
                                             notcontains:
                                               description: |-
@@ -5226,6 +5227,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-
@@ -6103,6 +6105,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6200,6 +6203,7 @@ spec:
                       type: array
                     name:
                       description: Name of the HTTPProxy
+                      minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the HTTPProxy to include. Defaults
@@ -6283,6 +6287,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6881,6 +6886,7 @@ spec:
                                                     description: |-
                                                       Name is the name of the header to match against. Name is required.
                                                       Header names are case insensitive.
+                                                    minLength: 1
                                                     type: string
                                                   notcontains:
                                                     description: |-
@@ -8146,6 +8152,7 @@ spec:
                     description: |-
                       The fully qualified domain name of the root of the ingress tree
                       all leaves of the DAG rooted at this object relate to the fqdn.
+                    minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   ipAllowPolicy:
@@ -8466,6 +8473,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1321,6 +1321,7 @@ spec:
                                               description: |-
                                                 Name is the name of the header to match against. Name is required.
                                                 Header names are case insensitive.
+                                              minLength: 1
                                               type: string
                                             notcontains:
                                               description: |-
@@ -5409,6 +5410,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-
@@ -6286,6 +6288,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -6383,6 +6386,7 @@ spec:
                       type: array
                     name:
                       description: Name of the HTTPProxy
+                      minLength: 1
                       type: string
                     namespace:
                       description: Namespace of the HTTPProxy to include. Defaults
@@ -6466,6 +6470,7 @@ spec:
                                 description: |-
                                   Name is the name of the header to match against. Name is required.
                                   Header names are case insensitive.
+                                minLength: 1
                                 type: string
                               notcontains:
                                 description: |-
@@ -7064,6 +7069,7 @@ spec:
                                                     description: |-
                                                       Name is the name of the header to match against. Name is required.
                                                       Header names are case insensitive.
+                                                    minLength: 1
                                                     type: string
                                                   notcontains:
                                                     description: |-
@@ -8329,6 +8335,7 @@ spec:
                     description: |-
                       The fully qualified domain name of the root of the ingress tree
                       all leaves of the DAG rooted at this object relate to the fqdn.
+                    minLength: 1
                     pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   ipAllowPolicy:
@@ -8649,6 +8656,7 @@ spec:
                                                   description: |-
                                                     Name is the name of the header to match against. Name is required.
                                                     Header names are case insensitive.
+                                                  minLength: 1
                                                   type: string
                                                 notcontains:
                                                   description: |-

--- a/test/e2e/httpproxy/required_field_validation_test.go
+++ b/test/e2e/httpproxy/required_field_validation_test.go
@@ -136,6 +136,68 @@ func testRequiredFieldValidation(namespace string) {
 		}
 		assert.True(t, isExpectedErr(err))
 
+		// These HTTPProxies use typed Go structs (rather than Unstructured) to
+		// reproduce https://github.com/projectcontour/contour/issues/3674:
+		// since the JSON tags for these fields do not include "omitempty",
+		// serializing a typed struct with an empty string value still
+		// includes the field, so only a minLength validation (not just
+		// "required") can catch it.
+		emptyConditionHeaderName := &contour_v1.HTTPProxy{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "empty-condition-header-name",
+			},
+			Spec: contour_v1.HTTPProxySpec{
+				Routes: []contour_v1.Route{
+					{
+						Conditions: []contour_v1.MatchCondition{
+							{
+								Header: &contour_v1.HeaderMatchCondition{
+									Name:    "",
+									Present: true,
+								},
+							},
+						},
+						Services: []contour_v1.Service{
+							{
+								Name: "foo",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		err = f.Client.Create(context.TODO(), emptyConditionHeaderName)
+		require.Error(t, err)
+		isExpectedErr = func(err error) bool {
+			return strings.Contains(err.Error(), "spec.routes.conditions.header.name") ||
+				strings.Contains(err.Error(), "spec.routes[0].conditions[0].header.name")
+		}
+		assert.True(t, isExpectedErr(err))
+
+		emptyIncludesName := &contour_v1.HTTPProxy{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "empty-includes-name",
+			},
+			Spec: contour_v1.HTTPProxySpec{
+				Includes: []contour_v1.Include{
+					{
+						Name:      "",
+						Namespace: "foo",
+					},
+				},
+			},
+		}
+		err = f.Client.Create(context.TODO(), emptyIncludesName)
+		require.Error(t, err)
+		isExpectedErr = func(err error) bool {
+			return strings.Contains(err.Error(), "spec.includes.name") ||
+				strings.Contains(err.Error(), "spec.includes[0].name")
+		}
+		assert.True(t, isExpectedErr(err))
+
 		servicePortRange := &contour_v1.HTTPProxy{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Namespace: namespace,

--- a/test/e2e/httpproxy/required_field_validation_test.go
+++ b/test/e2e/httpproxy/required_field_validation_test.go
@@ -32,10 +32,12 @@ func testRequiredFieldValidation(namespace string) {
 	Specify("required fields are validated on creation", func() {
 		t := f.T()
 
-		// This HTTPProxy is expressed as an Unstructured because the JSON
-		// tags for the relevant field do not include "omitempty", so when
-		// a typed Go struct is serialized to JSON the field *is* included
-		// and therefore does not fail validation.
+		// This HTTPProxy is expressed as an Unstructured, rather than a typed
+		// contour_v1.HTTPProxy, so the field can be omitted from the object
+		// entirely and trigger this "Required value" error. A typed struct
+		// always serializes this field, even as an empty string, because its
+		// JSON tag lacks "omitempty"; that case is exercised separately below
+		// and now fails a minLength check instead.
 		missingConditionHeaderName := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "projectcontour.io/v1",
@@ -77,10 +79,12 @@ func testRequiredFieldValidation(namespace string) {
 		}
 		assert.True(t, isExpectedErr(err))
 
-		// This HTTPProxy is expressed as an Unstructured because the JSON
-		// tags for the relevant field do not include "omitempty", so when
-		// a typed Go struct is serialized to JSON the field *is* included
-		// and therefore does not fail validation.
+		// This HTTPProxy is expressed as an Unstructured, rather than a typed
+		// contour_v1.HTTPProxy, so the field can be omitted from the object
+		// entirely and trigger this "Required value" error. A typed struct
+		// always serializes this field, even as an empty string, because its
+		// JSON tag lacks "omitempty"; that case is instead rejected by the
+		// field's pattern/minLength validation.
 		missingVirtualHostName := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "projectcontour.io/v1",
@@ -103,10 +107,12 @@ func testRequiredFieldValidation(namespace string) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "spec.virtualhost.fqdn: Required value")
 
-		// This HTTPProxy is expressed as an Unstructured because the JSON
-		// tags for the relevant field do not include "omitempty", so when
-		// a typed Go struct is serialized to JSON the field *is* included
-		// and therefore does not fail validation.
+		// This HTTPProxy is expressed as an Unstructured, rather than a typed
+		// contour_v1.HTTPProxy, so the field can be omitted from the object
+		// entirely and trigger this "Required value" error. A typed struct
+		// always serializes this field, even as an empty string, because its
+		// JSON tag lacks "omitempty"; that case is exercised separately below
+		// and now fails a minLength check instead.
 		missingIncludesName := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "projectcontour.io/v1",


### PR DESCRIPTION
Motivation:

HeaderMatchCondition.Name and Include.Name are required fields (no
`+optional`, no `omitempty` in their JSON tag), but had no
`+kubebuilder:validation:MinLength` annotation. Because the JSON tag
lacks `omitempty`, serializing a typed Go HTTPProxy struct always
includes these fields, even when left at the Go zero value `""`. With
no length validation, the API server's CRD schema accepted the empty
string, so a client using the typed Go API (as opposed to raw
YAML/JSON authored by hand) could silently create an HTTPProxy with an
empty header-match name or an empty include name, both of which are
never semantically valid. Note this is a validation gap, not a crash
or availability issue: an admin can already query for/notice
HTTPProxies whose routes reference an empty header name, since Contour
just ignores conditions it can't use; this change simply makes the API
server reject such objects at admission time instead.

VirtualHost.Fqdn was also called out in the issue, but already carries
a `+kubebuilder:validation:Pattern` regex that requires at least one
non-empty label, so it already rejected the empty string before this
change. Adding `MinLength=1` there is defense-in-depth / a clearer,
more direct validation error for that specific case, not a new
functional fix.

Approach:

Add `+kubebuilder:validation:MinLength=1` to HeaderMatchCondition.Name,
Include.Name, and VirtualHost.Fqdn in
apis/projectcontour/v1/httpproxy.go, then regenerate the CRD YAML
(examples/contour/01-crds.yaml and the derived examples/render/*.yaml
files) via controller-gen.

QueryParameterMatchCondition.Name has the same underlying gap but
isn't named in #3674 and is left out of this change to keep it
minimal; it can be a follow-up.

Validation:

- `go build ./...` and `go build -tags e2e ./...` both pass.
- `go test ./apis/... ./internal/dag/...` passes.
- `gofmt -l` reports no issues on changed files.
- Regenerated CRD YAML verified against a fresh `controller-gen` run:
  the diff is exclusively additive `minLength: 1` lines at the
  locations corresponding to the three changed fields (each type is
  inlined at multiple points in the schema, so multiple additions per
  field are expected).
- Added two new cases to
  test/e2e/httpproxy/required_field_validation_test.go that construct
  a typed contour_v1.HTTPProxy (not unstructured.Unstructured) with an
  explicit empty string Name for a HeaderMatchCondition and an
  Include, reproducing the exact scenario from the issue. These are
  gated by `//go:build e2e` and require a live cluster, so they were
  compiled/vetted (`go build -tags e2e ./test/e2e/httpproxy/...`,
  `go vet -tags e2e ./test/e2e/httpproxy/...`, both pass) but not
  executed in this environment.

This PR needs a changelogs/unreleased/<PR#>-pujitha24-small.md file
once the PR number is known (per CONTRIBUTING.md); suggested content:
"HTTPProxy `HeaderMatchCondition.name` and `Include.name` now require
a non-empty value, matching their documented required status."

Fixes #3674

Signed-off-by: Pujitha Paladugu <venkat@dema.shop>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
