### PR TITLE
Improve ExternalName service destination validation

### DIFF
--- a/changelogs/unreleased/7659-BeiHou1127-small.md
+++ b/changelogs/unreleased/7659-BeiHou1127-small.md
@@ -1,0 +1,1 @@
+Normalize and restrict loopback IP addresses in ExternalName service validation.

--- a/internal/dag/accessors.go
+++ b/internal/dag/accessors.go
@@ -15,6 +15,7 @@ package dag
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -98,9 +99,19 @@ func validateExternalName(svc *core_v1.Service, enableExternalNameSvc bool) erro
 		"local.projectcontour.io": {},
 	}
 
-	_, localhost := localhostNames[en]
-	if localhost {
+	// Normalize for comparison: a trailing dot denotes the root,
+	// so "localhost." must also be rejected.
+	normalized := strings.TrimSuffix(en, ".")
+	if _, localhost := localhostNames[normalized]; localhost {
 		return fmt.Errorf("%s/%s is an ExternalName service that points to localhost, this is not allowed", svc.Namespace, svc.Name)
+	}
+
+	// Reject literal IP addresses that would route to the Envoy pod's own
+	// loopback, link-local or unspecified interfaces (e.g. 127.0.0.1, 0.0.0.0).
+	if ip := net.ParseIP(normalized); ip != nil {
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() {
+			return fmt.Errorf("%s/%s is an ExternalName service that points to a loopback, link-local or unspecified IP address, this is not allowed", svc.Namespace, svc.Name)
+		}
 	}
 
 	return nil

--- a/internal/dag/accessors_test.go
+++ b/internal/dag/accessors_test.go
@@ -91,6 +91,54 @@ func TestBuilderLookupService(t *testing.T) {
 		},
 	}
 
+	externalNameLocalhostDot := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "externalnamelocalhostdot",
+			Namespace: "default",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type:         core_v1.ServiceTypeExternalName,
+			ExternalName: "localhost.",
+			Ports:        []core_v1.ServicePort{makeServicePort("http", "TCP", 80, 80)},
+		},
+	}
+
+	externalNameLoopbackIP := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "externalnameloopbackip",
+			Namespace: "default",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type:         core_v1.ServiceTypeExternalName,
+			ExternalName: "127.0.0.1",
+			Ports:        []core_v1.ServicePort{makeServicePort("http", "TCP", 80, 80)},
+		},
+	}
+
+	externalNameUnspecifiedIP := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "externalnameunspecifiedip",
+			Namespace: "default",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type:         core_v1.ServiceTypeExternalName,
+			ExternalName: "0.0.0.0",
+			Ports:        []core_v1.ServicePort{makeServicePort("http", "TCP", 80, 80)},
+		},
+	}
+
+	externalNameLinkLocalIP := &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "externalnamelinklocalip",
+			Namespace: "default",
+		},
+		Spec: core_v1.ServiceSpec{
+			Type:         core_v1.ServiceTypeExternalName,
+			ExternalName: "169.254.169.254",
+			Ports:        []core_v1.ServicePort{makeServicePort("http", "TCP", 80, 80)},
+		},
+	}
+
 	annotatedService := &core_v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:        "annotated-service",
@@ -148,6 +196,10 @@ func TestBuilderLookupService(t *testing.T) {
 		{Name: "servicehealthcheck", Namespace: "default"}:                   s2,
 		{Name: "externalnamevalid", Namespace: "default"}:                    externalNameValid,
 		{Name: "externalnamelocalhost", Namespace: "default"}:                externalNameLocalhost,
+		{Name: "externalnamelocalhostdot", Namespace: "default"}:             externalNameLocalhostDot,
+		{Name: "externalnameloopbackip", Namespace: "default"}:               externalNameLoopbackIP,
+		{Name: "externalnameunspecifiedip", Namespace: "default"}:            externalNameUnspecifiedIP,
+		{Name: "externalnamelinklocalip", Namespace: "default"}:              externalNameLinkLocalIP,
 		{Name: annotatedService.Name, Namespace: annotatedService.Namespace}: annotatedService,
 		{Name: appProtoService.Name, Namespace: appProtoService.Namespace}:   appProtoService,
 	}
@@ -212,6 +264,30 @@ func TestBuilderLookupService(t *testing.T) {
 			NamespacedName:        types.NamespacedName{Name: "externalnamelocalhost", Namespace: "default"},
 			port:                  80,
 			wantErr:               errors.New(`default/externalnamelocalhost is an ExternalName service that points to localhost, this is not allowed`),
+			enableExternalNameSvc: true,
+		},
+		"When ExternalName Services are enabled but a trailing-dot localhost ExternalName is used an error is returned": {
+			NamespacedName:        types.NamespacedName{Name: "externalnamelocalhostdot", Namespace: "default"},
+			port:                  80,
+			wantErr:               errors.New(`default/externalnamelocalhostdot is an ExternalName service that points to localhost, this is not allowed`),
+			enableExternalNameSvc: true,
+		},
+		"When ExternalName Services are enabled but a loopback IP ExternalName is used an error is returned": {
+			NamespacedName:        types.NamespacedName{Name: "externalnameloopbackip", Namespace: "default"},
+			port:                  80,
+			wantErr:               errors.New(`default/externalnameloopbackip is an ExternalName service that points to a loopback, link-local or unspecified IP address, this is not allowed`),
+			enableExternalNameSvc: true,
+		},
+		"When ExternalName Services are enabled but an unspecified IP ExternalName is used an error is returned": {
+			NamespacedName:        types.NamespacedName{Name: "externalnameunspecifiedip", Namespace: "default"},
+			port:                  80,
+			wantErr:               errors.New(`default/externalnameunspecifiedip is an ExternalName service that points to a loopback, link-local or unspecified IP address, this is not allowed`),
+			enableExternalNameSvc: true,
+		},
+		"When ExternalName Services are enabled but a link-local IP ExternalName is used an error is returned": {
+			NamespacedName:        types.NamespacedName{Name: "externalnamelinklocalip", Namespace: "default"},
+			port:                  80,
+			wantErr:               errors.New(`default/externalnamelinklocalip is an ExternalName service that points to a loopback, link-local or unspecified IP address, this is not allowed`),
 			enableExternalNameSvc: true,
 		},
 		"lookup service by port number with annotated number": {


### PR DESCRIPTION
### Description

This PR is a **defense-in-depth hardening enhancement** to tighten the existing validation of `ExternalName` service destinations in `internal/dag/accessors.go`.

While we acknowledge that any static, controller-side hostname blocklist is inherently bypassable (e.g., via public wildcard DNS services like `nip.io` or custom domains resolving to loopback), we can still improve the robustness of the existing "best-effort" `localhostNames` filter by blocking trivial, direct bypasses:

1. **Trailing Dot Normalization**: Ensures that FQDN representations of blocked names (such as `localhost.`) are correctly trimmed and rejected, aligning with DNS resolution semantics.
2. **Literal IP Blocking**: Rejects literal loopback, unspecified, and link-local IP addresses (e.g., `127.0.0.1`, `0.0.0.0`, `169.254.169.254`) that are directly inputted.

This change reduces the low-cost attack surface and aligns the implementation with the defensive intent already established in the codebase.

### Test Plan

Added comprehensive unit tests in `internal/dag/accessors_test.go` to cover the new hardening cases:
- Trailing dot variants (e.g., `localhost.`)
- Standard IPv4 loopback (`127.0.0.1`)
- Unspecified addresses (`0.0.0.0`)
- Link-local addresses (`169.254.169.254`)