### PR TITLE
Run codespell directly without actions-codespell to pin the version

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -40,12 +40,9 @@ jobs:
       with:
         persist-credentials: false
     - name: Codespell
-      uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
-      with:
-        skip: .git,*.png,*.woff,*.woff2,*.eot,*.ttf,*.jpg,*.ico,*.svg,./site/themes/contour/static/fonts/README.md,./vendor,./site/public,./hack/actions/check-changefile-exists.go,go.mod,go.sum
-        ignore_words_file: './.codespell.ignorewords'
-        check_filenames: true
-        check_hidden: true
+      # Use pipx run to pin the exact codespell version and avoid abrupt CI failures
+      # when a new version is released with an expanded dictionary. See #7649.
+      run: pipx run --spec codespell==2.4.3 codespell --check-filenames --check-hidden --ignore-words ./.codespell.ignorewords --skip '.git,*.png,*.woff,*.woff2,*.eot,*.ttf,*.jpg,*.ico,*.svg,./site/themes/contour/static/fonts/README.md,./vendor,./site/public,./hack/actions/check-changefile-exists.go,go.mod,go.sum'
   codegen:
     runs-on: ubuntu-latest
     steps:

--- a/design/global-external-authorization-design.md
+++ b/design/global-external-authorization-design.md
@@ -18,7 +18,7 @@ See [#4954](https://github.com/projectcontour/contour/issues/4954) for context.
 
 ## High-Level Design
 
-Contour will add HTTP support for Envoy's External Authorozation.
+Contour will add HTTP support for Envoy's External Authorization.
 
 Currently, Contour supports External Authorization only over HTTPS. External Authorization allows for requests to be authenticated before they are forwarded upstream. However, External authorization over HTTPS is incompatible with setups that terminate TLS at the cloud provider's load balancer layer because the Envoy HCM relies on the SNI to choose the correct filter chain. 
 

--- a/design/loadbalancer-hash-policy-design.md
+++ b/design/loadbalancer-hash-policy-design.md
@@ -172,7 +172,7 @@ type RequestHashPolicy struct {
 }
 ```
 
-While the number of options to support is unlikely to grow quickly, this option was not chosen as it is possible hashing attributes that require multiple fields of configurability would make this solution messy and unweildy.
+While the number of options to support is unlikely to grow quickly, this option was not chosen as it is possible hashing attributes that require multiple fields of configurability would make this solution messy and unwieldy.
 
 ### Only Address Header Hashing, Not Multiple Hash Options
 In order to deliver solely header hashing functionality, we could instead add an additional load balancing strategy `HeaderHash` and a configuration to supply a HTTP header name to hash on.


### PR DESCRIPTION
The `codespell-project/actions-codespell` action does not support pinning the version of the underlying `codespell` Python package. This means a new codespell release can silently break CI on a previously passing codebase.

Replace the action with a direct `pipx run` call that pins the exact `codespell` version. This prevents unexpected CI failures, at the cost of requiring manual version bumps when upgrading codespell.

Fixes #7649