### PR TITLE
Remove deprecated TLS Config.Rand field

### DIFF
--- a/cmd/contour/servecontext.go
+++ b/cmd/contour/servecontext.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -222,7 +221,6 @@ func tlsconfig(log logrus.FieldLogger, contourXDSTLS *contour_v1alpha1.TLS) *tls
 	return &tls.Config{
 		MinVersion: tls.VersionTLS13,
 		ClientAuth: tls.RequireAndVerifyClientCert,
-		Rand:       rand.Reader,
 		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
 			return loadConfig()
 		},


### PR DESCRIPTION
Golangci-lint gives complaint after compiling with Go 1.27 language level

```
Error: cmd/contour/servecontext.go:225:3: SA1019: (crypto/tls.Config).Rand has been deprecated since Go 1.27 and an alternative has been available since Go 1.26: this should be left nil in production. Not all TLS configurations are guaranteed to use Rand. Test code can use [testing/cryptotest.SetGlobalRandom] instead. (staticcheck)

    Rand:       rand.Reader,
    ^

1 issues:
* staticcheck: 1
```

See https://pkg.go.dev/crypto/tls@go1.27.0#Config for reasoning

```
	// Rand provides the source of entropy for the connection.
	// If Rand is nil, TLS uses the cryptographic random reader in package
	// crypto/rand. The Reader must be safe for use by multiple goroutines.
	//
	// Deprecated: this should be left nil in production. Not all TLS
	// configurations are guaranteed to use Rand. Test code can use
	// [testing/cryptotest.SetGlobalRandom] instead.
	Rand [io](https://pkg.go.dev/io).[Reader](https://pkg.go.dev/io#Reader)
```