### PR TITLE
Replace yages for e2e grpc service tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectcontour/yages v0.1.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/projectcontour/yages v0.1.0 h1:vcFpregOq5TVF0/AXLive1MY4CVMDkgL7/+qbUeIbDs=
-github.com/projectcontour/yages v0.1.0/go.mod h1:pcJrPa3dP17HwGj2YOfBZ4w5WmC1rSpv/X/sV4wauSw=
 github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=
 github.com/prometheus/client_golang v1.24.1/go.mod h1:F+oSRECHg4sse5ucfYpYDeIv/hu68Zo0uoHKetWnzcE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -39,9 +39,6 @@ import (
 const (
 	// EchoServerImage is the image to use as a backend fixture.
 	EchoServerImage = "gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e"
-
-	// GRPCServerImage is the image to use for tests that require a gRPC server.
-	GRPCServerImage = "ghcr.io/projectcontour/yages:v0.1.0"
 )
 
 // Fixtures holds references to all of the E2E fixtures helpers.
@@ -53,10 +50,6 @@ type Fixtures struct {
 	// EchoSecure provides helpers for working with the TLS-secured
 	// ingress-conformance-echo-tls test fixture.
 	EchoSecure *EchoSecure
-
-	// GRPC provides helpers for working with a gRPC echo server test
-	// fixture.
-	GRPC *GRPC
 }
 
 // Echo manages the ingress-conformance-echo fixture.
@@ -424,117 +417,6 @@ func (e *EchoSecure) Deploy(ns, name string, preApplyHook func(deployment *apps_
 	return func() {
 		require.NoError(e.t, e.client.Delete(context.TODO(), service))
 		require.NoError(e.t, e.client.Delete(context.TODO(), deployment))
-	}
-}
-
-type GRPC struct {
-	client client.Client
-	t      ginkgo.GinkgoTInterface
-}
-
-func (g *GRPC) Deploy(ns, name string) func() {
-	ns = valOrDefault(ns, "default")
-	name = valOrDefault(name, "grpc-echo")
-
-	deployment := &apps_v1.Deployment{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Spec: apps_v1.DeploymentSpec{
-			Replicas: ptr.To(int32(1)),
-			Selector: &meta_v1.LabelSelector{
-				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
-			},
-			Template: core_v1.PodTemplateSpec{
-				ObjectMeta: meta_v1.ObjectMeta{
-					Labels: map[string]string{"app.kubernetes.io/name": name},
-				},
-				Spec: core_v1.PodSpec{
-					TopologySpreadConstraints: []core_v1.TopologySpreadConstraint{
-						{
-							// Attempt to spread pods across different nodes if possible.
-							TopologyKey:       "kubernetes.io/hostname",
-							MaxSkew:           1,
-							WhenUnsatisfiable: core_v1.ScheduleAnyway,
-							LabelSelector: &meta_v1.LabelSelector{
-								MatchLabels: map[string]string{"app.kubernetes.io/name": name},
-							},
-						},
-					},
-					Containers: []core_v1.Container{
-						{
-							Name:            "grpc-echo",
-							Image:           GRPCServerImage,
-							ImagePullPolicy: core_v1.PullIfNotPresent,
-							Env: []core_v1.EnvVar{
-								{
-									Name:  "INGRESS_NAME",
-									Value: name,
-								},
-								{
-									Name:  "SERVICE_NAME",
-									Value: name,
-								},
-								{
-									Name: "POD_NAME",
-									ValueFrom: &core_v1.EnvVarSource{
-										FieldRef: &core_v1.ObjectFieldSelector{
-											FieldPath: "metadata.name",
-										},
-									},
-								},
-								{
-									Name: "NAMESPACE",
-									ValueFrom: &core_v1.EnvVarSource{
-										FieldRef: &core_v1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-							Ports: []core_v1.ContainerPort{
-								{
-									Name:          "grpc",
-									ContainerPort: 9000,
-								},
-							},
-							ReadinessProbe: &core_v1.Probe{
-								ProbeHandler: core_v1.ProbeHandler{
-									Exec: &core_v1.ExecAction{
-										Command: []string{"/grpc-health-probe", "-addr=localhost:9000"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	require.NoError(g.t, g.client.Create(context.TODO(), deployment))
-
-	service := &core_v1.Service{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-		Spec: core_v1.ServiceSpec{
-			Ports: []core_v1.ServicePort{
-				{
-					Name:       "grpc",
-					Port:       9000,
-					TargetPort: intstr.FromString("grpc"),
-				},
-			},
-			Selector: map[string]string{"app.kubernetes.io/name": name},
-		},
-	}
-	require.NoError(g.t, g.client.Create(context.TODO(), service))
-
-	return func() {
-		require.NoError(g.t, g.client.Delete(context.TODO(), service))
-		require.NoError(g.t, g.client.Delete(context.TODO(), deployment))
 	}
 }
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -246,10 +246,6 @@ func NewFramework(inClusterTestSuite bool) *Framework {
 				client: crClient,
 				t:      t,
 			},
-			GRPC: &GRPC{
-				client: crClient,
-				t:      t,
-			},
 		},
 		HTTP: &HTTP{
 			HTTPURLBase:        httpURLBase,

--- a/test/e2e/gateway/grpc_route_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_conflict_match_test.go
@@ -28,7 +28,7 @@ import (
 
 func testGRPCRouteConflictMatch(namespace string, gateway types.NamespacedName) {
 	Specify("Creates two GRPCRoutes, second one has conflict match against the first one, report Accepted: false", func() {
-		cleanup := f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+		e2e.StartLocalGRPCEchoService(GinkgoT(), f.Client, namespace, "grpc-echo")
 
 		By("create grpcroute-1 first")
 		route1 := &gatewayapi_v1.GRPCRoute{
@@ -89,7 +89,5 @@ func testGRPCRouteConflictMatch(namespace string, gateway types.NamespacedName) 
 		}
 		ok = f.CreateGRPCRouteAndWaitFor(route2, e2e.GRPCRouteNotAcceptedDueToConflict)
 		require.True(f.T(), ok)
-
-		cleanup()
 	})
 }

--- a/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
+++ b/test/e2e/gateway/grpc_route_partially_conflict_match_test.go
@@ -28,7 +28,7 @@ import (
 
 func testGRPCRoutePartiallyConflictMatch(namespace string, gateway types.NamespacedName) {
 	Specify("Creates two GRPCRoutes, second one has partial conflict match against the first one, has partially match condition", func() {
-		cleanup := f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+		e2e.StartLocalGRPCEchoService(GinkgoT(), f.Client, namespace, "grpc-echo")
 
 		By("create grpcroute-1 first")
 		route1 := &gatewayapi_v1.GRPCRoute{
@@ -89,7 +89,5 @@ func testGRPCRoutePartiallyConflictMatch(namespace string, gateway types.Namespa
 		f.CreateGRPCRouteAndWaitFor(route2, func(*gatewayapi_v1.GRPCRoute) bool {
 			return e2e.GRPCRoutePartiallyInvalid(route2) && e2e.GRPCRouteAccepted(route2)
 		})
-
-		cleanup()
 	})
 }

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -16,6 +16,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"io"
@@ -117,17 +118,26 @@ func httpClient(opts ...func(*http.Client)) *http.Client {
 // parameters until "condition" returns true or the timeout is reached.
 // It always returns the last HTTP response received.
 func (h *HTTP) RequestUntil(opts *HTTPRequestOpts) (*HTTPResponse, bool) {
-	req, err := http.NewRequest(http.MethodGet, opts.requestURLBase(h.HTTPURLBase)+opts.Path, opts.Body)
-	require.NoError(h.t, err, "error creating HTTP request")
-
-	req.Host = opts.Host
-	for _, opt := range opts.RequestOpts {
-		opt(req)
+	// Read the body once so each attempt can be given its own reader,
+	// otherwise retries would send an empty body.
+	var bodyBytes []byte
+	if opts.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(opts.Body)
+		require.NoError(h.t, err, "error reading request body")
 	}
 
 	client := httpClient(opts.ClientOpts...)
 
 	makeRequest := func() (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodGet, opts.requestURLBase(h.HTTPURLBase)+opts.Path, bytes.NewReader(bodyBytes))
+		require.NoError(h.t, err, "error creating HTTP request")
+
+		req.Host = opts.Host
+		for _, opt := range opts.RequestOpts {
+			opt(req)
+		}
+
 		return client.Do(req)
 	}
 
@@ -245,12 +255,13 @@ func OptSetSNI(name string) func(*tls.Config) {
 // parameters until "condition" returns true or the timeout is reached.
 // It always returns the last HTTP response received.
 func (h *HTTP) SecureRequestUntil(opts *HTTPSRequestOpts) (*HTTPResponse, bool) {
-	req, err := http.NewRequest(http.MethodGet, opts.requestURLBase(h.HTTPSURLBase)+opts.Path, opts.Body)
-	require.NoError(h.t, err, "error creating HTTP request")
-
-	req.Host = opts.Host
-	for _, opt := range opts.RequestOpts {
-		opt(req)
+	// Read the body once so each attempt can be given its own reader,
+	// otherwise retries would send an empty body.
+	var bodyBytes []byte
+	if opts.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(opts.Body)
+		require.NoError(h.t, err, "error reading request body")
 	}
 
 	client := httpClient()
@@ -267,6 +278,14 @@ func (h *HTTP) SecureRequestUntil(opts *HTTPSRequestOpts) (*HTTPResponse, bool) 
 	}
 
 	makeRequest := func() (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodGet, opts.requestURLBase(h.HTTPSURLBase)+opts.Path, bytes.NewReader(bodyBytes))
+		require.NoError(h.t, err, "error creating HTTP request")
+
+		req.Host = opts.Host
+		for _, opt := range opts.RequestOpts {
+			opt(req)
+		}
+
 		return client.Do(req)
 	}
 

--- a/test/e2e/httpproxy/grpc_test.go
+++ b/test/e2e/httpproxy/grpc_test.go
@@ -25,7 +25,6 @@ import (
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/projectcontour/yages/yages"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -33,6 +32,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -41,11 +42,10 @@ import (
 )
 
 func testGRPCServicePlaintext(namespace string) {
-	// Flake tracking issue: https://github.com/projectcontour/contour/issues/6092
-	Specify("requests to a gRPC service configured with plaintext work as expected", FlakeAttempts(3), func() {
+	Specify("requests to a gRPC service configured with plaintext work as expected", func() {
 		t := f.T()
 
-		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+		e2e.StartLocalGRPCEchoService(GinkgoT(), f.Client, namespace, "grpc-echo")
 		f.Certs.CreateSelfSignedCert(namespace, "echo", "grpc-echo-plaintext.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
@@ -73,7 +73,7 @@ func testGRPCServicePlaintext(namespace string) {
 						},
 						Conditions: []contour_v1.MatchCondition{
 							{
-								Prefix: "/yages.Echo/Ping",
+								Prefix: "/contourecho.Echo/Ping",
 							},
 						},
 					},
@@ -114,11 +114,12 @@ func testGRPCServicePlaintext(namespace string) {
 			// Give significant leeway for retries to complete with exponential backoff.
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 			defer cancel()
-			client := yages.NewEchoClient(conn)
-			resp, err := client.Ping(ctx, &yages.Empty{})
+
+			var resp wrapperspb.StringValue
+			err = conn.Invoke(ctx, "/contourecho.Echo/Ping", &emptypb.Empty{}, &resp)
 
 			require.NoErrorf(t, err, "gRPC error code %d", status.Code(err))
-			require.Equal(t, "pong", resp.Text)
+			require.Equal(t, "pong", resp.Value)
 		}
 	})
 }
@@ -127,7 +128,7 @@ func testGRPCWeb(namespace string) {
 	Specify("grpc-Web HTTP requests to a gRPC service work as expected", func() {
 		t := f.T()
 
-		f.Fixtures.GRPC.Deploy(namespace, "grpc-echo")
+		e2e.StartLocalGRPCEchoService(GinkgoT(), f.Client, namespace, "grpc-echo")
 		f.Certs.CreateSelfSignedCert(namespace, "echo", "grpc-web.projectcontour.io")
 
 		p := &contour_v1.HTTPProxy{
@@ -158,14 +159,13 @@ func testGRPCWeb(namespace string) {
 		require.True(f.T(), f.CreateHTTPProxyAndWaitFor(p, e2e.HTTPProxyValid))
 
 		// One byte marker that this is a data frame, and 4 bytes
-		// for the length (we can use 0 since the yages.Empty message
-		// is actually empty and has no fields).
+		// for the length (0 since emptypb.Empty has no fields).
 		// See: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md
 		bodyData := []byte{0x0, 0x0, 0x0, 0x0, 0x0}
 
 		res, ok := f.HTTP.SecureRequestUntil(&e2e.HTTPSRequestOpts{
 			Host: p.Spec.VirtualHost.Fqdn,
-			Path: "/yages.Echo/Ping",
+			Path: "/contourecho.Echo/Ping",
 			Body: bytes.NewReader(bodyData),
 			RequestOpts: []func(*http.Request){
 				func(req *http.Request) {
@@ -180,7 +180,7 @@ func testGRPCWeb(namespace string) {
 			Condition: func(res *e2e.HTTPResponse) bool {
 				if e2e.HasStatusCode(http.StatusOK)(res) {
 					resp := parseGRPCWebResponse(res.Body)
-					return resp.content != nil && resp.content.Text == "pong" &&
+					return resp.content != nil && resp.content.Value == "pong" &&
 						resp.trailers["grpc-status"] == "0"
 				}
 				return false
@@ -192,7 +192,7 @@ func testGRPCWeb(namespace string) {
 }
 
 type grpcWebResponse struct {
-	content  *yages.Content
+	content  *wrapperspb.StringValue
 	trailers map[string]string
 }
 
@@ -221,7 +221,7 @@ func parseGRPCWebResponse(body []byte) grpcWebResponse {
 	if dataLen > 0 {
 		require.Greater(t, len(body), currentPos+dataLen)
 
-		content := new(yages.Content)
+		content := new(wrapperspb.StringValue)
 		require.NoError(t, proto.Unmarshal(body[currentPos:currentPos+dataLen], content))
 		response.content = content
 		currentPos += dataLen

--- a/test/e2e/local_grpc_echo_service.go
+++ b/test/e2e/local_grpc_echo_service.go
@@ -1,0 +1,101 @@
+// Copyright Project Contour Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	core_v1 "k8s.io/api/core/v1"
+	discovery_v1 "k8s.io/api/discovery/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// grpcEchoServiceDesc is a hand-written gRPC service descriptor for
+// contourecho.Echo with a single unary method "Ping". This avoids any
+// dependency on protoc-generated code.
+var grpcEchoServiceDesc = grpc.ServiceDesc{
+	ServiceName: "contourecho.Echo",
+	HandlerType: (*any)(nil),
+	Methods: []grpc.MethodDesc{{
+		MethodName: "Ping",
+		Handler: func(_ any, _ context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+			req := new(emptypb.Empty)
+			if err := dec(req); err != nil {
+				return nil, err
+			}
+			return &wrapperspb.StringValue{Value: "pong"}, nil
+		},
+	}},
+}
+
+// StartLocalGRPCEchoService starts a cleartext gRPC server on
+// CONTOUR_E2E_LOCAL_HOST:<random-port> that implements
+// contourecho.Echo/Ping (returns StringValue "pong").
+//
+// It registers the server in-cluster as a headless Service and
+// EndpointSlice so Envoy can route to it. The server is stopped
+// automatically when the test completes.
+//
+// CONTOUR_E2E_LOCAL_HOST must be set to a host IP reachable from within
+// the cluster. The test is skipped if the variable is absent.
+func StartLocalGRPCEchoService(t ginkgo.GinkgoTInterface, c client.Client, ns, name string) {
+	hostIP := os.Getenv("CONTOUR_E2E_LOCAL_HOST")
+	if hostIP == "" {
+		ginkgo.Skip("CONTOUR_E2E_LOCAL_HOST must be set to a host IP reachable from within the cluster")
+	}
+
+	grpcServer := grpc.NewServer()
+	grpcServer.RegisterService(&grpcEchoServiceDesc, &struct{}{})
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(hostIP, "0"))
+	require.NoError(t, err)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+	t.Cleanup(func() { grpcServer.GracefulStop() })
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	require.NoError(t, c.Create(context.TODO(), &core_v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: core_v1.ServiceSpec{
+			Ports: []core_v1.ServicePort{{Name: "grpc", Protocol: core_v1.ProtocolTCP, Port: 9000}},
+		},
+	}))
+	require.NoError(t, c.Create(context.TODO(), &discovery_v1.EndpointSlice{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name, Namespace: ns,
+			Labels: map[string]string{discovery_v1.LabelServiceName: name},
+		},
+		AddressType: discovery_v1.AddressTypeIPv4,
+		Endpoints: []discovery_v1.Endpoint{
+			{Addresses: []string{hostIP}, Conditions: discovery_v1.EndpointConditions{Ready: ptr.To(true)}},
+		},
+		Ports: []discovery_v1.EndpointPort{
+			{Name: ptr.To("grpc"), Port: ptr.To(int32(port)), Protocol: ptr.To(core_v1.ProtocolTCP)}, //nolint:gosec
+		},
+	}))
+}


### PR DESCRIPTION
This PR drops [yages](https://github.com/projectcontour/yages) as a dependency for the e2e test suite by replacing it with a test server stub that runs directly within the test case as a goroutine.

This approach should avoid common e2e flake related to startup of external containers, it also fixes a bug where POST body was not correctly replayed at HTTP request retry. And it removes unmaintained container from the test environment.

Similar approach is suggested for gRPC authorization tests, see #7597

Fixes #7701
Fixes #6092