### PR TITLE
configure ext_authz filter when vhost authPolicy is disabled

### DIFF
--- a/changelogs/unreleased/7671-tsaarni-small.md
+++ b/changelogs/unreleased/7671-tsaarni-small.md
@@ -1,0 +1,1 @@
+Allow routes to enable external authorization with `authPolicy.disabled: false` when the virtualhost-level `authPolicy.disabled` is set to `true`.

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1560,7 +1560,7 @@ func validateExternalAuthExtensionService(ref contour_v1.ExtensionServiceReferen
 }
 
 func (p *HTTPProxyProcessor) computeSecureVirtualHostAuthorization(validCond *contour_v1.DetailedCondition, httpproxy *contour_v1.HTTPProxy, svhost *SecureVirtualHost) bool {
-	if httpproxy.Spec.VirtualHost.AuthorizationConfigured() && !httpproxy.Spec.VirtualHost.DisableAuthorization() && httpproxy.Spec.VirtualHost.Authorization.ExtensionServiceRef.IsConfigured() {
+	if httpproxy.Spec.VirtualHost.AuthorizationConfigured() && httpproxy.Spec.VirtualHost.Authorization.ExtensionServiceRef.IsConfigured() {
 		authorization := p.computeVirtualHostAuthorization(httpproxy.Spec.VirtualHost.Authorization, validCond, httpproxy)
 		if authorization == nil {
 			return false

--- a/internal/featuretests/v3/authorization_test.go
+++ b/internal/featuretests/v3/authorization_test.go
@@ -283,6 +283,52 @@ func authzOverrideDisabled(t *testing.T, rh ResourceEventHandlerWrapper, c *Cont
 		}),
 	)
 
+	cluster := grpcCluster("extension/auth/extension")
+	c.Request(listenerType).Equals(&envoy_service_discovery_v3.DiscoveryResponse{
+		TypeUrl: listenerType,
+		Resources: resources(t,
+			defaultHTTPListener(),
+			&envoy_config_listener_v3.Listener{
+				Name:    "ingress_https",
+				Address: envoy_v3.SocketAddress("0.0.0.0", 8443),
+				ListenerFilters: envoy_v3.ListenerFilters(
+					envoy_v3.TLSInspector(),
+				),
+				FilterChains: []*envoy_config_listener_v3.FilterChain{
+					filterchaintls(disabled, featuretests.TLSSecret(t, "certificate", &featuretests.ServerCertificate),
+						authzFilterFor(
+							disabled,
+							&envoy_filter_http_ext_authz_v3.ExtAuthz{
+								Services:               cluster,
+								ClearRouteCache:        true,
+								IncludePeerCertificate: true,
+								StatusOnError: &envoy_type_v3.HttpStatus{
+									Code: envoy_type_v3.StatusCode_Forbidden,
+								},
+								TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
+							},
+						),
+						nil, "h2", "http/1.1"),
+					filterchaintls(enabled, featuretests.TLSSecret(t, "certificate", &featuretests.ServerCertificate),
+						authzFilterFor(
+							enabled,
+							&envoy_filter_http_ext_authz_v3.ExtAuthz{
+								Services:               cluster,
+								ClearRouteCache:        true,
+								IncludePeerCertificate: true,
+								StatusOnError: &envoy_type_v3.HttpStatus{
+									Code: envoy_type_v3.StatusCode_Forbidden,
+								},
+								TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
+							},
+						),
+						nil, "h2", "http/1.1"),
+				},
+				SocketOptions: envoy_v3.NewSocketOptions().TCPKeepalive().Build(),
+			},
+			statsListener()),
+	})
+
 	// For each proxy, the `/default` route should have the
 	// same authorization enablement as the root proxy, and
 	// the other path should have the opposite enablement.

--- a/test/e2e/httpproxy/external_auth_http_test.go
+++ b/test/e2e/httpproxy/external_auth_http_test.go
@@ -323,5 +323,72 @@ var _ = Describe("httpproxy-ext-auth-http-global", func() {
 			Expect(res).NotTo(BeNil(), "request never succeeded")
 			Expect(ok).To(BeTrue(), "expected 200 (auth bypassed), got %d", res.StatusCode)
 		})
+
+		Specify("virtualhost authPolicy can opt out of global auth while a route re-enables it", func() {
+			f.Fixtures.Echo.Deploy(namespace, "echo")
+			f.Certs.CreateSelfSignedCert(namespace, "echo", "globalextauthvhostoptout.projectcontour.io")
+
+			p := &contour_v1.HTTPProxy{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "global-ext-auth-http-vhost-optout",
+				},
+				Spec: contour_v1.HTTPProxySpec{
+					VirtualHost: &contour_v1.VirtualHost{
+						Fqdn: "globalextauthvhostoptout.projectcontour.io",
+						TLS:  &contour_v1.TLS{SecretName: "echo"},
+						Authorization: &contour_v1.AuthorizationServer{
+							AuthPolicy: &contour_v1.AuthorizationPolicy{Disabled: true},
+						},
+					},
+					Routes: []contour_v1.Route{
+						{
+							Conditions: []contour_v1.MatchCondition{{Prefix: "/protected"}},
+							AuthPolicy: &contour_v1.AuthorizationPolicy{Disabled: false},
+							Services:   []contour_v1.Service{{Name: "echo", Port: 80}},
+						},
+						{
+							Conditions: []contour_v1.MatchCondition{{Prefix: "/public"}},
+							Services:   []contour_v1.Service{{Name: "echo", Port: 80}},
+						},
+					},
+				},
+			}
+			Expect(f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid)).To(BeTrue())
+
+			setHandler(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+
+			By("re-enabled route enforces global auth")
+			res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+				Host:      p.Spec.VirtualHost.Fqdn,
+				Path:      "/protected",
+				Condition: e2e.HasStatusCode(401),
+			})
+			Expect(res).NotTo(BeNil(), "request never succeeded")
+			Expect(ok).To(BeTrue(), "expected 401, got %d", res.StatusCode)
+
+			By("route inheriting the vhost opt-out has no authorization")
+			res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+				Host:      p.Spec.VirtualHost.Fqdn,
+				Path:      "/public",
+				Condition: e2e.HasStatusCode(200),
+			})
+			Expect(res).NotTo(BeNil(), "request never succeeded")
+			Expect(ok).To(BeTrue(), "expected 200, got %d", res.StatusCode)
+
+			By("re-enabled route allows the request when the auth server approves")
+			setHandler(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			res, ok = f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
+				Host:      p.Spec.VirtualHost.Fqdn,
+				Path:      "/protected",
+				Condition: e2e.HasStatusCode(200),
+			})
+			Expect(res).NotTo(BeNil(), "request never succeeded")
+			Expect(ok).To(BeTrue(), "expected 200, got %d", res.StatusCode)
+		})
 	})
 })


### PR DESCRIPTION
The `ext_authz` filter was not added to the listener when the virtualhost authorization `authPolicy.disabled` was set to `true` and route-level override `authPolicy.disabled` was `false`. This PR always configures the `ext_authz` filter on the listener when an extension service is referenced.