### PR TITLE
Fix cert rotation race in TestHTTPSService

### DIFF
--- a/internal/httpsvc/http_test.go
+++ b/internal/httpsvc/http_test.go
@@ -139,7 +139,7 @@ func TestHTTPSService(t *testing.T) {
 	caCertPool.AddCert(&ca)
 
 	// Wrap the first HTTP request in Eventually() since the server takes bit time to start.
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		resp, err := tryGet("https://localhost:8001/test", trustedTLSClientCert, caCertPool)
 		if err != nil {
 			return false
@@ -150,7 +150,7 @@ func TestHTTPSService(t *testing.T) {
 		assert.GreaterOrEqual(t, uint16(tls.VersionTLS13), resp.TLS.Version)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		return true
-	}, 1*time.Second, 100*time.Millisecond)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// Rotate server certificates.
 	err = contourCertAfterRotation.WritePEM(svc.Cert, svc.Key)


### PR DESCRIPTION
This PR fixes race condition in certificate rotation test case

```
2026/08/16 20:59:12 http: TLS handshake error from 127.0.0.1:49256: tls: client didn't provide a certificate
--- FAIL: TestHTTPSService (1.15s)
    log.go:27: time="2026-08-16T20:59:11Z" level=info msg="started HTTPS server" address="localhost:8001"
    http_test.go:142: 
        	Error Trace:	/Users/runner/work/contour/contour/internal/httpsvc/http_test.go:142
        	Error:      	Condition never satisfied
        	Test:       	TestHTTPSService
    http_test.go:149: 
        	Error Trace:	/Users/runner/work/contour/contour/internal/httpsvc/http_test.go:149
        	            				/Users/runner/hostedtoolcache/go/1.26.4/arm64/src/runtime/asm_arm64.s:1447
        	Error:      	Not equal: 
...
```

https://github.com/projectcontour/contour/actions/runs/31971829675/job/95225643907?pr=7678

