### PR TITLE
Add Stalled condition and top level observedGeneration

### DIFF
--- a/apis/projectcontour/v1/detailedconditions.go
+++ b/apis/projectcontour/v1/detailedconditions.go
@@ -99,7 +99,8 @@ type SubCondition struct {
 //
 // Remember that Conditions have a type, a status, and a reason.
 //
-// The type is the type of the condition, the most important one in this CRD set is `Valid`.
+// The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
+//
 // `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
 //
 // In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
@@ -109,6 +110,9 @@ type SubCondition struct {
 // `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
 // The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
 // slice if `status` is `false`.
+//
+// `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+// together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
 //
 // For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
 // When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
@@ -137,6 +141,9 @@ type DetailedCondition struct {
 const (
 	// ValidConditionType describes an valid condition.
 	ValidConditionType = "Valid"
+
+	// StalledConditionType is true when Contour cannot reconcile the resource.
+	StalledConditionType = "Stalled"
 
 	// ConditionTypeAuthError describes an error condition related to Auth.
 	ConditionTypeAuthError = "AuthError"

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -1531,6 +1531,11 @@ type HTTPProxyStatus struct {
 	CurrentStatus string `json:"currentStatus,omitempty"`
 	// +optional
 	Description string `json:"description,omitempty"`
+	// ObservedGeneration is the generation that Contour reconciled last.
+	// A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// +optional
 	// LoadBalancer contains the current status of the load balancer.
 	LoadBalancer core_v1.LoadBalancerStatus `json:"loadBalancer,omitempty"`
@@ -1538,9 +1543,9 @@ type HTTPProxyStatus struct {
 	// Conditions contains information about the current status of the HTTPProxy,
 	// in an upstream-friendly container.
 	//
-	// Contour will update a single condition, `Valid`, that is in normal-true polarity.
-	// That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-	// and vice versa.
+	// Contour will update the `Valid` and `Stalled` conditions.
+	// `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+	// `Stalled` is true when Contour cannot reconcile the resource.
 	//
 	// Contour will leave untouched any other Conditions set in this block,
 	// in case some other controller wants to add a Condition.

--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -114,9 +114,17 @@ type ExtensionServiceSpec struct {
 // ExtensionServiceStatus defines the observed state of an
 // ExtensionService resource.
 type ExtensionServiceStatus struct {
+	// ObservedGeneration is the generation that Contour reconciled last.
+	// A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions contains the current status of the ExtensionService resource.
 	//
-	// Contour will update a single condition, `Valid`, that is in normal-true polarity.
+	// Contour will update the `Valid` and `Stalled` conditions.
+	// `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+	// `Stalled` is true when Contour cannot reconcile the resource.
 	//
 	// Contour will not modify any other Conditions set in this block,
 	// in case some other controller wants to add a Condition.

--- a/changelogs/unreleased/7664-tsaarni-minor.md
+++ b/changelogs/unreleased/7664-tsaarni-minor.md
@@ -1,0 +1,10 @@
+## kstatus support for HTTPProxy and ExtensionService
+
+Clients that use [kstatus](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus) can now check if `HTTPProxy` and `ExtensionService` are reconciled.
+This includes [Helm](https://helm.sh/community/hips/hip-0022/), [Argo CD](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#using-kstatus), and [Flux](https://fluxcd.io/flux/components/kustomize/kustomizations/#health-checks).
+
+For both resources, Contour now writes:
+- `Stalled` in `.status.conditions`
+- `observedGeneration` in `.status`
+
+Downgrade note: older Contour releases do not support the `Stalled` status condition and cannot remove condition set by newer Contour version after a downgrade. This condition must be removed manually to prevent incorrect status reporting by kstatus clients.

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -1333,7 +1333,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -1341,6 +1341,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5761,7 +5763,9 @@ spec:
               conditions:
                 description: |-
                   Conditions contains the current status of the ExtensionService resource.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will not modify any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                 items:
@@ -5772,7 +5776,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -5780,6 +5784,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5950,6 +5956,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true
@@ -8698,9 +8711,9 @@ spec:
                 description: |-
                   Conditions contains information about the current status of the HTTPProxy,
                   in an upstream-friendly container.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
-                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-                  and vice versa.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will leave untouched any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                   If you are another controller owner and wish to add a condition, you *should*
@@ -8713,7 +8726,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -8721,6 +8734,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -8966,6 +8981,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         required:
         - metadata
@@ -9071,7 +9093,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -9079,6 +9101,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.

--- a/examples/render/contour-deployment.yaml
+++ b/examples/render/contour-deployment.yaml
@@ -1552,7 +1552,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -1560,6 +1560,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5980,7 +5982,9 @@ spec:
               conditions:
                 description: |-
                   Conditions contains the current status of the ExtensionService resource.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will not modify any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                 items:
@@ -5991,7 +5995,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -5999,6 +6003,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -6169,6 +6175,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true
@@ -8917,9 +8930,9 @@ spec:
                 description: |-
                   Conditions contains information about the current status of the HTTPProxy,
                   in an upstream-friendly container.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
-                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-                  and vice versa.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will leave untouched any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                   If you are another controller owner and wish to add a condition, you *should*
@@ -8932,7 +8945,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -8940,6 +8953,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -9185,6 +9200,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         required:
         - metadata
@@ -9290,7 +9312,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -9298,6 +9320,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.

--- a/examples/render/contour-gateway-provisioner.yaml
+++ b/examples/render/contour-gateway-provisioner.yaml
@@ -1344,7 +1344,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -1352,6 +1352,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5772,7 +5774,9 @@ spec:
               conditions:
                 description: |-
                   Conditions contains the current status of the ExtensionService resource.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will not modify any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                 items:
@@ -5783,7 +5787,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -5791,6 +5795,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5961,6 +5967,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true
@@ -8709,9 +8722,9 @@ spec:
                 description: |-
                   Conditions contains information about the current status of the HTTPProxy,
                   in an upstream-friendly container.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
-                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-                  and vice versa.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will leave untouched any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                   If you are another controller owner and wish to add a condition, you *should*
@@ -8724,7 +8737,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -8732,6 +8745,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -8977,6 +8992,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         required:
         - metadata
@@ -9082,7 +9104,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -9090,6 +9112,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.

--- a/examples/render/contour-gateway.yaml
+++ b/examples/render/contour-gateway.yaml
@@ -1369,7 +1369,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -1377,6 +1377,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5797,7 +5799,9 @@ spec:
               conditions:
                 description: |-
                   Conditions contains the current status of the ExtensionService resource.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will not modify any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                 items:
@@ -5808,7 +5812,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -5816,6 +5820,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5986,6 +5992,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true
@@ -8734,9 +8747,9 @@ spec:
                 description: |-
                   Conditions contains information about the current status of the HTTPProxy,
                   in an upstream-friendly container.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
-                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-                  and vice versa.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will leave untouched any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                   If you are another controller owner and wish to add a condition, you *should*
@@ -8749,7 +8762,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -8757,6 +8770,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -9002,6 +9017,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         required:
         - metadata
@@ -9107,7 +9129,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -9115,6 +9137,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.

--- a/examples/render/contour.yaml
+++ b/examples/render/contour.yaml
@@ -1552,7 +1552,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -1560,6 +1560,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -5980,7 +5982,9 @@ spec:
               conditions:
                 description: |-
                   Conditions contains the current status of the ExtensionService resource.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will not modify any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                 items:
@@ -5991,7 +5995,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -5999,6 +6003,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -6169,6 +6175,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         type: object
     served: true
@@ -8917,9 +8930,9 @@ spec:
                 description: |-
                   Conditions contains information about the current status of the HTTPProxy,
                   in an upstream-friendly container.
-                  Contour will update a single condition, `Valid`, that is in normal-true polarity.
-                  That is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`,
-                  and vice versa.
+                  Contour will update the `Valid` and `Stalled` conditions.
+                  `Valid` is in normal-true polarity, that is, when `currentStatus` is `valid`, the `Valid` condition will be `status: true`, and vice versa.
+                  `Stalled` is true when Contour cannot reconcile the resource.
                   Contour will leave untouched any other Conditions set in this block,
                   in case some other controller wants to add a Condition.
                   If you are another controller owner and wish to add a condition, you *should*
@@ -8932,7 +8945,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -8940,6 +8953,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.
@@ -9185,6 +9200,13 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation that Contour reconciled last.
+                  A value that differs from `metadata.generation` means that Contour did not act on the latest spec yet.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
         required:
         - metadata
@@ -9290,7 +9312,7 @@ spec:
                     `errors` holds information about sub-conditions which are fatal to that condition and render its state False.
                     `warnings` holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.
                     Remember that Conditions have a type, a status, and a reason.
-                    The type is the type of the condition, the most important one in this CRD set is `Valid`.
+                    The type is the type of the condition, the most important ones in this CRD set are `Valid` and `Stalled`.
                     `Valid` is a positive-polarity condition: when it is `status: true` there are no problems.
                     In more detail, `status: true` means that the object is has been ingested into Contour with no errors.
                     `warnings` may still be present, and will be indicated in the Reason field. There must be zero entries in the `errors`
@@ -9298,6 +9320,8 @@ spec:
                     `Valid`, `status: false` means that the object has had one or more fatal errors during processing into Contour.
                     The details of the errors will be present under the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`.
+                    `Stalled` is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+                    together with `observedGeneration` to determine whether Contour has finished reconciling a resource after an apply operation.
                     For DetailedConditions of types other than `Valid`, the Condition must be in the negative polarity.
                     When they have `status` `true`, there is an error. There must be at least one entry in the `errors` Subcondition slice.
                     When they have `status` `false`, there are no serious errors, and there must be zero entries in the `errors` slice.

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	k8s.io/client-go v0.36.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
+	sigs.k8s.io/cli-utils v0.37.2
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/gateway-api v1.3.0
 	sigs.k8s.io/kustomize/kyaml v0.21.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJP
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
-github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
-github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
@@ -420,6 +420,8 @@ k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbe
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
+sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
+sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
 sigs.k8s.io/controller-runtime v0.24.0 h1:Ck6N2LdS8Lovy1o25BB4r1xjvLEKUl1s2o9kU+KWDE4=
 sigs.k8s.io/controller-runtime v0.24.0/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.3.0 h1:q6okN+/UKDATola4JY7zXzx40WO4VISk7i9DIfOvr9M=

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -1,0 +1,92 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+)
+
+// computeConditions merges the condition updates into the existing list.
+// It returns the new list.
+func computeConditions(
+	existing []contour_v1.DetailedCondition,
+	generation int64,
+	transitionTime meta_v1.Time,
+	updates map[ConditionType]*contour_v1.DetailedCondition,
+) []contour_v1.DetailedCondition {
+	conditions := existing
+
+	for _, cond := range updates {
+		cond.ObservedGeneration = generation
+		cond.LastTransitionTime = transitionTime
+		conditions = setCondition(conditions, *cond)
+	}
+
+	// The kstatus library reads the Stalled condition to calculate reconciliation status.
+	// https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus
+	if valid := getConditionFor(conditions, contour_v1.ValidConditionType); valid != nil {
+		conditions = setCondition(conditions, stalledConditionFor(valid))
+	}
+
+	return conditions
+}
+
+// stalledConditionFor returns a Stalled condition derived from Valid with opposite polarity: Valid=true gives Stalled=false.
+func stalledConditionFor(valid *contour_v1.DetailedCondition) contour_v1.DetailedCondition {
+	stalled := contour_v1.DetailedCondition{
+		Condition: contour_v1.Condition{
+			Type:               contour_v1.StalledConditionType,
+			Status:             contour_v1.ConditionFalse,
+			Reason:             "Valid",
+			Message:            "No errors present",
+			ObservedGeneration: valid.ObservedGeneration,
+			LastTransitionTime: valid.LastTransitionTime,
+		},
+	}
+
+	if valid.Status == contour_v1.ConditionFalse {
+		stalled.Status = contour_v1.ConditionTrue
+		stalled.Reason = valid.Reason
+		stalled.Message = valid.Message
+	}
+
+	return stalled
+}
+
+// setCondition adds or replaces a condition of the same type.
+func setCondition(conditions []contour_v1.DetailedCondition, cond contour_v1.DetailedCondition) []contour_v1.DetailedCondition {
+	for i := range conditions {
+		if conditions[i].Type != cond.Type {
+			continue
+		}
+		if conditions[i].ObservedGeneration > cond.ObservedGeneration {
+			return conditions
+		}
+		cond.DeepCopyInto(&conditions[i])
+		return conditions
+	}
+	return append(conditions, cond)
+}
+
+// getConditionFor returns the condition with the given type, or nil.
+func getConditionFor(conditions []contour_v1.DetailedCondition, condType string) *contour_v1.DetailedCondition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/internal/status/extensionstatus.go
+++ b/internal/status/extensionstatus.go
@@ -74,23 +74,8 @@ func (e *ExtensionCacheEntry) AsStatusUpdate() k8s.StatusUpdate {
 
 		ext := o.DeepCopy()
 
-		for condType, cond := range e.Conditions {
-			cond.ObservedGeneration = e.Generation
-			cond.LastTransitionTime = e.TransitionTime
-
-			currCond := ext.Status.GetConditionFor(string(condType))
-			if currCond == nil {
-				ext.Status.Conditions = append(ext.Status.Conditions, *cond)
-				continue
-			}
-
-			// Don't update the condition if our observation is stale.
-			if currCond.ObservedGeneration > cond.ObservedGeneration {
-				continue
-			}
-
-			cond.DeepCopyInto(currCond)
-		}
+		ext.Status.Conditions = computeConditions(ext.Status.Conditions, e.Generation, e.TransitionTime, e.Conditions)
+		ext.Status.ObservedGeneration = e.Generation
 
 		return ext
 	})

--- a/internal/status/proxystatus.go
+++ b/internal/status/proxystatus.go
@@ -75,28 +75,12 @@ func (pu *ProxyUpdate) Mutate(obj client.Object) client.Object {
 
 	proxy := o.DeepCopy()
 
-	for condType, cond := range pu.Conditions {
-		cond.ObservedGeneration = pu.Generation
-		cond.LastTransitionTime = pu.TransitionTime
-
-		currCond := proxy.Status.GetConditionFor(string(condType))
-		if currCond == nil {
-			proxy.Status.Conditions = append(proxy.Status.Conditions, *cond)
-			continue
-		}
-
-		// Don't update the condition if our observation is stale.
-		if currCond.ObservedGeneration > cond.ObservedGeneration {
-			continue
-		}
-
-		cond.DeepCopyInto(currCond)
-
-	}
+	proxy.Status.Conditions = computeConditions(proxy.Status.Conditions, pu.Generation, pu.TransitionTime, pu.Conditions)
+	proxy.Status.ObservedGeneration = pu.Generation
 
 	// Set the old status fields using the Valid DetailedCondition's details.
 	// Other conditions are not relevant for these two fields.
-	validCond := proxy.Status.GetConditionFor(contour_v1.ValidConditionType)
+	validCond := getConditionFor(proxy.Status.Conditions, contour_v1.ValidConditionType)
 
 	switch validCond.Status {
 	case contour_v1.ConditionTrue:

--- a/internal/status/proxystatus_test.go
+++ b/internal/status/proxystatus_test.go
@@ -61,11 +61,12 @@ func TestConditionFor(t *testing.T) {
 
 func TestStatusMutator(t *testing.T) {
 	type testcase struct {
-		testProxy         contour_v1.HTTPProxy
-		proxyUpdate       ProxyUpdate
-		wantConditions    []contour_v1.DetailedCondition
-		wantCurrentStatus string
-		wantDescription   string
+		testProxy              contour_v1.HTTPProxy
+		proxyUpdate            ProxyUpdate
+		wantConditions         []contour_v1.DetailedCondition
+		wantCurrentStatus      string
+		wantDescription        string
+		wantObservedGeneration int64
 	}
 
 	testTransitionTime := meta_v1.NewTime(time.Now())
@@ -79,6 +80,7 @@ func TestStatusMutator(t *testing.T) {
 			assert.Equal(t, tc.wantConditions, o.Status.Conditions, desc)
 			assert.Equal(t, tc.wantCurrentStatus, o.Status.CurrentStatus, desc)
 			assert.Equal(t, tc.wantDescription, o.Status.Description, desc)
+			assert.Equal(t, tc.wantObservedGeneration, o.Status.ObservedGeneration, desc)
 		default:
 			t.Fatal("Got a non-HTTPProxy object.")
 		}
@@ -132,9 +134,20 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.StalledConditionType,
+					Status:             contour_v1.ConditionFalse,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Valid",
+					Message:            "No errors present",
+				},
+			},
 		},
-		wantCurrentStatus: string(ProxyStatusValid),
-		wantDescription:   "Valid HTTPProxy",
+		wantCurrentStatus:      string(ProxyStatusValid),
+		wantDescription:        "Valid HTTPProxy",
+		wantObservedGeneration: testGeneration,
 	}
 	run("valid with one warning", validConditionWarning)
 
@@ -186,9 +199,20 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.StalledConditionType,
+					Status:             contour_v1.ConditionTrue,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "ErrorPresent",
+					Message:            "At least one error present, see Errors for details",
+				},
+			},
 		},
-		wantCurrentStatus: string(ProxyStatusInvalid),
-		wantDescription:   "At least one error present, see Errors for details",
+		wantCurrentStatus:      string(ProxyStatusInvalid),
+		wantDescription:        "At least one error present, see Errors for details",
+		wantObservedGeneration: testGeneration,
 	}
 	run("invalid status, one error", inValidConditionError)
 
@@ -240,9 +264,20 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.StalledConditionType,
+					Status:             contour_v1.ConditionTrue,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Orphaned",
+					Message:            "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
+				},
+			},
 		},
