### PR TITLE
Add dependabot group for codeql action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,9 @@ updates:
       patterns:
       - "actions/upload-artifact"
       - "actions/download-artifact"
+    codeql-action:
+      patterns:
+      - "github/codeql-action/*"
 
 # release branch targets
 - target-branch: release-1.33
@@ -91,5 +94,8 @@ updates:
       patterns:
       - "actions/upload-artifact"
       - "actions/download-artifact"
+    codeql-action:
+      patterns:
+      - "github/codeql-action/*"
 
 


### PR DESCRIPTION
This PR splits the dependabot updates for `github.com/github/codeql-action/{init,autobuild,analyze}` into a group, so that the versions will be bumped in single PR.  

This avoids CI failure that happens when bumped separately, like this

```
Error: Loaded a configuration file for version '4.37.1', but running version '4.37.4'
```
