### PR TITLE
Kstatus compatibility

### DIFF
--- a/apis/projectcontour/v1/detailedconditions.go
+++ b/apis/projectcontour/v1/detailedconditions.go
@@ -137,14 +137,14 @@ type DetailedCondition struct {
 const (
 	// ValidConditionType describes an valid condition.
 	ValidConditionType = "Valid"
-	
+
 	// ReadyConditionType is the kstatus-compatible condition type.
 	// This condition mirrors the Valid condition to enable compatibility with
 	// tools that use kstatus (Helm 4, Flux, Argo CD, kubectl wait).
 	// kstatus specifically looks for a condition with type "Ready" to determine
 	// if a custom resource has been successfully reconciled.
 	ReadyConditionType = "Ready"
-	
+
 	// ConditionTypeAuthError describes an error condition related to Auth.
 	ConditionTypeAuthError = "AuthError"
 

--- a/apis/projectcontour/v1/detailedconditions.go
+++ b/apis/projectcontour/v1/detailedconditions.go
@@ -137,7 +137,14 @@ type DetailedCondition struct {
 const (
 	// ValidConditionType describes an valid condition.
 	ValidConditionType = "Valid"
-
+	
+	// ReadyConditionType is the kstatus-compatible condition type.
+	// This condition mirrors the Valid condition to enable compatibility with
+	// tools that use kstatus (Helm 4, Flux, Argo CD, kubectl wait).
+	// kstatus specifically looks for a condition with type "Ready" to determine
+	// if a custom resource has been successfully reconciled.
+	ReadyConditionType = "Ready"
+	
 	// ConditionTypeAuthError describes an error condition related to Auth.
 	ConditionTypeAuthError = "AuthError"
 

--- a/apis/projectcontour/v1/detailedconditions.go
+++ b/apis/projectcontour/v1/detailedconditions.go
@@ -198,3 +198,36 @@ const (
 	// to the configuration of Listeners.
 	ConditionTypeListenerError = "ListenerError"
 )
+
+// ReadyDetailedConditionFromValid creates a kstatus-compatible Ready DetailedCondition
+// that mirrors the given Valid DetailedCondition including errors and warnings.
+// This enables tools like Helm 4, Flux, and Argo CD to correctly determine
+// when a Contour resource has been successfully reconciled.
+func ReadyDetailedConditionFromValid(valid *DetailedCondition) *DetailedCondition {
+	if valid == nil {
+		return nil
+	}
+
+	ready := &DetailedCondition{
+		Condition: Condition{
+			Type:               ReadyConditionType,
+			Status:             valid.Status,
+			Reason:             valid.Reason,
+			Message:            valid.Message,
+			LastTransitionTime: valid.LastTransitionTime,
+			ObservedGeneration: valid.ObservedGeneration,
+		},
+	}
+
+	// Copy errors and warnings slices
+	if len(valid.Errors) > 0 {
+		ready.Errors = make([]SubCondition, len(valid.Errors))
+		copy(ready.Errors, valid.Errors)
+	}
+	if len(valid.Warnings) > 0 {
+		ready.Warnings = make([]SubCondition, len(valid.Warnings))
+		copy(ready.Warnings, valid.Warnings)
+	}
+
+	return ready
+}

--- a/apis/projectcontour/v1/readycondition_test.go
+++ b/apis/projectcontour/v1/readycondition_test.go
@@ -1,0 +1,161 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReadyDetailedConditionFromValid(t *testing.T) {
+	now := meta_v1.NewTime(time.Now())
+
+	tests := map[string]struct {
+		valid *DetailedCondition
+		want  *DetailedCondition
+	}{
+		"nil input returns nil": {
+			valid: nil,
+			want:  nil,
+		},
+		"valid condition with errors and warnings": {
+			valid: &DetailedCondition{
+				Condition: Condition{
+					Type:               ValidConditionType,
+					Status:             ConditionFalse,
+					Reason:             "MultipleReasons",
+					Message:            "Multiple errors and warnings",
+					LastTransitionTime: now,
+					ObservedGeneration: 7,
+				},
+				Errors: []SubCondition{
+					{
+						Type:    ConditionTypeServiceError,
+						Status:  ConditionTrue,
+						Reason:  "ServiceNotFound",
+						Message: "Service 'foo' not found",
+					},
+				},
+				Warnings: []SubCondition{
+					{
+						Type:    ConditionTypeTLSError,
+						Status:  ConditionTrue,
+						Reason:  "TLSDeprecation",
+						Message: "TLS 1.0 is deprecated",
+					},
+				},
+			},
+			want: &DetailedCondition{
+				Condition: Condition{
+					Type:               ReadyConditionType,
+					Status:             ConditionFalse,
+					Reason:             "MultipleReasons",
+					Message:            "Multiple errors and warnings",
+					LastTransitionTime: now,
+					ObservedGeneration: 7,
+				},
+				Errors: []SubCondition{
+					{
+						Type:    ConditionTypeServiceError,
+						Status:  ConditionTrue,
+						Reason:  "ServiceNotFound",
+						Message: "Service 'foo' not found",
+					},
+				},
+				Warnings: []SubCondition{
+					{
+						Type:    ConditionTypeTLSError,
+						Status:  ConditionTrue,
+						Reason:  "TLSDeprecation",
+						Message: "TLS 1.0 is deprecated",
+					},
+				},
+			},
+		},
+		"valid condition without errors or warnings": {
+			valid: &DetailedCondition{
+				Condition: Condition{
+					Type:               ValidConditionType,
+					Status:             ConditionTrue,
+					Reason:             "Valid",
+					Message:            "Valid HTTPProxy",
+					LastTransitionTime: now,
+					ObservedGeneration: 1,
+				},
+			},
+			want: &DetailedCondition{
+				Condition: Condition{
+					Type:               ReadyConditionType,
+					Status:             ConditionTrue,
+					Reason:             "Valid",
+					Message:            "Valid HTTPProxy",
+					LastTransitionTime: now,
+					ObservedGeneration: 1,
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ReadyDetailedConditionFromValid(tc.valid)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestReadyConditionTypeConstant(t *testing.T) {
+	// kstatus specifically looks for "Ready" condition type
+	// This test ensures the constant is correct for kstatus compatibility
+	require.Equal(t, "Ready", ReadyConditionType, "ReadyConditionType must be 'Ready' for kstatus compatibility")
+}
+
+func TestReadyConditionIsIndependentCopy(t *testing.T) {
+	// Ensure that modifying the returned Ready condition doesn't affect the original Valid condition
+	now := meta_v1.NewTime(time.Now())
+
+	valid := &DetailedCondition{
+		Condition: Condition{
+			Type:               ValidConditionType,
+			Status:             ConditionTrue,
+			Reason:             "Valid",
+			Message:            "Valid HTTPProxy",
+			LastTransitionTime: now,
+			ObservedGeneration: 1,
+		},
+		Errors: []SubCondition{
+			{
+				Type:    ConditionTypeServiceError,
+				Status:  ConditionTrue,
+				Reason:  "TestReason",
+				Message: "Test message",
+			},
+		},
+	}
+
+	ready := ReadyDetailedConditionFromValid(valid)
+	require.NotNil(t, ready)
+
+	// Modify the ready condition
+	ready.Message = "Modified message"
+	ready.Errors[0].Message = "Modified error message"
+
+	// Verify original is unchanged
+	assert.Equal(t, "Valid HTTPProxy", valid.Message)
+	assert.Equal(t, "Test message", valid.Errors[0].Message)
+}

--- a/design/global-external-authorization-design.md
+++ b/design/global-external-authorization-design.md
@@ -18,7 +18,7 @@ See [#4954](https://github.com/projectcontour/contour/issues/4954) for context.
 
 ## High-Level Design
 
-Contour will add HTTP support for Envoy's External Authorozation.
+Contour will add HTTP support for Envoy's External Authorization.
 
 Currently, Contour supports External Authorization only over HTTPS. External Authorization allows for requests to be authenticated before they are forwarded upstream. However, External authorization over HTTPS is incompatible with setups that terminate TLS at the cloud provider's load balancer layer because the Envoy HCM relies on the SNI to choose the correct filter chain. 
 

--- a/design/loadbalancer-hash-policy-design.md
+++ b/design/loadbalancer-hash-policy-design.md
@@ -172,7 +172,7 @@ type RequestHashPolicy struct {
 }
 ```
 
-While the number of options to support is unlikely to grow quickly, this option was not chosen as it is possible hashing attributes that require multiple fields of configurability would make this solution messy and unweildy.
+While the number of options to support is unlikely to grow quickly, this option was not chosen as it is possible hashing attributes that require multiple fields of configurability would make this solution messy and unwieldy.
 
 ### Only Address Header Hashing, Not Multiple Hash Options
 In order to deliver solely header hashing functionality, we could instead add an additional load balancing strategy `HeaderHash` and a configuration to supply a HTTP header name to hash on.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -8612,6 +8612,7 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
+                            - error
                             - port
                             - protocol
                             type: object

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1,4 +1,5 @@
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1406,6 +1407,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5252,6 +5254,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5730,6 +5733,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8631,6 +8635,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1626,6 +1626,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5471,6 +5472,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5949,6 +5951,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8831,6 +8834,7 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
+                            - error
                             - port
                             - protocol
                             type: object
@@ -8849,6 +8853,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -218,6 +218,7 @@ data:
     #   port: 8003
 
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -10,6 +10,7 @@
 #       examples/gateway-provisioner/03-gateway-provisioner.yaml
 
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1417,6 +1418,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5263,6 +5265,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5741,6 +5744,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8623,6 +8627,7 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
+                            - error
                             - port
                             - protocol
                             type: object
@@ -8641,6 +8646,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -35,6 +35,7 @@ metadata:
   namespace: projectcontour
 
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1442,6 +1443,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5288,6 +5290,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5766,6 +5769,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8648,6 +8652,7 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
+                            - error
                             - port
                             - protocol
                             type: object
@@ -8666,6 +8671,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -218,6 +218,7 @@ data:
     #   port: 8003
 
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1625,6 +1626,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5471,6 +5473,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5949,6 +5952,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8831,6 +8835,7 @@ spec:
                                   The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
+                            - error
                             - port
                             - protocol
                             type: object
@@ -8849,6 +8854,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/hack/generate-crd-yaml.sh
+++ b/hack/generate-crd-yaml.sh
@@ -24,23 +24,4 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen --version
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd:crdVersions=v1 "paths=${PATHS}" "output:dir=${TEMPDIR}"
 
-# Remove "error" from required fields in load balancer status.
-# For details, see:
-# - https://github.com/projectcontour/contour/issues/7391
-# - https://github.com/kubernetes-sigs/controller-tools/pull/944#issuecomment-3314629362
-# This workaround can be removed if the upstream Kubernetes type resolves the conflicting markers.
-readonly HTTPPROXY_CRD="${TEMPDIR}/projectcontour.io_httpproxies.yaml"
-readonly PATCH_PATH="/spec/versions/0/schema/openAPIV3Schema/properties/status/properties/loadBalancer/properties/ingress/items/properties/ports/items/required/0"
-
-kubectl::patch() {
-  kubectl patch -f "$HTTPPROXY_CRD" --local --type=json -p "$1" "${@:2}"
-}
-
-kubectl::patch "[{\"op\": \"test\", \"path\": \"$PATCH_PATH\", \"value\": \"error\"}]" --dry-run=client > /dev/null || {
-  echo "Error: CRD structure has changed. The workaround for issue #7391 may no longer be needed or needs updating."
-  exit 1
-}
-
-kubectl::patch "[{\"op\": \"remove\", \"path\": \"$PATCH_PATH\"}]" -o yaml > "$HTTPPROXY_CRD.tmp" && { echo "---"; cat "$HTTPPROXY_CRD.tmp"; } > "$HTTPPROXY_CRD"
-
-ls "${TEMPDIR}"/*.yaml | xargs cat | sed '/^$/d' > "${REPO}/examples/contour/01-crds.yaml"
+ls "${TEMPDIR}"/*.yaml | xargs -I {} sh -c 'echo "---"; cat {}' | sed '/^$/d' > "${REPO}/examples/contour/01-crds.yaml"

--- a/internal/status/extensionstatus.go
+++ b/internal/status/extensionstatus.go
@@ -92,6 +92,23 @@ func (e *ExtensionCacheEntry) AsStatusUpdate() k8s.StatusUpdate {
 			cond.DeepCopyInto(currCond)
 		}
 
+		// Set the Ready condition for kstatus compatibility (Helm 4, Flux, Argo CD, kubectl wait).
+		// The Ready condition mirrors the Valid condition.
+		if validCond, ok := e.Conditions[ValidCondition]; ok {
+			readyCond := contour_v1.ReadyDetailedConditionFromValid(validCond)
+			if readyCond != nil {
+				readyCond.ObservedGeneration = e.Generation
+				readyCond.LastTransitionTime = e.TransitionTime
+
+				currReadyCond := ext.Status.GetConditionFor(contour_v1.ReadyConditionType)
+				if currReadyCond == nil {
+					ext.Status.Conditions = append(ext.Status.Conditions, *readyCond)
+				} else if currReadyCond.ObservedGeneration <= readyCond.ObservedGeneration {
+					readyCond.DeepCopyInto(currReadyCond)
+				}
+			}
+		}
+
 		return ext
 	})
 

--- a/internal/status/proxystatus.go
+++ b/internal/status/proxystatus.go
@@ -114,7 +114,7 @@ func (pu *ProxyUpdate) Mutate(obj client.Object) client.Object {
 		// proxy.Status.Description = validCond.Reason + ": " + validCond.Message
 		proxy.Status.Description = validCond.Message
 	}
-	
+
 	// Set the Ready condition for kstatus compatibility (Helm 4, Flux, Argo CD, kubectl wait).
 	// The Ready condition mirrors the Valid condition to enable these tools to correctly
 	// determine when the HTTPProxy has been successfully reconciled.

--- a/internal/status/proxystatus.go
+++ b/internal/status/proxystatus.go
@@ -114,6 +114,21 @@ func (pu *ProxyUpdate) Mutate(obj client.Object) client.Object {
 		// proxy.Status.Description = validCond.Reason + ": " + validCond.Message
 		proxy.Status.Description = validCond.Message
 	}
+	
+	// Set the Ready condition for kstatus compatibility (Helm 4, Flux, Argo CD, kubectl wait).
+	// The Ready condition mirrors the Valid condition to enable these tools to correctly
+	// determine when the HTTPProxy has been successfully reconciled.
+	if validCond != nil {
+		readyCond := contour_v1.ReadyDetailedConditionFromValid(validCond)
+		if readyCond != nil {
+			currReadyCond := proxy.Status.GetConditionFor(contour_v1.ReadyConditionType)
+			if currReadyCond == nil {
+				proxy.Status.Conditions = append(proxy.Status.Conditions, *readyCond)
+			} else if currReadyCond.ObservedGeneration <= readyCond.ObservedGeneration {
+				readyCond.DeepCopyInto(currReadyCond)
+			}
+		}
+	}
 
 	return proxy
 }

--- a/internal/status/proxystatus_test.go
+++ b/internal/status/proxystatus_test.go
@@ -132,7 +132,26 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			// Ready condition mirrors Valid for kstatus compatibility
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.ReadyConditionType,
+					Status:             contour_v1.ConditionTrue,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Valid",
+					Message:            "Valid HTTPProxy",
+				},
+				Warnings: []contour_v1.SubCondition{
+					{
+						Type:    "TLSError",
+						Reason:  "TLSConfigError",
+						Message: "Syntax Error in TLS Config",
+					},
+				},
+			},
 		},
+		
 		wantCurrentStatus: string(ProxyStatusValid),
 		wantDescription:   "Valid HTTPProxy",
 	}
@@ -172,6 +191,24 @@ func TestStatusMutator(t *testing.T) {
 			{
 				Condition: contour_v1.Condition{
 					Type:               string(ValidCondition),
+					Status:             contour_v1.ConditionFalse,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "ErrorPresent",
+					Message:            "At least one error present, see Errors for details",
+				},
+				Errors: []contour_v1.SubCondition{
+					{
+						Type:    "TLSError",
+						Reason:  "TLSConfigError",
+						Message: "Syntax Error in TLS Config",
+					},
+				},
+			},
+			// Ready condition mirrors Valid for kstatus compatibility
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.ReadyConditionType,
 					Status:             contour_v1.ConditionFalse,
 					ObservedGeneration: testGeneration,
 					LastTransitionTime: testTransitionTime,
@@ -240,6 +277,24 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			// Ready condition mirrors Valid for kstatus compatibility
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.ReadyConditionType,
+					Status:             contour_v1.ConditionFalse,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Orphaned",
+					Message:            "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
+				},
+				Errors: []contour_v1.SubCondition{
+					{
+						Type:    "Orphaned",
+						Reason:  "Orphaned",
+						Message: "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
+					},
+				},
+			},
 		},
 		wantCurrentStatus: string(ProxyStatusOrphaned),
 		wantDescription:   "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
@@ -291,6 +346,24 @@ func TestStatusMutator(t *testing.T) {
 			{
 				Condition: contour_v1.Condition{
 					Type:               string(ValidCondition),
+					Status:             contour_v1.ConditionTrue,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Valid",
+					Message:            "Valid HTTPProxy",
+				},
+				Warnings: []contour_v1.SubCondition{
+					{
+						Type:    "TLSError",
+						Reason:  "TLSConfigError",
+						Message: "Syntax Error in TLS Config",
+					},
+				},
+			},
+			// Ready condition mirrors Valid for kstatus compatibility
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.ReadyConditionType,
 					Status:             contour_v1.ConditionTrue,
 					ObservedGeneration: testGeneration,
 					LastTransitionTime: testTransitionTime,

--- a/internal/status/proxystatus_test.go
+++ b/internal/status/proxystatus_test.go
@@ -151,7 +151,7 @@ func TestStatusMutator(t *testing.T) {
 				},
 			},
 		},
-		
+
 		wantCurrentStatus: string(ProxyStatusValid),
 		wantDescription:   "Valid HTTPProxy",
 	}


### PR DESCRIPTION
### Problem
Since the introduction of kstatus in Helm 4, custom resources can now be monitored during install. For HTTPProxy and ExtensionService CRs, the Valid condition type is not recognized by kstatus logic,
which specifically looks for a Ready condition. This causes Helm to assume resources are immediately ready, defeating the purpose of --wait.

### Solution
Mirror the Valid condition into an additional Ready condition, which kstatus recognizes. The Valid condition is preserved for backward compatibility and Contour's existing tooling, while the Ready
condition enables proper integration with Helm 4, Flux, Argo CD, and kubectl wait.

### Cleanup
Removed the workaround for #7391 in hack/generate-crd-yaml.sh as it is no longer needed with k8s.io/api v0.35.4.