-		wantCurrentStatus: string(ProxyStatusOrphaned),
-		wantDescription:   "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
+		wantCurrentStatus:      string(ProxyStatusOrphaned),
+		wantDescription:        "this HTTPProxy is not part of a delegation chain from a root HTTPProxy",
+		wantObservedGeneration: testGeneration,
 	}
 
 	run("orphaned HTTPProxy", orphanedCondition)
@@ -305,9 +340,20 @@ func TestStatusMutator(t *testing.T) {
 					},
 				},
 			},
+			{
+				Condition: contour_v1.Condition{
+					Type:               contour_v1.StalledConditionType,
+					Status:             contour_v1.ConditionFalse,
+					ObservedGeneration: testGeneration,
+					LastTransitionTime: testTransitionTime,
+					Reason:             "Valid",
+					Message:            "No errors present",
+				},
+			},
 		},
-		wantCurrentStatus: string(ProxyStatusValid),
-		wantDescription:   "Valid HTTPProxy",
+		wantCurrentStatus:      string(ProxyStatusValid),
+		wantDescription:        "Valid HTTPProxy",
+		wantObservedGeneration: testGeneration,
 	}
 
 	run("Test updating existing Valid Condition", updateExistingValidCond)

--- a/site/content/docs/main/config/api-reference.html
+++ b/site/content/docs/main/config/api-reference.html
@@ -970,14 +970,16 @@ of the condition.</p>
 <p><code>errors</code> holds information about sub-conditions which are fatal to that condition and render its state False.</p>
 <p><code>warnings</code> holds information about sub-conditions which are not fatal to that condition and do not force the state to be False.</p>
 <p>Remember that Conditions have a type, a status, and a reason.</p>
-<p>The type is the type of the condition, the most important one in this CRD set is <code>Valid</code>.
-<code>Valid</code> is a positive-polarity condition: when it is <code>status: true</code> there are no problems.</p>
+<p>The type is the type of the condition, the most important ones in this CRD set are <code>Valid</code> and <code>Stalled</code>.</p>
+<p><code>Valid</code> is a positive-polarity condition: when it is <code>status: true</code> there are no problems.</p>
 <p>In more detail, <code>status: true</code> means that the object is has been ingested into Contour with no errors.
 <code>warnings</code> may still be present, and will be indicated in the Reason field. There must be zero entries in the <code>errors</code>
 slice in this case.</p>
 <p><code>Valid</code>, <code>status: false</code> means that the object has had one or more fatal errors during processing into Contour.
 The details of the errors will be present under the <code>errors</code> field. There must be at least one error in the <code>errors</code>
 slice if <code>status</code> is <code>false</code>.</p>
+<p><code>Stalled</code> is true when Contour cannot reconcile the resource. Clients that use the kstatus library read this condition
+together with <code>observedGeneration</code> to determine whether Contour has finished reconciling a resource after an apply operation.</p>
 <p>For DetailedConditions of types other than <code>Valid</code>, the Condition must be in the negative polarity.
 When they have <code>status</code> <code>true</code>, there is an error. There must be at least one entry in the <code>errors</code> Subcondition slice.
 When they have <code>status</code> <code>false</code>, there are no serious errors, and there must be zero entries in the <code>errors</code> slice.
@@ -1866,6 +1868,20 @@ string
 </tr>
 <tr>
 <td style="white-space:nowrap">
+<code>observedGeneration</code>
+<br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the generation that Contour reconciled last.
+A value that differs from <code>metadata.generation</code> means that Contour did not act on the latest spec yet.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>loadBalancer</code>
 <br>
 <em>
@@ -1893,9 +1909,9 @@ Kubernetes core/v1.LoadBalancerStatus
 <em>(Optional)</em>
 <p>Conditions contains information about the current status of the HTTPProxy,
 in an upstream-friendly container.</p>
-<p>Contour will update a single condition, <code>Valid</code>, that is in normal-true polarity.
-That is, when <code>currentStatus</code> is <code>valid</code>, the <code>Valid</code> condition will be <code>status: true</code>,
-and vice versa.</p>
+<p>Contour will update the <code>Valid</code> and <code>Stalled</code> conditions.
+<code>Valid</code> is in normal-true polarity, that is, when <code>currentStatus</code> is <code>valid</code>, the <code>Valid</code> condition will be <code>status: true</code>, and vice versa.
+<code>Stalled</code> is true when Contour cannot reconcile the resource.</p>
 <p>Contour will leave untouched any other Conditions set in this block,
 in case some other controller wants to add a Condition.</p>
 <p>If you are another controller owner and wish to add a condition, you <em>should</em>
@@ -8104,6 +8120,20 @@ ExtensionService resource.</p>
 <tbody>
 <tr>
 <td style="white-space:nowrap">
+<code>observedGeneration</code>
+<br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the generation that Contour reconciled last.
+A value that differs from <code>metadata.generation</code> means that Contour did not act on the latest spec yet.</p>
+</td>
+</tr>
+<tr>
+<td style="white-space:nowrap">
 <code>conditions</code>
 <br>
 <em>
@@ -8115,7 +8145,9 @@ ExtensionService resource.</p>
 <td>
 <em>(Optional)</em>
 <p>Conditions contains the current status of the ExtensionService resource.</p>
-<p>Contour will update a single condition, <code>Valid</code>, that is in normal-true polarity.</p>
+<p>Contour will update the <code>Valid</code> and <code>Stalled</code> conditions.
+<code>Valid</code> is in normal-true polarity, that is, when <code>currentStatus</code> is <code>valid</code>, the <code>Valid</code> condition will be <code>status: true</code>, and vice versa.
+<code>Stalled</code> is true when Contour cannot reconcile the resource.</p>
 <p>Contour will not modify any other Conditions set in this block,
 in case some other controller wants to add a Condition.</p>
 </td>

--- a/test/e2e/httpproxy/httpproxy_test.go
+++ b/test/e2e/httpproxy/httpproxy_test.go
@@ -738,6 +738,11 @@ descriptors:
 
 	f.NamespacedTest("httpproxy-crl", testClientCertRevocation)
 
+	// Status that the kstatus library can compute.
+	f.NamespacedTest("httpproxy-kstatus-current", testKstatusCurrentProxy)
+	f.NamespacedTest("httpproxy-kstatus-failed", testKstatusFailedProxy)
+	f.NamespacedTest("httpproxy-kstatus-in-progress", testKstatusInProgressStatus)
+
 	Context("gRPC tests", func() {
 		f.NamespacedTest("grpc-upstream-plaintext", testGRPCServicePlaintext)
 

--- a/test/e2e/httpproxy/kstatus_test.go
+++ b/test/e2e/httpproxy/kstatus_test.go
@@ -1,0 +1,158 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package httpproxy
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+
+	contour_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/projectcontour/contour/test/e2e"
+)
+
+// These tests call the kstatus library to compute the status of an HTTPProxy.
+// A client uses that status to know when Contour has fully reconciled the resource.
+//
+// kstatus does not know the Contour `Valid` condition.
+// It computes the status from `status.observedGeneration` and from the `Stalled` condition instead.
+// https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus
+
+// computeStatus converts the HTTPProxy to Unstructured and computes its status.
+func computeStatus(proxy *contour_v1.HTTPProxy) *status.Result {
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(proxy)
+	require.NoError(f.T(), err)
+
+	result, err := status.Compute(&unstructured.Unstructured{Object: content})
+	require.NoError(f.T(), err)
+
+	return result
+}
+
+func testKstatusCurrentProxy(namespace string) {
+	Specify("kstatus reports Current for a valid HTTPProxy", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+
+		proxy := &contour_v1.HTTPProxy{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "kstatus-valid",
+			},
+			Spec: contour_v1.HTTPProxySpec{
+				VirtualHost: &contour_v1.VirtualHost{
+					Fqdn: "kstatus-valid.projectcontour.io",
+				},
+				Routes: []contour_v1.Route{{
+					Services: []contour_v1.Service{{
+						Name: "echo",
+						Port: 80,
+					}},
+				}},
+			},
+		}
+		require.True(t, f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid))
+
+		assert.Equal(t, proxy.Generation, proxy.Status.ObservedGeneration, "Contour must record the generation that it reconciled")
+
+		stalled := proxy.Status.GetConditionFor(contour_v1.StalledConditionType)
+		require.NotNil(t, stalled, "the Stalled condition must be present")
+		assert.Equal(t, contour_v1.ConditionFalse, stalled.Status)
+		assert.Equal(t, "Valid", stalled.Reason)
+		assert.Equal(t, "No errors present", stalled.Message)
+
+		assert.Equal(t, status.CurrentStatus, computeStatus(proxy).Status)
+	})
+}
+
+func testKstatusFailedProxy(namespace string) {
+	Specify("kstatus reports Failed for an invalid HTTPProxy", func() {
+		t := f.T()
+
+		proxy := &contour_v1.HTTPProxy{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "kstatus-invalid",
+			},
+			Spec: contour_v1.HTTPProxySpec{
+				VirtualHost: &contour_v1.VirtualHost{
+					Fqdn: "kstatus-invalid.projectcontour.io",
+				},
+				Routes: []contour_v1.Route{{
+					Services: []contour_v1.Service{{
+						Name: "does-not-exist",
+						Port: 80,
+					}},
+				}},
+			},
+		}
+		require.True(t, f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyInvalid))
+
+		valid := proxy.Status.GetConditionFor(contour_v1.ValidConditionType)
+		require.NotNil(t, valid, "the Valid condition must be present")
+
+		stalled := proxy.Status.GetConditionFor(contour_v1.StalledConditionType)
+		require.NotNil(t, stalled, "the Stalled condition must be present")
+		assert.Equal(t, contour_v1.ConditionTrue, stalled.Status)
+		assert.Equal(t, valid.Reason, stalled.Reason)
+		assert.Equal(t, valid.Message, stalled.Message)
+		assert.Equal(t, "ErrorPresent", stalled.Reason)
+
+		result := computeStatus(proxy)
+		assert.Equal(t, status.FailedStatus, result.Status)
+		assert.Equal(t, stalled.Message, result.Message)
+	})
+}
+
+func testKstatusInProgressStatus(namespace string) {
+	Specify("kstatus reports InProgress while the status is old", func() {
+		t := f.T()
+
+		f.Fixtures.Echo.Deploy(namespace, "echo")
+
+		proxy := &contour_v1.HTTPProxy{
+			ObjectMeta: meta_v1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "kstatus-stale",
+			},
+			Spec: contour_v1.HTTPProxySpec{
+				VirtualHost: &contour_v1.VirtualHost{
+					Fqdn: "kstatus-stale.projectcontour.io",
+				},
+				Routes: []contour_v1.Route{{
+					Services: []contour_v1.Service{{
+						Name: "echo",
+						Port: 80,
+					}},
+				}},
+			},
+		}
+		require.True(t, f.CreateHTTPProxyAndWaitFor(proxy, e2e.HTTPProxyValid))
+		require.Equal(t, status.CurrentStatus, computeStatus(proxy).Status)
+
+		// Fake unreconciled resource by stepping `metadata.generation` so that it is greater than `status.observedGeneration`.
+		// Contour reconciles fast so this is the only way to get a stable stale status.
+		stale := proxy.DeepCopy()
+		stale.Generation = proxy.Status.ObservedGeneration + 1
+
+		assert.Equal(t, status.InProgressStatus, computeStatus(stale).Status)
+	})
+}


### PR DESCRIPTION
This PR adds following

* New condition type `Stalled` is written to `HTTPProxy.status.conditions` and `ExtensionService.status.conditions` 
* New fields `HTTPProxy.status.observedGeneration` and `ExtensionService.status.observedGeneration` were added

These are needed when client uses `sigs.k8s.io/cli-utils/pkg/kstatus/status` library to derive a single value that represents the status of `HTTPProxy` or `ExtensionService` resource. 

The logic is explained at https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus. No common specification exists to determine if a resource has successfully reconciled. For example, `HTTPProxy` uses `Valid` condition, while some projects use a`Ready` condition. The kstatus library defines two recommended conditions: `Reconciling` and `Stalled`.  This PR adopts only the `Stalled` condition. 

The library will determine status in following way:

1. If `observedGeneration < generation` then the library returns `InProgress` ([src link](https://github.com/kubernetes-sigs/cli-utils/blob/v0.37.2/pkg/kstatus/status/generic.go#L73-L99))
2. If `Stalled: True` the library returns `Failed` ([src link](https://github.com/kubernetes-sigs/cli-utils/blob/v0.37.2/pkg/kstatus/status/generic.go#L54-L67))
3. Otherwise the library returns `Current` ([src link](https://github.com/kubernetes-sigs/cli-utils/blob/v0.37.2/pkg/kstatus/status/status.go#L130-L138))

Besides these, the library returns status `Terminating` when `metadata.deletionTimestamp` is set by the Kubernetes API server.

This PR adds [`kstatus`](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus) library as a test dependency to verify that expected status is reported for `HTTPProxy` in different scenarios. Clients that use kstatus include [Helm4](https://helm.sh/community/hips/hip-0022/) and [FluxCD](https://fluxcd.io/flux/components/kustomize/kustomizations/#kustomization-status). Both use a fork of the library ([link](https://github.com/fluxcd/cli-utils/tree/main/pkg/kstatus)) but behaviour should be the same.

**Downgrade note**: older Contour releases do not support the `Stalled` status condition and cannot remove condition set by newer Contour version after a downgrade. This condition must be removed manually to prevent incorrect status reporting by kstatus clients.

Fixes #7670

This PR replaces #7648